### PR TITLE
chore(eslint): turn off complexity linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     'import/order': 'off',
     'max-lines-per-function': 'off',
     'no-console': ['warn'],
+    complexity: ['off'],
   },
   env: {
     browser: true,


### PR DESCRIPTION
Components like TextInput has a lot of conditions but eslint has a restriction on the complexity of an arrow function which in our case is a React Component. Can We turn this rule off?