### PR TITLE
fix(native/bottomsheet): update content height based on footer

### DIFF
--- a/src/molecules/BottomSheet/BottomSheet.native.js
+++ b/src/molecules/BottomSheet/BottomSheet.native.js
@@ -80,6 +80,7 @@ const BottomSheet = ({
   const bottomSheetVisibility = useRef(visible);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [contentHeight, setContentHeight] = useState(0);
+  const [footerHeight, setFooterHeight] = useState(0);
   const bottomsheetChildrenGroupByDisplayName = reactChildrenGroupByDisplayName(children);
 
   const headerComponent = bottomsheetChildrenGroupByDisplayName.BottomSheetHeader;
@@ -119,11 +120,18 @@ const BottomSheet = ({
     setContentHeight(e.nativeEvent.layout.height);
   }, []);
 
+  const handleFooterLayoutChange = useCallback((e) => {
+    setFooterHeight(e.nativeEvent.layout.height);
+  }, []);
+
   let contentContainerHeight = DEFAULT_SNAP_POINT - headerHeight;
   if (initialHeight > 0) {
     contentContainerHeight = initialHeight - headerHeight;
   }
-  const isScrollableContent = contentHeight > contentContainerHeight;
+  // scrollable is always false when adjustToContentHeight={true}
+  const isScrollableContent = adjustToContentHeight
+    ? false
+    : contentHeight > contentContainerHeight;
 
   const handleBottomSheetClose = () => {
     if (onClose && typeof onClose === 'function') {
@@ -177,7 +185,9 @@ const BottomSheet = ({
                 />
               </Size>
             )}
-            {footerComponent?.length ? footerComponent : null}
+            {footerComponent?.length ? (
+              <View onLayout={handleFooterLayoutChange}>{footerComponent}</View>
+            ) : null}
           </View>
         </Position>
       }
@@ -193,7 +203,9 @@ const BottomSheet = ({
       alwaysOpen={initialHeight}
       rootStyle={styles.rootStyle({ theme })}
     >
-      <View onLayout={handleContentLayoutChange}>{contentComponent}</View>
+      <Space padding={[0, 0, footerHeight / 8, 0]}>
+        <View onLayout={handleContentLayoutChange}>{contentComponent}</View>
+      </Space>
     </RNModalize>
   );
 };

--- a/src/molecules/BottomSheet/BottomSheet.native.js
+++ b/src/molecules/BottomSheet/BottomSheet.native.js
@@ -112,16 +112,16 @@ const BottomSheet = ({
     );
   }
 
-  const handleHeaderLayoutChange = useCallback((e) => {
-    setHeaderHeight(e.nativeEvent.layout.height);
+  const handleHeaderLayoutChange = useCallback(({ nativeEvent }) => {
+    setHeaderHeight(nativeEvent.layout.height);
   }, []);
 
-  const handleContentLayoutChange = useCallback((e) => {
-    setContentHeight(e.nativeEvent.layout.height);
+  const handleContentLayoutChange = useCallback(({ nativeEvent }) => {
+    setContentHeight(nativeEvent.layout.height);
   }, []);
 
-  const handleFooterLayoutChange = useCallback((e) => {
-    setFooterHeight(e.nativeEvent.layout.height);
+  const handleFooterLayoutChange = useCallback(({ nativeEvent }) => {
+    setFooterHeight(nativeEvent.layout.height);
   }, []);
 
   let contentContainerHeight = DEFAULT_SNAP_POINT - headerHeight;

--- a/src/molecules/BottomSheet/BottomSheet.stories.js
+++ b/src/molecules/BottomSheet/BottomSheet.stories.js
@@ -98,6 +98,47 @@ storiesOf('BottomSheet', module)
       </>
     );
   })
+  .add('non-scrollable with footer', () => {
+    return (
+      <>
+        <Text>Non-Scrollable BottomSheet with Footer</Text>
+        <BottomSheet visible={true} onClose={() => {}} adjustToContentHeight>
+          <BottomSheet.Header>
+            <Space padding={[1]}>
+              <View>
+                <Text>Header</Text>
+              </View>
+            </Space>
+          </BottomSheet.Header>
+
+          <BottomSheet.Content>
+            <Space padding={[2]}>
+              <View>
+                <Text>Yamaha</Text>
+              </View>
+            </Space>
+
+            <Space padding={[2]}>
+              <View>
+                <Text>Honda</Text>
+              </View>
+            </Space>
+
+            <Space padding={[2]}>
+              <View>
+                <Text>Kawasaki</Text>
+              </View>
+            </Space>
+          </BottomSheet.Content>
+          <BottomSheet.Footer>
+            <View>
+              <Text>Footer</Text>
+            </View>
+          </BottomSheet.Footer>
+        </BottomSheet>
+      </>
+    );
+  })
   .add('without Header', () => {
     return (
       <>

--- a/src/molecules/BottomSheet/BottomSheetFooter.native.js
+++ b/src/molecules/BottomSheet/BottomSheetFooter.native.js
@@ -13,7 +13,11 @@ const BottomSheetFooter = ({ children }) => {
   return children ? (
     <FooterContainer>
       <Divider color="shade.920" horizontal />
-      {children ? <Space padding={[1, 2, 1, 2]}>{children}</Space> : null}
+      {children ? (
+        <Space padding={[1, 2, 1, 2]}>
+          <View>{children}</View>
+        </Space>
+      ) : null}
     </FooterContainer>
   ) : null;
 };

--- a/src/molecules/BottomSheet/BottomSheetFooter.native.js
+++ b/src/molecules/BottomSheet/BottomSheetFooter.native.js
@@ -13,11 +13,9 @@ const BottomSheetFooter = ({ children }) => {
   return children ? (
     <FooterContainer>
       <Divider color="shade.920" horizontal />
-      {children ? (
-        <Space padding={[1, 2, 1, 2]}>
-          <View>{children}</View>
-        </Space>
-      ) : null}
+      <Space padding={[1, 2, 1, 2]}>
+        <View>{children}</View>
+      </Space>
     </FooterContainer>
   ) : null;
 };

--- a/src/molecules/BottomSheet/__tests__/BottomSheet.native.test.js
+++ b/src/molecules/BottomSheet/__tests__/BottomSheet.native.test.js
@@ -19,15 +19,7 @@ describe('<BottomSheet />', () => {
 
   it('renders BottomSheet with Header, Footer and Content Defined', () => {
     const { container } = renderWithTheme(
-      <BottomSheet
-        visible={true}
-        FooterComponent={
-          <View>
-            <Text>Footer</Text>
-          </View>
-        }
-        onClose={mockOnClose}
-      >
+      <BottomSheet visible={true} onClose={mockOnClose}>
         <BottomSheet.Header>
           <View>
             <Text>Header</Text>
@@ -50,16 +42,7 @@ describe('<BottomSheet />', () => {
 
   it('renders bottomsheet when initialHeight prop is passed', () => {
     const { container } = renderWithTheme(
-      <BottomSheet
-        visible={true}
-        initialHeight={300}
-        FooterComponent={
-          <View>
-            <Text>Footer</Text>
-          </View>
-        }
-        onClose={() => {}}
-      >
+      <BottomSheet visible={true} initialHeight={300} onClose={() => {}}>
         <BottomSheet.Header>
           <View>
             <Text>Header</Text>
@@ -101,15 +84,50 @@ describe('<BottomSheet />', () => {
     }));
 
     const { container } = renderWithTheme(
-      <BottomSheet
-        visible={true}
-        FooterComponent={
+      <BottomSheet visible={true} onClose={mockOnClose}>
+        <BottomSheet.Header>
+          <View>
+            <Text>Header</Text>
+          </View>
+        </BottomSheet.Header>
+        <BottomSheet.Content>
+          {data.map((item) => (
+            <View key={item.id}>
+              <Text>{item.name}</Text>
+            </View>
+          ))}
+        </BottomSheet.Content>
+        <BottomSheet.Footer>
           <View>
             <Text>Footer</Text>
           </View>
-        }
-        onClose={mockOnClose}
-      >
+        </BottomSheet.Footer>
+      </BottomSheet>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders non-scrollable bottomsheet', () => {
+    const list = [
+      'Samsung',
+      'Xiaomi',
+      'OnePlus',
+      'Apple',
+      'Vivo',
+      'Oppo',
+      'Lenovo',
+      'LG',
+      'Nokia',
+      'HTC',
+    ];
+
+    const data = new Array(list.length).fill({}).map((item, index) => ({
+      id: index,
+      name: list[index],
+    }));
+
+    const { container } = renderWithTheme(
+      <BottomSheet visible={true} onClose={mockOnClose} adjustToContentHeight>
         <BottomSheet.Header>
           <View>
             <Text>Header</Text>
@@ -135,15 +153,7 @@ describe('<BottomSheet />', () => {
   it('should throw error when multiple Headers are passed to bottomsheet', () => {
     expect(() =>
       renderWithTheme(
-        <BottomSheet
-          visible={true}
-          FooterComponent={
-            <View>
-              <Text>Footer</Text>
-            </View>
-          }
-          onClose={mockOnClose}
-        >
+        <BottomSheet visible={true} onClose={mockOnClose}>
           <BottomSheet.Header>
             <View>
               <Text>Header1</Text>
@@ -172,15 +182,7 @@ describe('<BottomSheet />', () => {
   it('should throw error when multiple Footer are passed to bottomsheet', () => {
     expect(() =>
       renderWithTheme(
-        <BottomSheet
-          visible={true}
-          FooterComponent={
-            <View>
-              <Text>Footer</Text>
-            </View>
-          }
-          onClose={mockOnClose}
-        >
+        <BottomSheet visible={true} onClose={mockOnClose}>
           <BottomSheet.Header>
             <View>
               <Text>Header1</Text>
@@ -209,14 +211,7 @@ describe('<BottomSheet />', () => {
   it('should throw error when onClose method callback is not passed', () => {
     expect(() =>
       renderWithTheme(
-        <BottomSheet
-          visible={true}
-          FooterComponent={
-            <View>
-              <Text>Footer</Text>
-            </View>
-          }
-        >
+        <BottomSheet visible={true}>
           <BottomSheet.Header>
             <View>
               <Text>Header1</Text>

--- a/src/molecules/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.js.snap
+++ b/src/molecules/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.js.snap
@@ -1642,3 +1642,630 @@ exports[`<BottomSheet /> renders linear-gradient view at bottom when content hei
   </View>
 </View>
 `;
+
+exports[`<BottomSheet /> renders non-scrollable bottomsheet 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    pointerEvents="auto"
+    style={
+      Array [
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "zIndex": 9998,
+        },
+        Object {
+          "elevation": 5,
+          "shadowColor": "rgba(11, 112, 231, 0.10)",
+          "shadowOffset": Object {
+            "height": -4,
+            "width": 0,
+          },
+          "shadowOpacity": 0.8,
+          "shadowRadius": 15,
+        },
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="box-none"
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "#fff",
+              "borderTopLeftRadius": 12,
+              "borderTopRightRadius": 12,
+              "elevation": 4,
+              "height": undefined,
+              "marginTop": "auto",
+              "maxHeight": 1299,
+              "shadowColor": "#000",
+              "shadowOffset": Object {
+                "height": 10,
+                "width": 0,
+              },
+              "shadowOpacity": 0.1,
+              "shadowRadius": 12,
+              "transform": Array [
+                Object {
+                  "translateY": 1299,
+                },
+              ],
+              "zIndex": 5,
+            },
+            Object {
+              "paddingBottom": 0,
+            },
+          ]
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "zIndex": undefined,
+            }
+          }
+        >
+          <View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgba(255, 255, 255, 1.0)",
+                    "borderTopLeftRadius": 8,
+                    "borderTopRightRadius": 8,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Array [
+                      Object {
+                        "paddingBottom": 12,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 8,
+                      },
+                      Array [
+                        Object {
+                          "alignItems": "center",
+                          "flexDirection": "column",
+                        },
+                      ],
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "backgroundColor": "rgba(22, 47, 86, 0.05)",
+                        "borderRadius": 4,
+                      },
+                      Array [
+                        Object {
+                          "height": 4,
+                          "width": 64,
+                        },
+                      ],
+                    ]
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Array [
+                    Array [
+                      Object {
+                        "paddingBottom": 8,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 8,
+                      },
+                    ],
+                  ]
+                }
+              >
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Header
+                  </Text>
+                </View>
+              </View>
+              <View
+                color="shade.920"
+                dividerDirection="horizontal"
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "rgba(22, 47, 86, 0.05)",
+                      "height": 1,
+                      "width": "100%",
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </View>
+        <View
+          collapsable={false}
+          style={
+            Object {
+              "backgroundColor": "rgba(255, 255, 255, 1.0)",
+              "flex": 0,
+              "flexGrow": 0,
+              "flexShrink": 1,
+            }
+          }
+        >
+          <ScrollView
+            bounces={true}
+            collapsable={false}
+            keyboardDismissMode="interactive"
+            scrollEnabled={false}
+            scrollEventThrottle={16}
+          >
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    },
+                  ],
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Array [
+                      Object {
+                        "paddingBottom": 8,
+                        "paddingLeft": 16,
+                        "paddingRight": 16,
+                        "paddingTop": 8,
+                      },
+                    ],
+                  ]
+                }
+              >
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Samsung
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Xiaomi
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    OnePlus
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Apple
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Vivo
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Oppo
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Lenovo
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    LG
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    Nokia
+                  </Text>
+                </View>
+                <View>
+                  <Text
+                    _isUnderlined={false}
+                    _letterSpacing="small"
+                    align="left"
+                    color="shade.980"
+                    size="large"
+                    style={
+                      Array [
+                        Object {
+                          "color": "rgba(22, 47, 86, 0.87)",
+                          "fontFamily": "Lato-Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                          "textAlign": "left",
+                          "textDecorationLine": "none",
+                        },
+                      ]
+                    }
+                    testID="ds-text"
+                    weight="regular"
+                  >
+                    HTC
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </ScrollView>
+        </View>
+      </View>
+      <View
+        collapsable={false}
+        pointerEvents="auto"
+        style={
+          Object {
+            "bottom": 0,
+            "height": undefined,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 0,
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          pointerEvents="auto"
+          style={
+            Object {
+              "backgroundColor": "rgba(22, 47, 86, 0.38)",
+              "bottom": 0,
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      collapsable={false}
+      style={
+        Object {
+          "zIndex": undefined,
+        }
+      }
+    >
+      <View
+        bottom={0}
+        left={0}
+        position="absolute"
+        right={0}
+        style={
+          Array [
+            Array [
+              Object {
+                "position": "absolute",
+              },
+            ],
+          ]
+        }
+      >
+        <View>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgba(255, 255, 255, 1.0)",
+                },
+              ]
+            }
+          >
+            <View
+              color="shade.920"
+              dividerDirection="horizontal"
+              style={
+                Array [
+                  Object {
+                    "backgroundColor": "rgba(22, 47, 86, 0.05)",
+                    "height": 1,
+                    "width": "100%",
+                  },
+                ]
+              }
+            />
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 8,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": 8,
+                    },
+                  ],
+                ]
+              }
+            >
+              <View>
+                <Text
+                  _isUnderlined={false}
+                  _letterSpacing="small"
+                  align="left"
+                  color="shade.980"
+                  size="large"
+                  style={
+                    Array [
+                      Object {
+                        "color": "rgba(22, 47, 86, 0.87)",
+                        "fontFamily": "Lato-Regular",
+                        "fontSize": 16,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                        "textAlign": "left",
+                        "textDecorationLine": "none",
+                      },
+                    ]
+                  }
+                  testID="ds-text"
+                  weight="regular"
+                >
+                  Footer
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/src/molecules/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.js.snap
+++ b/src/molecules/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.js.snap
@@ -207,7 +207,20 @@ exports[`<BottomSheet /> renders BottomSheet with Header, Footer and Content Def
             scrollEnabled={false}
             scrollEventThrottle={16}
           >
-            <View>
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    },
+                  ],
+                ]
+              }
+            >
               <View
                 style={
                   Array [
@@ -308,66 +321,70 @@ exports[`<BottomSheet /> renders BottomSheet with Header, Footer and Content Def
           ]
         }
       >
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgba(255, 255, 255, 1.0)",
-              },
-            ]
-          }
-        >
+        <View>
           <View
-            color="shade.920"
-            dividerDirection="horizontal"
             style={
               Array [
                 Object {
-                  "backgroundColor": "rgba(22, 47, 86, 0.05)",
-                  "height": 1,
-                  "width": "100%",
+                  "backgroundColor": "rgba(255, 255, 255, 1.0)",
                 },
               ]
             }
-          />
-          <View
-            style={
-              Array [
-                Array [
-                  Object {
-                    "paddingBottom": 8,
-                    "paddingLeft": 16,
-                    "paddingRight": 16,
-                    "paddingTop": 8,
-                  },
-                ],
-              ]
-            }
           >
-            <Text
-              _isUnderlined={false}
-              _letterSpacing="small"
-              align="left"
-              color="shade.980"
-              size="large"
+            <View
+              color="shade.920"
+              dividerDirection="horizontal"
               style={
                 Array [
                   Object {
-                    "color": "rgba(22, 47, 86, 0.87)",
-                    "fontFamily": "Lato-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                    "textDecorationLine": "none",
+                    "backgroundColor": "rgba(22, 47, 86, 0.05)",
+                    "height": 1,
+                    "width": "100%",
                   },
                 ]
               }
-              testID="ds-text"
-              weight="regular"
+            />
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 8,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": 8,
+                    },
+                  ],
+                ]
+              }
             >
-              Footer
-            </Text>
+              <View>
+                <Text
+                  _isUnderlined={false}
+                  _letterSpacing="small"
+                  align="left"
+                  color="shade.980"
+                  size="large"
+                  style={
+                    Array [
+                      Object {
+                        "color": "rgba(22, 47, 86, 0.87)",
+                        "fontFamily": "Lato-Regular",
+                        "fontSize": 16,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                        "textAlign": "left",
+                        "textDecorationLine": "none",
+                      },
+                    ]
+                  }
+                  testID="ds-text"
+                  weight="regular"
+                >
+                  Footer
+                </Text>
+              </View>
+            </View>
           </View>
         </View>
       </View>
@@ -583,7 +600,20 @@ exports[`<BottomSheet /> renders bottomsheet when initialHeight prop is passed 1
             scrollEnabled={false}
             scrollEventThrottle={16}
           >
-            <View>
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    },
+                  ],
+                ]
+              }
+            >
               <View
                 style={
                   Array [
@@ -684,66 +714,70 @@ exports[`<BottomSheet /> renders bottomsheet when initialHeight prop is passed 1
           ]
         }
       >
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgba(255, 255, 255, 1.0)",
-              },
-            ]
-          }
-        >
+        <View>
           <View
-            color="shade.920"
-            dividerDirection="horizontal"
             style={
               Array [
                 Object {
-                  "backgroundColor": "rgba(22, 47, 86, 0.05)",
-                  "height": 1,
-                  "width": "100%",
+                  "backgroundColor": "rgba(255, 255, 255, 1.0)",
                 },
               ]
             }
-          />
-          <View
-            style={
-              Array [
-                Array [
-                  Object {
-                    "paddingBottom": 8,
-                    "paddingLeft": 16,
-                    "paddingRight": 16,
-                    "paddingTop": 8,
-                  },
-                ],
-              ]
-            }
           >
-            <Text
-              _isUnderlined={false}
-              _letterSpacing="small"
-              align="left"
-              color="shade.980"
-              size="large"
+            <View
+              color="shade.920"
+              dividerDirection="horizontal"
               style={
                 Array [
                   Object {
-                    "color": "rgba(22, 47, 86, 0.87)",
-                    "fontFamily": "Lato-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                    "textDecorationLine": "none",
+                    "backgroundColor": "rgba(22, 47, 86, 0.05)",
+                    "height": 1,
+                    "width": "100%",
                   },
                 ]
               }
-              testID="ds-text"
-              weight="regular"
+            />
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 8,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": 8,
+                    },
+                  ],
+                ]
+              }
             >
-              Footer
-            </Text>
+              <View>
+                <Text
+                  _isUnderlined={false}
+                  _letterSpacing="small"
+                  align="left"
+                  color="shade.980"
+                  size="large"
+                  style={
+                    Array [
+                      Object {
+                        "color": "rgba(22, 47, 86, 0.87)",
+                        "fontFamily": "Lato-Regular",
+                        "fontSize": 16,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                        "textAlign": "left",
+                        "textDecorationLine": "none",
+                      },
+                    ]
+                  }
+                  testID="ds-text"
+                  weight="regular"
+                >
+                  Footer
+                </Text>
+              </View>
+            </View>
           </View>
         </View>
       </View>
@@ -905,7 +939,20 @@ exports[`<BottomSheet /> renders default BottomSheet 1`] = `
             scrollEnabled={false}
             scrollEventThrottle={16}
           >
-            <View />
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    },
+                  ],
+                ]
+              }
+            />
           </ScrollView>
         </View>
       </View>
@@ -1176,7 +1223,20 @@ exports[`<BottomSheet /> renders linear-gradient view at bottom when content hei
             scrollEnabled={false}
             scrollEventThrottle={16}
           >
-            <View>
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    },
+                  ],
+                ]
+              }
+            >
               <View
                 style={
                   Array [
@@ -1511,66 +1571,70 @@ exports[`<BottomSheet /> renders linear-gradient view at bottom when content hei
           ]
         }
       >
-        <View
-          style={
-            Array [
-              Object {
-                "backgroundColor": "rgba(255, 255, 255, 1.0)",
-              },
-            ]
-          }
-        >
+        <View>
           <View
-            color="shade.920"
-            dividerDirection="horizontal"
             style={
               Array [
                 Object {
-                  "backgroundColor": "rgba(22, 47, 86, 0.05)",
-                  "height": 1,
-                  "width": "100%",
+                  "backgroundColor": "rgba(255, 255, 255, 1.0)",
                 },
               ]
             }
-          />
-          <View
-            style={
-              Array [
-                Array [
-                  Object {
-                    "paddingBottom": 8,
-                    "paddingLeft": 16,
-                    "paddingRight": 16,
-                    "paddingTop": 8,
-                  },
-                ],
-              ]
-            }
           >
-            <Text
-              _isUnderlined={false}
-              _letterSpacing="small"
-              align="left"
-              color="shade.980"
-              size="large"
+            <View
+              color="shade.920"
+              dividerDirection="horizontal"
               style={
                 Array [
                   Object {
-                    "color": "rgba(22, 47, 86, 0.87)",
-                    "fontFamily": "Lato-Regular",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "textAlign": "left",
-                    "textDecorationLine": "none",
+                    "backgroundColor": "rgba(22, 47, 86, 0.05)",
+                    "height": 1,
+                    "width": "100%",
                   },
                 ]
               }
-              testID="ds-text"
-              weight="regular"
+            />
+            <View
+              style={
+                Array [
+                  Array [
+                    Object {
+                      "paddingBottom": 8,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": 8,
+                    },
+                  ],
+                ]
+              }
             >
-              Footer
-            </Text>
+              <View>
+                <Text
+                  _isUnderlined={false}
+                  _letterSpacing="small"
+                  align="left"
+                  color="shade.980"
+                  size="large"
+                  style={
+                    Array [
+                      Object {
+                        "color": "rgba(22, 47, 86, 0.87)",
+                        "fontFamily": "Lato-Regular",
+                        "fontSize": 16,
+                        "letterSpacing": 0,
+                        "lineHeight": 24,
+                        "textAlign": "left",
+                        "textDecorationLine": "none",
+                      },
+                    ]
+                  }
+                  testID="ds-text"
+                  weight="regular"
+                >
+                  Footer
+                </Text>
+              </View>
+            </View>
           </View>
         </View>
       </View>


### PR DESCRIPTION
1. Calculates content height based on footer height when `adjustToContentHeight` prop is true. 
2. Disables the gradient effect when `adjustToContentHeight` is true.
3. Removes FooterComponent prop from test cases(my bad, wonder why did I leave it completely unnoticed!)