### PR TITLE
fix(TextInput): check inputRef.current inside useEffect

### DIFF
--- a/src/atoms/TextInput/TextInput.web.js
+++ b/src/atoms/TextInput/TextInput.web.js
@@ -343,7 +343,7 @@ const TextInput = ({
 
   useEffect(() => {
     // Adjust height of textarea as user types for outlined variant
-    if (_isMultiline && variant === 'outlined') {
+    if (inputRef.current && _isMultiline && variant === 'outlined') {
       inputRef.current.style.height = 'inherit';
       const height = inputRef.current.scrollHeight;
       // if scroll-height is greater than 60 then keep height at 60 for some space between Input & Line


### PR DESCRIPTION
Getting an error when running tests on OnboardingRevamp. Need to check if it is due to the missing check for ref.current before accessing its style property.