### PR TITLE
fix(TextInput/react): increase specificity for placeholder style

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -54,6 +54,7 @@ module.exports = {
             ssr: true,
           },
         ],
+        '@babel/plugin-proposal-nullish-coalescing-operator',
       ],
     },
     'web-production': {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@babel/cli": "7.8.4",
     "@babel/core": "7.9.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "7.12.1",
     "@babel/preset-env": "7.9.0",
     "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "7.12.7",

--- a/src/atoms/TextArea/__tests__/__snapshots__/TextArea.web.test.js.snap
+++ b/src/atoms/TextArea/__tests__/__snapshots__/TextArea.web.test.js.snap
@@ -34,7 +34,7 @@ exports[`<TextArea /> default should render TextArea with default props 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"
@@ -91,7 +91,7 @@ exports[`<TextArea /> disabled should render a disabled TextArea 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 UVPts Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 jYgntY Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 disabled=""
                 id="sample-id"
@@ -147,7 +147,7 @@ exports[`<TextArea /> errorText should render TextArea with help text if errorTe
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"
@@ -215,7 +215,7 @@ exports[`<TextArea /> errorText with maxLength should render TextArea with chara
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 maxlength="10"
                 placeholder=""
@@ -297,7 +297,7 @@ exports[`<TextArea /> focus should have focus when TextArea is focused 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 id="sample-id"
                 placeholder=""
@@ -351,7 +351,7 @@ exports[`<TextArea /> helpText should render TextArea with help text if helpText
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"
@@ -419,7 +419,7 @@ exports[`<TextArea /> helpText with maxLength should render TextArea with charac
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 maxlength="10"
                 placeholder=""
@@ -497,7 +497,7 @@ exports[`<TextArea /> label should render a TextArea with labelPosition on left 
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 cQyOdz Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dilovX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 id="sample-id"
                 placeholder=""
@@ -548,7 +548,7 @@ exports[`<TextArea /> label should render a TextArea with labelPosition on top(d
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 cQyOdz Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dilovX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 id="sample-id"
                 placeholder=""
@@ -602,7 +602,7 @@ exports[`<TextArea /> label should render a TextArea with labelPosition on top(d
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 id="sample-id"
                 placeholder=""
@@ -652,7 +652,7 @@ exports[`<TextArea /> variant should render filled variant with default props 1`
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 cQyOdz Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dilovX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="3"
@@ -704,7 +704,7 @@ exports[`<TextArea /> variant should render outlined variant with default props 
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"
@@ -757,7 +757,7 @@ exports[`<TextArea /> width should render a TextArea with auto width 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 hHYXCZ Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"
@@ -810,7 +810,7 @@ exports[`<TextArea /> width should render a TextArea with medium(default) width 
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"
@@ -863,7 +863,7 @@ exports[`<TextArea /> width should render a TextArea with small width 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 dCQgNm Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-area"
                 placeholder=""
                 rows="1"

--- a/src/atoms/TextInput/TextInput.web.js
+++ b/src/atoms/TextInput/TextInput.web.js
@@ -127,15 +127,17 @@ const StyledInput = styled.input`
   &:active {
     outline: none;
   }
-  &::placeholder {
-    color: ${(props) => props.placeholderTextColor};
-  }
   &::selection {
     background-color: ${(props) => props.theme.colors.primary[980]};
   }
   /* Removes red box shadow rectangle on firefox */
   &:invalid {
     box-shadow: none;
+  }
+  &&& {
+    &::placeholder {
+      color: ${(props) => props.placeholderTextColor};
+    }
   }
 `;
 

--- a/src/atoms/TextInput/__tests__/__snapshots__/TextInput.web.test.js.snap
+++ b/src/atoms/TextInput/__tests__/__snapshots__/TextInput.web.test.js.snap
@@ -35,7 +35,7 @@ exports[`<TextInput /> _isMultiline should render a input tag if _isMultiline is
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -89,7 +89,7 @@ exports[`<TextInput /> _isMultiline should render a textarea tag if _isMultiline
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <textarea
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -143,7 +143,7 @@ exports[`<TextInput /> default should render a TextInput with default props 1`] 
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -200,7 +200,7 @@ exports[`<TextInput /> disabled should render a disabled TextInput 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 UVPts Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 jYgntY Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 disabled=""
                 id="sample-id"
@@ -255,7 +255,7 @@ exports[`<TextInput /> errorText should render a TextInput with error text if er
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -322,7 +322,7 @@ exports[`<TextInput /> errorText with maxLength should render a TextInput with c
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 maxlength="10"
                 placeholder="Enter text here"
@@ -403,7 +403,7 @@ exports[`<TextInput /> focus should have focus when input is focused 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -456,7 +456,7 @@ exports[`<TextInput /> helpText should render a TextInput with help text if help
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -523,7 +523,7 @@ exports[`<TextInput /> helpText with maxLength should render a TextInput with ch
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 maxlength="10"
                 placeholder="Enter text here"
@@ -616,7 +616,7 @@ exports[`<TextInput /> iconLeft should render a TextInput with iconLeft 1`] = `
                 />
               </svg>
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -670,7 +670,7 @@ exports[`<TextInput /> iconRight should render a TextInput with iconRight 1`] = 
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -734,7 +734,7 @@ exports[`<TextInput /> label should render a TextInput with labelPosition on lef
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 cQyOdz Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dilovX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -785,7 +785,7 @@ exports[`<TextInput /> label should render a TextInput with labelPosition on top
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 cQyOdz Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dilovX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -839,7 +839,7 @@ exports[`<TextInput /> label should render a TextInput with labelPosition on top
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -900,7 +900,7 @@ exports[`<TextInput /> prefix should render a TextInput with prefix 1`] = `
                 ₹
               </div>
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -954,7 +954,7 @@ exports[`<TextInput /> suffix should render a TextInput with suffix 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 id="sample-id"
                 placeholder="Enter text here"
@@ -1010,7 +1010,7 @@ exports[`<TextInput /> variant should render a filled variant with default props
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 cQyOdz Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dilovX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 iBpGMC Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -1062,7 +1062,7 @@ exports[`<TextInput /> variant should render a outlined variant with default pro
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -1114,7 +1114,7 @@ exports[`<TextInput /> width should render a TextInput with auto width 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 hHYXCZ Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -1166,7 +1166,7 @@ exports[`<TextInput /> width should render a TextInput with medium(default) widt
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 cTcGbL Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"
@@ -1218,7 +1218,7 @@ exports[`<TextInput /> width should render a TextInput with small width 1`] = `
               class="Viewweb__View-sc-1i53gcl-0 TextInputweb__InputContainer-th1lpa-0 cXrEYp Sizeweb__Size-t4oux4-0 dCQgNm Flexweb__Flex-h5ddrw-0 bXkbdN"
             >
               <input
-                class="TextInputweb__StyledInput-th1lpa-1 jYgNJX Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
+                class="TextInputweb__StyledInput-th1lpa-1 dKteyD Sizeweb__Size-t4oux4-0 fitCCE Spaceweb__Space-sc-1gh69p2-0 elJMNa Flexweb__Flex-h5ddrw-0 cndXnK"
                 data-testid="ds-text-input"
                 placeholder="Enter text here"
                 type="text"

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,7 +399,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0", "@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+"@babel/plugin-proposal-nullish-coalescing-operator@7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0", "@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c"
   integrity sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==


### PR DESCRIPTION
Increase specificity for the placeholder style as this code https://github.com/razorpay/dashboard/blob/master/web/css/rzp/layout.styl#L406 is overriding the placeholder styles otherwise.