### PR TITLE
feat(native/FileUpload): add Native FileUpload component

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -184,6 +184,8 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
   - React-jsinspector (0.61.5)
+  - react-native-document-picker (4.2.0):
+    - React-Core
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
   - React-RCTAnimation (0.61.5):
@@ -247,6 +249,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
+  - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -299,6 +302,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
+  react-native-document-picker:
+    :path: "../node_modules/react-native-document-picker"
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -347,6 +352,7 @@ SPEC CHECKSUMS:
   React-jsi: cb2cd74d7ccf4cffb071a46833613edc79cdf8f7
   React-jsiexecutor: d5525f9ed5f782fdbacb64b9b01a43a9323d2386
   React-jsinspector: fa0ecc501688c3c4c34f28834a76302233e29dc0
+  react-native-document-picker: 44ecae7103090b6789cca010f06f5205fd1cb66e
   React-RCTActionSheet: 600b4d10e3aea0913b5a92256d2719c0cdd26d76
   React-RCTAnimation: 791a87558389c80908ed06cc5dfc5e7920dfa360
   React-RCTBlob: d89293cc0236d9cb0933d85e430b0bbe81ad1d72

--- a/jest-setup.native.js
+++ b/jest-setup.native.js
@@ -2,3 +2,40 @@
 jest.mock('react-native-reanimated', () =>
   jest.requireActual('./node_modules/react-native-reanimated/mock'),
 );
+
+jest.mock('react-native-document-picker', () => {
+  return {
+    pick: jest.fn(() =>
+      Promise.resolve({
+        uri: 'content://xyz.jpeg',
+        type: 'jpeg',
+        name: 'someFileName',
+        size: 2345,
+      }),
+    ),
+    types: {
+      allFiles: 'allFiles',
+      audio: 'audio',
+      csv: 'csv',
+      doc: 'doc',
+      docx: 'docx',
+      images: 'images',
+      pdf: 'pdf',
+      plainText: 'plainText',
+      ppt: 'ppt',
+      pptx: 'pptx',
+      video: 'video',
+      xls: 'xls',
+      xlsx: 'xlsx',
+      zip: 'zip',
+    },
+    isCancel: jest.fn(() => false),
+  };
+});
+
+jest.mock('react-native/Libraries/LayoutAnimation/LayoutAnimation', () => ({
+  ...jest.requireActual('react-native/Libraries/LayoutAnimation/LayoutAnimation'),
+  easeInEaseOut: jest.fn(),
+  configureNext: jest.fn(),
+  create: jest.fn(),
+}));

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@testing-library/react-hooks": "3.2.1",
     "intl": "1.2.5",
     "lodash": "4.17.15",
+    "react-native-document-picker": "4.2.0",
     "react-native-gesture-handler": "1.8.0",
     "react-native-linear-gradient": "2.5.6",
     "react-native-modal": "11.5.6",

--- a/src/icons/UploadCloud/UploadCloud.native.js
+++ b/src/icons/UploadCloud/UploadCloud.native.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Svg, { Path, Defs, ClipPath, G } from 'react-native-svg';
+import { getThemeColors } from '../../_helpers/theme';
+import colors from '../../tokens/colors';
+
+function UploadCloud({ width, height, fill }) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <G clipPath="url(#prefix__clip0)" fill={fill}>
+        <Path d="M1.013 6.843A9 9 0 0117.48 8H18a6 6 0 012.869 11.268 1 1 0 01-.958-1.756A4 4 0 0018 10H16.74a1 1 0 01-.968-.75 7 7 0 10-12.023 6.388 1 1 0 11-1.498 1.324A9 9 0 011.013 6.843z" />
+        <Path d="M12.707 11.293a1 1 0 00-1.414 0l-4 4a1 1 0 101.414 1.414L11 14.414V21a1 1 0 102 0v-6.586l2.293 2.293a1 1 0 001.414-1.414l-4-4z" />
+      </G>
+      <Defs>
+        <ClipPath id="prefix__clip0">
+          <Path fill="#fff" d="M0 0h24v24H0z" />
+        </ClipPath>
+      </Defs>
+    </Svg>
+  );
+}
+
+UploadCloud.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  fill: PropTypes.oneOf(getThemeColors()),
+};
+
+UploadCloud.defaultProps = {
+  width: 24,
+  height: 24,
+  fill: colors.sapphire[800],
+};
+
+export default UploadCloud;

--- a/src/icons/UploadCloud/UploadCloud.web.js
+++ b/src/icons/UploadCloud/UploadCloud.web.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getThemeColors } from '../../_helpers/theme';
+import colors from '../../tokens/colors';
+
+function UploadCloud({ width, height, fill }) {
+  return (
+    <svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <g clipPath="url(#prefix__clip0)" fill={fill}>
+        <path d="M1.013 6.843A9 9 0 0117.48 8H18a6 6 0 012.869 11.268 1 1 0 01-.958-1.756A4 4 0 0018 10H16.74a1 1 0 01-.968-.75 7 7 0 10-12.023 6.388 1 1 0 11-1.498 1.324A9 9 0 011.013 6.843z" />
+        <path d="M12.707 11.293a1 1 0 00-1.414 0l-4 4a1 1 0 101.414 1.414L11 14.414V21a1 1 0 102 0v-6.586l2.293 2.293a1 1 0 001.414-1.414l-4-4z" />
+      </g>
+      <defs>
+        <clipPath id="prefix__clip0">
+          <path fill="#fff" d="M0 0h24v24H0z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}
+
+UploadCloud.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  fill: PropTypes.oneOf(getThemeColors()),
+};
+
+UploadCloud.defaultProps = {
+  width: 24,
+  height: 24,
+  fill: colors.sapphire[800],
+};
+
+export default UploadCloud;

--- a/src/icons/UploadCloud/index.js
+++ b/src/icons/UploadCloud/index.js
@@ -1,0 +1,1 @@
+export { default } from './UploadCloud';

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -47,6 +47,7 @@ const icons = {
   subscription: require('./Subscription').default,
   success: require('./Success').default,
   trash: require('./Trash').default,
+  uploadCloud: require('./UploadCloud').default,
   wiFiOff: require('./WiFiOff').default,
   wiFiOn: require('./WiFiOn').default,
 };

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -55,16 +55,16 @@ const FileUpload = ({
 
   const handleFilePick = async () => {
     try {
-      const res = await DocumentPicker.pick({
+      const document = await DocumentPicker.pick({
         type: !fileTypes
           ? DocumentPicker.types.allFiles
           : Object.keys(DocumentPicker.types).filter((type) => fileTypes.includes(type)),
       });
       onFileSelected({
-        uri: res.uri,
-        type: res.type,
-        name: res.name,
-        size: res.size,
+        uri: document.uri,
+        type: document.type,
+        name: document.name,
+        size: document.size,
       });
     } catch (err) {
       if (DocumentPicker.isCancel(err)) {

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -17,32 +17,31 @@ const DashedButton = styled(TouchableOpacity)`
   background-color: ${(props) => props.theme.colors.background[200]};
   border: 1px dashed ${(props) => props.theme.colors.tone[900]};
   border-radius: 2px;
-  padding: 10px 12px;
 `;
 
 const UploadContainer = styled(View)`
-  padding: 8px 12px;
   border: 1px solid ${(props) => props.theme.colors.tone[900]};
   background-color: ${(props) => props.theme.colors.background[200]};
+  border-radius: 4px;
 `;
 
 const FileUpload = ({
   title,
   progress,
   file,
-  accept,
+  fileTypes,
   errorText,
   helpText,
-  onError,
-  onFileUpload,
-  onRemove,
+  onFileSelectionError,
+  onFileSelected,
+  onFileRemoved,
 }) => {
   const [fileName, setFileName] = useState(file);
   const hasUploadCompleted = progress >= MAX_PROGRESS_VALUE;
 
-  const handleClose = () => {
+  const handleFileRemoval = () => {
     // setFileName('');
-    onRemove();
+    onFileRemoved();
   };
 
   useEffect(() => {
@@ -54,14 +53,14 @@ const FileUpload = ({
     LayoutAnimation.easeInEaseOut();
   }, [file]);
 
-  const handleDocumentPick = async () => {
+  const handleFilePick = async () => {
     try {
       const res = await DocumentPicker.pick({
-        type: !accept
+        type: !fileTypes
           ? DocumentPicker.types.allFiles
-          : Object.keys(DocumentPicker.types).filter((type) => accept.includes(type)),
+          : Object.keys(DocumentPicker.types).filter((type) => fileTypes.includes(type)),
       });
-      onFileUpload({
+      onFileSelected({
         uri: res.uri,
         type: res.type,
         name: res.name,
@@ -71,7 +70,7 @@ const FileUpload = ({
       if (DocumentPicker.isCancel(err)) {
         // User when cancels the native selection
       } else {
-        onError(err);
+        onFileSelectionError(err);
       }
     }
   };
@@ -81,47 +80,51 @@ const FileUpload = ({
       <Size height={6} width={30}>
         <Flex alignItems="center" justifyContent="center">
           {fileName ? (
-            <UploadContainer>
-              <Flex flexDirection="row" alignItems="center">
-                <Space margin={[0, 0, 1, 0]}>
-                  <View>
-                    {hasUploadCompleted && !errorText ? (
-                      <Space margin={[0, 1, 0, 0]}>
+            <Space padding={[1, 1.5]}>
+              <UploadContainer>
+                <Flex flexDirection="row" alignItems="center">
+                  <Space margin={[0, 0, 1, 0]}>
+                    <View>
+                      {hasUploadCompleted && !errorText ? (
+                        <Space margin={[0, 1, 0, 0]}>
+                          <View>
+                            <Icon size="small" fill="positive.960" name="checkedCircle" />
+                          </View>
+                        </Space>
+                      ) : null}
+                      <Flex flex={2}>
                         <View>
-                          <Icon size="small" fill="positive.960" name="checkedCircle" />
+                          <Text size="xsmall" color="shade.980">
+                            {title}
+                          </Text>
                         </View>
-                      </Space>
-                    ) : null}
-                    <Flex flex={2}>
+                      </Flex>
+                      <TouchableOpacity onPress={handleFileRemoval}>
+                        <Icon size="small" name="close" fill="shade.800" />
+                      </TouchableOpacity>
+                    </View>
+                  </Space>
+                </Flex>
+                <ProgressBar size="small" progress={progress} error={errorText} />
+              </UploadContainer>
+            </Space>
+          ) : (
+            <Space padding={[1.25, 1.5]}>
+              <DashedButton onPress={handleFilePick} activeOpacity={0.7}>
+                <Flex flexDirection="row">
+                  <View>
+                    <Icon name="uploadCloud" fill="primary.800" size="small" />
+                    <Space margin={[0, 0, 0, 0.5]}>
                       <View>
-                        <Text size="xsmall" color="shade.980">
+                        <Text size="xsmall" weight="bold" color="primary.800" maxLines={1}>
                           {title}
                         </Text>
                       </View>
-                    </Flex>
-                    <TouchableOpacity onPress={handleClose}>
-                      <Icon size="small" name="close" fill="shade.800" />
-                    </TouchableOpacity>
+                    </Space>
                   </View>
-                </Space>
-              </Flex>
-              <ProgressBar size="small" progress={progress} error={errorText} />
-            </UploadContainer>
-          ) : (
-            <DashedButton onPress={handleDocumentPick}>
-              <Flex flexDirection="row">
-                <View>
-                  <Icon name="uploadCloud" fill="primary.800" size="small" />
-                  <Space margin={[0, 0, 0, 0.5]}>
-                    <View>
-                      <Text size="xsmall" weight="bold" color="primary.800" maxLines={1}>
-                        {title}
-                      </Text>
-                    </View>
-                  </Space>
-                </View>
-              </Flex>
-            </DashedButton>
+                </Flex>
+              </DashedButton>
+            </Space>
           )}
         </Flex>
       </Size>
@@ -142,20 +145,20 @@ FileUpload.propTypes = {
   progress: PropTypes.number,
   title: PropTypes.string,
   file: PropTypes.string,
-  accept: PropTypes.arrayOf(Object.keys(DocumentPicker.types)), // Accepts: ["allFiles", "audio", "csv", "doc", "docx", "images", "pdf", "plainText", "ppt", "pptx", "video", "xls", "xlsx", "zip"]
+  fileTypes: PropTypes.arrayOf(Object.keys(DocumentPicker.types)), // Accepts: ["allFiles", "audio", "csv", "doc", "docx", "images", "pdf", "plainText", "ppt", "pptx", "video", "xls", "xlsx", "zip"]
   errorText: PropTypes.string,
   helpText: PropTypes.string,
-  onError: PropTypes.func,
-  onFileUpload: PropTypes.func,
-  onRemove: PropTypes.func,
+  onFileSelectionError: PropTypes.func,
+  onFileSelected: PropTypes.func,
+  onFileRemoved: PropTypes.func,
 };
 
 FileUpload.defaultProps = {
   file: '',
   title: 'Upload',
-  onError: () => {},
-  onFileUpload: () => {},
-  onRemove: () => {},
+  onFileSelectionError: () => {},
+  onFileSelected: () => {},
+  onFileRemoved: () => {},
 };
 
 export default FileUpload;

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -35,13 +35,14 @@ const FileUpload = ({
   helpText,
   onError,
   onFileUpload,
+  onRemove,
 }) => {
   const [fileName, setFileName] = useState(file);
   const hasUploadCompleted = progress >= MAX_PROGRESS_VALUE;
 
   const handleClose = () => {
-    setFileName('');
-    LayoutAnimation.easeInEaseOut();
+    // setFileName('');
+    onRemove();
   };
 
   useEffect(() => {
@@ -50,6 +51,7 @@ const FileUpload = ({
     } else if (!file) {
       setFileName('');
     }
+    LayoutAnimation.easeInEaseOut();
   }, [file]);
 
   const handleDocumentPick = async () => {
@@ -145,6 +147,7 @@ FileUpload.propTypes = {
   helpText: PropTypes.string,
   onError: PropTypes.func,
   onFileUpload: PropTypes.func,
+  onRemove: PropTypes.func,
 };
 
 FileUpload.defaultProps = {
@@ -152,6 +155,7 @@ FileUpload.defaultProps = {
   title: 'Upload',
   onError: () => {},
   onFileUpload: () => {},
+  onRemove: () => {},
 };
 
 export default FileUpload;

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -40,7 +40,6 @@ const FileUpload = ({
   const hasUploadCompleted = progress >= MAX_PROGRESS_VALUE;
 
   const handleFileRemoval = () => {
-    // setFileName('');
     onFileRemoved();
   };
 

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react';
+import { TouchableOpacity, LayoutAnimation } from 'react-native';
+import styled from 'styled-components/native';
+import DocumentPicker from 'react-native-document-picker';
+import PropTypes from 'prop-types';
+import View from '../../atoms/View';
+import Text from '../../atoms/Text';
+import Size from '../../atoms/Size';
+import Flex from '../../atoms/Flex';
+import Space from '../../atoms/Space';
+import Icon from '../../atoms/Icon';
+import ProgressBar from './ProgressBar';
+
+const MAX_PROGRESS_VALUE = 100;
+
+const DashedButton = styled(TouchableOpacity)`
+  background-color: ${(props) => props.theme.colors.background[200]};
+  border: 1px dashed ${(props) => props.theme.colors.tone[900]};
+  border-radius: 2px;
+  padding: 10px 12px;
+`;
+
+const UploadContainer = styled(View)`
+  padding: 8px 12px;
+  border: 1px solid ${(props) => props.theme.colors.tone[900]};
+  background-color: ${(props) => props.theme.colors.background[200]};
+`;
+
+const FileUpload = ({
+  title,
+  progress,
+  file,
+  accept,
+  errorText,
+  helpText,
+  onError,
+  onFileUpload,
+}) => {
+  const [fileName, setFileName] = useState(file);
+  const hasUploadCompleted = progress >= MAX_PROGRESS_VALUE;
+
+  const handleClose = () => {
+    setFileName('');
+    LayoutAnimation.easeInEaseOut();
+  };
+
+  useEffect(() => {
+    if (file) {
+      setFileName(file);
+    } else if (!file) {
+      setFileName('');
+    }
+  }, [file]);
+
+  const handleDocumentPick = async () => {
+    try {
+      const res = await DocumentPicker.pick({
+        type: !accept
+          ? DocumentPicker.types.allFiles
+          : Object.keys(DocumentPicker.types).filter((type) => accept.includes(type)),
+      });
+      console.log('OPOPOP', {
+        uri: res.uri,
+        type: res.type,
+        name: res.name,
+        size: res.size,
+      });
+      onFileUpload({
+        uri: res.uri,
+        type: res.type,
+        name: res.name,
+        size: res.size,
+      });
+    } catch (err) {
+      if (DocumentPicker.isCancel(err)) {
+        // User when cancels the native selection
+      } else {
+        onError(err);
+      }
+    }
+  };
+
+  return (
+    <View>
+      <Size height={6} width={30}>
+        <Flex alignItems="center" justifyContent="center">
+          {fileName ? (
+            <UploadContainer>
+              <Flex flexDirection="row" alignItems="center">
+                <Space margin={[0, 0, 1, 0]}>
+                  <View>
+                    {hasUploadCompleted && !errorText ? (
+                      <Space margin={[0, 1, 0, 0]}>
+                        <View>
+                          <Icon size="small" fill="positive.960" name="checkedCircle" />
+                        </View>
+                      </Space>
+                    ) : null}
+                    <Flex flex={2}>
+                      <View>
+                        <Text size="xsmall" color="shade.980">
+                          {title}
+                        </Text>
+                      </View>
+                    </Flex>
+                    <TouchableOpacity onPress={handleClose}>
+                      <Icon size="small" name="close" fill="shade.800" />
+                    </TouchableOpacity>
+                  </View>
+                </Space>
+              </Flex>
+              <ProgressBar size="small" progress={progress} error={errorText} />
+            </UploadContainer>
+          ) : (
+            <DashedButton onPress={handleDocumentPick}>
+              <Flex flexDirection="row">
+                <View>
+                  <Icon name="uploadCloud" fill="primary.800" size="small" />
+                  <Space margin={[0, 0, 0, 0.5]}>
+                    <View>
+                      <Text size="xsmall" weight="bold" color="primary.800" maxLines={1}>
+                        {title}
+                      </Text>
+                    </View>
+                  </Space>
+                </View>
+              </Flex>
+            </DashedButton>
+          )}
+        </Flex>
+      </Size>
+      {errorText || helpText ? (
+        <Space margin={[0.5, 0, 0, 0]}>
+          <View>
+            <Text size="xsmall" color={errorText ? 'negative.900' : 'shade.950'}>
+              {errorText || helpText}
+            </Text>
+          </View>
+        </Space>
+      ) : null}
+    </View>
+  );
+};
+
+FileUpload.propTypes = {
+  progress: PropTypes.number,
+  title: PropTypes.string,
+  file: PropTypes.string,
+  accept: PropTypes.arrayOf(Object.keys(DocumentPicker.types)), // Accepts: ["allFiles", "audio", "csv", "doc", "docx", "images", "pdf", "plainText", "ppt", "pptx", "video", "xls", "xlsx", "zip"]
+  errorText: PropTypes.string,
+  helpText: PropTypes.string,
+  onError: PropTypes.func,
+  onFileUpload: PropTypes.func,
+};
+
+FileUpload.defaultProps = {
+  file: '',
+  title: 'Upload',
+  onError: () => {},
+  onFileUpload: () => {},
+};
+
+export default FileUpload;

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -28,7 +28,7 @@ const UploadContainer = styled(View)`
 const FileUpload = ({
   title,
   progress,
-  file,
+  fileName,
   fileTypes,
   errorText,
   helpText,
@@ -36,7 +36,7 @@ const FileUpload = ({
   onFileSelected,
   onFileRemoved,
 }) => {
-  const [fileName, setFileName] = useState(file);
+  const [file, setFileName] = useState(fileName);
   const hasUploadCompleted = progress >= MAX_PROGRESS_VALUE;
 
   const handleFileRemoval = () => {
@@ -45,13 +45,13 @@ const FileUpload = ({
   };
 
   useEffect(() => {
-    if (file) {
-      setFileName(file);
-    } else if (!file) {
+    if (fileName) {
+      setFileName(fileName);
+    } else if (!fileName) {
       setFileName('');
     }
     LayoutAnimation.easeInEaseOut();
-  }, [file]);
+  }, [fileName]);
 
   const handleFilePick = async () => {
     try {
@@ -79,7 +79,7 @@ const FileUpload = ({
     <View>
       <Size height={6} width={30}>
         <Flex alignItems="center" justifyContent="center">
-          {fileName ? (
+          {file ? (
             <Space padding={[1, 1.5]}>
               <UploadContainer>
                 <Flex flexDirection="row" alignItems="center">
@@ -144,7 +144,7 @@ const FileUpload = ({
 FileUpload.propTypes = {
   progress: PropTypes.number,
   title: PropTypes.string,
-  file: PropTypes.string,
+  fileName: PropTypes.string,
   fileTypes: PropTypes.arrayOf(Object.keys(DocumentPicker.types)), // Accepts: ["allFiles", "audio", "csv", "doc", "docx", "images", "pdf", "plainText", "ppt", "pptx", "video", "xls", "xlsx", "zip"]
   errorText: PropTypes.string,
   helpText: PropTypes.string,
@@ -154,7 +154,7 @@ FileUpload.propTypes = {
 };
 
 FileUpload.defaultProps = {
-  file: '',
+  fileName: '',
   title: 'Upload',
   onFileSelectionError: () => {},
   onFileSelected: () => {},

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -76,68 +76,70 @@ const FileUpload = ({
   };
 
   return (
-    <View>
-      <Size height={6} width={30}>
-        <Flex alignItems="center" justifyContent="center">
-          {file ? (
-            <Space padding={[1, 1.5]}>
-              <UploadContainer>
-                <Flex flexDirection="row" alignItems="center">
-                  <Space margin={[0, 0, 1, 0]}>
-                    <View>
-                      {hasUploadCompleted && !errorText ? (
-                        <Space margin={[0, 1, 0, 0]}>
+    <Size width="100%">
+      <View>
+        <Size height={6}>
+          <Flex alignItems="center" justifyContent="center">
+            {file ? (
+              <Space padding={[1, 1.5]}>
+                <UploadContainer>
+                  <Flex flexDirection="row" alignItems="center">
+                    <Space margin={[0, 0, 1, 0]}>
+                      <View>
+                        {hasUploadCompleted && !errorText ? (
+                          <Space margin={[0, 1, 0, 0]}>
+                            <View>
+                              <Icon size="small" fill="positive.960" name="checkedCircle" />
+                            </View>
+                          </Space>
+                        ) : null}
+                        <Flex flex={2}>
                           <View>
-                            <Icon size="small" fill="positive.960" name="checkedCircle" />
+                            <Text size="xsmall" color="shade.980">
+                              {title}
+                            </Text>
                           </View>
-                        </Space>
-                      ) : null}
-                      <Flex flex={2}>
+                        </Flex>
+                        <TouchableOpacity onPress={handleFileRemoval}>
+                          <Icon size="small" name="close" fill="shade.800" />
+                        </TouchableOpacity>
+                      </View>
+                    </Space>
+                  </Flex>
+                  <ProgressBar size="small" progress={progress} error={errorText} />
+                </UploadContainer>
+              </Space>
+            ) : (
+              <Space padding={[1.25, 1.5]}>
+                <DashedButton onPress={handleFilePick} activeOpacity={0.7}>
+                  <Flex flexDirection="row">
+                    <View>
+                      <Icon name="uploadCloud" fill="primary.800" size="small" />
+                      <Space margin={[0, 0, 0, 0.5]}>
                         <View>
-                          <Text size="xsmall" color="shade.980">
+                          <Text size="xsmall" weight="bold" color="primary.800" maxLines={1}>
                             {title}
                           </Text>
                         </View>
-                      </Flex>
-                      <TouchableOpacity onPress={handleFileRemoval}>
-                        <Icon size="small" name="close" fill="shade.800" />
-                      </TouchableOpacity>
+                      </Space>
                     </View>
-                  </Space>
-                </Flex>
-                <ProgressBar size="small" progress={progress} error={errorText} />
-              </UploadContainer>
-            </Space>
-          ) : (
-            <Space padding={[1.25, 1.5]}>
-              <DashedButton onPress={handleFilePick} activeOpacity={0.7}>
-                <Flex flexDirection="row">
-                  <View>
-                    <Icon name="uploadCloud" fill="primary.800" size="small" />
-                    <Space margin={[0, 0, 0, 0.5]}>
-                      <View>
-                        <Text size="xsmall" weight="bold" color="primary.800" maxLines={1}>
-                          {title}
-                        </Text>
-                      </View>
-                    </Space>
-                  </View>
-                </Flex>
-              </DashedButton>
-            </Space>
-          )}
-        </Flex>
-      </Size>
-      {errorText || helpText ? (
-        <Space margin={[0.5, 0, 0, 0]}>
-          <View>
-            <Text size="xsmall" color={errorText ? 'negative.900' : 'shade.950'}>
-              {errorText || helpText}
-            </Text>
-          </View>
-        </Space>
-      ) : null}
-    </View>
+                  </Flex>
+                </DashedButton>
+              </Space>
+            )}
+          </Flex>
+        </Size>
+        {errorText || helpText ? (
+          <Space margin={[0.5, 0, 0, 0]}>
+            <View>
+              <Text size="xsmall" color={errorText ? 'negative.900' : 'shade.950'}>
+                {errorText || helpText}
+              </Text>
+            </View>
+          </Space>
+        ) : null}
+      </View>
+    </Size>
   );
 };
 

--- a/src/molecules/FileUpload/FileUpload.native.js
+++ b/src/molecules/FileUpload/FileUpload.native.js
@@ -59,12 +59,6 @@ const FileUpload = ({
           ? DocumentPicker.types.allFiles
           : Object.keys(DocumentPicker.types).filter((type) => accept.includes(type)),
       });
-      console.log('OPOPOP', {
-        uri: res.uri,
-        type: res.type,
-        name: res.name,
-        size: res.size,
-      });
       onFileUpload({
         uri: res.uri,
         type: res.type,

--- a/src/molecules/FileUpload/FileUpload.stories.js
+++ b/src/molecules/FileUpload/FileUpload.stories.js
@@ -10,7 +10,7 @@ storiesOf('FileUpload', module)
     component: FileUpload,
   })
   .add('default', () => (
-    <Flex flex={1} justifyContent="space-between" alignItems="center">
+    <Flex flex={1} alignItems="center">
       <View>
         <Space margin={[1, 0]}>
           <View>

--- a/src/molecules/FileUpload/FileUpload.stories.js
+++ b/src/molecules/FileUpload/FileUpload.stories.js
@@ -1,9 +1,37 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { storiesOf } from '@storybook/react';
 import Space from '../../atoms/Space';
 import View from '../../atoms/View';
 import Flex from '../../atoms/Flex';
 import FileUpload from '../FileUpload';
+
+const FileUploadProgressDemo = () => {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setProgress(Math.random() * 100);
+    }, 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, []);
+
+  return (
+    <Flex flex={1} alignItems="center">
+      <View>
+        <FileUpload
+          file="abc"
+          title="Uploading file abc"
+          progress={progress}
+          onFileSelectionError={() => {}}
+          onFileSelected={() => {}}
+          helpText="Progress bar changing randomly"
+        />
+      </View>
+    </Flex>
+  );
+};
 
 storiesOf('FileUpload', module)
   .addParameters({
@@ -69,4 +97,7 @@ storiesOf('FileUpload', module)
         </Space>
       </View>
     </Flex>
-  ));
+  ))
+  .add('FileUpload with progress change', () => {
+    return <FileUploadProgressDemo />;
+  });

--- a/src/molecules/FileUpload/FileUpload.stories.js
+++ b/src/molecules/FileUpload/FileUpload.stories.js
@@ -21,7 +21,7 @@ const FileUploadProgressDemo = () => {
     <Flex flex={1} alignItems="center">
       <View>
         <FileUpload
-          file="abc"
+          fileName="abc"
           title="Uploading file abc"
           progress={progress}
           onFileSelectionError={() => {}}
@@ -52,7 +52,7 @@ storiesOf('FileUpload', module)
         <Space margin={[1, 0]}>
           <View>
             <FileUpload
-              file="abc"
+              fileName="abc"
               title="Uploading file abc"
               progress={30}
               onFileSelectionError={() => {}}
@@ -64,7 +64,7 @@ storiesOf('FileUpload', module)
         <Space margin={[1, 0]}>
           <View>
             <FileUpload
-              file="abc"
+              fileName="abc"
               title="Uploaded the file"
               progress={100}
               onFileSelectionError={() => {}}
@@ -76,7 +76,7 @@ storiesOf('FileUpload', module)
         <Space margin={[1, 0]}>
           <View>
             <FileUpload
-              file=""
+              fileName=""
               onFileSelectionError={() => {}}
               onFileSelected={() => {}}
               errorText="Error for not meeting the file constraints"
@@ -86,7 +86,7 @@ storiesOf('FileUpload', module)
         <Space margin={[1, 0]}>
           <View>
             <FileUpload
-              file="abc"
+              fileName="abc"
               title="Uploaded file abc"
               progress={100}
               onFileSelectionError={() => {}}

--- a/src/molecules/FileUpload/FileUpload.stories.js
+++ b/src/molecules/FileUpload/FileUpload.stories.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Space from '../../atoms/Space';
+import View from '../../atoms/View';
+import Flex from '../../atoms/Flex';
+import FileUpload from '../FileUpload';
+
+storiesOf('FileUpload', module)
+  .addParameters({
+    component: FileUpload,
+  })
+  .add('default', () => (
+    <Flex flex={1} justifyContent="space-between" alignItems="center">
+      <View>
+        <Space margin={[1, 0]}>
+          <View>
+            <FileUpload onError={() => {}} onFileUpload={() => {}} helpText="File Upload Empty" />
+          </View>
+        </Space>
+        <Space margin={[1, 0]}>
+          <View>
+            <FileUpload
+              file="abc"
+              title="Uploading file abc"
+              progress={30}
+              onError={() => {}}
+              onFileUpload={() => {}}
+              helpText="Uploading file with 30% progress"
+            />
+          </View>
+        </Space>
+        <Space margin={[1, 0]}>
+          <View>
+            <FileUpload
+              file="abc"
+              title="Uploaded the file"
+              progress={100}
+              onError={() => {}}
+              onFileUpload={() => {}}
+              helpText="Uploaded file with progress 100%"
+            />
+          </View>
+        </Space>
+        <Space margin={[1, 0]}>
+          <View>
+            <FileUpload
+              file=""
+              onError={() => {}}
+              onFileUpload={() => {}}
+              errorText="Error for not meeting the file constraints"
+            />
+          </View>
+        </Space>
+        <Space margin={[1, 0]}>
+          <View>
+            <FileUpload
+              file="abc"
+              title="Uploaded file abc"
+              progress={100}
+              onError={() => {}}
+              onFileUpload={() => {}}
+              errorText="Case where some server error occured"
+            />
+          </View>
+        </Space>
+      </View>
+    </Flex>
+  ));

--- a/src/molecules/FileUpload/FileUpload.stories.js
+++ b/src/molecules/FileUpload/FileUpload.stories.js
@@ -38,65 +38,63 @@ storiesOf('FileUpload', module)
     component: FileUpload,
   })
   .add('default', () => (
-    <Flex flex={1} alignItems="center">
-      <View>
-        <Space margin={[1, 0]}>
-          <View>
-            <FileUpload
-              onFileSelectionError={() => {}}
-              onFileSelected={() => {}}
-              helpText="File Upload Empty"
-            />
-          </View>
-        </Space>
-        <Space margin={[1, 0]}>
-          <View>
-            <FileUpload
-              fileName="abc"
-              title="Uploading file abc"
-              progress={30}
-              onFileSelectionError={() => {}}
-              onFileSelected={() => {}}
-              helpText="Uploading file with 30% progress"
-            />
-          </View>
-        </Space>
-        <Space margin={[1, 0]}>
-          <View>
-            <FileUpload
-              fileName="abc"
-              title="Uploaded the file"
-              progress={100}
-              onFileSelectionError={() => {}}
-              onFileSelected={() => {}}
-              helpText="Uploaded file with progress 100%"
-            />
-          </View>
-        </Space>
-        <Space margin={[1, 0]}>
-          <View>
-            <FileUpload
-              fileName=""
-              onFileSelectionError={() => {}}
-              onFileSelected={() => {}}
-              errorText="Error for not meeting the file constraints"
-            />
-          </View>
-        </Space>
-        <Space margin={[1, 0]}>
-          <View>
-            <FileUpload
-              fileName="abc"
-              title="Uploaded file abc"
-              progress={100}
-              onFileSelectionError={() => {}}
-              onFileSelected={() => {}}
-              errorText="Case where some server error occured"
-            />
-          </View>
-        </Space>
-      </View>
-    </Flex>
+    <React.Fragment>
+      <Space margin={[1, 0]}>
+        <View>
+          <FileUpload
+            onFileSelectionError={() => {}}
+            onFileSelected={() => {}}
+            helpText="File Upload Empty"
+          />
+        </View>
+      </Space>
+      <Space margin={[1, 0]}>
+        <View>
+          <FileUpload
+            fileName="abc"
+            title="Uploading file abc"
+            progress={30}
+            onFileSelectionError={() => {}}
+            onFileSelected={() => {}}
+            helpText="Uploading file with 30% progress"
+          />
+        </View>
+      </Space>
+      <Space margin={[1, 0]}>
+        <View>
+          <FileUpload
+            fileName="abc"
+            title="Uploaded the file"
+            progress={100}
+            onFileSelectionError={() => {}}
+            onFileSelected={() => {}}
+            helpText="Uploaded file with progress 100%"
+          />
+        </View>
+      </Space>
+      <Space margin={[1, 0]}>
+        <View>
+          <FileUpload
+            fileName=""
+            onFileSelectionError={() => {}}
+            onFileSelected={() => {}}
+            errorText="Error for not meeting the file constraints"
+          />
+        </View>
+      </Space>
+      <Space margin={[1, 0]}>
+        <View>
+          <FileUpload
+            fileName="abc"
+            title="Uploaded file abc"
+            progress={100}
+            onFileSelectionError={() => {}}
+            onFileSelected={() => {}}
+            errorText="Case where some server error occured"
+          />
+        </View>
+      </Space>
+    </React.Fragment>
   ))
   .add('FileUpload with progress change', () => {
     return <FileUploadProgressDemo />;

--- a/src/molecules/FileUpload/FileUpload.stories.js
+++ b/src/molecules/FileUpload/FileUpload.stories.js
@@ -14,7 +14,11 @@ storiesOf('FileUpload', module)
       <View>
         <Space margin={[1, 0]}>
           <View>
-            <FileUpload onError={() => {}} onFileUpload={() => {}} helpText="File Upload Empty" />
+            <FileUpload
+              onFileSelectionError={() => {}}
+              onFileSelected={() => {}}
+              helpText="File Upload Empty"
+            />
           </View>
         </Space>
         <Space margin={[1, 0]}>
@@ -23,8 +27,8 @@ storiesOf('FileUpload', module)
               file="abc"
               title="Uploading file abc"
               progress={30}
-              onError={() => {}}
-              onFileUpload={() => {}}
+              onFileSelectionError={() => {}}
+              onFileSelected={() => {}}
               helpText="Uploading file with 30% progress"
             />
           </View>
@@ -35,8 +39,8 @@ storiesOf('FileUpload', module)
               file="abc"
               title="Uploaded the file"
               progress={100}
-              onError={() => {}}
-              onFileUpload={() => {}}
+              onFileSelectionError={() => {}}
+              onFileSelected={() => {}}
               helpText="Uploaded file with progress 100%"
             />
           </View>
@@ -45,8 +49,8 @@ storiesOf('FileUpload', module)
           <View>
             <FileUpload
               file=""
-              onError={() => {}}
-              onFileUpload={() => {}}
+              onFileSelectionError={() => {}}
+              onFileSelected={() => {}}
               errorText="Error for not meeting the file constraints"
             />
           </View>
@@ -57,8 +61,8 @@ storiesOf('FileUpload', module)
               file="abc"
               title="Uploaded file abc"
               progress={100}
-              onError={() => {}}
-              onFileUpload={() => {}}
+              onFileSelectionError={() => {}}
+              onFileSelected={() => {}}
               errorText="Case where some server error occured"
             />
           </View>

--- a/src/molecules/FileUpload/FileUpload.web.js
+++ b/src/molecules/FileUpload/FileUpload.web.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const FileUpload = () => <div>WIP</div>;
+
+export default FileUpload;

--- a/src/molecules/FileUpload/ProgressBar.native.js
+++ b/src/molecules/FileUpload/ProgressBar.native.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import View from '../../atoms/View';
 import Position from '../../atoms/Position';
 import { getColor, getColorKeys } from '../../_helpers/theme';
+import Size from '../../atoms/Size';
 
 const styles = {
   height({ size }) {
@@ -25,10 +26,8 @@ const styles = {
 };
 
 const ProgressContainer = styled(View)`
-  width: 100%;
   max-height: ${(props) => props.height};
   height: ${(props) => props.height};
-  max-width: 100%;
   border-radius: 100px;
   background-color: ${(props) => props.theme.colors.background[800]};
 `;
@@ -57,16 +56,18 @@ const ProgressBar = ({ progress, error, size, color }) => {
   });
 
   return (
-    <ProgressContainer height={styles.height({ size })}>
-      <Position position="absolute" top={0} bottom={0} left={0} right={0}>
-        <StyledProgressBar
-          height={styles.height({ size })}
-          error={error}
-          style={{ width }}
-          color={styles.progressColor({ error, color })}
-        />
-      </Position>
-    </ProgressContainer>
+    <Size width="100%" maxWidth="100%">
+      <ProgressContainer height={styles.height({ size })}>
+        <Position position="absolute" top={0} bottom={0} left={0} right={0}>
+          <StyledProgressBar
+            height={styles.height({ size })}
+            error={error}
+            style={{ width }}
+            color={styles.progressColor({ error, color })}
+          />
+        </Position>
+      </ProgressContainer>
+    </Size>
   );
 };
 

--- a/src/molecules/FileUpload/ProgressBar.native.js
+++ b/src/molecules/FileUpload/ProgressBar.native.js
@@ -1,0 +1,85 @@
+import React, { useRef, useEffect } from 'react';
+import styled from 'styled-components/native';
+import { Animated } from 'react-native';
+import PropTypes from 'prop-types';
+import View from '../../atoms/View';
+import Position from '../../atoms/Position';
+import { getColor, getColorKeys } from '../../_helpers/theme';
+
+const styles = {
+  height({ size }) {
+    switch (size) {
+      case 'large':
+        return '12px';
+      case 'medium':
+        return '8px';
+      case 'small':
+        return '4px';
+      default:
+        return '8px';
+    }
+  },
+  progressColor({ error, color }) {
+    return error ? 'negative.960' : color;
+  },
+};
+
+const ProgressContainer = styled(View)`
+  width: 100%;
+  max-height: ${(props) => props.height};
+  height: ${(props) => props.height};
+  max-width: 100%;
+  border-radius: 100px;
+  background-color: ${(props) => props.theme.colors.background[800]};
+`;
+
+const StyledProgressBar = styled(Animated.View)`
+  background-color: ${(props) => getColor(props.theme, props.color)};
+  height: ${(props) => props.height};
+  border-radius: 100px;
+  max-width: 100%;
+`;
+
+const ProgressBar = ({ progress, error, size, color }) => {
+  const animation = useRef(new Animated.Value(progress));
+
+  useEffect(() => {
+    Animated.timing(animation.current, {
+      toValue: progress,
+      duration: 300,
+    }).start();
+  }, [progress]);
+
+  const width = animation.current.interpolate({
+    inputRange: [0, 100],
+    outputRange: ['0%', '100%'],
+    extrapolate: 'clamp',
+  });
+
+  return (
+    <ProgressContainer height={styles.height({ size })}>
+      <Position position="absolute" top={0} bottom={0} left={0} right={0}>
+        <StyledProgressBar
+          height={styles.height({ size })}
+          error={error}
+          style={{ width }}
+          color={styles.progressColor({ error, color })}
+        />
+      </Position>
+    </ProgressContainer>
+  );
+};
+
+ProgressBar.propTypes = {
+  color: PropTypes.oneOf(getColorKeys()),
+  error: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  progress: PropTypes.number,
+};
+
+ProgressBar.defaultProps = {
+  size: 'medium',
+  color: 'positive.960',
+};
+
+export default ProgressBar;

--- a/src/molecules/FileUpload/ProgressBar.native.js
+++ b/src/molecules/FileUpload/ProgressBar.native.js
@@ -26,17 +26,13 @@ const styles = {
 };
 
 const ProgressContainer = styled(View)`
-  max-height: ${(props) => props.height};
-  height: ${(props) => props.height};
   border-radius: 100px;
   background-color: ${(props) => props.theme.colors.background[800]};
 `;
 
 const StyledProgressBar = styled(Animated.View)`
   background-color: ${(props) => getColor(props.theme, props.color)};
-  height: ${(props) => props.height};
   border-radius: 100px;
-  max-width: 100%;
 `;
 
 const ProgressBar = ({ progress, error, size, color }) => {
@@ -56,15 +52,16 @@ const ProgressBar = ({ progress, error, size, color }) => {
   });
 
   return (
-    <Size width="100%" maxWidth="100%">
-      <ProgressContainer height={styles.height({ size })}>
+    <Size width="100%" maxWidth="100%" height={styles.height({ size })}>
+      <ProgressContainer>
         <Position position="absolute" top={0} bottom={0} left={0} right={0}>
-          <StyledProgressBar
-            height={styles.height({ size })}
-            error={error}
-            style={{ width }}
-            color={styles.progressColor({ error, color })}
-          />
+          <Size maxWidth="100%" height={styles.height({ size })}>
+            <StyledProgressBar
+              error={error}
+              style={{ width }}
+              color={styles.progressColor({ error, color })}
+            />
+          </Size>
         </Position>
       </ProgressContainer>
     </Size>

--- a/src/molecules/FileUpload/__tests__/FileUpload.native.test.js
+++ b/src/molecules/FileUpload/__tests__/FileUpload.native.test.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { fireEvent, act } from '@testing-library/react-native';
+import FileUpload from '../index';
+import { renderWithTheme } from '../../../_helpers/testing';
+
+describe('<FileUpload />', () => {
+  test('renders empty FileUpload component', () => {
+    const { container } = renderWithTheme(<FileUpload />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should call onFileSelected when clicked on FileUpload Component', async () => {
+    const onFileSelectedCallback = jest.fn();
+    const { getByText } = renderWithTheme(<FileUpload onFileSelected={onFileSelectedCallback} />);
+    const fileUploadComponent = getByText(/upload/i);
+
+    await act(async () => {
+      await fireEvent.press(fileUploadComponent);
+    });
+
+    expect(onFileSelectedCallback).toHaveBeenCalled();
+    expect(onFileSelectedCallback).toHaveBeenCalledWith({
+      name: 'someFileName',
+      size: 2345,
+      type: 'jpeg',
+      uri: 'content://xyz.jpeg',
+    });
+  });
+
+  test('should call onFileSelected when clicked on FileUpload Component', async () => {
+    const onFileSelectedCallback = jest.fn();
+    const { getByText } = renderWithTheme(<FileUpload onFileSelected={onFileSelectedCallback} />);
+    const fileUploadComponent = getByText(/upload/i);
+
+    await act(async () => {
+      await fireEvent.press(fileUploadComponent);
+    });
+
+    expect(onFileSelectedCallback).toHaveBeenCalled();
+    expect(onFileSelectedCallback).toHaveBeenCalledWith({
+      name: 'someFileName',
+      size: 2345,
+      type: 'jpeg',
+      uri: 'content://xyz.jpeg',
+    });
+  });
+
+  test('renders FileUpload when file is already selected', () => {
+    const { container } = renderWithTheme(<FileUpload progress={100} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('renders FileUpload with custom title', () => {
+    const { getByText } = renderWithTheme(
+      <FileUpload progress={80} file="abc" title="Uploading file abc" />,
+    );
+    expect(getByText(/uploading file abc/i)).toBeTruthy();
+  });
+
+  test('renders FileUpload with helpText', () => {
+    const { getByText } = renderWithTheme(
+      <FileUpload
+        progress={80}
+        file="abc"
+        title="Uploading file abc"
+        helpText="This is FileUpload helpText"
+      />,
+    );
+    expect(getByText(/this is FileUpload helpText/i)).toBeTruthy();
+  });
+
+  test('renders FileUpload with errorText', () => {
+    const { getByText } = renderWithTheme(
+      <FileUpload
+        progress={80}
+        file="abc"
+        title="Uploading file abc"
+        errorText="This is FileUpload errorText"
+      />,
+    );
+    expect(getByText(/this is FileUpload errorText/i)).toBeTruthy();
+  });
+});

--- a/src/molecules/FileUpload/__tests__/FileUpload.native.test.js
+++ b/src/molecules/FileUpload/__tests__/FileUpload.native.test.js
@@ -52,7 +52,7 @@ describe('<FileUpload />', () => {
 
   test('renders FileUpload with custom title', () => {
     const { getByText } = renderWithTheme(
-      <FileUpload progress={80} file="abc" title="Uploading file abc" />,
+      <FileUpload progress={80} fileName="abc" title="Uploading file abc" />,
     );
     expect(getByText(/uploading file abc/i)).toBeTruthy();
   });
@@ -61,7 +61,7 @@ describe('<FileUpload />', () => {
     const { getByText } = renderWithTheme(
       <FileUpload
         progress={80}
-        file="abc"
+        fileName="abc"
         title="Uploading file abc"
         helpText="This is FileUpload helpText"
       />,
@@ -73,7 +73,7 @@ describe('<FileUpload />', () => {
     const { getByText } = renderWithTheme(
       <FileUpload
         progress={80}
-        file="abc"
+        fileName="abc"
         title="Uploading file abc"
         errorText="This is FileUpload errorText"
       />,

--- a/src/molecules/FileUpload/__tests__/__snapshots__/FileUpload.native.test.js.snap
+++ b/src/molecules/FileUpload/__tests__/__snapshots__/FileUpload.native.test.js.snap
@@ -1,0 +1,343 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FileUpload /> renders FileUpload when file is already selected 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View>
+    <TouchableOpacity
+      activeOpacity={0.7}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgba(255, 255, 255, 1.0)",
+            "borderColor": "rgba(224, 228, 249, 1.0)",
+            "borderRadius": 2,
+            "borderStyle": "dashed",
+            "borderWidth": 1,
+          },
+          Array [
+            Object {
+              "paddingBottom": 10,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 10,
+            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "column",
+                "justifyContent": "center",
+              },
+              Array [
+                Object {
+                  "height": 48,
+                  "width": 240,
+                },
+              ],
+            ],
+          ],
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+            ],
+          ]
+        }
+      >
+        <RNSVGSvgView
+          align="xMidYMid"
+          bbHeight={16}
+          bbWidth={16}
+          fill="none"
+          focusable={false}
+          height={16}
+          meetOrSlice={0}
+          minX={0}
+          minY={0}
+          style={
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+              },
+              Object {
+                "flex": 0,
+                "height": 16,
+                "width": 16,
+              },
+            ]
+          }
+          vbHeight={24}
+          vbWidth={24}
+          width={16}
+        >
+          <RNSVGGroup
+            fill={null}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+          >
+            <RNSVGGroup
+              clipPath="prefix__clip0"
+              fill={4281041898}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+            >
+              <RNSVGPath
+                d="M1.013 6.843A9 9 0 0117.48 8H18a6 6 0 012.869 11.268 1 1 0 01-.958-1.756A4 4 0 0018 10H16.74a1 1 0 01-.968-.75 7 7 0 10-12.023 6.388 1 1 0 11-1.498 1.324A9 9 0 011.013 6.843z"
+              />
+              <RNSVGPath
+                d="M12.707 11.293a1 1 0 00-1.414 0l-4 4a1 1 0 101.414 1.414L11 14.414V21a1 1 0 102 0v-6.586l2.293 2.293a1 1 0 001.414-1.414l-4-4z"
+              />
+            </RNSVGGroup>
+            <RNSVGDefs>
+              <RNSVGClipPath
+                name="prefix__clip0"
+              >
+                <RNSVGPath
+                  d="M0 0h24v24H0z"
+                  fill={4294967295}
+                  propList={
+                    Array [
+                      "fill",
+                    ]
+                  }
+                />
+              </RNSVGClipPath>
+            </RNSVGDefs>
+          </RNSVGGroup>
+        </RNSVGSvgView>
+        <View
+          style={
+            Array [
+              Array [
+                Object {
+                  "marginBottom": 0,
+                  "marginLeft": 4,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                },
+              ],
+            ]
+          }
+        >
+          <Text
+            _isUnderlined={false}
+            _letterSpacing="small"
+            align="left"
+            color="primary.800"
+            numberOfLines={1}
+            size="xsmall"
+            style={
+              Array [
+                Object {
+                  "color": "rgba(43, 131, 234, 1.0 )",
+                  "fontFamily": "Lato-Bold",
+                  "fontSize": 12,
+                  "letterSpacing": 0,
+                  "lineHeight": 18,
+                  "textAlign": "left",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            testID="ds-text"
+            weight="bold"
+          >
+            Upload
+          </Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  </View>
+</View>
+`;
+
+exports[`<FileUpload /> renders empty FileUpload component 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View>
+    <TouchableOpacity
+      activeOpacity={0.7}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "rgba(255, 255, 255, 1.0)",
+            "borderColor": "rgba(224, 228, 249, 1.0)",
+            "borderRadius": 2,
+            "borderStyle": "dashed",
+            "borderWidth": 1,
+          },
+          Array [
+            Object {
+              "paddingBottom": 10,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 10,
+            },
+            Array [
+              Object {
+                "alignItems": "center",
+                "flexDirection": "column",
+                "justifyContent": "center",
+              },
+              Array [
+                Object {
+                  "height": 48,
+                  "width": 240,
+                },
+              ],
+            ],
+          ],
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Array [
+              Object {
+                "flexDirection": "row",
+              },
+            ],
+          ]
+        }
+      >
+        <RNSVGSvgView
+          align="xMidYMid"
+          bbHeight={16}
+          bbWidth={16}
+          fill="none"
+          focusable={false}
+          height={16}
+          meetOrSlice={0}
+          minX={0}
+          minY={0}
+          style={
+            Array [
+              Object {
+                "backgroundColor": "transparent",
+                "borderWidth": 0,
+              },
+              Object {
+                "flex": 0,
+                "height": 16,
+                "width": 16,
+              },
+            ]
+          }
+          vbHeight={24}
+          vbWidth={24}
+          width={16}
+        >
+          <RNSVGGroup
+            fill={null}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+          >
+            <RNSVGGroup
+              clipPath="prefix__clip0"
+              fill={4281041898}
+              propList={
+                Array [
+                  "fill",
+                ]
+              }
+            >
+              <RNSVGPath
+                d="M1.013 6.843A9 9 0 0117.48 8H18a6 6 0 012.869 11.268 1 1 0 01-.958-1.756A4 4 0 0018 10H16.74a1 1 0 01-.968-.75 7 7 0 10-12.023 6.388 1 1 0 11-1.498 1.324A9 9 0 011.013 6.843z"
+              />
+              <RNSVGPath
+                d="M12.707 11.293a1 1 0 00-1.414 0l-4 4a1 1 0 101.414 1.414L11 14.414V21a1 1 0 102 0v-6.586l2.293 2.293a1 1 0 001.414-1.414l-4-4z"
+              />
+            </RNSVGGroup>
+            <RNSVGDefs>
+              <RNSVGClipPath
+                name="prefix__clip0"
+              >
+                <RNSVGPath
+                  d="M0 0h24v24H0z"
+                  fill={4294967295}
+                  propList={
+                    Array [
+                      "fill",
+                    ]
+                  }
+                />
+              </RNSVGClipPath>
+            </RNSVGDefs>
+          </RNSVGGroup>
+        </RNSVGSvgView>
+        <View
+          style={
+            Array [
+              Array [
+                Object {
+                  "marginBottom": 0,
+                  "marginLeft": 4,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                },
+              ],
+            ]
+          }
+        >
+          <Text
+            _isUnderlined={false}
+            _letterSpacing="small"
+            align="left"
+            color="primary.800"
+            numberOfLines={1}
+            size="xsmall"
+            style={
+              Array [
+                Object {
+                  "color": "rgba(43, 131, 234, 1.0 )",
+                  "fontFamily": "Lato-Bold",
+                  "fontSize": 12,
+                  "letterSpacing": 0,
+                  "lineHeight": 18,
+                  "textAlign": "left",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            testID="ds-text"
+            weight="bold"
+          >
+            Upload
+          </Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  </View>
+</View>
+`;

--- a/src/molecules/FileUpload/__tests__/__snapshots__/FileUpload.native.test.js.snap
+++ b/src/molecules/FileUpload/__tests__/__snapshots__/FileUpload.native.test.js.snap
@@ -10,7 +10,17 @@ exports[`<FileUpload /> renders FileUpload when file is already selected 1`] = `
     }
   }
 >
-  <View>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "width": "100%",
+          },
+        ],
+      ]
+    }
+  >
     <TouchableOpacity
       activeOpacity={0.7}
       style={
@@ -38,7 +48,6 @@ exports[`<FileUpload /> renders FileUpload when file is already selected 1`] = `
               Array [
                 Object {
                   "height": 48,
-                  "width": 240,
                 },
               ],
             ],
@@ -181,7 +190,17 @@ exports[`<FileUpload /> renders empty FileUpload component 1`] = `
     }
   }
 >
-  <View>
+  <View
+    style={
+      Array [
+        Array [
+          Object {
+            "width": "100%",
+          },
+        ],
+      ]
+    }
+  >
     <TouchableOpacity
       activeOpacity={0.7}
       style={
@@ -209,7 +228,6 @@ exports[`<FileUpload /> renders empty FileUpload component 1`] = `
               Array [
                 Object {
                   "height": 48,
-                  "width": 240,
                 },
               ],
             ],

--- a/src/molecules/FileUpload/index.js
+++ b/src/molecules/FileUpload/index.js
@@ -1,0 +1,1 @@
+export { default } from './FileUpload';

--- a/storybook/native/main.js
+++ b/storybook/native/main.js
@@ -37,6 +37,7 @@ configure(() => {
   require('../../src/molecules/SegmentControl/SegmentControl.stories');
   require('../../src/molecules/Snackbar/Snackbar.stories');
   require('../../src/molecules/Tabs/Tabs.stories');
+  require('../../src/molecules/FileUpload/FileUpload.stories');
 }, module);
 
 // add decorators

--- a/storybook/native/main.js
+++ b/storybook/native/main.js
@@ -33,11 +33,11 @@ configure(() => {
   require('../../src/atoms/TextInput/TextInput.stories');
   require('../../src/molecules/Amount/Amount.stories');
   require('../../src/molecules/BottomSheet/BottomSheet.stories');
+  require('../../src/molecules/FileUpload/FileUpload.stories');
   require('../../src/molecules/Modal/Modal.stories');
   require('../../src/molecules/SegmentControl/SegmentControl.stories');
   require('../../src/molecules/Snackbar/Snackbar.stories');
   require('../../src/molecules/Tabs/Tabs.stories');
-  require('../../src/molecules/FileUpload/FileUpload.stories');
 }, module);
 
 // add decorators

--- a/yarn.lock
+++ b/yarn.lock
@@ -14762,6 +14762,11 @@ react-native-color-picker@^0.4.0:
     prop-types "^15.5.10"
     tinycolor2 "^1.4.1"
 
+react-native-document-picker@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-4.2.0.tgz#2d6f560fd902c5f9034c287941a9505f037b6eeb"
+  integrity sha512-bZlQ3ooOO+2G0J0vSvcWWv1OojMwhEhiF5M7gCKp3LT/VPikZnmzIGgCkhcu8HexxWLuaGToSAQAUL2VcSo5oQ==
+
 react-native-gesture-handler@1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.8.0.tgz#18f61f51da50320f938957b0ee79bc58f47449dc"


### PR DESCRIPTION
- Props for File Upload Component

```
{
  progress: number, // to indicate the progress of the upload
  title: string, 
  file: string, // file name
  accept: array, // Accepts: ["allFiles", "audio", "csv", "doc", "docx", "images", "pdf", "plainText", "ppt", "pptx", "video", "xls", "xlsx", "zip"]
  errorText: string,
  helpText: string,
  onError: func, // Callback is called when the native module is not able to pick the file
  onFileUpload: func, // Callback is called when file is successfully picked by native module,
  onRemove: func, //callback when user clicks on cross icon
}
```
- Currently Progress Bar component resides within FileUpload Component, will move it to separate component once the APIs are finalized.
- ProgressBar Pops 
```
  {
    color: "", // color of the progress bar[blade colors]
    error: string, 
    size: oneOf(['small', 'medium', 'large']),
    progress: PropTypes.number

  }
```
- NOTE: Have not written test cases for it, wanted to confirm on the API. 🙈 