### PR TITLE
fix(Snackbar): remove content on hiding snackbar

### DIFF
--- a/src/molecules/Snackbar/Snackbar.native.js
+++ b/src/molecules/Snackbar/Snackbar.native.js
@@ -111,59 +111,61 @@ const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position })
         }}
         onLayout={handleLayout}
       >
-        <Size width={`${SNACKBAR_WIDTH}px`}>
-          <Space padding={[1.5]}>
-            <Flex flexDirection="row" alignItems="center">
-              <SnackbarContainer variant={variant}>
-                {icon ? (
-                  <Space padding={[0, 1, 0, 0]}>
-                    <View>
-                      <Icon name={icon} size="medium" fill="light.900" testID="snackbar-icon" />
-                    </View>
+        {isVisible ? (
+          <Size width={`${SNACKBAR_WIDTH}px`}>
+            <Space padding={[1.5]}>
+              <Flex flexDirection="row" alignItems="center">
+                <SnackbarContainer variant={variant}>
+                  {icon ? (
+                    <Space padding={[0, 1, 0, 0]}>
+                      <View>
+                        <Icon name={icon} size="medium" fill="light.900" testID="snackbar-icon" />
+                      </View>
+                    </Space>
+                  ) : null}
+                  <Space padding={[0, 2, 0, 0]}>
+                    <Flex flex={1}>
+                      <View>
+                        <Text size="medium" color="light.900" maxLines={maxLines}>
+                          {title}
+                        </Text>
+                      </View>
+                    </Flex>
                   </Space>
-                ) : null}
-                <Space padding={[0, 2, 0, 0]}>
-                  <Flex flex={1}>
-                    <View>
-                      <Text size="medium" color="light.900" maxLines={maxLines}>
-                        {title}
-                      </Text>
-                    </View>
-                  </Flex>
-                </Space>
-                {action?.label ? (
-                  <Space padding={[0, 0.75, 0, 0]}>
-                    <View>
-                      <Button
-                        variant="secondary"
-                        size="xsmall"
-                        variantColor="light"
-                        onClick={handleAction}
-                        testID="ds-snackbar-action-button"
-                      >
-                        {action.label}
-                      </Button>
-                    </View>
-                  </Space>
-                ) : null}
-                {onClose ? (
-                  <Space padding={[0, 0.75, 0, 0]}>
-                    <View>
-                      <Button
-                        variant="tertiary"
-                        size="xsmall"
-                        icon="close"
-                        variantColor="light"
-                        onClick={handleClose}
-                        testID="ds-snackbar-close-button"
-                      />
-                    </View>
-                  </Space>
-                ) : null}
-              </SnackbarContainer>
-            </Flex>
-          </Space>
-        </Size>
+                  {action?.label ? (
+                    <Space padding={[0, 0.75, 0, 0]}>
+                      <View>
+                        <Button
+                          variant="secondary"
+                          size="xsmall"
+                          variantColor="light"
+                          onClick={handleAction}
+                          testID="ds-snackbar-action-button"
+                        >
+                          {action.label}
+                        </Button>
+                      </View>
+                    </Space>
+                  ) : null}
+                  {onClose ? (
+                    <Space padding={[0, 0.75, 0, 0]}>
+                      <View>
+                        <Button
+                          variant="tertiary"
+                          size="xsmall"
+                          icon="close"
+                          variantColor="light"
+                          onClick={handleClose}
+                          testID="ds-snackbar-close-button"
+                        />
+                      </View>
+                    </Space>
+                  ) : null}
+                </SnackbarContainer>
+              </Flex>
+            </Space>
+          </Size>
+        ) : null}
       </Animated.View>
     </Position>
   );
@@ -172,7 +174,10 @@ const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position })
 Snackbar.propTypes = {
   variant: PropTypes.oneOf(['positive', 'negative', 'warning', 'neutral']),
   title: PropTypes.string,
-  action: PropTypes.shape({ label: PropTypes.string, onClick: PropTypes.func }),
+  action: PropTypes.shape({
+    label: PropTypes.string,
+    onClick: PropTypes.func,
+  }),
   onClose: PropTypes.func,
   maxLines: PropTypes.number,
   icon: PropTypes.oneOf(Object.keys(icons)),

--- a/src/molecules/Snackbar/Snackbar.native.js
+++ b/src/molecules/Snackbar/Snackbar.native.js
@@ -115,7 +115,7 @@ const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position })
         }}
         onLayout={handleLayout}
       >
-        {isContentVisible ? (
+        {isVisible || isContentVisible ? (
           <Size width={`${SNACKBAR_WIDTH}px`}>
             <Space padding={[1.5]}>
               <Flex flexDirection="row" alignItems="center">

--- a/src/molecules/Snackbar/Snackbar.native.js
+++ b/src/molecules/Snackbar/Snackbar.native.js
@@ -42,6 +42,7 @@ const SnackbarContainer = styled(View)`
 const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position }) => {
   const { isVisible, close } = useSnackbar();
   const [bottomY, setBottomY] = useState(0);
+  const [isContentVisible, setIsContentVisible] = useState(false);
   const animationConfig = {
     animationValue: {
       initial: 0,
@@ -70,6 +71,7 @@ const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position })
 
   useEffect(() => {
     if (isVisible) {
+      setIsContentVisible(true);
       Animated.timing(visibility, {
         toValue: animationConfig.animationValue.final,
         useNativeDriver: true,
@@ -80,7 +82,9 @@ const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position })
         toValue: animationConfig.animationValue.initial,
         useNativeDriver: true,
         duration: animationConfig.duration,
-      }).start();
+      }).start(() => {
+        setIsContentVisible(false);
+      });
     }
   }, [isVisible]);
 
@@ -111,7 +115,7 @@ const Snackbar = ({ variant, title, action, onClose, maxLines, icon, position })
         }}
         onLayout={handleLayout}
       >
-        {isVisible ? (
+        {isContentVisible ? (
           <Size width={`${SNACKBAR_WIDTH}px`}>
             <Space padding={[1.5]}>
               <Flex flexDirection="row" alignItems="center">


### PR DESCRIPTION
On Android even if snackbar is not visible, Its content still remains on foreground. This is creating issue for the content which is at bottom on the screen. Users are unable to click whatever is behind the snackbar(even if snackbar is hidden).

<div style={{padding:"100px",alignItems:"center",display:"flex"}} >
<img src="https://user-images.githubusercontent.com/30696104/115831623-7a777780-a42f-11eb-96e1-cf543f37ab09.jpg" height="650" width="325"/>
<img src="https://user-images.githubusercontent.com/30696104/115831635-7cd9d180-a42f-11eb-8163-887a018796eb.jpg" height="650" width="325" />
</div>
