### PR TITLE
ci(workflows): use self-hosted runners

### DIFF
--- a/.github/workflows/blade-old-release.yml
+++ b/.github/workflows/blade-old-release.yml
@@ -11,7 +11,7 @@ jobs:
   release:
     name: Release
     runs-on: [self-hosted]
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v2

--- a/.github/workflows/blade-old-release.yml
+++ b/.github/workflows/blade-old-release.yml
@@ -10,16 +10,18 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Use Node v14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+      - name: Install Yarn
+        run: npm install -g yarn
       - name: Setup Cache & Install Dependencies
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/blade-old-release.yml
+++ b/.github/workflows/blade-old-release.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: Release
     runs-on: [self-hosted]
+    timeout-minutes: 5
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v2

--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -9,6 +9,7 @@ jobs:
   validate:
     name: Validate Source Code
     runs-on: [self-hosted]
+    timeout-minutes: 5
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v2

--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -9,7 +9,7 @@ jobs:
   validate:
     name: Validate Source Code
     runs-on: [self-hosted]
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v2

--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   validate:
     name: Validate Source Code
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v2
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
+      - name: Install Yarn
+        run: npm install -g yarn
       - name: Setup Cache & Install Dependencies
         uses: bahmutov/npm-install@v1
         with:


### PR DESCRIPTION
This PR migrates all the workflows to use `self-hosted` github runners