### PR TITLE
fix(amount.native): Add missing lineHeight case when size='xsmall'

### DIFF
--- a/.changeset/spotty-islands-do.md
+++ b/.changeset/spotty-islands-do.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade-old': patch
+---
+
+Fix Amount molecule's lineHeight when size='xsmall'

--- a/packages/blade-old/src/molecules/Amount/Amount.native.js
+++ b/packages/blade-old/src/molecules/Amount/Amount.native.js
@@ -46,6 +46,8 @@ const styles = {
     },
     lineHeight({ size }) {
       switch (size) {
+        case 'xsmall':
+          return 'small';
         case 'medium':
           return 'medium';
         case 'large':


### PR DESCRIPTION
## Description

Amount component had default `lineHeight` of `xxlarge` when `size='xsmall'` which should be `small` (in sync with `Text` component behaviour)

## Fix
Add case for `xsmall` in `lineHeight` function

## Screenshots

Before
![image](https://user-images.githubusercontent.com/43565572/119632954-e5510f80-be2e-11eb-92f4-83ec099adadd.png)

After
![image](https://user-images.githubusercontent.com/43565572/119632857-d2d6d600-be2e-11eb-90c0-7b87c2198a9b.png)


