### PR TITLE
feat(blade-old): adds support for accessibilityLabel and testID

### DIFF
--- a/packages/blade-old/src/_helpers/automation-attributes.native.js
+++ b/packages/blade-old/src/_helpers/automation-attributes.native.js
@@ -1,3 +1,4 @@
-export default (defaultKey) => ({
-  testID: defaultKey,
-});
+import pickBy from './pickBy';
+import identity from './identity';
+
+export default ({ testID, accessibilityLabel }) => pickBy({ accessibilityLabel, testID }, identity);

--- a/packages/blade-old/src/_helpers/automation-attributes.web.js
+++ b/packages/blade-old/src/_helpers/automation-attributes.web.js
@@ -1,3 +1,5 @@
-export default (defaultKey) => ({
-  'data-testid': defaultKey,
-});
+import pickBy from './pickBy';
+import identity from './identity';
+
+export default ({ testID, accessibilityLabel }) =>
+  pickBy({ 'aria-label': accessibilityLabel, 'data-testid': testID }, identity);

--- a/packages/blade-old/src/_helpers/identity.js
+++ b/packages/blade-old/src/_helpers/identity.js
@@ -1,0 +1,3 @@
+import identity from 'lodash/identity';
+
+export default identity;

--- a/packages/blade-old/src/_helpers/pickBy.js
+++ b/packages/blade-old/src/_helpers/pickBy.js
@@ -1,0 +1,3 @@
+import pickBy from 'lodash/pickBy';
+
+export default pickBy;

--- a/packages/blade-old/src/atoms/Button/Button.native.js
+++ b/packages/blade-old/src/atoms/Button/Button.native.js
@@ -237,6 +237,7 @@ const StyledButton = styled(TouchableHighlight)`
 `;
 
 const Button = ({
+  accessibilityLabel,
   onClick,
   children,
   variant,
@@ -287,7 +288,7 @@ const Button = ({
               color,
               theme,
             })}
-            {...automation(testID)}
+            {...automation({ testID, accessibilityLabel })}
           >
             <React.Fragment>
               {icon && iconAlign === 'left' && (
@@ -371,6 +372,7 @@ const Button = ({
 };
 
 Button.propTypes = {
+  accessibilityLabel: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.string,
   variant: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),

--- a/packages/blade-old/src/atoms/Button/Button.stories.js
+++ b/packages/blade-old/src/atoms/Button/Button.stories.js
@@ -39,6 +39,8 @@ storiesOf('Button', module)
                 size={select('Sizes', sizes, 'medium')}
                 variant={select('Variants', variants, 'primary')}
                 block
+                testID="button_1"
+                accessibilityLabel="block_button"
               >
                 Block Button
               </Button>

--- a/packages/blade-old/src/atoms/Button/Button.web.js
+++ b/packages/blade-old/src/atoms/Button/Button.web.js
@@ -355,6 +355,7 @@ const StyledButton = styled.button`
 `;
 
 const Button = ({
+  accessibilityLabel,
   onClick,
   children,
   variant,
@@ -420,7 +421,7 @@ const Button = ({
             type={type}
             id={id}
             name={name}
-            {...automation(testID)}
+            {...automation({ testID, accessibilityLabel })}
           >
             <React.Fragment>
               {icon && iconAlign === 'left' ? (
@@ -500,6 +501,7 @@ const Button = ({
 };
 
 Button.propTypes = {
+  accessibilityLabel: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.string,
   variant: PropTypes.oneOf(['primary', 'secondary', 'tertiary']),


### PR DESCRIPTION
Added support for `testID` and `accessibilityLabel`

- [ ] Web
- [ ] Native

![Screenshot 2021-08-23 at 2 39 02 PM](https://user-images.githubusercontent.com/32242596/130422562-6e8bbdc4-8af8-4bcc-93a2-e531bff2144d.png)
