### PR TITLE
feat(blade-old): add download icon

### DIFF
--- a/packages/blade-old/src/icons/Download/Download.native.js
+++ b/packages/blade-old/src/icons/Download/Download.native.js
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Svg, { Path } from 'react-native-svg';
+import { getThemeColors } from '../../_helpers/theme';
+import colors from '../../tokens/colors';
+export default function Download({ width, height, fill }) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M13 2a1 1 0 10-2 0v11.586l-2.293-2.293a1 1 0 00-1.414 1.414l4 4 .007.007a.996.996 0 00.697.286h.006c.272 0 .518-.11.697-.286l.008-.008 4-3.999a1 1 0 00-1.415-1.414L13 13.586V2z"
+        fill={fill}
+      />
+      <Path
+        d="M3 16a1 1 0 011 1v3a1 1 0 001 1h14a1 1 0 001-1v-3a1 1 0 112 0v3a3 3 0 01-3 3H5a3 3 0 01-3-3v-3a1 1 0 011-1z"
+        fill={fill}
+      />
+    </Svg>
+  );
+}
+
+Download.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  fill: PropTypes.oneOf(getThemeColors()),
+};
+
+Download.defaultProps = {
+  width: 24,
+  height: 24,
+  fill: colors.sapphire[800],
+};

--- a/packages/blade-old/src/icons/Download/Download.web.js
+++ b/packages/blade-old/src/icons/Download/Download.web.js
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { getThemeColors } from '../../_helpers/theme';
+import colors from '../../tokens/colors';
+
+export default function Download({ width, height, fill }) {
+  return (
+    <svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <path
+        d="M13 2a1 1 0 10-2 0v11.586l-2.293-2.293a1 1 0 00-1.414 1.414l4 4 .007.007a.996.996 0 00.697.286h.006c.272 0 .518-.11.697-.286l.008-.008 4-3.999a1 1 0 00-1.415-1.414L13 13.586V2z"
+        fill={fill}
+      />
+      <path
+        d="M3 16a1 1 0 011 1v3a1 1 0 001 1h14a1 1 0 001-1v-3a1 1 0 112 0v3a3 3 0 01-3 3H5a3 3 0 01-3-3v-3a1 1 0 011-1z"
+        fill={fill}
+      />
+    </svg>
+  );
+}
+
+Download.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  fill: PropTypes.oneOf(getThemeColors()),
+};
+
+Download.defaultProps = {
+  width: 24,
+  height: 24,
+  fill: colors.sapphire[800],
+};

--- a/packages/blade-old/src/icons/Download/index.js
+++ b/packages/blade-old/src/icons/Download/index.js
@@ -1,0 +1,1 @@
+export { default } from './Download';

--- a/packages/blade-old/src/icons/index.js
+++ b/packages/blade-old/src/icons/index.js
@@ -23,6 +23,7 @@ const icons = {
   clock: require('./Clock').default,
   close: require('./Close').default,
   copy: require('./Copy').default,
+  download: require('./Download').default,
   emptyCircle: require('./EmptyCircle').default,
   failure: require('./Failure').default,
   feather: require('./Feather').default,


### PR DESCRIPTION
Adds `download` icon for `payment gateway` feature.
<img width="462" alt="Screenshot 2021-08-26 at 1 17 20 PM" src="https://user-images.githubusercontent.com/19744238/130922865-a719ede1-4c5f-4fac-a41a-8092a516c5a8.png">
