### PR TITLE
feat(blade-old): add weight support in Link native component

### DIFF
--- a/.changeset/gold-lies-divide.md
+++ b/.changeset/gold-lies-divide.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade-old': minor
+---
+
+added weight support in Link native component

--- a/packages/blade-old/src/atoms/Link/Link.native.js
+++ b/packages/blade-old/src/atoms/Link/Link.native.js
@@ -2,10 +2,11 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { TouchableOpacity } from 'react-native';
 import Text from '../Text';
+import baseTheme from '../../tokens/theme';
 import automation from '../../_helpers/automation-attributes';
 import Flex from '../Flex';
 
-const Link = ({ children, onClick, size, hitSlop, testID }) => {
+const Link = ({ children, onClick, size, weight, hitSlop, testID }) => {
   const [active, setActive] = useState(false);
   const inactiveTextColor = 'primary.800';
   const activeTextColor = 'primary.600';
@@ -30,6 +31,7 @@ const Link = ({ children, onClick, size, hitSlop, testID }) => {
         <Text
           color={active ? activeTextColor : inactiveTextColor}
           size={size}
+          weight={weight}
           _isUnderlined={active}
         >
           {children}
@@ -43,6 +45,7 @@ Link.propTypes = {
   children: PropTypes.string.isRequired,
   onClick: PropTypes.func,
   size: PropTypes.oneOf(['xxsmall', 'xsmall', 'small', 'medium', 'large']),
+  weight: PropTypes.oneOf(Object.keys(baseTheme.fonts.weight)),
   testID: PropTypes.string,
   hitSlop: PropTypes.shape({
     left: PropTypes.number,
@@ -55,6 +58,7 @@ Link.propTypes = {
 Link.defaultProps = {
   onClick: () => {},
   size: 'medium',
+  weight: 'bold',
   testID: 'ds-link',
 };
 

--- a/packages/blade-old/src/atoms/Link/Link.native.js
+++ b/packages/blade-old/src/atoms/Link/Link.native.js
@@ -58,7 +58,7 @@ Link.propTypes = {
 Link.defaultProps = {
   onClick: () => {},
   size: 'medium',
-  weight: 'bold',
+  weight: 'regular',
   testID: 'ds-link',
 };
 

--- a/packages/blade-old/src/atoms/Link/__tests__/Link.native.test.js
+++ b/packages/blade-old/src/atoms/Link/__tests__/Link.native.test.js
@@ -34,6 +34,24 @@ describe('Renders <Link /> correctly', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('snapshot testing, renders regular link', () => {
+    const displayText = 'Displaying some link';
+    const { container } = renderWithTheme(<Link weight="regular">{displayText}</Link>);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('snapshot testing, renders light link', () => {
+    const displayText = 'Displaying some link';
+    const { container } = renderWithTheme(<Link weight="light">{displayText}</Link>);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('snapshot testing, renders bold link', () => {
+    const displayText = 'Displaying some link';
+    const { container } = renderWithTheme(<Link weight="bold">{displayText}</Link>);
+    expect(container).toMatchSnapshot();
+  });
+
   it('onPressIn/onPressOut link styles look as expected', () => {
     const displayText = 'Displaying some link';
     const { getByText, container } = renderWithTheme(<Link>{displayText}</Link>);

--- a/packages/blade-old/src/atoms/Link/__tests__/__snapshots__/Link.native.test.js.snap
+++ b/packages/blade-old/src/atoms/Link/__tests__/__snapshots__/Link.native.test.js.snap
@@ -34,7 +34,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         Array [
           Object {
             "color": "rgba(123, 178, 242, 1.0)",
-            "fontFamily": "Lato-Regular",
+            "fontFamily": "Lato-Bold",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -44,7 +44,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         ]
       }
       testID="ds-text"
-      weight="regular"
+      weight="bold"
     >
       Displaying some link
     </Text>
@@ -86,7 +86,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Regular",
+            "fontFamily": "Lato-Bold",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -96,7 +96,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         ]
       }
       testID="ds-text"
-      weight="regular"
+      weight="bold"
     >
       Displaying some link
     </Text>
@@ -138,7 +138,7 @@ exports[`Renders <Link /> correctly snapshot testing 1`] = `
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Regular",
+            "fontFamily": "Lato-Bold",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -148,7 +148,59 @@ exports[`Renders <Link /> correctly snapshot testing 1`] = `
         ]
       }
       testID="ds-text"
-      weight="regular"
+      weight="bold"
+    >
+      Displaying some link
+    </Text>
+  </TouchableOpacity>
+</View>
+`;
+
+exports[`Renders <Link /> correctly snapshot testing, renders bold link 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <TouchableOpacity
+    activeOpacity={1}
+    style={
+      Array [
+        Array [
+          Object {
+            "alignSelf": "flex-start",
+            "flexDirection": "column",
+          },
+        ],
+      ]
+    }
+    testID="ds-link"
+  >
+    <Text
+      _isUnderlined={false}
+      _letterSpacing="small"
+      align="left"
+      color="primary.800"
+      size="medium"
+      style={
+        Array [
+          Object {
+            "color": "rgba(43, 131, 234, 1.0 )",
+            "fontFamily": "Lato-Bold",
+            "fontSize": 14,
+            "letterSpacing": 0,
+            "lineHeight": 20,
+            "textAlign": "left",
+            "textDecorationLine": "none",
+          },
+        ]
+      }
+      testID="ds-text"
+      weight="bold"
     >
       Displaying some link
     </Text>
@@ -190,7 +242,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders large link 1`] = `
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Regular",
+            "fontFamily": "Lato-Bold",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -200,7 +252,59 @@ exports[`Renders <Link /> correctly snapshot testing, renders large link 1`] = `
         ]
       }
       testID="ds-text"
-      weight="regular"
+      weight="bold"
+    >
+      Displaying some link
+    </Text>
+  </TouchableOpacity>
+</View>
+`;
+
+exports[`Renders <Link /> correctly snapshot testing, renders light link 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <TouchableOpacity
+    activeOpacity={1}
+    style={
+      Array [
+        Array [
+          Object {
+            "alignSelf": "flex-start",
+            "flexDirection": "column",
+          },
+        ],
+      ]
+    }
+    testID="ds-link"
+  >
+    <Text
+      _isUnderlined={false}
+      _letterSpacing="small"
+      align="left"
+      color="primary.800"
+      size="medium"
+      style={
+        Array [
+          Object {
+            "color": "rgba(43, 131, 234, 1.0 )",
+            "fontFamily": "Lato-Light",
+            "fontSize": 14,
+            "letterSpacing": 0,
+            "lineHeight": 20,
+            "textAlign": "left",
+            "textDecorationLine": "none",
+          },
+        ]
+      }
+      testID="ds-text"
+      weight="light"
     >
       Displaying some link
     </Text>
@@ -209,6 +313,58 @@ exports[`Renders <Link /> correctly snapshot testing, renders large link 1`] = `
 `;
 
 exports[`Renders <Link /> correctly snapshot testing, renders medium link 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <TouchableOpacity
+    activeOpacity={1}
+    style={
+      Array [
+        Array [
+          Object {
+            "alignSelf": "flex-start",
+            "flexDirection": "column",
+          },
+        ],
+      ]
+    }
+    testID="ds-link"
+  >
+    <Text
+      _isUnderlined={false}
+      _letterSpacing="small"
+      align="left"
+      color="primary.800"
+      size="medium"
+      style={
+        Array [
+          Object {
+            "color": "rgba(43, 131, 234, 1.0 )",
+            "fontFamily": "Lato-Bold",
+            "fontSize": 14,
+            "letterSpacing": 0,
+            "lineHeight": 20,
+            "textAlign": "left",
+            "textDecorationLine": "none",
+          },
+        ]
+      }
+      testID="ds-text"
+      weight="bold"
+    >
+      Displaying some link
+    </Text>
+  </TouchableOpacity>
+</View>
+`;
+
+exports[`Renders <Link /> correctly snapshot testing, renders regular link 1`] = `
 <View
   collapsable={true}
   pointerEvents="box-none"
@@ -294,7 +450,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders small link 1`] = `
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Regular",
+            "fontFamily": "Lato-Bold",
             "fontSize": 13,
             "letterSpacing": 0,
             "lineHeight": 18,
@@ -304,7 +460,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders small link 1`] = `
         ]
       }
       testID="ds-text"
-      weight="regular"
+      weight="bold"
     >
       Displaying some link
     </Text>
@@ -346,7 +502,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders visited link 1`] =
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Regular",
+            "fontFamily": "Lato-Bold",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -356,7 +512,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders visited link 1`] =
         ]
       }
       testID="ds-text"
-      weight="regular"
+      weight="bold"
     >
       Displaying some link
     </Text>

--- a/packages/blade-old/src/atoms/Link/__tests__/__snapshots__/Link.native.test.js.snap
+++ b/packages/blade-old/src/atoms/Link/__tests__/__snapshots__/Link.native.test.js.snap
@@ -34,7 +34,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         Array [
           Object {
             "color": "rgba(123, 178, 242, 1.0)",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -44,7 +44,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>
@@ -86,7 +86,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -96,7 +96,7 @@ exports[`Renders <Link /> correctly onPressIn/onPressOut link styles look as exp
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>
@@ -138,7 +138,7 @@ exports[`Renders <Link /> correctly snapshot testing 1`] = `
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -148,7 +148,7 @@ exports[`Renders <Link /> correctly snapshot testing 1`] = `
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>
@@ -242,7 +242,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders large link 1`] = `
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,
@@ -252,7 +252,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders large link 1`] = `
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>
@@ -346,7 +346,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders medium link 1`] = 
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -356,7 +356,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders medium link 1`] = 
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>
@@ -450,7 +450,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders small link 1`] = `
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 13,
             "letterSpacing": 0,
             "lineHeight": 18,
@@ -460,7 +460,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders small link 1`] = `
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>
@@ -502,7 +502,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders visited link 1`] =
         Array [
           Object {
             "color": "rgba(43, 131, 234, 1.0 )",
-            "fontFamily": "Lato-Bold",
+            "fontFamily": "Lato-Regular",
             "fontSize": 14,
             "letterSpacing": 0,
             "lineHeight": 20,
@@ -512,7 +512,7 @@ exports[`Renders <Link /> correctly snapshot testing, renders visited link 1`] =
         ]
       }
       testID="ds-text"
-      weight="bold"
+      weight="regular"
     >
       Displaying some link
     </Text>


### PR DESCRIPTION
## Description

This PR adds `weight` support in the native `<Link />` component. By default, the `weight` is `regular`.

Recently, for a feature I was working on, a bold web link was there in design like in the screenshot below and there is no way to add `weight` in `<Link />` as of now. Hope this PR solves the use case.

### Screenshot

<details>
<summary>Usage</summary>

![image](https://user-images.githubusercontent.com/21218732/141289069-b850f31d-deb0-4e73-a657-c7e164179018.png)

</details>

## Usage

1. Regular weight by default
```
<Link onClick={navigateToWebDashboard} size="medium" testID="web-dashboard-link">
  web dashboard
</Link>
```

2. `<Link />` with `light` weight
```
<Link weight="light" onClick={navigateToWebDashboard} size="medium" testID="web-dashboard-link">
  web dashboard
</Link>
```

3. `<Link />` with `bold` weight
```
<Link weight="bold" onClick={navigateToWebDashboard} size="medium" testID="web-dashboard-link">
  web dashboard
</Link>
```

## Notes

The husky's pre-commit hook was giving me some typescript errors in `examples` folder. I committed changes by bypassing husky. Requesting someone to kindly look into them, It's probably because of `.d.ts` files.
Adding husky output below:

```
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
husky > pre-commit (node v14.17.4)
[STARTED] Preparing...
[SUCCESS] Preparing...
[STARTED] Running tasks...
[STARTED] Running tasks for *.(js|jsx|ts|tsx)
[STARTED] Running tasks for *.(json|js|jsx|ts|tsx)
[STARTED] eslint
[STARTED] prettier --write
[SUCCESS] prettier --write
[SUCCESS] Running tasks for *.(json|js|jsx|ts|tsx)
[SUCCESS] eslint
[STARTED] stylelint
[SUCCESS] stylelint
[SUCCESS] Running tasks for *.(js|jsx|ts|tsx)
[SUCCESS] Running tasks...
[STARTED] Applying modifications...
[SUCCESS] Applying modifications...
[STARTED] Cleaning up...
[SUCCESS] Cleaning up...
$ /Users/ayush.gupta/Documents/rzp/blade/node_modules/.bin/tsc
packages/examples/tokens-usage/src/App.tsx(1,10): error TS2305: Module '"@razorpay/blade/components"' has no exported member 'BladeProvider'.
packages/examples/tokens-usage/src/Card.tsx(2,20): error TS2305: Module '"@razorpay/blade/components"' has no exported member 'Theme'.
packages/examples/tokens-usage/src/Card.tsx(102,41): error TS2339: Property 'fonts' does not exist on type 'Typography'.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
husky > pre-commit hook failed (add --no-verify to bypass)

```
