### PR TITLE
fix(blade-old): updated support of  rn-modalize for RN v0.65

### DIFF
--- a/.changeset/mighty-cars-explode.md
+++ b/.changeset/mighty-cars-explode.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-old": minor
+---
+
+fix(blade-old): updated support of react-nataive-modalize for RN v0.65

--- a/packages/blade-old/package.json
+++ b/packages/blade-old/package.json
@@ -36,7 +36,7 @@
     "react-native-gesture-handler": "1.8.0",
     "react-native-linear-gradient": "2.5.6",
     "react-native-modal": "11.5.6",
-    "react-native-modalize": "2.0.4",
+    "react-native-modalize": "2.0.12",
     "react-native-reanimated": "1.9.0",
     "react-native-status-bar-height": "2.5.0",
     "react-native-svg": "12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17393,10 +17393,10 @@ react-native-modal@^11.0.2:
     prop-types "^15.6.2"
     react-native-animatable "1.3.3"
 
-react-native-modalize@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-modalize/-/react-native-modalize-2.0.4.tgz#0b9d441473baf0243f4fe1c208bd05aac58f05eb"
-  integrity sha512-imwMBfvbJdgGqzkfYI4t5jT5nrjXN9c+kEh1iPkEWJE2tz8dpcyWeyniXATmGmsqFkuQJvZY9o5LrYLY8BnduA==
+react-native-modalize@2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/react-native-modalize/-/react-native-modalize-2.0.12.tgz#0e48b2e7d496deca3d241414f233b29df34f4b30"
+  integrity sha512-IKPBM4RXLNLaH1WFX8/yPHlbRei15TNcMMftQzi+juG0ibbsAPbEXkbt+KKs7O1dvmOF8sZwRH3SbWjFlcxtAw==
 
 react-native-reanimated@1.9.0:
   version "1.9.0"


### PR DESCRIPTION
### Description

The PG mobile is on react native v0.65, in which the API of keyboard listeners has changed.

The `react-native-modalize` package which is a dependency of `blade-old` also uses keyboard listeners internally.

This PR updates the `react-native-modalize` support for RN v0.65 and above.


### Warning Screenshot

![image](https://user-images.githubusercontent.com/36567063/145516197-9b0810c0-d971-4fe9-831e-2ee4c6d7129e.png)
