### PR TITLE
fix(blade-old): include scripts while publishing

### DIFF
--- a/.changeset/sharp-dragons-hope.md
+++ b/.changeset/sharp-dragons-hope.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-old": patch
+---
+
+fix(blade-old): include scripts while publishing

--- a/packages/blade-old/package.json
+++ b/packages/blade-old/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "src",
-    "public"
+    "public",
+    "scripts"
   ],
   "scripts": {
     "web": "npm run web:storybook",


### PR DESCRIPTION
The `scripts` directory was not added to `files` array in `package.json` and hence was not getting published to npm. As a side-effect of this the migration to new version just broke because the it the command was unable to locate the codemod script.