### PR TITLE
fix(blade-old): icon migrate script dangling imports

### DIFF
--- a/.changeset/quiet-impalas-explain.md
+++ b/.changeset/quiet-impalas-explain.md
@@ -1,5 +1,4 @@
 ---
-"@razorpay/blade": patch
 "@razorpay/blade-old": patch
 ---
 

--- a/.changeset/quiet-impalas-explain.md
+++ b/.changeset/quiet-impalas-explain.md
@@ -1,0 +1,6 @@
+---
+"@razorpay/blade": patch
+"@razorpay/blade-old": patch
+---
+
+fix: icon migrate script dangling imports

--- a/packages/blade-old/scripts/icon-migrate-codemod/transforms/blade-old-icon.ts
+++ b/packages/blade-old/scripts/icon-migrate-codemod/transforms/blade-old-icon.ts
@@ -8,8 +8,6 @@ import {
   JSXElement,
 } from 'jscodeshift';
 
-export const parser = 'jsx';
-
 const isJSXAttribute = (elm: JSXAttribute | JSXSpreadAttribute): elm is JSXAttribute => {
   return elm.type === 'JSXAttribute';
 };
@@ -57,9 +55,12 @@ const transform: Transform = (file, api, _options) => {
     node.openingElement.attributes = props;
   });
 
-  FIRST_IMPORT.insertAfter(
-    j.importDeclaration(imports, j.stringLiteral('@razorpay/blade-old/src/icons'), 'value'),
-  );
+  // only add import if we have any icons to replace.
+  if (imports.length > 0) {
+    FIRST_IMPORT.insertAfter(
+      j.importDeclaration(imports, j.stringLiteral('@razorpay/blade-old/src/icons'), 'value'),
+    );
+  }
 
   return root.toSource();
 };


### PR DESCRIPTION
While migrating razorpay mobile app repo, folks found issues with the codmod, this PR addresses two issues: 

- Fixes dangling import which is being added on every file
- Fixes CLI unable to change parser type to TSX 