### PR TITLE
feat(Modal): Migrate react-native-modal to 13.0.0

### DIFF
--- a/.changeset/dull-vans-ring.md
+++ b/.changeset/dull-vans-ring.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-old": minor
+---
+
+feat(Modal): Migrate react-native-modal to 13.0.0

--- a/packages/blade-old/package.json
+++ b/packages/blade-old/package.json
@@ -41,7 +41,7 @@
     "react-native-document-picker": "4.2.0",
     "react-native-gesture-handler": "1.8.0",
     "react-native-linear-gradient": "2.5.6",
-    "react-native-modal": "11.5.6",
+    "react-native-modal": "13.0.0",
     "react-native-modalize": "2.0.12",
     "react-native-reanimated": "1.9.0",
     "react-native-status-bar-height": "2.5.0",

--- a/packages/blade-old/src/molecules/Modal/Modal.native.js
+++ b/packages/blade-old/src/molecules/Modal/Modal.native.js
@@ -64,6 +64,7 @@ const Modal = ({ children, variant, visible, onClose, onBackdropClick }) => {
           onBackButtonPress={onClose}
           backdropColor={theme.colors.overlay[200]}
           propagateSwipe
+          useNativeDriverForBackdrop
         >
           <ModalContainer variant="centered">
             {onClose ? (
@@ -125,6 +126,7 @@ const Modal = ({ children, variant, visible, onClose, onBackdropClick }) => {
             avoidKeyboard={true}
             backdropColor={theme.colors.overlay[200]}
             propagateSwipe
+            useNativeDriverForBackdrop
           >
             <ModalContainer variant="bottomsheet">
               <Flex alignItems="center">

--- a/packages/blade-old/src/molecules/Modal/__tests__/__snapshots__/Modal.native.test.js.snap
+++ b/packages/blade-old/src/molecules/Modal/__tests__/__snapshots__/Modal.native.test.js.snap
@@ -12,12 +12,16 @@ exports[`<Modal /> centered Modal onClose callback is not passed 1`] = `
 >
   <Modal
     animationType="none"
+    deviceHeight={null}
+    deviceWidth={null}
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
+    panResponderThreshold={4}
     scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
+    statusBarTranslucent={false}
     supportedOrientations={
       Array [
         "portrait",
@@ -26,6 +30,7 @@ exports[`<Modal /> centered Modal onClose callback is not passed 1`] = `
     }
     swipeThreshold={100}
     transparent={true}
+    useNativeDriverForBackdrop={true}
     visible={true}
   >
     <TouchableWithoutFeedback>
@@ -46,12 +51,16 @@ exports[`<Modal /> centered Modal onClose callback is not passed 1`] = `
       />
     </TouchableWithoutFeedback>
     <View
+      deviceHeight={null}
+      deviceWidth={null}
       hideModalContentWhileAnimating={false}
+      panResponderThreshold={4}
       pointerEvents="box-none"
       scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
+      statusBarTranslucent={false}
       style={
         Object {
           "flex": 1,
@@ -75,6 +84,7 @@ exports[`<Modal /> centered Modal onClose callback is not passed 1`] = `
         ]
       }
       swipeThreshold={100}
+      useNativeDriverForBackdrop={true}
     >
       <View
         style={
@@ -222,12 +232,16 @@ exports[`<Modal /> centered Modal onClose callback is passed 1`] = `
 >
   <Modal
     animationType="none"
+    deviceHeight={null}
+    deviceWidth={null}
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
+    panResponderThreshold={4}
     scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
+    statusBarTranslucent={false}
     supportedOrientations={
       Array [
         "portrait",
@@ -236,6 +250,7 @@ exports[`<Modal /> centered Modal onClose callback is passed 1`] = `
     }
     swipeThreshold={100}
     transparent={true}
+    useNativeDriverForBackdrop={true}
     visible={true}
   >
     <TouchableWithoutFeedback>
@@ -256,12 +271,16 @@ exports[`<Modal /> centered Modal onClose callback is passed 1`] = `
       />
     </TouchableWithoutFeedback>
     <View
+      deviceHeight={null}
+      deviceWidth={null}
       hideModalContentWhileAnimating={false}
+      panResponderThreshold={4}
       pointerEvents="box-none"
       scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
+      statusBarTranslucent={false}
       style={
         Object {
           "flex": 1,
@@ -285,6 +304,7 @@ exports[`<Modal /> centered Modal onClose callback is passed 1`] = `
         ]
       }
       swipeThreshold={100}
+      useNativeDriverForBackdrop={true}
     >
       <View
         style={
@@ -539,12 +559,16 @@ exports[`<Modal /> renders bottomsheet Modal 1`] = `
 >
   <Modal
     animationType="none"
+    deviceHeight={null}
+    deviceWidth={null}
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
+    panResponderThreshold={4}
     scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
+    statusBarTranslucent={false}
     supportedOrientations={
       Array [
         "portrait",
@@ -553,6 +577,7 @@ exports[`<Modal /> renders bottomsheet Modal 1`] = `
     }
     swipeThreshold={100}
     transparent={true}
+    useNativeDriverForBackdrop={true}
     visible={true}
   >
     <TouchableWithoutFeedback>
@@ -573,12 +598,16 @@ exports[`<Modal /> renders bottomsheet Modal 1`] = `
       />
     </TouchableWithoutFeedback>
     <View
+      deviceHeight={null}
+      deviceWidth={null}
       hideModalContentWhileAnimating={false}
+      panResponderThreshold={4}
       pointerEvents="box-none"
       scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
+      statusBarTranslucent={false}
       style={
         Object {
           "flex": 1,
@@ -602,6 +631,7 @@ exports[`<Modal /> renders bottomsheet Modal 1`] = `
         ]
       }
       swipeThreshold={100}
+      useNativeDriverForBackdrop={true}
     >
       <View
         style={
@@ -749,12 +779,16 @@ exports[`<Modal /> renders fullscreen Modal 1`] = `
 >
   <Modal
     animationType="none"
+    deviceHeight={null}
+    deviceWidth={null}
     hardwareAccelerated={false}
     hideModalContentWhileAnimating={false}
+    panResponderThreshold={4}
     scrollHorizontal={false}
     scrollOffset={0}
     scrollOffsetMax={0}
     scrollTo={null}
+    statusBarTranslucent={false}
     supportedOrientations={
       Array [
         "portrait",
@@ -763,6 +797,7 @@ exports[`<Modal /> renders fullscreen Modal 1`] = `
     }
     swipeThreshold={100}
     transparent={true}
+    useNativeDriverForBackdrop={true}
     visible={true}
   >
     <TouchableWithoutFeedback>
@@ -783,12 +818,16 @@ exports[`<Modal /> renders fullscreen Modal 1`] = `
       />
     </TouchableWithoutFeedback>
     <View
+      deviceHeight={null}
+      deviceWidth={null}
       hideModalContentWhileAnimating={false}
+      panResponderThreshold={4}
       pointerEvents="box-none"
       scrollHorizontal={false}
       scrollOffset={0}
       scrollOffsetMax={0}
       scrollTo={null}
+      statusBarTranslucent={false}
       style={
         Object {
           "flex": 1,
@@ -812,6 +851,7 @@ exports[`<Modal /> renders fullscreen Modal 1`] = `
         ]
       }
       swipeThreshold={100}
+      useNativeDriverForBackdrop={true}
     >
       <View
         style={

--- a/yarn.lock
+++ b/yarn.lock
@@ -20706,10 +20706,10 @@ react-native-modal-selector@^2.0.2:
   dependencies:
     prop-types "^15.5.10"
 
-react-native-modal@11.5.6:
-  version "11.5.6"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-11.5.6.tgz#bb25a78c35a5e24f45de060e5f64284397d38a87"
-  integrity sha512-APGNfbvgC4hXbJqcSADu79GLoMKIHUmgR3fDQ7rCGZNBypkStSP8imZ4PKK/OzIZZfjGU9aP49jhMgGbhY9KHA==
+react-native-modal@13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-13.0.0.tgz#b7117400cae8548e713eed760077dee44f78628e"
+  integrity sha512-k6r9T31mc7HIDFj1V53ceAAN1dwc8052c4JLtDVEmEQ19Bbq9yiLXoDsQuNb+hB8A+2tVOXmo5Gq4IQfb11upw==
   dependencies:
     prop-types "^15.6.2"
     react-native-animatable "1.3.3"


### PR DESCRIPTION
Description

Update react-native-modal to v13.0.0

Fixes
- Remove usage of `EventEmitter.removeListener()` deprecated API
- Add `useNativeDriverForBackdrop` to fix backdrop flicker issue on modal dismissal.

