### PR TITLE
fix(blade): add `preinstall` script to set `https` protocol instead of `git`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "lint": "eslint --ext js,jsx,ts,tsx packages",
     "release": "changeset publish",
+    "preinstall": "git config url.\"https://github.com/\".insteadOf git://github.com/",
     "postinstall": "run-s build install-tokens-usage-dependencies",
     "build": "lerna run --scope @razorpay/blade build",
     "install-tokens-usage-dependencies": "cd packages/examples/tokens-usage && yarn"


### PR DESCRIPTION
add `preinstall` script since a lot of npm packages use `git://github.com/CharlesMangwa/simple-markdown.git` in their dependencies and because there's an EOL for [`git` protocol](ofhttps://github.blog/2021-09-01-improving-git-protocol-security-github/) the installations start failing since we have couple of downstream packages as well. So adding the git config as a preinstall script which will force the git to use `https` whenever it finds `git` while installing packages.