### PR TITLE
build: make git config global to set `https` protocol instead of `git`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "lint": "eslint --ext js,jsx,ts,tsx packages",
     "release": "changeset publish",
-    "preinstall": "git config url.\"https://github.com/\".insteadOf git://github.com/",
+    "preinstall": "git config --global url.\"https://github.com/\".insteadOf git://github.com/",
     "postinstall": "run-s build install-tokens-usage-dependencies",
     "build": "lerna run --scope @razorpay/blade build",
     "install-tokens-usage-dependencies": "cd packages/examples/tokens-usage && yarn"


### PR DESCRIPTION
Fixes the failing CI while installing node dependencies