### PR TITLE
fix(blade): make children prop across Typography suite better

### DIFF
--- a/packages/blade/src/components/Typography/BaseText/BaseText.stories.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.stories.tsx
@@ -9,14 +9,16 @@ export default {
   args: {
     color: 'surface.text.normal.lowContrast',
     fontFamily: 'text',
-    fontSize: 700,
+    fontSize: 200,
     fontWeight: 'regular',
     fontStyle: 'normal',
     textAlign: 'left',
     textDecorationLine: 'none',
-    lineHeight: '5xl',
+    lineHeight: 'l',
     name: 'Storybook',
-    children: 'Base Text',
+    as: 'span',
+    children:
+      'Current Accounts supercharged by RazorpayX come with integrated tools and integrations that make financial management and accounting simple',
   },
   parameters: {
     docs: {

--- a/packages/blade/src/components/Typography/BaseText/BaseText.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.tsx
@@ -26,7 +26,7 @@ export type BaseTextProps = {
   textAlign?: 'center' | 'justify' | 'left' | 'right';
   truncateAfterLines?: number;
   className?: string;
-  children?: React.ReactNode;
+  children: React.ReactNode;
 };
 
 const BaseText = ({

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -7,7 +7,7 @@ import type { BaseTextProps } from '../BaseText';
 
 type HeadingCommonProps = {
   type: TextTypes;
-  children?: React.ReactNode;
+  children: string;
 };
 
 type HeadingNormalVariant = HeadingCommonProps & {
@@ -38,8 +38,8 @@ const getProps = <T extends { variant: 'small' | 'medium' | 'large' | 'subheadin
   variant,
   type,
   weight,
-}: Pick<HeadingProps<T>, 'variant' | 'type' | 'weight'>): BaseTextProps => {
-  const props: BaseTextProps = {
+}: Pick<HeadingProps<T>, 'variant' | 'type' | 'weight'>): Omit<BaseTextProps, 'children'> => {
+  const props: Omit<BaseTextProps, 'children'> = {
     color: `surface.text.${type}.lowContrast`,
     fontSize: 25,
     fontWeight: weight,

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -9,7 +9,7 @@ import type { BaseTextProps } from '../BaseText/BaseText';
 type TextCommonProps = {
   type: TextTypes;
   truncateAfterLines?: number;
-  children?: React.ReactNode;
+  children: React.ReactNode;
 };
 
 type TextBodyVariant = TextCommonProps & {
@@ -44,8 +44,9 @@ const getProps = <T extends { variant: 'body' | 'caption' }>({
   variant,
   type,
   weight,
-}: Pick<TextProps<T>, 'type' | 'variant' | 'weight'>): BaseTextProps & TextForwardedAs => {
-  const props: BaseTextProps & TextForwardedAs = {
+}: Pick<TextProps<T>, 'type' | 'variant' | 'weight'>): Omit<BaseTextProps, 'children'> &
+  TextForwardedAs => {
+  const props: Omit<BaseTextProps, 'children'> & TextForwardedAs = {
     color: `surface.text.${type}.lowContrast`,
     fontSize: 25,
     fontWeight: weight,
@@ -95,7 +96,7 @@ const Text = <T extends { variant: 'body' | 'caption' }>({
   truncateAfterLines,
   children,
 }: TextProps<T>): ReactElement => {
-  const props: BaseTextProps & TextForwardedAs = {
+  const props: Omit<BaseTextProps, 'children'> & TextForwardedAs = {
     truncateAfterLines,
     ...getProps({ variant, type, weight }),
   };

--- a/packages/blade/src/components/Typography/Title/Title.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.tsx
@@ -7,11 +7,14 @@ import type { BaseTextProps } from '../BaseText/BaseText';
 export type TitleProps = {
   variant: 'large' | 'medium' | 'small';
   type: TextTypes;
-  children?: React.ReactNode;
+  children: string;
 };
 
-const getProps = ({ variant, type }: TitleProps): BaseTextProps => {
-  const props: BaseTextProps = {
+const getProps = ({
+  variant,
+  type,
+}: Pick<TitleProps, 'variant' | 'type'>): Omit<BaseTextProps, 'children'> => {
+  const props: Omit<BaseTextProps, 'children'> = {
     color: `surface.text.${type}.lowContrast`,
     fontSize: 25,
     fontWeight: 'bold',

--- a/packages/blade/src/components/Typography/_decisions/decisions.md
+++ b/packages/blade/src/components/Typography/_decisions/decisions.md
@@ -26,10 +26,27 @@ The APIs for all the above component will look something like below
     letterSpacing="letterSpacing"
     formatting="bold/italic/strike"
     as="h1-h6/p/span"
-  />
+  >
+    Some Text
+  </BaseText>
   ```
 
-- `Title`
+Type of `children: React.ReactNode`
+
+- Children are mandatory
+- We could accept any valid ReactNode which is one of `ReactElement | ReactText | ReactFragment | ReactPortal | boolean | null | undefined`.
+- The reason to accept `ReactNode` for `BaseText` is since this is a raw structure for the consumers they can satisfy their use case of building anything custom for rare use cases. For example, composing BaseText components by nesting them to make one word bold in a sentence.
+
+```
+<BaseText>
+	<BaseText weight="bold">Current <BaseText/>
+	  Accounts supercharged by RazorpayX come with integrated tools and integrations that make financial management and accounting simple
+</BaseText>
+```
+
+- This gives flexibility and also makes sure people are still under the boundaries of DS
+
+* `Title`
 
   This component is meant to be used for Titles(bigger banner style kind of text) mostly on landing pages or page level headings.
 
@@ -41,7 +58,13 @@ The APIs for all the above component will look something like below
   </Title>
   ```
 
-- `Heading`
+Type of `children: string`
+
+- Children are mandatory
+- We would accept only String for Title components since there's no use case where people would want to have special formatting in Title.
+- There are use cases on our landing pages where we highlight or animate certain parts of the word or even add a logo inside the title. For those use cases, I guess consumers have to use two components and place them side by side regardless of using some layout utilities(of course since heading and title are block elements).
+
+* `Heading`
 
   As the name indicates these will be used for headings on the page.
 
@@ -55,6 +78,14 @@ The APIs for all the above component will look something like below
     Some Heading
   </Heading>
   ```
+
+Type of `children: string`
+
+- Children are mandatory
+- We would accept only String for Heading components since there's no use case where people would want to have special formating in Heading.
+- There are use cases on our landing pages where we highlight or animate certain parts of the word or even add a logo inside the title. For those use cases, I guess consumers have to use two components and place them side by side regardless of using some layout utilities(of course since heading and title are block elements).
+
+Why prop name `variant`?
 
 We decided to call the prop `variant` instead of `size` since `size` restricts you to a unit of "size" whereas variant is a free form prop that can be actually a variant of something so it conveys intent.
 
@@ -78,6 +109,12 @@ Another option would be having a `size` prop that would lead us to have a "large
     Some Text
   </Text>
   ```
+
+Type of `children: React.ReactNode`
+
+- Children are mandatory
+- We could accept any valid ReactNode which is one of `ReactElement | ReactText | ReactFragment | ReactPortal | boolean | null | undefined`.
+- The reason to accept `ReactNode` and not `string` for `Text` is since it's a body text which will mostly be used in paragraphs and the main content on the page so it's better to have the flexibility for consumers because usually in the body text there are use cases to add some code snippets inline or highlight a word within the paragraph without explicitly building the `Text` component from scratch using `BaseText`.
 
 - `Code`
 


### PR DESCRIPTION
This PR streamlines the type of children that each component of the `Typography` family accepts. Here are the decisions that were taken:

### BaseText
`children: React.ReactNode`
* Children are mandatory
* We could accept any valid ReactNode which is one of `ReactElement | ReactText | ReactFragment | ReactPortal | boolean | null | undefined`.
* The reason to accept `ReactNode` for `BaseText` is since this is a raw structure for the consumers they can satisfy their use case of building anything custom for rare use cases. For example, composing BaseText components by nesting them to make one word bold in a sentence. 
```
<BaseText>
	<BaseText weight="bold">Current <BaseText/>
	  Accounts supercharged by RazorpayX come with integrated tools and integrations that make financial management and accounting simple
</BaseText>
```
* This gives flexibility and also makes sure people are still under the boundaries of DS

### Text
`children: React.ReactNode`
* Children are mandatory
* We could accept any valid ReactNode which is one of `ReactElement | ReactText | ReactFragment | ReactPortal | boolean | null | undefined`.
* The reason to accept `ReactNode` and not `string` for `Text` is since it's a body text which will mostly be used in paragraphs and the main content on the page so it's better to have the flexibility for consumers because usually in the body text there are use cases to add some code snippets inline or highlight a word within the paragraph without explicitly building the `Text` component from scratch using `BaseText`.

### Title / Heading
`children: string`
* Children are mandatory
* We would accept only String for Title/Heading components since there's no use case where people would want to have special formatting in Title or Heading.
* There are use cases on our landing pages where we highlight or animate certain parts of the word or even add a logo inside the title. For those use cases, I guess consumers have to use two components and place them side by side regardless of using some layout utilities(of course since heading and title are block elements).

