### PR TITLE
fix(typography): added accessibilityRole in heading and title component

### DIFF
--- a/packages/blade/src/components/Typography/BaseText/BaseText.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.tsx
@@ -27,6 +27,10 @@ export type BaseTextProps = {
   truncateAfterLines?: number;
   className?: string;
   children: React.ReactNode;
+  /**
+   * @platform native
+   */
+  accessibilityRole?: string;
 };
 
 const BaseText = ({
@@ -42,6 +46,7 @@ const BaseText = ({
   children,
   truncateAfterLines,
   className,
+  accessibilityRole,
 }: BaseTextProps): ReactElement => {
   const { theme } = useTheme();
   const textColor = getIn(theme.colors, color);
@@ -63,6 +68,7 @@ const BaseText = ({
       textAlign={textAlign}
       numberOfLines={truncateAfterLines}
       className={className}
+      accessibilityRole={accessibilityRole}
     >
       {children}
     </StyledBaseText>

--- a/packages/blade/src/components/Typography/BaseText/StyledBaseText.d.ts
+++ b/packages/blade/src/components/Typography/BaseText/StyledBaseText.d.ts
@@ -11,4 +11,5 @@ export type StyledBaseTextProps = {
   as?: 'code' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
   textAlign?: 'center' | 'justify' | 'left' | 'right';
   numberOfLines?: number;
+  accessibilityRole?: string;
 };

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -54,6 +54,7 @@ const getProps = <T extends { variant: HeadingVariant }>({
     fontStyle: 'normal',
     lineHeight: 'xl',
     fontFamily: 'text',
+    accessibilityRole: 'header',
   };
   const isPlatformWeb = getPlatformType() === 'browser' || getPlatformType() === 'node';
 

--- a/packages/blade/src/components/Typography/Heading/__tests__/__snapshots__/Heading.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Heading/__tests__/__snapshots__/Heading.native.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Heading /> should render Heading with default properties 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 56%, 17%, 1)"
   fontFamily="Lato"
   fontSize="17px"
@@ -31,6 +32,7 @@ exports[`<Heading /> should render Heading with default properties 1`] = `
 
 exports[`<Heading /> should render Heading with variant "large" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 18%, 45%, 1)"
   fontFamily="Lato"
   fontSize="20px"
@@ -60,6 +62,7 @@ exports[`<Heading /> should render Heading with variant "large" 1`] = `
 
 exports[`<Heading /> should render Heading with variant "medium" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(216, 16%, 60%, 1)"
   fontFamily="Lato"
   fontSize="18px"
@@ -89,6 +92,7 @@ exports[`<Heading /> should render Heading with variant "medium" 1`] = `
 
 exports[`<Heading /> should render Heading with variant "small" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 56%, 17%, 1)"
   fontFamily="Lato"
   fontSize="17px"
@@ -118,6 +122,7 @@ exports[`<Heading /> should render Heading with variant "small" 1`] = `
 
 exports[`<Heading /> should render Heading with variant "small" and contrast "high" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(0, 0%, 100%, 1)"
   fontFamily="Lato"
   fontSize="17px"
@@ -147,6 +152,7 @@ exports[`<Heading /> should render Heading with variant "small" and contrast "hi
 
 exports[`<Heading /> should render Heading with variant "subheading" and weight "bold" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 18%, 45%, 1)"
   fontFamily="Lato"
   fontSize="14px"

--- a/packages/blade/src/components/Typography/Title/Title.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.tsx
@@ -24,6 +24,7 @@ const getProps = ({
     fontStyle: 'normal',
     lineHeight: '4xl',
     fontFamily: 'text',
+    accessibilityRole: 'header',
   };
   const isPlatformWeb = getPlatformType() === 'browser' || getPlatformType() === 'node';
 

--- a/packages/blade/src/components/Typography/Title/__tests__/__snapshots__/Title.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Title/__tests__/__snapshots__/Title.native.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<Title /> should render Title with default properties 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 56%, 17%, 1)"
   fontFamily="Lato"
   fontSize="24px"
@@ -31,6 +32,7 @@ exports[`<Title /> should render Title with default properties 1`] = `
 
 exports[`<Title /> should render Title with variant "large" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 18%, 45%, 1)"
   fontFamily="Lato"
   fontSize="35px"
@@ -60,6 +62,7 @@ exports[`<Title /> should render Title with variant "large" 1`] = `
 
 exports[`<Title /> should render Title with variant "medium" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(216, 16%, 60%, 1)"
   fontFamily="Lato"
   fontSize="27px"
@@ -89,6 +92,7 @@ exports[`<Title /> should render Title with variant "medium" 1`] = `
 
 exports[`<Title /> should render Title with variant "small" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(217, 56%, 17%, 1)"
   fontFamily="Lato"
   fontSize="24px"
@@ -118,6 +122,7 @@ exports[`<Title /> should render Title with variant "small" 1`] = `
 
 exports[`<Title /> should render Title with variant "small" and contrast "high" 1`] = `
 <Text
+  accessibilityRole="header"
   color="hsla(0, 0%, 100%, 1)"
   fontFamily="Lato"
   fontSize="24px"


### PR DESCRIPTION
- Improved the accessibility of heading and title component by adding accessibilityRole prop in BaseText

before: 

SR announces "Inaccessible heading example"

https://user-images.githubusercontent.com/35374649/171153739-fed9fd82-6b70-43ce-b07f-3e4dbf2d611f.mov

After: 

SR announces "Accessible heading example, heading"

https://user-images.githubusercontent.com/35374649/171153818-729fbde5-f9e7-4b0d-a047-6f62ded3a8fa.mov

These headers will also be available as landmark signposts.