### PR TITLE
feat: add button stories

### DIFF
--- a/packages/blade/.storybook/react-native/storybook.requires.js
+++ b/packages/blade/.storybook/react-native/storybook.requires.js
@@ -23,13 +23,15 @@ argsEnhancers.forEach((enhancer) => addArgsEnhancer(enhancer));
 
 const getStories = () => {
   return [
+    require('../../src/components/Button/Button/Button.stories.tsx'),
     require('../../src/components/Icons/Icons.stories.tsx'),
+    require('../../src/components/SkipNav/SkipNav.stories.tsx'),
     require('../../src/components/Typography/BaseText/BaseText.stories.tsx'),
     require('../../src/components/Typography/Heading/Heading.stories.tsx'),
     require('../../src/components/Typography/Text/Text.stories.tsx'),
     require('../../src/components/Typography/Title/Title.stories.tsx'),
-    require('../../src/storybook-recipes/AccessibilityInterop/AccessibilityInteropDemo.stories.tsx'),
     require('../../src/components/VisuallyHidden/VisuallyHidden.stories.tsx'),
+    require('../../src/storybook-recipes/AccessibilityInterop/AccessibilityInteropDemo.stories.tsx'),
     require('../../src/storybook-recipes/SimpleCardWithTokens/CardWithTokens.stories.tsx'),
     require('../../src/components/Button/BaseButton/BaseButton.stories.internal.tsx'),
   ];

--- a/packages/blade/src/components/Button/Button/Button.stories.tsx
+++ b/packages/blade/src/components/Button/Button/Button.stories.tsx
@@ -2,8 +2,11 @@ import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 import type { ReactElement } from 'react';
 import { Highlight, Link } from '@storybook/design-system';
+import styled from 'styled-components';
 import iconMap from '../../Icons/iconMap';
 import useMakeFigmaURL from '../../../_helpers/storybook/useMakeFigmaURL';
+import BaseText from '../../Typography/BaseText';
+import { CreditCardIcon } from '../../Icons';
 import type { ButtonProps } from './Button';
 import ButtonComponent from './Button';
 
@@ -40,6 +43,10 @@ const Page = (): ReactElement => {
       <Title>Usage</Title>
       <Highlight language="tsx">{`import { Button } from '@razorpay/blade/components' \nimport type { ButtonProps } from '@razorpay/blade/components'`}</Highlight>
       <Title>Example</Title>
+      <Subtitle>
+        This is the default button. You can change the properties of this button using the controls
+        in the table below.
+      </Subtitle>
       <Primary />
       <Title>Properties</Title>
       <ArgsTable story={PRIMARY_STORY} />
@@ -49,7 +56,7 @@ const Page = (): ReactElement => {
 };
 
 export default {
-  title: 'Components/Button/Button',
+  title: 'Components/Button',
   component: ButtonComponent,
   args: {
     variant: 'primary',
@@ -87,6 +94,167 @@ const ButtonTemplate: ComponentStory<typeof ButtonComponent> = ({ icon, children
   );
 };
 
-export const Button = ButtonTemplate.bind({});
+const StyledBaseText = styled(BaseText)({ padding: '8px 0px' });
+const ButtonWithSizeTemplate: ComponentStory<typeof ButtonComponent> = ({
+  children = 'Button',
+  ...args
+}) => {
+  return (
+    <>
+      <StyledBaseText fontWeight="bold">xsmall</StyledBaseText>
+      <ButtonComponent {...args} size="xsmall">
+        {children}
+      </ButtonComponent>
+
+      <StyledBaseText fontWeight="bold">small</StyledBaseText>
+      <ButtonComponent {...args} size="small">
+        {children}
+      </ButtonComponent>
+
+      <StyledBaseText fontWeight="bold">medium</StyledBaseText>
+      <ButtonComponent {...args} size="medium">
+        {children}
+      </ButtonComponent>
+
+      <StyledBaseText fontWeight="bold">large</StyledBaseText>
+      <ButtonComponent {...args} size="large">
+        {children}
+      </ButtonComponent>
+    </>
+  );
+};
+
+const ButtonWithVariantTemplate: ComponentStory<typeof ButtonComponent> = ({
+  children = 'Button',
+  ...args
+}) => {
+  return (
+    <>
+      <StyledBaseText fontWeight="bold">Primary</StyledBaseText>
+      <ButtonComponent {...args} variant="primary">
+        {children}
+      </ButtonComponent>
+
+      <StyledBaseText fontWeight="bold">Secondary</StyledBaseText>
+      <ButtonComponent {...args} variant="secondary">
+        {children}
+      </ButtonComponent>
+
+      <StyledBaseText fontWeight="bold">Tertiary</StyledBaseText>
+      <ButtonComponent {...args} variant="tertiary">
+        {children}
+      </ButtonComponent>
+    </>
+  );
+};
+
+export const Default = ButtonTemplate.bind({});
 // Need to do this because of storybook's weird naming convention, More details here: https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy#single-story-hoisting
-Button.storyName = 'Button';
+Default.storyName = 'Default';
+
+export const PrimaryButton = ButtonWithSizeTemplate.bind({});
+PrimaryButton.storyName = 'Primary';
+PrimaryButton.args = {
+  variant: 'primary',
+};
+PrimaryButton.parameters = {
+  docs: {
+    description: {
+      story: 'Primary Button in different sizes',
+    },
+  },
+};
+
+export const SecondaryButton = ButtonWithSizeTemplate.bind({});
+SecondaryButton.storyName = 'Secondary';
+SecondaryButton.args = {
+  variant: 'secondary',
+};
+SecondaryButton.parameters = {
+  docs: {
+    description: {
+      story: 'Secondary Button in different sizes',
+    },
+  },
+};
+
+export const TertiaryButton = ButtonWithSizeTemplate.bind({});
+TertiaryButton.storyName = 'Tertiary';
+TertiaryButton.args = {
+  variant: 'tertiary',
+};
+TertiaryButton.parameters = {
+  docs: {
+    description: {
+      story: 'Tertiary Button in different sizes',
+    },
+  },
+};
+
+export const DisabledButton = ButtonWithVariantTemplate.bind({});
+DisabledButton.storyName = 'Disabled';
+DisabledButton.args = {
+  isDisabled: true,
+};
+DisabledButton.parameters = {
+  docs: {
+    description: {
+      story: 'Primary, Secondary & Tertiary buttons in disabled states',
+    },
+  },
+};
+
+export const IconLeftButton = ButtonWithVariantTemplate.bind({});
+IconLeftButton.storyName = 'Left Icon';
+IconLeftButton.args = {
+  icon: CreditCardIcon,
+  iconPosition: 'left',
+};
+IconLeftButton.parameters = {
+  docs: {
+    description: {
+      story: 'Primary, Secondary & Tertiary buttons with an Icon on Left',
+    },
+  },
+};
+
+export const IconRightButton = ButtonWithVariantTemplate.bind({});
+IconRightButton.storyName = 'Right Icon';
+IconRightButton.args = {
+  icon: CreditCardIcon,
+  iconPosition: 'right',
+};
+IconRightButton.parameters = {
+  docs: {
+    description: {
+      story: 'Primary, Secondary & Tertiary buttons with an Icon on Right',
+    },
+  },
+};
+
+export const IconOnlyButton = ButtonWithVariantTemplate.bind({});
+IconOnlyButton.storyName = 'Icon Only';
+IconOnlyButton.args = {
+  icon: CreditCardIcon,
+  children: '',
+};
+IconOnlyButton.parameters = {
+  docs: {
+    description: {
+      story: 'Primary, Secondary & Tertiary buttons with only an Icon',
+    },
+  },
+};
+
+export const FullWidthButton = ButtonWithVariantTemplate.bind({});
+FullWidthButton.storyName = 'Full Width';
+FullWidthButton.args = {
+  isFullWidth: true,
+};
+FullWidthButton.parameters = {
+  docs: {
+    description: {
+      story: 'Primary, Secondary & Tertiary buttons with full width',
+    },
+  },
+};

--- a/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { Highlight } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import { Text } from '../Typography';
-import { SkipNavContent, SkipNavLink } from '.';
+import { SkipNavContent, SkipNavLink } from './SkipNav';
 
 const Page = (): ReactElement => {
   return (

--- a/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
+++ b/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
@@ -17,7 +17,7 @@ const getBaseTextStyles = ({
   font-style: ${fontStyle};
   text-decoration-line: ${textDecorationLine};
   line-height: ${lineHeight};
-  ${textAlign ? `text-align: ${textAlign};` : ''}
+  ${textAlign ? `text-align: ${textAlign};` : ''};
 `;
 
 export default getBaseTextStyles;


### PR DESCRIPTION
Renders similarly on native but ignores story descriptions

**Web:**
<img width="186" alt="Screenshot 2022-06-23 at 2 27 05 PM" src="https://user-images.githubusercontent.com/24487274/175260317-4160d0b1-15d4-4c0a-b113-98037db48816.png">

**Native:**
<img width="375" alt="Screenshot 2022-06-23 at 2 26 44 PM" src="https://user-images.githubusercontent.com/24487274/175260285-453dd865-6475-4fcc-9188-95708fc6256b.png">

