### PR TITLE
Updated the phases of DS image to latest stage

### DIFF
--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -62,4 +62,4 @@ This package is under **maintenance** and it won't have any major releases. It w
 # ⌛️ Current State
 
 Here's a glimpse of where we are currently in our journey of building the design system.
-![phases-of-ds](https://user-images.githubusercontent.com/11384858/154620767-882e7159-1122-4904-ad65-6ad0e6541b2b.png)
+![phases-of-ds](https://user-images.githubusercontent.com/4298450/178475659-ead9f003-72a2-46b2-8a41-e395fcf10a77.png)


### PR DESCRIPTION
### [Updated image on doc](https://github.com/razorpay/blade/blob/blade-guide-imgHotfix/packages/blade/docs/guides/Intro.stories.mdx#%EF%B8%8F-current-state)
Replaced the `phases of DS` image towards the end of the file.
![phases-of-ds](https://user-images.githubusercontent.com/4298450/178475659-ead9f003-72a2-46b2-8a41-e395fcf10a77.png)