### PR TITLE
fix(blade-old): remove unnecessary warning for `Checkbox` props

### DIFF
--- a/.changeset/early-mayflies-retire.md
+++ b/.changeset/early-mayflies-retire.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-old": patch
+---
+
+fix(checkbox): remove unnecessary warning for checkbox props

--- a/packages/blade-old/src/atoms/Checkbox/Checkbox.native.js
+++ b/packages/blade-old/src/atoms/Checkbox/Checkbox.native.js
@@ -228,7 +228,7 @@ Checkbox.propTypes = {
   onChange: PropTypes.func.isRequired,
   testID: PropTypes.string,
   helpText: (props, propName, componentName) => {
-    if (props.size === 'small') {
+    if (props.size === 'small' && props.helpText !== '') {
       return new Error(
         `[${propName}]. ${propName} is ignored as it is not supported when size is small in ${componentName}`,
       );
@@ -243,7 +243,7 @@ Checkbox.propTypes = {
     return null;
   },
   errorText: (props, propName, componentName) => {
-    if (props.size === 'small') {
+    if (props.size === 'small' && props.errorText !== '') {
       return new Error(
         `[${propName}]. ${propName} is ignored as it is not supported when size is small in ${componentName}`,
       );

--- a/packages/blade-old/src/atoms/Checkbox/Checkbox.web.js
+++ b/packages/blade-old/src/atoms/Checkbox/Checkbox.web.js
@@ -277,7 +277,7 @@ Checkbox.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
   helpText: (props, propName, componentName) => {
-    if (props.size === 'small') {
+    if (props.size === 'small' && props.errorText !== '') {
       return new Error(
         `[${propName}]. ${propName} is ignored as it is not supported when size is small in ${componentName}`,
       );
@@ -292,7 +292,7 @@ Checkbox.propTypes = {
     return null;
   },
   errorText: (props, propName, componentName) => {
-    if (props.size === 'small') {
+    if (props.size === 'small' && props.errorText !== '') {
       return new Error(
         `[${propName}]. ${propName} is ignored as it is not supported when size is small in ${componentName}`,
       );

--- a/packages/blade-old/src/atoms/Checkbox/Checkbox.web.js
+++ b/packages/blade-old/src/atoms/Checkbox/Checkbox.web.js
@@ -277,7 +277,7 @@ Checkbox.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
   helpText: (props, propName, componentName) => {
-    if (props.size === 'small' && props.errorText !== '') {
+    if (props.size === 'small' && props.helpText !== '') {
       return new Error(
         `[${propName}]. ${propName} is ignored as it is not supported when size is small in ${componentName}`,
       );


### PR DESCRIPTION
## Description

### Bug
The `<Checkbox />` component in `blade-old` gave the following unnecessary warning whenever we passed `size="small"` to it.
These used to come even if didn't pass these _optional_ props to `<Checkbox />` but passed `size` as "small".
For eg, using `<Checkbox />` as below gave an error in console & unit tests.
```jsx
<Checkbox
  testID="whatsapp-checkbox"
  size="small"
  title={translate('contactDetails.whatsappOptinCheckboxTitle')}
  checked={checked}
  onChange={onChange}
  disabled={disabled}
/>
```

1. Warning for `helpText`
```
console.error
    Warning: Failed prop type: [helpText]. helpText is ignored as it is not supported when size is small in Checkbox
        at Checkbox (/Users/ayush.gupta/Documents/rzp/pr-reviews/pr-frontend-mobile-app/node_modules/@razorpay/blade-old/src/atoms/Checkbox/Checkbox.native.js:105:3)
```

2. Warning for `errorText`
```
console.error
    Warning: Failed prop type: [errorText]. errorText is ignored as it is not supported when size is small in Checkbox
        at Checkbox (/Users/ayush.gupta/Documents/rzp/pr-reviews/pr-frontend-mobile-app/node_modules/@razorpay/blade-old/src/atoms/Checkbox/Checkbox.native.js:105:3)
```

### Fix
I added an additional check for the warning to only come when `size` is "small" but `helpText`/`errorText` shouldn't also be empty (default prop values).

## JIRA
[SSAB-226](https://razorpay.atlassian.net/browse/SSAB-226)