### PR TITLE
infra: disable dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: '/'
+    # disallow version update PRs, security updates have a separate limit configured from settings UI
+    open-pull-requests-limit: 0
     schedule:
       interval: daily
       time: '04:00'


### PR DESCRIPTION
Only security updates will happen now
- [Docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)

![image](https://user-images.githubusercontent.com/6682655/183004138-987ebb45-2616-430a-b36a-6e0a889c7e68.png)
