### PR TITLE
chore: fix path exact types

### DIFF
--- a/packages/blade/src/components/Icons/_Svg/Path/Path.d.ts
+++ b/packages/blade/src/components/Icons/_Svg/Path/Path.d.ts
@@ -1,6 +1,8 @@
-export type NonDashedProps<T> = {
-  [K in keyof T]: K extends `${string}-${string}` ? never : T[K];
-};
+// https://github.com/microsoft/TypeScript/issues/12936#issuecomment-368244671
+export type Exact<T, X extends T> = T &
+  {
+    [K in keyof X]: K extends keyof T ? X[K] : never;
+  };
 
 export type PathProps = {
   clipPath?: string;

--- a/packages/blade/src/components/Icons/_Svg/Path/Path.d.ts
+++ b/packages/blade/src/components/Icons/_Svg/Path/Path.d.ts
@@ -1,4 +1,20 @@
-// https://github.com/microsoft/TypeScript/issues/12936#issuecomment-368244671
+/**
+ * Exact<> type ensures that a generic function accepts exact props, no exccess props
+ * @see https://github.com/microsoft/TypeScript/issues/12936#issuecomment-368244671
+ * @example
+ *
+ * ```ts
+ * type UserOptions = { name: string; age: number };
+ *
+ * function makeUser<T extends UserOptions>(props: T) {}
+ * makeUser({ name: '', age: 1, nice: 2 });
+ * //                           ^ doesn't throw error
+ *
+ * function makeUserExact<T extends Exact<UserOptions, T>>(props: T) {}
+ * makeUserExact({ name: '', age: 1, nice: 2 });
+ * //                                ^ correctly throw error
+ * ```
+ */
 export type Exact<T, X extends T> = T &
   {
     [K in keyof X]: K extends keyof T ? X[K] : never;

--- a/packages/blade/src/components/Icons/_Svg/Path/Path.native.tsx
+++ b/packages/blade/src/components/Icons/_Svg/Path/Path.native.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from 'react';
 import { Path as PathNative } from 'react-native-svg';
-import type { NonDashedProps, PathProps } from './Path.d';
+import type { Exact, PathProps } from './Path.d';
 
-const Path = <T extends PathProps>({
+const Path = <Props extends Exact<PathProps, Props>>({
   d,
   clipPath,
   clipRule,
@@ -13,7 +13,7 @@ const Path = <T extends PathProps>({
   strokeLinecap,
   strokeLinejoin,
   strokeWidth,
-}: NonDashedProps<T>): ReactElement => {
+}: Props): ReactElement => {
   return (
     <PathNative
       d={d}

--- a/packages/blade/src/components/Icons/_Svg/Path/Path.web.tsx
+++ b/packages/blade/src/components/Icons/_Svg/Path/Path.web.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
-import type { PathProps, NonDashedProps } from './Path.d';
+import type { Exact, PathProps } from './Path.d';
 
-const Path = <T extends PathProps>({
+const Path = <Props extends Exact<PathProps, Props>>({
   d,
   clipPath,
   clipRule,
@@ -12,7 +12,7 @@ const Path = <T extends PathProps>({
   strokeLinecap,
   strokeLinejoin,
   strokeWidth,
-}: NonDashedProps<T>): ReactElement => {
+}: Props): ReactElement => {
   return (
     <path
       d={d}


### PR DESCRIPTION
- Adds an Exact<> type which will fix the edge cases in SVG Path props