### PR TITLE
docs(Installation): add styled-components as dependency

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -32,10 +32,10 @@ Before you install the package, make sure that you have performed following step
 
 ## ⬇️ Add blade to your application
 
-1. Install blade as a dependency
+1. Install blade as a dependency. Blade has a peer dependency on `styled-components`, you can skip adding it if you already have it installed in your project.
 
 ```shell
-yarn add @razorpay/blade
+yarn add @razorpay/blade styled-components
 ```
 
 2. Follow [this guide](#-install-fonts) to install the fonts.


### PR DESCRIPTION
Was testing out Blade on CRA, adds a missing step in installation