### PR TITLE
changed native text-input helptext color to improve contrast

### DIFF
--- a/.changeset/wild-ghosts-bake.md
+++ b/.changeset/wild-ghosts-bake.md
@@ -1,0 +1,6 @@
+---
+"@razorpay/blade": patch
+"@razorpay/blade-old": patch
+---
+
+changed native text-input helptext color

--- a/packages/blade-old/src/atoms/TextInput/CharacterCount.native.js
+++ b/packages/blade-old/src/atoms/TextInput/CharacterCount.native.js
@@ -8,9 +8,9 @@ import View from '../View';
 const styles = {
   color({ disabled }) {
     if (disabled) {
-      return 'shade.930';
+      return 'shade.940';
     } else {
-      return 'shade.950';
+      return 'shade.960';
     }
   },
 };

--- a/packages/blade-old/src/atoms/TextInput/Text.native.js
+++ b/packages/blade-old/src/atoms/TextInput/Text.native.js
@@ -9,11 +9,11 @@ import isEmpty from '../../_helpers/isEmpty';
 const styles = {
   color({ disabled, errorText }) {
     if (disabled) {
-      return 'shade.930';
+      return 'shade.940';
     } else if (!isEmpty(errorText)) {
       return 'negative.900';
     } else {
-      return 'shade.950';
+      return 'shade.960';
     }
   },
 };


### PR DESCRIPTION
## Description
- The text fields in pg-mobile app have helper text, character counter They are currently unreadable due to the font size and poor contrast.
- We have changed the helper text & character counter color value from `shade.950` to `shade.960`
- For disabled state color value changed from `shade.930` to `shade.940`
- This [document](https://docs.google.com/document/d/1qkblBEpZ7UZtpYF-5rGuYl1RI6joFeGbr13w4E614UU/edit) has the screenshots which are showing the changes for both pg-mobile and x-mobile app.
- [Slack thread](https://razorpay.slack.com/archives/C01HD2D4U14/p1660030157149279)

## JIRA
[SSAB-343](https://razorpay.atlassian.net/browse/SSAB-343)