### PR TITLE
fix: TextInput imports

### DIFF
--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -31,3 +31,6 @@ jobs:
       - name: Run TypeScript Checks
         run: yarn typecheck
         working-directory: packages/blade
+      - name: Build Blade
+        run: yarn build
+        working-directory: packages/blade

--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -25,7 +25,22 @@ type SpanProps = CommonProps & {
   htmlFor?: undefined;
 };
 
-export type FormLabelProps = LabelProps | SpanProps;
+type FormLabelProps = LabelProps | SpanProps;
+
+export type FormInputLabelProps = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Desktop only prop. Default value on mobile will be `top`
+   */
+  labelPosition?: 'left' | 'top';
+  /**
+   * Displays `(optional)` when `optional` is passed or `*` when `required` is passed
+   */
+  necessityIndicator?: 'required' | 'optional' | 'none';
+};
 
 const FormLabel = ({
   as = 'span',

--- a/packages/blade/src/components/Form/FormTypes.ts
+++ b/packages/blade/src/components/Form/FormTypes.ts
@@ -1,5 +1,3 @@
-import type { FormLabelProps } from './FormLabel';
-
 export type FormInputHandleOnEvent = ({
   name,
   value,
@@ -9,21 +7,6 @@ export type FormInputHandleOnEvent = ({
 }) => void;
 
 export type FormInputOnEvent = ({ name, value }: { name?: string; value?: string }) => void;
-
-export type FormInputLabelProps = {
-  /**
-   * Label to be shown for the input field
-   */
-  label: string;
-  /**
-   * Desktop only prop. Default value on mobile will be `top`
-   */
-  labelPosition?: FormLabelProps['position'];
-  /**
-   * Displays `(optional)` when `optional` is passed or `*` when `required` is passed
-   */
-  necessityIndicator?: FormLabelProps['necessityIndicator'];
-};
 
 export type FormInputValidationProps = {
   /**

--- a/packages/blade/src/components/Form/index.ts
+++ b/packages/blade/src/components/Form/index.ts
@@ -1,3 +1,9 @@
 export { FormHint } from './FormHint';
+export type { FormHintProps } from './FormHint';
 export { FormLabel } from './FormLabel';
-export * from './FormTypes';
+export type { FormInputLabelProps } from './FormLabel';
+export type {
+  FormInputHandleOnEvent,
+  FormInputOnEvent,
+  FormInputValidationProps,
+} from './FormTypes';

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import type { ReactNode } from 'react';
-import { StyledBaseInput } from './StyledBaseInput';
-import { BaseInputVisuals } from './BaseInputVisuals';
-import { BaseInputWrapper } from './BaseInputWrapper';
-import Box from '~components/Box';
-import { FormHint, FormLabel } from '~components/Form';
-import { getPlatformType, makeAccessible, useBreakpoint } from '~utils';
 import type {
   FormInputLabelProps,
   FormInputValidationProps,
   FormInputHandleOnEvent,
   FormInputOnEvent,
-} from '~components/Form';
-import type { FormHintProps } from '~components/Form/FormHint';
+  FormHintProps,
+} from '../../Form';
+import { StyledBaseInput } from './StyledBaseInput';
+import { BaseInputVisuals } from './BaseInputVisuals';
+import { BaseInputWrapper } from './BaseInputWrapper';
+import { FormHint, FormLabel } from '~components/Form';
+import type { IconComponent } from '~components/Icons';
+import Box from '~components/Box';
+
+import { getPlatformType, makeAccessible, useBreakpoint } from '~utils';
 import { useFormId } from '~components/Form/useFormId';
 import { useTheme } from '~components/BladeProvider';
-import type { IconComponent } from '~components/Icons';
 import useInteraction from '~src/hooks/useInteraction';
 
 export type BaseInputProps = FormInputLabelProps &

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import type { TextInput as TextInputReactNative } from 'react-native';
-import type { BaseInputProps } from '~components/Input/BaseInput';
+import type { BaseInputProps } from '../BaseInput';
 import { BaseInput } from '~components/Input/BaseInput';
 import type { IconComponent } from '~components/Icons';
 import { InfoIcon, CloseIcon } from '~components/Icons';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6642,7 +6642,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.38", "@types/react@>=16.0.0", "@types/react@>=16.9.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@>=16.9.0":
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
   integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
@@ -6657,6 +6657,15 @@
   integrity sha512-jJjHo1uOe+NENRIBvF46tJimUvPnmbQ41Ax0pEm7pRvhPg+wuj8VMOHHiMvaGmZRzRrCtm7KnL5OOE/6kHPK8w==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
+  integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/react@17.0.4":


### PR DESCRIPTION
Issue: aliased imports from `~components/Form` breaks the type generation

Workaround(not ideal but unblocking release for now): replace alias imports with relative imports `~components/Form` ➡️ `../../Form`