### PR TITLE
feat: add easier to remember npm scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ These steps should get you up and started for local development setup. Please en
 - Run storybook for web:
 
   ```sh
-  yarn react
+  yarn start:web
   ```
 
 - That's it!
@@ -60,16 +60,10 @@ These steps should get you up and started for local development setup. Please en
   >
   > Follow the note [here](https://reactnative.dev/docs/environment-setup#cocoapods) if you're using M1
 
-- `cd` back to `packages/blade`. Start the storybook server for React Native:
+- `cd` back to `packages/blade`. Start storybook dev-server for ios-
 
   ```sh
-  yarn react-native:storybook:start
-  ```
-
-- Keep the process running and in a new tab or terminal window start the storybook app on iOS:
-
-  ```sh
-  yarn react-native:storybook:ios
+  yarn start:ios
   ```
 
   > **Tip:**
@@ -93,17 +87,17 @@ These steps should get you up and started for local development setup. Please en
   >
   > At times, you might run into some weird issues during installation. Sometimes restarting your computer does the trick. You can also `cd` into the `android` directory and run `./gradlew clean` to clean up cache and built files when retrying installation or running the app.
 
-- `cd` back to `packages/blade`. Start the storybook server for React Native:
+- `cd` back to `packages/blade`. Start the storybook dev-server for android:
 
   ```sh
-  yarn react-native:storybook:start
+  yarn start:android
   ```
 
-- Start up the emulator from Android Studio (sometimes it doesn't auto boot). Keep the process running and in a new tab or terminal window start the storybook app on Android:
-
-  ```sh
-  yarn react-native:storybook:android
-  ```
+  > **Note**
+  >
+  > If you already have `yarn start:ios` running, you might have to close it since `yarn start:android` will try to run react-native server on the same port and fail with port taken error.
+  > 
+  > If you want to run both, android and ios at the same time, you can use `yarn start:native` instead.
 
   > **Note**
   >
@@ -125,6 +119,7 @@ These steps should get you up and started for local development setup. Please en
     }
   }
   ```
+- You can use `yarn start:all` command to run storybooks on all platforms like web, android, and ios (better to not use it in development though to avoid stressing your laptop)
 
 ## Troubleshooting guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ These steps should get you up and started for local development setup. Please en
   >
   > Follow the note [here](https://reactnative.dev/docs/environment-setup#cocoapods) if you're using M1
 
-- `cd` back to `packages/blade`. Start storybook dev-server for ios-
+- `cd` back to `packages/blade`. Start storybook dev-server for ios:
 
   ```sh
   yarn start:ios

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -55,6 +55,11 @@
     "react": "yarn run react:storybook",
     "react:storybook": "FRAMEWORK=REACT start-storybook -c ./.storybook/react -p 9009",
     "react:storybook:build": "FRAMEWORK=REACT build-storybook -c ./.storybook/react -o storybook-site",
+    "start:ios": "run-p react-native:storybook:start react-native:storybook:ios",
+    "start:android": "run-p react-native:storybook:start react-native:storybook:android",
+    "start:native": "run-p react-native:storybook:start react-native:storybook:android react-native:storybook:ios",
+    "start:web": "yarn react",
+    "start:all": "run-p start:native start:web",
     "chromatic": "npx chromatic"
   },
   "dependencies": {


### PR DESCRIPTION
Added npm scripts that are a bit easier to remember. Now single commands like `yarn start:ios` and `yarn start:android` can run emulator and server both.

Also added `yarn start:all` to run everything everywhere and `yarn start:native` to run android and ios at the same time.