### PR TITLE
feat(Code): update API decisions for `Code` and `Text`

### DIFF
--- a/packages/blade/src/components/Typography/_decisions/decisions.md
+++ b/packages/blade/src/components/Typography/_decisions/decisions.md
@@ -106,7 +106,7 @@ Another option would be having a `size` prop that would lead us to have a "large
 
   ```jsx
   <Text
-    variant=" medium | large | caption"
+    variant="body | caption"
     weight="regular | bold"
     size="small | medium"
     type="normal | subtle | subdued | muted | placeholder"
@@ -130,7 +130,7 @@ Type of `children: React.ReactNode`
   Text will internally use `BaseText` to render. Natively we'll use html `<code></code>` tag for web and native `<Text></Text>` react-native to render the code text.
 
   ```jsx
-  <Code variant="large | caption" type="normal | subtle | subdued | muted | placeholder">
+  <Code variant="large | medium" type="normal | subtle | subdued | muted | placeholder">
     SENTRY_AUTH_TOKEN:xyz
   </Code>
   ```

--- a/packages/blade/src/components/Typography/_decisions/decisions.md
+++ b/packages/blade/src/components/Typography/_decisions/decisions.md
@@ -130,7 +130,11 @@ Type of `children: React.ReactNode`
   Text will internally use `BaseText` to render. Natively we'll use html `<code></code>` tag for web and native `<Text></Text>` react-native to render the code text.
 
   ```jsx
-  <Code variant="large | medium" type="normal | subtle | subdued | muted | placeholder">
+  <Code size="large | medium" type="normal | subtle | subdued | muted | placeholder">
     SENTRY_AUTH_TOKEN:xyz
   </Code>
   ```
+
+  Using `size` here because that is what we use in `Text` as well and symantically `size="large"` makes a lot more sense.
+
+  In future, we want to make `size` as a consistent prop for sizing all components and use `variant` for values that can't be added to size.


### PR DESCRIPTION
## For Text

In implementation, I can see we're using `body | caption` instead of `medium | large | caption`. In decisions it doesn't seem updated so added it here. Need to confirm with Kamlesh if that is expected.

## For Code

Mostly the previous decisions look good to me. I've only changed `variant` prop to `size` and changed value from `caption` to `medium` because that is what I see on Figma file. Don't see `caption` variant anywhere there.

<img width="510" alt="image" src="https://user-images.githubusercontent.com/30949385/190597582-24760e06-b049-4c00-a5c8-2432676e8109.png">
