### PR TITLE
fix(BaseInput): use cursor not-allowed for disabled inputs

### DIFF
--- a/.changeset/spicy-mails-doubt.md
+++ b/.changeset/spicy-mails-doubt.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(BaseInput): use cursor not-allowed for disabled inputs

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
@@ -35,6 +35,7 @@ const StyledBaseNativeInput = styled.input<
   ':focus': {
     outline: 'none',
   },
+  cursor: props.disabled ? 'not-allowed' : 'auto',
 }));
 
 const autoCompleteSuggestionTypeMap = {

--- a/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.web.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`<BaseInput /> should render 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c9::-webkit-input-placeholder {
@@ -488,6 +489,7 @@ exports[`<BaseInput /> should render with icons 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c11::-webkit-input-placeholder {

--- a/packages/blade/src/components/Input/PasswordField/__tests__/__snapshots__/PasswordField.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/PasswordField/__tests__/__snapshots__/PasswordField.web.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`<PasswordField /> should render 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c9::-webkit-input-placeholder {

--- a/packages/blade/src/components/Input/TextArea/__tests__/__snapshots__/TextArea.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/TextArea/__tests__/__snapshots__/TextArea.web.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`<TextArea /> should render 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c9::-webkit-input-placeholder {
@@ -472,6 +473,7 @@ exports[`<TextArea /> should set number of lines 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c9::-webkit-input-placeholder {

--- a/packages/blade/src/components/Input/TextInput/__tests__/__snapshots__/TextInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/TextInput/__tests__/__snapshots__/TextInput.web.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`<TextInput /> should render 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c9::-webkit-input-placeholder {
@@ -505,6 +506,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
   resize: none;
   outline: none;
   border: none;
+  cursor: auto;
 }
 
 .c13::-webkit-input-placeholder {


### PR DESCRIPTION
## Screenshots

| PasswordField | TextInput |
| - | - |
|  <img width="1512" alt="Screen Shot 2022-09-22 at 13 00 43" src="https://user-images.githubusercontent.com/6682655/191685738-880ba662-2393-43e6-807a-d19e9ef5ef9f.png"> | <img width="1512" alt="Screen Shot 2022-09-22 at 13 00 57" src="https://user-images.githubusercontent.com/6682655/191685773-3e9b1a6e-5fec-43ec-850a-7024e378d374.png"> |
