### PR TITLE
chore: add vscode settings import exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,3 @@ buck-out/
 
 # CocoaPods
 **/ios/Pods/
-
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.preferences.autoImportFileExcludePatterns": [
+    "**/**/*.stories.tsx",
+    "**/**/*.stories.internal.tsx",
+    "**/storybook-recipes",
+    "packages/blade/src/components/index.ts",
+    "@testing-library/user-event/dist/types/**",
+    "@storybook/*",
+  ]
+}


### PR DESCRIPTION
Adds vscode settings with import exclusions. 

So we get the benefit of [TS4.8 auto exclude imports ](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#exclude-globs-auto-import)