### PR TITLE
feat(Typography)!: make `Heading`, `Title`, and `Text` API consistent

### DIFF
--- a/.changeset/five-tomatoes-try.md
+++ b/.changeset/five-tomatoes-try.md
@@ -1,23 +1,27 @@
 ---
-"@razorpay/blade": major
+'@razorpay/blade': major
 ---
 
 feat(Typography): make `size` prop consistent for `Heading`, `Title`, and `Text`
 
 > **Note**
 >
-> Breaking Change! 
+> Breaking Change!
 > This is a breaking change for apps that are using `Title` or `Heading` component from blade. Rest of the apps can upgrade without any migrations.
 
 #### Migration
 
+_**Tip:** If you're using TypeScript, run `yarn tsc` and that should throw errors wherever a change is required._
+
 1. **`<Title />`:** Rename `variant` prop to `size` in Title
+
 ```diff
 - <Title variant="small">Some Title</Title>
 + <Title size="small">Some Title</Title>
 ```
 
-2. **`<Heading />`:** Rename `variant` prop to `size` if the value is `small`, `medium,` or `large`. No change is on `variant="subheading"`.
+2. **`<Heading />`:** Rename `variant` prop to `size` if the value is `small`, `medium,` or `large`. No change is required on `variant="subheading"`.
+
 ```diff
 <Heading variant="subheading">Nothing changes here</Heading> // No change here
 

--- a/.changeset/five-tomatoes-try.md
+++ b/.changeset/five-tomatoes-try.md
@@ -1,0 +1,39 @@
+---
+"@razorpay/blade": major
+---
+
+feat(Typography): make `size` prop consistent for `Heading`, `Title`, and `Text`
+
+> **Note**
+>
+> Breaking Change! 
+> This is a breaking change for apps that are using `Title` or `Heading` component from blade. Rest of the apps can upgrade without any migrations.
+
+#### Migration
+
+1. **`<Title />`:** Rename `variant` prop to `size` in Title
+```diff
+- <Title variant="small">Some Title</Title>
++ <Title size="small">Some Title</Title>
+```
+
+2. **`<Heading />`:** Rename `variant` prop to `size` if the value is `small`, `medium,` or `large`. No change is on `variant="subheading"`.
+```diff
+<Heading variant="subheading">Nothing changes here</Heading> // No change here
+
+- <Heading variant="medium">Medium Heading</Heading>
++ <Heading size="medium">Medium Heading</Heading>
+```
+
+##### Edge Cases
+
+Make sure to follow migration on new component if `Title` or `Heading` from blade is overriden with styled-components.
+
+```diff
+const MyTitle = styled(Title)`
+  // some styles
+`
+
+- <MyTitle variant="large" />
++ <MyTitle size="large" />
+```

--- a/.changeset/five-tomatoes-try.md
+++ b/.changeset/five-tomatoes-try.md
@@ -4,7 +4,7 @@
 
 feat(Typography): make `size` prop consistent for `Heading`, `Title`, and `Text`
 
-> **Note**
+> **Warning**
 >
 > Breaking Change!
 > This is a breaking change for apps that are using `Title` or `Heading` component from blade. Rest of the apps can upgrade without any migrations.

--- a/packages/blade/src/components/Alert/Alert.tsx
+++ b/packages/blade/src/components/Alert/Alert.tsx
@@ -135,7 +135,7 @@ const Alert = ({
 
   const _title = title ? (
     <Box marginBottom="spacing.2">
-      <Heading variant="small" contrast={contrast}>
+      <Heading size="small" contrast={contrast}>
         {title}
       </Heading>
     </Box>

--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -57,6 +57,11 @@ const HeadingStoryMeta: Meta<HeadingProps<{ variant: 'regular' | 'subheading' }>
     weight: 'bold',
     contrast: 'low',
   },
+  argTypes: {
+    size: {
+      description: 'Decides size of the Heading',
+    },
+  },
   parameters: {
     docs: {
       page: () => <Page />,

--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -46,13 +46,12 @@ const Page = (): ReactElement => {
   );
 };
 
-const HeadingStoryMeta: Meta<
-  HeadingProps<{ variant: 'small' | 'medium' | 'large' | 'subheading' }>
-> = {
+const HeadingStoryMeta: Meta<HeadingProps<{ variant: 'regular' | 'subheading' }>> = {
   title: 'Components/Typography/Heading',
   component: HeadingComponent,
   args: {
-    variant: 'large',
+    variant: 'regular',
+    size: 'large',
     type: 'normal',
     children: 'Get Started With Payment Gateway',
     weight: 'bold',

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -23,6 +23,9 @@ type HeadingNormalVariant = HeadingCommonProps & {
 
 type HeadingSubHeadingVariant = HeadingCommonProps & {
   variant?: Extract<HeadingVariant, 'subheading'>;
+  /**
+   * `size` cannot be used with variant="subheading". Either change to variant="regular" or remove size prop
+   */
   size?: undefined;
   weight?: keyof Pick<Theme['typography']['fonts']['weight'], 'bold'>;
 };

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -67,7 +67,7 @@ const getProps = <T extends { variant: HeadingVariant }>({
   };
 
   if (variant === 'regular') {
-    if (size === 'small') {
+    if (!size || size === 'small') {
       props.fontSize = 200;
       props.lineHeight = '2xl';
       props.as = isPlatformWeb ? 'h6' : undefined;
@@ -84,6 +84,11 @@ const getProps = <T extends { variant: HeadingVariant }>({
     if (weight === 'regular') {
       throw new Error(`[Blade: Heading]: weight cannot be 'regular' when variant is 'subheading'`);
     }
+    if (size) {
+      throw new Error(
+        `[Blade: Heading]: size prop cannot be added when variant is 'subheading'. Use variant 'regular' or remove size prop`,
+      );
+    }
     props.fontSize = 75;
     props.lineHeight = 's';
     props.as = isPlatformWeb ? 'h6' : undefined;
@@ -94,7 +99,7 @@ const getProps = <T extends { variant: HeadingVariant }>({
 
 export const Heading = <T extends { variant: HeadingVariant }>({
   variant = 'regular',
-  size = 'small',
+  size, // Not setting default value since the `size` should be undefined with variant="subheading"
   type = 'normal',
   weight = 'bold',
   contrast = 'low',

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -17,6 +17,10 @@ type HeadingCommonProps = {
 
 type HeadingNormalVariant = HeadingCommonProps & {
   variant?: Exclude<HeadingVariant, 'subheading'>;
+  /**
+   *
+   * @default small
+   */
   size?: HeadingSize;
   weight?: keyof Theme['typography']['fonts']['weight'];
 };

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -6,7 +6,8 @@ import type { ColorContrast, ColorContrastTypes, TextTypes } from '~tokens/theme
 import { getPlatformType } from '~utils';
 import type { Theme } from '~components/BladeProvider';
 
-type HeadingVariant = 'small' | 'medium' | 'large' | 'subheading';
+type HeadingVariant = 'regular' | 'subheading';
+type HeadingSize = 'small' | 'medium' | 'large';
 
 type HeadingCommonProps = {
   type?: TextTypes;
@@ -16,11 +17,13 @@ type HeadingCommonProps = {
 
 type HeadingNormalVariant = HeadingCommonProps & {
   variant?: Exclude<HeadingVariant, 'subheading'>;
+  size?: HeadingSize;
   weight?: keyof Theme['typography']['fonts']['weight'];
 };
 
 type HeadingSubHeadingVariant = HeadingCommonProps & {
   variant?: Extract<HeadingVariant, 'subheading'>;
+  size?: undefined;
   weight?: keyof Pick<Theme['typography']['fonts']['weight'], 'bold'>;
 };
 
@@ -40,10 +43,11 @@ export type HeadingProps<T> = T extends {
 
 const getProps = <T extends { variant: HeadingVariant }>({
   variant,
+  size,
   type,
   weight,
   contrast,
-}: Pick<HeadingProps<T>, 'variant' | 'type' | 'weight' | 'contrast'>): Omit<
+}: Pick<HeadingProps<T>, 'variant' | 'size' | 'type' | 'weight' | 'contrast'>): Omit<
   BaseTextProps,
   'children'
 > => {
@@ -59,18 +63,20 @@ const getProps = <T extends { variant: HeadingVariant }>({
     accessibilityProps: isPlatformWeb ? {} : { role: 'heading' },
   };
 
-  if (variant === 'small') {
-    props.fontSize = 200;
-    props.lineHeight = '2xl';
-    props.as = isPlatformWeb ? 'h6' : undefined;
-  } else if (variant === 'medium') {
-    props.fontSize = 300;
-    props.lineHeight = '3xl';
-    props.as = isPlatformWeb ? 'h5' : undefined;
-  } else if (variant === 'large') {
-    props.fontSize = 400;
-    props.lineHeight = '3xl';
-    props.as = isPlatformWeb ? 'h4' : undefined;
+  if (variant === 'regular') {
+    if (size === 'small') {
+      props.fontSize = 200;
+      props.lineHeight = '2xl';
+      props.as = isPlatformWeb ? 'h6' : undefined;
+    } else if (size === 'medium') {
+      props.fontSize = 300;
+      props.lineHeight = '3xl';
+      props.as = isPlatformWeb ? 'h5' : undefined;
+    } else if (size === 'large') {
+      props.fontSize = 400;
+      props.lineHeight = '3xl';
+      props.as = isPlatformWeb ? 'h4' : undefined;
+    }
   } else if (variant === 'subheading') {
     if (weight === 'regular') {
       throw new Error(`[Blade: Heading]: weight cannot be 'regular' when variant is 'subheading'`);
@@ -84,12 +90,13 @@ const getProps = <T extends { variant: HeadingVariant }>({
 };
 
 export const Heading = <T extends { variant: HeadingVariant }>({
-  variant = 'small',
+  variant = 'regular',
+  size = 'small',
   type = 'normal',
   weight = 'bold',
   contrast = 'low',
   children,
 }: HeadingProps<T>): ReactElement => {
-  const props = getProps({ variant, type, weight, contrast });
+  const props = getProps({ variant, size, type, weight, contrast });
   return <BaseText {...props}>{children}</BaseText>;
 };

--- a/packages/blade/src/components/Typography/Heading/__tests__/Heading.native.test.tsx
+++ b/packages/blade/src/components/Typography/Heading/__tests__/Heading.native.test.tsx
@@ -13,10 +13,10 @@ describe('<Heading />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "small" and contrast "high"', () => {
+  it('should render Heading with size "small" and contrast "high"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { toJSON, getByText } = renderWithTheme(
-      <Heading type="normal" variant="small" weight="regular" contrast="high">
+      <Heading type="normal" size="small" weight="regular" contrast="high">
         {displayText}
       </Heading>,
     );
@@ -24,10 +24,10 @@ describe('<Heading />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "small"', () => {
+  it('should render Heading with size "small"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { toJSON, getByText } = renderWithTheme(
-      <Heading type="normal" variant="small" weight="regular">
+      <Heading type="normal" size="small" weight="regular">
         {displayText}
       </Heading>,
     );
@@ -35,10 +35,10 @@ describe('<Heading />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "medium"', () => {
+  it('should render Heading with size "medium"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { toJSON, getByText } = renderWithTheme(
-      <Heading type="muted" variant="medium" weight="regular">
+      <Heading type="muted" size="medium" weight="regular">
         {displayText}
       </Heading>,
     );
@@ -46,10 +46,10 @@ describe('<Heading />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "large"', () => {
+  it('should render Heading with size "large"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { toJSON, getByText } = renderWithTheme(
-      <Heading type="subdued" variant="large" weight="regular">
+      <Heading type="subdued" size="large" weight="regular">
         {displayText}
       </Heading>,
     );

--- a/packages/blade/src/components/Typography/Heading/__tests__/Heading.native.test.tsx
+++ b/packages/blade/src/components/Typography/Heading/__tests__/Heading.native.test.tsx
@@ -85,4 +85,22 @@ describe('<Heading />', () => {
       }
     }
   });
+
+  it('should throw error when variant is "subheading" but weight "regular" is passed', () => {
+    try {
+      const displayText = 'Get Started With Payment Gateway';
+      renderWithTheme(
+        // @ts-expect-error testing failure case when size is passed with variant='subheading'
+        <Heading type="normal" variant="subheading" size="small">
+          {displayText}
+        </Heading>,
+      );
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(error.message).toMatchInlineSnapshot(
+          `"[Blade: Heading]: size prop cannot be added when variant is 'subheading'. Use variant 'regular' or remove size prop"`,
+        );
+      }
+    }
+  });
 });

--- a/packages/blade/src/components/Typography/Heading/__tests__/Heading.web.test.tsx
+++ b/packages/blade/src/components/Typography/Heading/__tests__/Heading.web.test.tsx
@@ -15,10 +15,10 @@ describe('<Heading />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "small" and contrast "high"', () => {
+  it('should render Heading with size "small" and contrast "high"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Heading type="normal" variant="small" weight="regular" contrast="high">
+      <Heading type="normal" size="small" weight="regular" contrast="high">
         {displayText}
       </Heading>,
     );
@@ -27,10 +27,10 @@ describe('<Heading />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "small"', () => {
+  it('should render Heading with size "small"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Heading type="normal" variant="small" weight="regular">
+      <Heading type="normal" size="small" weight="regular">
         {displayText}
       </Heading>,
     );
@@ -39,10 +39,10 @@ describe('<Heading />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "medium"', () => {
+  it('should render Heading with size "medium"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Heading type="muted" variant="medium" weight="regular">
+      <Heading type="muted" size="medium" weight="regular">
         {displayText}
       </Heading>,
     );
@@ -51,10 +51,10 @@ describe('<Heading />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render Heading with variant "large"', () => {
+  it('should render Heading with size "large"', () => {
     const displayText = 'Get Started With Payment Gateway';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Heading type="subdued" variant="large" weight="regular">
+      <Heading type="subdued" size="large" weight="regular">
         {displayText}
       </Heading>,
     );

--- a/packages/blade/src/components/Typography/Heading/__tests__/Heading.web.test.tsx
+++ b/packages/blade/src/components/Typography/Heading/__tests__/Heading.web.test.tsx
@@ -93,6 +93,24 @@ describe('<Heading />', () => {
     }
   });
 
+  it('should throw error when variant is "subheading" but size is defined', () => {
+    try {
+      const displayText = 'Get Started With Payment Gateway';
+      renderWithTheme(
+        // @ts-expect-error testing failure case when size is passed with variant='subheading'
+        <Heading type="normal" variant="subheading" size="large">
+          {displayText}
+        </Heading>,
+      );
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        expect(error.message).toMatchInlineSnapshot(
+          `"[Blade: Heading]: size prop cannot be added when variant is 'subheading'. Use variant 'regular' or remove size prop"`,
+        );
+      }
+    }
+  });
+
   it('should be accessible', async () => {
     const { container } = renderWithTheme(<Heading>Text content</Heading>);
     await assertAccessible(container);

--- a/packages/blade/src/components/Typography/Heading/__tests__/__snapshots__/Heading.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Heading/__tests__/__snapshots__/Heading.native.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<Heading /> should render Heading with default properties 1`] = `
 </Text>
 `;
 
-exports[`<Heading /> should render Heading with variant "large" 1`] = `
+exports[`<Heading /> should render Heading with size "large" 1`] = `
 <Text
   accessibilityRole="header"
   color="surface.text.subdued.lowContrast"
@@ -72,7 +72,7 @@ exports[`<Heading /> should render Heading with variant "large" 1`] = `
 </Text>
 `;
 
-exports[`<Heading /> should render Heading with variant "medium" 1`] = `
+exports[`<Heading /> should render Heading with size "medium" 1`] = `
 <Text
   accessibilityRole="header"
   color="surface.text.muted.lowContrast"
@@ -108,7 +108,7 @@ exports[`<Heading /> should render Heading with variant "medium" 1`] = `
 </Text>
 `;
 
-exports[`<Heading /> should render Heading with variant "small" 1`] = `
+exports[`<Heading /> should render Heading with size "small" 1`] = `
 <Text
   accessibilityRole="header"
   color="surface.text.normal.lowContrast"
@@ -144,7 +144,7 @@ exports[`<Heading /> should render Heading with variant "small" 1`] = `
 </Text>
 `;
 
-exports[`<Heading /> should render Heading with variant "small" and contrast "high" 1`] = `
+exports[`<Heading /> should render Heading with size "small" and contrast "high" 1`] = `
 <Text
   accessibilityRole="header"
   color="surface.text.normal.highContrast"

--- a/packages/blade/src/components/Typography/Heading/__tests__/__snapshots__/Heading.web.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Heading/__tests__/__snapshots__/Heading.web.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Heading /> should render Heading with default properties 1`] = `
 </div>
 `;
 
-exports[`<Heading /> should render Heading with variant "large" 1`] = `
+exports[`<Heading /> should render Heading with size "large" 1`] = `
 .c0 {
   color: hsla(217,18%,45%,1);
   font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -58,7 +58,7 @@ exports[`<Heading /> should render Heading with variant "large" 1`] = `
 </div>
 `;
 
-exports[`<Heading /> should render Heading with variant "medium" 1`] = `
+exports[`<Heading /> should render Heading with size "medium" 1`] = `
 .c0 {
   color: hsla(216,16%,60%,1);
   font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -87,7 +87,7 @@ exports[`<Heading /> should render Heading with variant "medium" 1`] = `
 </div>
 `;
 
-exports[`<Heading /> should render Heading with variant "small" 1`] = `
+exports[`<Heading /> should render Heading with size "small" 1`] = `
 .c0 {
   color: hsla(217,56%,17%,1);
   font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -116,7 +116,7 @@ exports[`<Heading /> should render Heading with variant "small" 1`] = `
 </div>
 `;
 
-exports[`<Heading /> should render Heading with variant "small" and contrast "high" 1`] = `
+exports[`<Heading /> should render Heading with size "small" and contrast "high" 1`] = `
 .c0 {
   color: hsla(0,0%,100%,1);
   font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";

--- a/packages/blade/src/components/Typography/Title/Title.stories.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.stories.tsx
@@ -59,7 +59,7 @@ const TitleStoryMeta: Meta<TitleProps> = {
   title: 'Components/Typography/Title',
   component: TitleComponent,
   args: {
-    variant: 'large',
+    size: 'large',
     type: 'normal',
     children: 'Power your finance, grow your business',
     contrast: 'low',

--- a/packages/blade/src/components/Typography/Title/Title.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.tsx
@@ -5,17 +5,17 @@ import type { ColorContrast, ColorContrastTypes, TextTypes } from '~tokens/theme
 import { getPlatformType } from '~utils';
 
 export type TitleProps = {
-  variant?: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium' | 'large';
   contrast?: ColorContrastTypes;
   type?: TextTypes;
   children: string;
 };
 
 const getProps = ({
-  variant,
+  size,
   type,
   contrast,
-}: Pick<TitleProps, 'variant' | 'type' | 'contrast'>): Omit<BaseTextProps, 'children'> => {
+}: Pick<TitleProps, 'size' | 'type' | 'contrast'>): Omit<BaseTextProps, 'children'> => {
   const isPlatformWeb = getPlatformType() === 'browser' || getPlatformType() === 'node';
   const colorContrast: keyof ColorContrast = contrast ? `${contrast}Contrast` : 'lowContrast';
   const props: Omit<BaseTextProps, 'children'> = {
@@ -28,15 +28,15 @@ const getProps = ({
     accessibilityProps: isPlatformWeb ? {} : { role: 'heading' },
   };
 
-  if (variant === 'small') {
+  if (size === 'small') {
     props.fontSize = 600;
     props.lineHeight = '4xl';
     props.as = isPlatformWeb ? 'h3' : undefined;
-  } else if (variant === 'medium') {
+  } else if (size === 'medium') {
     props.fontSize = 700;
     props.lineHeight = '4xl';
     props.as = isPlatformWeb ? 'h2' : undefined;
-  } else if (variant === 'large') {
+  } else if (size === 'large') {
     props.fontSize = 1000;
     props.lineHeight = '6xl';
     props.as = isPlatformWeb ? 'h1' : undefined;
@@ -46,11 +46,11 @@ const getProps = ({
 };
 
 export const Title = ({
-  variant = 'small',
+  size = 'small',
   type = 'normal',
   contrast = 'low',
   children,
 }: TitleProps): ReactElement => {
-  const props = getProps({ variant, type, contrast });
+  const props = getProps({ size, type, contrast });
   return <BaseText {...props}>{children}</BaseText>;
 };

--- a/packages/blade/src/components/Typography/Title/__tests__/Title.native.test.tsx
+++ b/packages/blade/src/components/Typography/Title/__tests__/Title.native.test.tsx
@@ -16,7 +16,7 @@ describe('<Title />', () => {
   it('should render Title with variant "small" and contrast "high"', () => {
     const displayText = 'Displaying Landing Screen Title';
     const { toJSON, getByText } = renderWithTheme(
-      <Title type="normal" variant="small" contrast="high">
+      <Title type="normal" size="small" contrast="high">
         {displayText}
       </Title>,
     );
@@ -27,7 +27,7 @@ describe('<Title />', () => {
   it('should render Title with variant "small"', () => {
     const displayText = 'Displaying Landing Screen Title';
     const { toJSON, getByText } = renderWithTheme(
-      <Title type="normal" variant="small">
+      <Title type="normal" size="small">
         {displayText}
       </Title>,
     );
@@ -38,7 +38,7 @@ describe('<Title />', () => {
   it('should render Title with variant "medium"', () => {
     const displayText = 'Displaying Landing Screen Title';
     const { toJSON, getByText } = renderWithTheme(
-      <Title type="muted" variant="medium">
+      <Title type="muted" size="medium">
         {displayText}
       </Title>,
     );
@@ -49,7 +49,7 @@ describe('<Title />', () => {
   it('should render Title with variant "large"', () => {
     const displayText = 'Displaying Landing Screen Title';
     const { toJSON, getByText } = renderWithTheme(
-      <Title type="subdued" variant="large">
+      <Title type="subdued" size="large">
         {displayText}
       </Title>,
     );

--- a/packages/blade/src/components/Typography/Title/__tests__/Title.web.test.tsx
+++ b/packages/blade/src/components/Typography/Title/__tests__/Title.web.test.tsx
@@ -18,7 +18,7 @@ describe('<Title />', () => {
   it('should render Title with variant "small" and contrast "high"', () => {
     const displayText = 'Displaying Landing Page Title';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Title type="normal" variant="small" contrast="high">
+      <Title type="normal" size="small" contrast="high">
         {displayText}
       </Title>,
     );
@@ -30,7 +30,7 @@ describe('<Title />', () => {
   it('should render Title with variant "small"', () => {
     const displayText = 'Displaying Landing Page Title';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Title type="normal" variant="small">
+      <Title type="normal" size="small">
         {displayText}
       </Title>,
     );
@@ -42,7 +42,7 @@ describe('<Title />', () => {
   it('should render Title with variant "medium"', () => {
     const displayText = 'Displaying Landing Page Title';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Title type="muted" variant="medium">
+      <Title type="muted" size="medium">
         {displayText}
       </Title>,
     );
@@ -54,7 +54,7 @@ describe('<Title />', () => {
   it('should render Title with variant "large"', () => {
     const displayText = 'Displaying Landing Page Title';
     const { container, getByRole, getByText } = renderWithTheme(
-      <Title type="subdued" variant="large">
+      <Title type="subdued" size="large">
         {displayText}
       </Title>,
     );


### PR DESCRIPTION
> **Warning**
>
> Breaking Change. Changes the prop names and values in some Typography components.

## Problem

Slack Discussion - https://razorpay.slack.com/archives/G01B3LQ9H0W/p1663325670139239?thread_ts=1663318580.283669&cid=G01B3LQ9H0W

Currently the API for typography components is not consistent with each other. For e.g. - 
```jsx
<>
  <Title variant="medium">Medium Title</Title>
  <Heading variant="small">Small Heading</Heading>
  <Text size="small">Small Text</Text>
</>
```

As you can see some component use `variant` for deciding the size whereas `Text` uses `size`.

## Changes

- In `Title`: Rename `variant` to `size`
- In `Heading`: Add `variant="regular"` and add size with `small | medium | large` type

## New Code

All typography components will now use `size` prop for deciding the size. 

```jsx
<>
  <Title size="medium">Medium Title</Title>
  <Heading size="small" variant="regular">Small Heading</Heading>
  <Text size="small">Small Text</Text>
</>
```

## Error Handling

This change adds one scenario where someone can add `subheading` and `size` both at the same time which is invalid.

```jsx
<Heading variant="subheading" size="small">Small Heading</Heading>
```

The TS will handle this scenario and show type error
<img width="933" alt="image" src="https://user-images.githubusercontent.com/30949385/193001538-e7885326-b822-49ba-a6f0-71cc9b93605e.png">
