### PR TITLE
fix(Link.stories.js): ignore semgrep on Link stories

### DIFF
--- a/packages/blade-old/src/atoms/Link/Link.stories.js
+++ b/packages/blade-old/src/atoms/Link/Link.stories.js
@@ -24,7 +24,7 @@ storiesOf('Link', module)
   .add('default', () => (
     <Link
       size={select('Size', sizeOptions, 'large')}
-      //@ts-expect-error
+      // nosemgrep
       href={text('Href', 'https://razorpay.com', 'Web')}
       target={select('Target', targetOptions, 'link', 'Web')}
       rel={text('Rel', 'author', 'Web')}


### PR DESCRIPTION
Some Security semgrep check is failing on master. I am ignoring it for now since it's just a storybook file and that too from old blade repo.

Removed the `@ts-expect-error` because there isn't any TS error on that file so don't think so we need it anymore