### PR TITLE
feat(Link): add size small

### DIFF
--- a/.changeset/tall-garlics-change.md
+++ b/.changeset/tall-garlics-change.md
@@ -1,0 +1,11 @@
+---
+"@razorpay/blade": major
+---
+
+feat(Link): add size small
+
+> **Warning**
+>
+> Breaking change: icons in links are slightly bumped up now to match the designs
+
+<img width="379" alt="image" src="https://user-images.githubusercontent.com/6682655/196698626-e73dcc07-3d35-49e1-8ead-95c5826f3c41.png">

--- a/.changeset/tall-garlics-change.md
+++ b/.changeset/tall-garlics-change.md
@@ -1,11 +1,11 @@
 ---
-"@razorpay/blade": major
+'@razorpay/blade': minor
 ---
 
-feat(Link): add size small
+feat(Link): add `size` prop and support for `small` size
 
-> **Warning**
+> **Note**
 >
-> Breaking change: icons in links are slightly bumped up now to match the designs
+> Icons in links are slightly bumped up now to match the designs
 
 <img width="379" alt="image" src="https://user-images.githubusercontent.com/6682655/196698626-e73dcc07-3d35-49e1-8ead-95c5826f3c41.png">

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -23,6 +23,13 @@ type BaseLinkCommonProps = {
   iconPosition?: 'left' | 'right';
   onClick?: (event: SyntheticEvent) => void;
   accessibilityLabel?: string;
+
+  /**
+   * Sets the size of the link
+   *
+   * @default medium
+   */
+  size?: 'small' | 'medium';
 };
 
 /*
@@ -88,6 +95,7 @@ type BaseLinkStyleProps = {
   role: 'button' | 'link';
   defaultRel: BaseLinkProps['rel'];
   type?: 'button';
+  fontSize: BaseTextProps['fontSize'];
 };
 
 const getColorToken = ({
@@ -132,7 +140,7 @@ const getProps = ({
   contrast,
   isVisited,
   target,
-  hasIcon,
+  size,
 }: {
   theme: Theme;
   variant: NonNullable<BaseLinkProps['variant']>;
@@ -143,7 +151,7 @@ const getProps = ({
   contrast: NonNullable<BaseLinkProps['contrast']>;
   isVisited: boolean;
   target: BaseLinkProps['target'];
-  hasIcon: boolean;
+  size: 'small' | 'medium';
 }): BaseLinkStyleProps => {
   const isButton = variant === 'button';
   const props: BaseLinkStyleProps = {
@@ -158,7 +166,8 @@ const getProps = ({
       isDisabled,
       isVisited,
     }) as IconProps['color'],
-    iconSize: hasIcon && (!children || children?.trim().length === 0) ? 'medium' : 'small',
+    fontSize: size === 'medium' ? 100 : 75,
+    iconSize: size,
     iconPadding: children?.trim() ? 'spacing.2' : 'spacing.0',
     textColor: getColorToken({
       variant,
@@ -199,6 +208,7 @@ const BaseLink = ({
   className,
   // @ts-expect-error avoiding exposing to public
   style,
+  size = 'medium',
 }: BaseLinkProps): ReactElement => {
   const [isVisited, setIsVisited] = useState(false);
   const { currentInteraction, setCurrentInteraction, ...syntheticEvents } = useInteraction();
@@ -214,6 +224,7 @@ const BaseLink = ({
     iconColor,
     iconPadding,
     iconSize,
+    fontSize,
     textColor,
     focusRingColor,
     motionDuration,
@@ -233,7 +244,7 @@ const BaseLink = ({
     contrast,
     isVisited,
     target,
-    hasIcon: Boolean(Icon),
+    size,
   });
 
   const handleOnClick = (event: SyntheticEvent): void => {
@@ -277,7 +288,7 @@ const BaseLink = ({
         <BaseText
           textDecorationLine={textDecorationLine}
           color={textColor}
-          fontSize={100}
+          fontSize={fontSize}
           textAlign="center"
           fontWeight="bold"
         >

--- a/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.native.test.tsx.snap
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.native.test.tsx.snap
@@ -1774,11 +1774,11 @@ exports[`<BaseLink /> should render link with icon with default iconPosition 1`]
       <RNSVGSvgView
         accessibilityElementsHidden={true}
         align="xMidYMid"
-        bbHeight="12px"
-        bbWidth="12px"
+        bbHeight="16px"
+        bbWidth="16px"
         fill="none"
         focusable={false}
-        height="12px"
+        height="16px"
         importantForAccessibility="no-hide-descendants"
         meetOrSlice={0}
         minX={0}
@@ -1791,14 +1791,14 @@ exports[`<BaseLink /> should render link with icon with default iconPosition 1`]
             },
             Object {
               "flex": 0,
-              "height": 12,
-              "width": 12,
+              "height": 16,
+              "width": 16,
             },
           ]
         }
         vbHeight={24}
         vbWidth={24}
-        width="12px"
+        width="16px"
       >
         <RNSVGGroup
           fill={null}
@@ -1948,11 +1948,11 @@ exports[`<BaseLink /> should render link with icon with left iconPosition 1`] = 
       <RNSVGSvgView
         accessibilityElementsHidden={true}
         align="xMidYMid"
-        bbHeight="12px"
-        bbWidth="12px"
+        bbHeight="16px"
+        bbWidth="16px"
         fill="none"
         focusable={false}
-        height="12px"
+        height="16px"
         importantForAccessibility="no-hide-descendants"
         meetOrSlice={0}
         minX={0}
@@ -1965,14 +1965,14 @@ exports[`<BaseLink /> should render link with icon with left iconPosition 1`] = 
             },
             Object {
               "flex": 0,
-              "height": 12,
-              "width": 12,
+              "height": 16,
+              "width": 16,
             },
           ]
         }
         vbHeight={24}
         vbWidth={24}
-        width="12px"
+        width="16px"
       >
         <RNSVGGroup
           fill={null}
@@ -2153,11 +2153,11 @@ exports[`<BaseLink /> should render link with icon with right iconPosition 1`] =
       <RNSVGSvgView
         accessibilityElementsHidden={true}
         align="xMidYMid"
-        bbHeight="12px"
-        bbWidth="12px"
+        bbHeight="16px"
+        bbWidth="16px"
         fill="none"
         focusable={false}
-        height="12px"
+        height="16px"
         importantForAccessibility="no-hide-descendants"
         meetOrSlice={0}
         minX={0}
@@ -2170,14 +2170,14 @@ exports[`<BaseLink /> should render link with icon with right iconPosition 1`] =
             },
             Object {
               "flex": 0,
-              "height": 12,
-              "width": 12,
+              "height": 16,
+              "width": 16,
             },
           ]
         }
         vbHeight={24}
         vbWidth={24}
-        width="12px"
+        width="16px"
       >
         <RNSVGGroup
           fill={null}

--- a/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.web.test.tsx.snap
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.web.test.tsx.snap
@@ -1779,9 +1779,9 @@ exports[`<BaseLink /> should render link with icon with default iconPosition 1`]
         <svg
           aria-hidden="true"
           fill="none"
-          height="12px"
+          height="16px"
           viewBox="0 0 24 24"
-          width="12px"
+          width="16px"
         >
           <path
             d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
@@ -1909,9 +1909,9 @@ exports[`<BaseLink /> should render link with icon with left iconPosition 1`] = 
         <svg
           aria-hidden="true"
           fill="none"
-          height="12px"
+          height="16px"
           viewBox="0 0 24 24"
-          width="12px"
+          width="16px"
         >
           <path
             d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
@@ -2047,9 +2047,9 @@ exports[`<BaseLink /> should render link with icon with right iconPosition 1`] =
         <svg
           aria-hidden="true"
           fill="none"
-          height="12px"
+          height="16px"
           viewBox="0 0 24 24"
-          width="12px"
+          width="16px"
         >
           <path
             d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"

--- a/packages/blade/src/components/Link/BaseLink/types.ts
+++ b/packages/blade/src/components/Link/BaseLink/types.ts
@@ -19,4 +19,5 @@ export type StyledBaseLinkProps = {
   setCurrentInteraction: Dispatch<SetStateAction<keyof ActionStates>>;
   accessibilityProps: Record<string, unknown>;
   type?: 'button';
+  size?: 'small' | 'medium';
 };

--- a/packages/blade/src/components/Link/Link/Link.stories.tsx
+++ b/packages/blade/src/components/Link/Link/Link.stories.tsx
@@ -13,11 +13,11 @@ import { Highlight, Link as StorybookLink } from '@storybook/design-system';
 import type { LinkProps } from './Link';
 import LinkComponent from './Link';
 import iconMap from '~components/Icons/iconMap';
-import { InfoIcon } from '~components/Icons';
+import { DownloadIcon, InfoIcon } from '~components/Icons';
 import { BaseText } from '~components/Typography/BaseText';
 import Box from '~components/Box';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
-import { Text } from '~components/Typography';
+import { Heading, Text } from '~components/Typography';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -188,6 +188,62 @@ DisabledLinkButton.parameters = {
   docs: {
     description: {
       story: 'Link Button in a disabled state',
+    },
+  },
+};
+
+export const LinkSizes: ComponentStory<typeof LinkComponent> = () => {
+  const href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+  const onClick = (): void => console.log('Never gonna give you up');
+
+  return (
+    <Box display="flex" flexDirection="row">
+      <Box display="flex" flexDirection="column" marginRight="spacing.5">
+        <Box marginBottom="spacing.3">
+          <Heading>Anchor variant</Heading>
+        </Box>
+        <Box marginBottom="spacing.2">
+          <LinkComponent
+            variant="anchor"
+            href={href}
+            target="_blank"
+            size="small"
+            icon={DownloadIcon}
+          >
+            Small anchor link
+          </LinkComponent>
+        </Box>
+        <LinkComponent
+          variant="anchor"
+          href={href}
+          target="_blank"
+          size="medium"
+          icon={DownloadIcon}
+        >
+          Medium anchor link
+        </LinkComponent>
+      </Box>
+      <Box display="flex" flexDirection="column">
+        <Box marginBottom="spacing.3">
+          <Heading>Button variant</Heading>
+        </Box>
+        <Box marginBottom="spacing.2">
+          <LinkComponent size="small" variant="button" onClick={onClick} icon={DownloadIcon}>
+            Small link button
+          </LinkComponent>
+        </Box>
+        <LinkComponent size="medium" variant="button" onClick={onClick} icon={DownloadIcon}>
+          Medium link button
+        </LinkComponent>
+      </Box>
+    </Box>
+  );
+};
+LinkSizes.parameters = {
+  docs: {
+    description: {
+      story:
+        '`size` prop can be used to render a `small` or `medium` (default) sized Link component',
     },
   },
 };

--- a/packages/blade/src/components/Link/Link/Link.stories.tsx
+++ b/packages/blade/src/components/Link/Link/Link.stories.tsx
@@ -207,6 +207,7 @@ export const LinkSizes: ComponentStory<typeof LinkComponent> = () => {
             variant="anchor"
             href={href}
             target="_blank"
+            rel="noopener noreferrer"
             size="small"
             icon={DownloadIcon}
           >
@@ -217,6 +218,7 @@ export const LinkSizes: ComponentStory<typeof LinkComponent> = () => {
           variant="anchor"
           href={href}
           target="_blank"
+          rel="noopener noreferrer"
           size="medium"
           icon={DownloadIcon}
         >

--- a/packages/blade/src/components/Link/Link/Link.tsx
+++ b/packages/blade/src/components/Link/Link/Link.tsx
@@ -11,6 +11,13 @@ type LinkCommonProps = {
   href?: string;
   target?: string;
   accessibilityLabel?: string;
+
+  /**
+   * Sets the size of the link
+   *
+   * @default medium
+   */
+  size?: 'small' | 'medium';
 };
 
 /*
@@ -72,6 +79,7 @@ const Link = ({
   target,
   rel,
   accessibilityLabel,
+  size = 'medium',
 }: LinkProps): ReactElement => {
   return (
     <BaseLink
@@ -80,6 +88,7 @@ const Link = ({
       iconPosition={iconPosition}
       onClick={onClick}
       accessibilityLabel={accessibilityLabel}
+      size={size}
     />
   );
 };

--- a/packages/blade/src/components/Link/Link/__tests__/Link.native.test.tsx
+++ b/packages/blade/src/components/Link/Link/__tests__/Link.native.test.tsx
@@ -20,6 +20,16 @@ describe('<Link />', () => {
     expect(getByText('Learn More')).toBeTruthy();
   });
 
+  it('should render with small size', () => {
+    const linkText = 'Learn More';
+    const { toJSON } = renderWithTheme(
+      <Link icon={InfoIcon} size="small">
+        {linkText}
+      </Link>,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
   it('should render open href URL on press', async () => {
     const linkText = 'Learn More';
     const { getByText } = renderWithTheme(<Link href="https://www.google.com/">{linkText}</Link>);

--- a/packages/blade/src/components/Link/Link/__tests__/Link.web.test.tsx
+++ b/packages/blade/src/components/Link/Link/__tests__/Link.web.test.tsx
@@ -16,6 +16,16 @@ describe('<Link />', () => {
     expect(getByText('Learn More')).toBeInTheDocument();
   });
 
+  it('should render with small size', () => {
+    const linkText = 'Learn More';
+    const { container } = renderWithTheme(
+      <Link icon={InfoIcon} size="small">
+        {linkText}
+      </Link>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
   it('should render link with an href, target and rel', () => {
     const linkText = 'Learn More';
     const { getByRole } = renderWithTheme(

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.native.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.native.test.tsx.snap
@@ -963,3 +963,177 @@ exports[`<Link /> should render link with icon without text 1`] = `
   </View>
 </View>
 `;
+
+exports[`<Link /> should render with small size 1`] = `
+<View
+  accessibilityRole="link"
+  accessibilityState={
+    Object {
+      "disabled": false,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      Object {
+        "alignSelf": "flex-start",
+        "backgroundColor": "transparent",
+        "borderColor": "black",
+        "borderStyle": "solid",
+        "borderWidth": 0,
+        "outline": "none",
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+        "textDecorationColor": "black",
+        "textDecorationLine": "none",
+        "textDecorationStyle": "solid",
+      },
+    ]
+  }
+>
+  <View
+    alignItems="center"
+    className="content-container"
+    display="flex"
+    flexDirection="row"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "flexDirection": "row",
+        },
+      ]
+    }
+  >
+    <View
+      alignItems="center"
+      display="flex"
+      paddingRight="spacing.2"
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "paddingRight": 4,
+          },
+        ]
+      }
+    >
+      <RNSVGSvgView
+        accessibilityElementsHidden={true}
+        align="xMidYMid"
+        bbHeight="12px"
+        bbWidth="12px"
+        fill="none"
+        focusable={false}
+        height="12px"
+        importantForAccessibility="no-hide-descendants"
+        meetOrSlice={0}
+        minX={0}
+        minY={0}
+        style={
+          Array [
+            Object {
+              "backgroundColor": "transparent",
+              "borderWidth": 0,
+            },
+            Object {
+              "flex": 0,
+              "height": 12,
+              "width": 12,
+            },
+          ]
+        }
+        vbHeight={24}
+        vbWidth={24}
+        width="12px"
+      >
+        <RNSVGGroup
+          fill={null}
+          propList={
+            Array [
+              "fill",
+            ]
+          }
+        >
+          <RNSVGPath
+            d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
+            fill={4281042419}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+          />
+          <RNSVGPath
+            d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z"
+            fill={4281042419}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+          />
+          <RNSVGPath
+            clipRule={0}
+            d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z"
+            fill={4281042419}
+            fillRule={0}
+            propList={
+              Array [
+                "fill",
+                "fillRule",
+              ]
+            }
+          />
+        </RNSVGGroup>
+      </RNSVGSvgView>
+    </View>
+    <Text
+      color="action.text.link.default"
+      fontSize={75}
+      fontWeight="bold"
+      style={
+        Array [
+          Object {
+            "color": "hsla(213, 89%, 56%, 1)",
+            "fontFamily": "Lato",
+            "fontSize": 12,
+            "fontStyle": "normal",
+            "fontWeight": "700",
+            "lineHeight": 24,
+            "marginBottom": 0,
+            "marginLeft": 0,
+            "marginRight": 0,
+            "marginTop": 0,
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 0,
+            "textAlign": "center",
+            "textDecorationLine": "none",
+          },
+        ]
+      }
+      textAlign="center"
+      textDecorationLine="none"
+    >
+      Learn More
+    </Text>
+  </View>
+</View>
+`;

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.native.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.native.test.tsx.snap
@@ -342,11 +342,11 @@ exports[`<Link /> should render link with icon with default iconPosition 1`] = `
       <RNSVGSvgView
         accessibilityElementsHidden={true}
         align="xMidYMid"
-        bbHeight="12px"
-        bbWidth="12px"
+        bbHeight="16px"
+        bbWidth="16px"
         fill="none"
         focusable={false}
-        height="12px"
+        height="16px"
         importantForAccessibility="no-hide-descendants"
         meetOrSlice={0}
         minX={0}
@@ -359,14 +359,14 @@ exports[`<Link /> should render link with icon with default iconPosition 1`] = `
             },
             Object {
               "flex": 0,
-              "height": 12,
-              "width": 12,
+              "height": 16,
+              "width": 16,
             },
           ]
         }
         vbHeight={24}
         vbWidth={24}
-        width="12px"
+        width="16px"
       >
         <RNSVGGroup
           fill={null}
@@ -516,11 +516,11 @@ exports[`<Link /> should render link with icon with left iconPosition 1`] = `
       <RNSVGSvgView
         accessibilityElementsHidden={true}
         align="xMidYMid"
-        bbHeight="12px"
-        bbWidth="12px"
+        bbHeight="16px"
+        bbWidth="16px"
         fill="none"
         focusable={false}
-        height="12px"
+        height="16px"
         importantForAccessibility="no-hide-descendants"
         meetOrSlice={0}
         minX={0}
@@ -533,14 +533,14 @@ exports[`<Link /> should render link with icon with left iconPosition 1`] = `
             },
             Object {
               "flex": 0,
-              "height": 12,
-              "width": 12,
+              "height": 16,
+              "width": 16,
             },
           ]
         }
         vbHeight={24}
         vbWidth={24}
-        width="12px"
+        width="16px"
       >
         <RNSVGGroup
           fill={null}
@@ -721,11 +721,11 @@ exports[`<Link /> should render link with icon with right iconPosition 1`] = `
       <RNSVGSvgView
         accessibilityElementsHidden={true}
         align="xMidYMid"
-        bbHeight="12px"
-        bbWidth="12px"
+        bbHeight="16px"
+        bbWidth="16px"
         fill="none"
         focusable={false}
-        height="12px"
+        height="16px"
         importantForAccessibility="no-hide-descendants"
         meetOrSlice={0}
         minX={0}
@@ -738,14 +738,14 @@ exports[`<Link /> should render link with icon with right iconPosition 1`] = `
             },
             Object {
               "flex": 0,
-              "height": 12,
-              "width": 12,
+              "height": 16,
+              "width": 16,
             },
           ]
         }
         vbHeight={24}
         vbWidth={24}
-        width="12px"
+        width="16px"
       >
         <RNSVGGroup
           fill={null}

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.web.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.web.test.tsx.snap
@@ -793,3 +793,133 @@ exports[`<Link /> should render link with icon without text 1`] = `
   </a>
 </div>
 `;
+
+exports[`<Link /> should render with small size 1`] = `
+.c0 {
+  padding: 0;
+  background-color: transparent;
+  outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: 2px;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 70ms;
+  transition-duration: 70ms;
+}
+
+.c0 .content-container {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  border-radius: 2px;
+}
+
+.c0:focus .content-container {
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18);
+}
+
+.c0 * {
+  -webkit-transition-property: color,fill;
+  transition-property: color,fill;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 70ms;
+  transition-duration: 70ms;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-right: 4px;
+}
+
+.c3 {
+  color: hsla(213,89%,56%,1);
+  font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+<div>
+  <a
+    aria-disabled="false"
+    class="c0"
+    cursor="pointer"
+    role="link"
+  >
+    <div
+      class="c1 content-container"
+      display="flex"
+    >
+      <div
+        class="c2"
+        display="flex"
+      >
+        <svg
+          aria-hidden="true"
+          fill="none"
+          height="12px"
+          viewBox="0 0 24 24"
+          width="12px"
+        >
+          <path
+            d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
+            fill="hsla(213, 89%, 56%, 1)"
+          />
+          <path
+            d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z"
+            fill="hsla(213, 89%, 56%, 1)"
+          />
+          <path
+            clip-rule="evenodd"
+            d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z"
+            fill="hsla(213, 89%, 56%, 1)"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div
+        class="c3"
+        color="action.text.link.default"
+        font-size="75"
+        font-weight="bold"
+      >
+        Learn More
+      </div>
+    </div>
+  </a>
+</div>
+`;

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.web.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.web.test.tsx.snap
@@ -373,9 +373,9 @@ exports[`<Link /> should render link with icon with default iconPosition 1`] = `
         <svg
           aria-hidden="true"
           fill="none"
-          height="12px"
+          height="16px"
           viewBox="0 0 24 24"
-          width="12px"
+          width="16px"
         >
           <path
             d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
@@ -503,9 +503,9 @@ exports[`<Link /> should render link with icon with left iconPosition 1`] = `
         <svg
           aria-hidden="true"
           fill="none"
-          height="12px"
+          height="16px"
           viewBox="0 0 24 24"
-          width="12px"
+          width="16px"
         >
           <path
             d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
@@ -641,9 +641,9 @@ exports[`<Link /> should render link with icon with right iconPosition 1`] = `
         <svg
           aria-hidden="true"
           fill="none"
-          height="12px"
+          height="16px"
           viewBox="0 0 24 24"
-          width="12px"
+          width="16px"
         >
           <path
             d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"

--- a/packages/blade/src/components/Link/_decisions/decisions.md
+++ b/packages/blade/src/components/Link/_decisions/decisions.md
@@ -30,6 +30,7 @@ Internal component that exposes certain extra props to enable creation of Compon
 | target | `string` | No | undefined | The target for the link component.<br><br>Note: This prop is only valid for `anchor` variant. |
 | rel | `string` | No | undefined | The rel for the link component.<br><br>Note: <br>- This prop is only valid for `anchor` variant.<br>-When `target` prop is set to `_blank`, `rel` will be automatically set to `noopener noreferrer` which can be overridden by passing the `rel` prop. |
 | accessibilityLabel | `string` | No | undefined | The `aria-label` (web) & `accessibilityLabel` (native) of the link component. |
+| size | `small` | `medium` | No | `medium` | Font size |
 
 
 ## Link Component
@@ -49,6 +50,7 @@ A Link component that can act as a `<button>` as well as an `<anchor>` element. 
 | target | `string` | No | undefined | The target for the link component.<br><br>Note: This prop is only valid for `anchor` variant. |
 | rel | `string` | No | undefined | The rel for the link component.<br><br>Note: <br>- This prop is only valid for `anchor` variant.<br>-When `target` prop is set to `_blank`, `rel` will be automatically set to `noopener noreferrer` which can be overridden by passing the `rel` prop. |
 | accessibilityLabel | `string` | No | undefined | The `aria-label` (web) & `accessibilityLabel` (native) of the link component. |
+| size | `small` | `medium` | No | `medium` | Font size |
 
      
 ## Component Breakdown


### PR DESCRIPTION
## Details

- Adds a new `size` prop that is medium by default but can accept a small value too.
- BaseLink updated to the same.
- Also fixes an inconsistency where icon only links would appear slightly larger in size. Now matches the design behavior.

> **Warning**
>
> Because of how this affects icons in links the icons would appear slightly bumped up in size now

## Screenshots

### Web

<img width="379" alt="image" src="https://user-images.githubusercontent.com/6682655/196696181-04b16d24-12ac-49f7-afd6-85474952d4bb.png">

### Mobile

| ios | android |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-10-19 at 18 07 46](https://user-images.githubusercontent.com/6682655/196695663-ec60c583-5d81-4490-9d34-765f9d6ce4b6.png) | ![Screenshot_1666183364](https://user-images.githubusercontent.com/6682655/196695738-90cfb9e3-a392-4434-b23b-74a2eda3ae8d.png) |

## References

- [Figma](https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=12699%3A147155)
- [Storybook](https://61c19ee8d3d282003ac1d81c-ovefkbhcyl.chromatic.com/?path=/story/components-link--link-sizes&globals=measureEnabled:false)