### PR TITLE
fix: npm releases with changeset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,7 @@ jobs:
           publish: yarn release
           commit: 'build(blade): update version'
           title: 'build(blade): update version'
+
+      - name: Publish to public npm registry
+        if: steps.changesets.outputs.published == 'true'
+        run: yarn publish-npm

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tsc:blade": "yarn workspace @razorpay/blade typecheck",
     "lint": "eslint --ext js,jsx,ts,tsx packages",
     "publish-npm": "lerna run --scope @razorpay/blade publish-npm",
-    "release": "changeset publish && yarn publish-npm",
+    "release": "changeset publish",
     "preinstall": "git config --global url.\"https://github.com/\".insteadOf git://github.com/",
     "build": "lerna run --scope @razorpay/blade build"
   },


### PR DESCRIPTION
Currently we are publishing to public npm registry on every commit to master. 
We only should publish it when we merge the builder version PRs.