### PR TITLE
feat: add README to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create Release Pull Request & Publish packages
         id: changesets
         uses: changesets/action@v1
-        if: ${{ github.event_name != 'workflow_dispatch' }} # only run on master merges
+        if: github.event_name != 'workflow_dispatch' # only run on master merges
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
         with:
@@ -43,6 +43,5 @@ jobs:
         if: steps.changesets.outputs.published == true || github.event_name == 'workflow_dispatch' # run when the package is published via changeset or if a release is triggered manually.
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo ${{steps.changesets.outputs.published}}
-          echo ${{ github.event_name }}
+        run: yarn publish-npm
+          

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This package is under active development.
 
 - [Documentation](https://master--61c19ee8d3d282003ac1d81c.chromatic.com)
 - [Installation Guide](https://master--61c19ee8d3d282003ac1d81c.chromatic.com/?path=/docs/guides-installation--page)
-- [Contributing guidelines](./CONTRIBUTING.md)
+- [Contributing guidelines](https://github.com/razorpay/blade/blob/master/CONTRIBUTING.md)
 
 ---
 
@@ -36,4 +36,4 @@ This package is under active development.
 
 ## 📝 License
 
-Licensed under the [MIT License](./LICENSE).
+Licensed under the [MIT License](https://github.com/razorpay/blade/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -25,16 +25,14 @@ This package is under active development.
 - [Installation Guide](https://master--61c19ee8d3d282003ac1d81c.chromatic.com/?path=/docs/guides-installation--page)
 - [Contributing guidelines](./CONTRIBUTING.md)
 
-
-------
+---
 
 > **Note**
 >
 > The blade-old package has been moved to it's own repo.
-> [github.com/razorpay/blade-old](https://github.com/razorpay/blade-old)
-> 
+> [github.com/razorpay/blade-old](https://github.com/razorpay/blade-old) (Only accessible to Razorpay employees)
+>
 > It is under **maintenance** and it won't have any major releases.
-
 
 ## 📝 License
 

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -12,22 +12,27 @@ import { Meta } from '@storybook/addon-docs';
 Before you install the package, make sure that you have performed following steps:
 
 - You must be running Node version >=14.19.0
-- For Razorpay Employees,
-  - Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages)
-    - Enable SSO by clicking `Authorize` button next to Razorpay logo.
-  - Run `code ~/.bashrc` or `code ~/.zshrc` in your editor and add this line
-    ```
-    export GITHUB_ACCESS_TOKEN="<YOUR_TOKEN>"
-    ```
-    > Note: Replace `<YOUR_TOKEN>` with your actual GitHub Personal Access Token
-  - Run `source ~/.bashrc` or `source ~/.zshrc` based on the file you added your token.
-  - Run `code ~/.npmrc` and append the following
-    ```bash
-    # add following to your .npmrc
-    @razorpay:registry=https://npm.pkg.github.com/
-    //npm.pkg.github.com/:always-auth=true
-    //npm.pkg.github.com/:_authToken=${GITHUB_ACCESS_TOKEN}
-    ```
+
+<details>
+<summary>Razorpay Employees have to point @razorpay scope to GitHub Package Registry. Follow the steps below</summary>
+
+- Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages)
+  - Enable SSO by clicking `Authorize` button next to Razorpay logo.
+- Run `code ~/.bashrc` or `code ~/.zshrc` in your editor and add this line
+  ```
+  export GITHUB_ACCESS_TOKEN="<YOUR_TOKEN>"
+  ```
+  > Note: Replace `<YOUR_TOKEN>` with your actual GitHub Personal Access Token
+- Run `source ~/.bashrc` or `source ~/.zshrc` based on the file you added your token.
+- Run `code ~/.npmrc` and append the following
+  ```bash
+  # add following to your .npmrc
+  @razorpay:registry=https://npm.pkg.github.com/
+  //npm.pkg.github.com/:always-auth=true
+  //npm.pkg.github.com/:_authToken=${GITHUB_ACCESS_TOKEN}
+  ```
+
+</details>
 
 ## ⬇️ Add blade to your application
 

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -11,24 +11,23 @@ import { Meta } from '@storybook/addon-docs';
 
 Before you install the package, make sure that you have performed following steps:
 
-- You must be running Node version >=14.0.0
-- You must have `yarn` installed
-- Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages)
-  - If you belong to razorpay organisation then you will need to enable SSO by clicking `Authorize` button next to Razorpay logo.
-- Run `code ~/.bashrc` or `code ~/.zshrc` in your editor and add this line
-  ```
-  export GITHUB_ACCESS_TOKEN="<YOUR_TOKEN>"
-  ```
-  > Note: Replace `<YOUR_TOKEN>` with your actual GitHub Personal Access Token
-- Run `source ~/.bashrc` or `source ~/.zshrc` based on the file you added your token.
-- Run `code ~/.npmrc` and append the following
-
-```bash
-# add following to your .npmrc
-@razorpay:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:always-auth=true
-//npm.pkg.github.com/:_authToken=${GITHUB_ACCESS_TOKEN}
-```
+- You must be running Node version >=14.19.0
+- For Razorpay Employees (External ),
+  - Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages)
+    - Enable SSO by clicking `Authorize` button next to Razorpay logo.
+  - Run `code ~/.bashrc` or `code ~/.zshrc` in your editor and add this line
+    ```
+    export GITHUB_ACCESS_TOKEN="<YOUR_TOKEN>"
+    ```
+    > Note: Replace `<YOUR_TOKEN>` with your actual GitHub Personal Access Token
+  - Run `source ~/.bashrc` or `source ~/.zshrc` based on the file you added your token.
+  - Run `code ~/.npmrc` and append the following
+    ```bash
+    # add following to your .npmrc
+    @razorpay:registry=https://npm.pkg.github.com/
+    //npm.pkg.github.com/:always-auth=true
+    //npm.pkg.github.com/:_authToken=${GITHUB_ACCESS_TOKEN}
+    ```
 
 ## ⬇️ Add blade to your application
 

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -12,7 +12,7 @@ import { Meta } from '@storybook/addon-docs';
 Before you install the package, make sure that you have performed following steps:
 
 - You must be running Node version >=14.19.0
-- For Razorpay Employees (External ),
+- For Razorpay Employees,
   - Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages)
     - Enable SSO by clicking `Authorize` button next to Razorpay logo.
   - Run `code ~/.bashrc` or `code ~/.zshrc` in your editor and add this line

--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -39,9 +39,9 @@ Blade has 2 packages
 
 This package is under **active development**. We'll only refer to this version of blade throughout this documentation.
 
-## [`@razorpay/blade-old`](https://github.com/razorpay/blade/tree/master/packages/blade-old)
+## [`@razorpay/blade-old`](https://github.com/razorpay/blade-old#--blade-old)
 
-This package is under **maintenance** and it won't have any major releases. It will be **deprecated** once the newer version (`@razorpay/blade`) is ready for a stable release. Documentation for this package can be found [here](https://github.com/razorpay/blade/blob/master/packages/blade-old/README.md)
+This package is under **maintenance** and it won't have any major releases. It will be **deprecated** once the newer version (`@razorpay/blade`) is ready for a stable release. The repository is private and only accessible to Razorpay Employees. Documentation for this package can be found [here](https://github.com/razorpay/blade-old#--blade-old)
 
 # 📝 Versioning & Publishing
 

--- a/packages/blade/docs/guides/LocalDevelopment.stories.mdx
+++ b/packages/blade/docs/guides/LocalDevelopment.stories.mdx
@@ -6,6 +6,9 @@ import { Meta } from '@storybook/addon-docs';
 
 <br />
 <br />
+## Contributing
+
+Check out [CONTRIBUTING.md](https://github.com/razorpay/blade/blob/master/CONTRIBUTING.md) for local installation and setup
 
 ## Editor Setup
 
@@ -46,11 +49,12 @@ We use `react-testing-library` for writing tests. If you want to write platform 
   cd packages/blade
   yarn test:react-native
   ```
-> To update the snapshots run the test commands with `-u` as suffix
+  > To update the snapshots run the test commands with `-u` as suffix
 
 ## Troubleshooting
-* `Blade requires "FRAMEWORK" environment variable to be set. Valid values are "REACT" and "REACT_NATIVE". Instead, received: undefined`
+
+- `Blade requires "FRAMEWORK" environment variable to be set. Valid values are "REACT" and "REACT_NATIVE". Instead, received: undefined`
 
   **Issue:** This is an issue that happens mostly if you run `yarn android` directly. For some reason `FRAMEWORK` doesn't gets passed to React Native application
 
-  **Fix:** If you come across this issue then you first run `yarn start` and then run `yarn android`. 
+  **Fix:** If you come across this issue then you first run `yarn start` and then run `yarn android`.

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@razorpay/blade",
+  "description": "The Design System that powers Razorpay",
   "version": "3.4.1",
   "license": "MIT",
   "engines": {
@@ -17,6 +18,11 @@
     "tokens.js",
     "utils.d.ts",
     "utils.js"
+  ],
+  "keywords": [
+    "design system",
+    "razorpay",
+    "blade"
   ],
   "exports": {
     "./components": {

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -21,6 +21,8 @@
   ],
   "keywords": [
     "design system",
+    "react",
+    "react native",
     "razorpay",
     "blade"
   ],

--- a/packages/blade/scripts/publish-to-npm.js
+++ b/packages/blade/scripts/publish-to-npm.js
@@ -21,6 +21,7 @@ const execa = require('execa');
 
 const BLADE_ROOT = path.join(__dirname, '..');
 const NPMRC_PATH = path.join(BLADE_ROOT, '.npmrc');
+const MONOREPO_ROOT = path.join(BLADE_ROOT, '..', '..');
 
 const npmRcContent = `@razorpay:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:always-auth=true
@@ -29,13 +30,15 @@ const npmRcContent = `@razorpay:registry=https://registry.npmjs.org/
 
 console.log('[blade]: Publishing on NPM ✨');
 
+fs.copyFileSync(path.join(MONOREPO_ROOT, 'README.md'), path.join(BLADE_ROOT, 'README.md'));
 fs.writeFileSync(NPMRC_PATH, npmRcContent);
 
 try {
-  execa.commandSync('npm publish', {
+  execa.commandSync('npm publish --dry-run', {
     cwd: BLADE_ROOT,
     stdio: 'inherit',
   });
 } finally {
   fs.rmSync(NPMRC_PATH);
+  fs.rmSync(path.join(BLADE_ROOT, 'README.md'));
 }

--- a/packages/blade/scripts/publish-to-npm.js
+++ b/packages/blade/scripts/publish-to-npm.js
@@ -21,7 +21,7 @@ const execa = require('execa');
 
 const BLADE_ROOT = path.join(__dirname, '..');
 const NPMRC_PATH = path.join(BLADE_ROOT, '.npmrc');
-const MONOREPO_ROOT = path.join(BLADE_ROOT, '..', '..');
+const MONOREPO_ROOT = path.join(BLADE_ROOT, '../..');
 
 const npmRcContent = `@razorpay:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:always-auth=true

--- a/packages/blade/scripts/publish-to-npm.js
+++ b/packages/blade/scripts/publish-to-npm.js
@@ -34,7 +34,7 @@ fs.copyFileSync(path.join(MONOREPO_ROOT, 'README.md'), path.join(BLADE_ROOT, 'RE
 fs.writeFileSync(NPMRC_PATH, npmRcContent);
 
 try {
-  execa.commandSync('npm publish --dry-run', {
+  execa.commandSync('npm publish', {
     cwd: BLADE_ROOT,
     stdio: 'inherit',
   });


### PR DESCRIPTION
**Changes**
- Move README from root to blade package while publishing and remove after publishing
- Updated the installation guide, and some minor text in our storybook docs according to changes after npm registry publish. (Added comments below with reasoning)

Fixes #762 