### PR TITLE
build: fix npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           commit: 'build(blade): update version'
           title: 'build(blade): update version'
       - name: Publish to public npm registry
-        if: steps.changesets.outputs.published == true || github.event_name == 'workflow_dispatch' # run when the package is published via changeset or if a release is triggered manually.
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch' # run when the package is published via changeset or if a release is triggered manually.
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn publish-npm


### PR DESCRIPTION
We should check for a string `'true'` instead of a boolean `true`

Ref: https://github.com/changesets/action#:~:text=if%3A%20steps.changesets.outputs.published%20%3D%3D%20%27true%27