### PR TITLE
feat(FigmaEmbed): add Figma Embed integration to Storybook

### DIFF
--- a/packages/blade/src/_helpers/storybook/FigmaEmbed.tsx
+++ b/packages/blade/src/_helpers/storybook/FigmaEmbed.tsx
@@ -1,0 +1,18 @@
+function FigmaEmbed({ src }: { src: string }): JSX.Element {
+  return (
+    <>
+      <iframe
+        title="Badge Figma"
+        style={{ border: 'none' }}
+        width="800"
+        height="450"
+        src={`https://www.figma.com/embed?embed_host=share&url=${src}`}
+        allowFullScreen
+      />
+      <br />
+      <br />
+    </>
+  );
+}
+
+export default FigmaEmbed;

--- a/packages/blade/src/_helpers/storybook/FigmaEmbed.tsx
+++ b/packages/blade/src/_helpers/storybook/FigmaEmbed.tsx
@@ -1,12 +1,12 @@
-function FigmaEmbed({ src }: { src: string }): JSX.Element {
+function FigmaEmbed(props: { src: string; title: string }): JSX.Element {
   return (
     <>
       <iframe
-        title="Badge Figma"
+        title={props.title}
         style={{ border: 'none' }}
         width="800"
         height="450"
-        src={`https://www.figma.com/embed?embed_host=share&url=${src}`}
+        src={`https://www.figma.com/embed?embed_host=share&url=${props.src}`}
         allowFullScreen
       />
       <br />

--- a/packages/blade/src/components/Badge/Badge.stories.tsx
+++ b/packages/blade/src/components/Badge/Badge.stories.tsx
@@ -9,7 +9,7 @@ import {
   Description,
 } from '@storybook/addon-docs';
 import capitalize from 'lodash/capitalize';
-import { Highlight, Link } from '@storybook/design-system';
+import { Highlight } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import type { BadgeProps } from './Badge';
 import { Badge as BadgeComponent } from './Badge';
@@ -19,6 +19,7 @@ import Box from '~components/Box';
 import { Text as BladeText } from '~components/Typography';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
 import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -45,11 +46,7 @@ const Page = (): ReactElement => {
         Badges are used to show small amount of color coded metadata, which are ideal for getting
         user attention.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
-      <br />
-      <br />
+      <FigmaEmbed src={figmaURL} />
       <Title>Usage</Title>
       <Sandbox>
         {`

--- a/packages/blade/src/components/Badge/Badge.stories.tsx
+++ b/packages/blade/src/components/Badge/Badge.stories.tsx
@@ -46,7 +46,7 @@ const Page = (): ReactElement => {
         Badges are used to show small amount of color coded metadata, which are ideal for getting
         user attention.
       </Subtitle>
-      <FigmaEmbed src={figmaURL} />
+      <FigmaEmbed title="Badge Figma Design" src={figmaURL} />
       <Title>Usage</Title>
       <Sandbox>
         {`


### PR DESCRIPTION
<img alt="Integrate all the things" src="https://user-images.githubusercontent.com/30949385/199401352-c117e0c3-4822-4f17-9793-32ad3f661755.png" width="150" />

## Description

Adds figma embed integration to Storybook.

```jsx
import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
// ...
<FigmaEmbed title="Badge Figma Design" src={figmaURL} />
```

Can be used with `useMakeFigmaURL` to add theming support. Check this diff in this PR :D

Try it out here - https://61c19ee8d3d282003ac1d81c-ognnptlqpg.chromatic.com/?path=/docs/components-badge--badge

https://user-images.githubusercontent.com/30949385/199401012-aea03e57-3e6d-4c38-8865-7906e2a18959.mov

## Todo

- Add support for other components (This PR only adds support to `Badge.stories` to keep the diff minimal). Will be adding this in follow up PRs later.