### PR TITLE
feat(storybook): Blade theme support for Storybook's UI

### DIFF
--- a/packages/blade/.storybook/react/docs-components.js
+++ b/packages/blade/.storybook/react/docs-components.js
@@ -1,0 +1,54 @@
+import { Text, Title } from '../../src/components';
+
+import { BaseText } from '../../src/components/Typography/BaseText';
+import styled from 'styled-components';
+
+export const MarginBox = styled.div`
+  margin: 12px 0px;
+`;
+
+export function H1({ children }) {
+  return <Title size="large">{children}</Title>;
+}
+
+export function H2({ children }) {
+  return (
+    <>
+      <div style={{ padding: '24px' }} />
+      <Title size="medium">{children}</Title>
+    </>
+  );
+}
+
+export function H3({ children }) {
+  return (
+    <>
+      <div style={{ padding: '12px' }} />
+      <Title size="small">{children}</Title>
+    </>
+  );
+}
+
+export function Paragraph({ children }) {
+  return (
+    <MarginBox>
+      <Text>{children}</Text>
+    </MarginBox>
+  );
+}
+
+export function List({ children }) {
+  return (
+    <BaseText
+      as="li"
+      css={{
+        '&:not(:first-child)': {
+          paddingTop: '1rem',
+        },
+        fontSize: '14px',
+      }}
+    >
+      {children}
+    </BaseText>
+  );
+}

--- a/packages/blade/.storybook/react/manager.js
+++ b/packages/blade/.storybook/react/manager.js
@@ -1,10 +1,11 @@
 // .storybook/manager.js
 import React from 'react';
+import { create } from '@storybook/theming';
 import { addons, types } from '@storybook/addons';
 import { useGlobals } from '@storybook/api';
 import { Icons, IconButton } from '@storybook/components';
 
-export const theme = {
+export const theme = create({
   base: 'light',
 
   colorPrimary: '#FF4785',
@@ -40,7 +41,7 @@ export const theme = {
   brandTitle: 'Blade',
   brandUrl: 'https://github.com/razorpay/blade',
   // brandImage: 'https://place-hold.it/350x150',
-};
+});
 
 const ADDON_ID = 'internal-components-addon';
 const TOOL_ID = 'internal-components-tool';
@@ -52,7 +53,7 @@ hiddenStoryStyle.textContent = `
 `;
 document.head.append(hiddenStoryStyle);
 
-export const toggleHiddenStoryStyle = isDisabled => hiddenStoryStyle.disabled = isDisabled
+export const toggleHiddenStoryStyle = (isDisabled) => (hiddenStoryStyle.disabled = isDisabled);
 
 const InternalStoryAddon = () => {
   const [{ showInternalComponents }, updateGlobals] = useGlobals();
@@ -61,7 +62,7 @@ const InternalStoryAddon = () => {
     updateGlobals({
       showInternalComponents: !showInternalComponents,
     });
-    toggleHiddenStoryStyle(!showInternalComponents)
+    toggleHiddenStoryStyle(!showInternalComponents);
   }, [showInternalComponents]);
 
   return (

--- a/packages/blade/.storybook/react/manager.js
+++ b/packages/blade/.storybook/react/manager.js
@@ -23,7 +23,7 @@ export const theme = create({
   fontCode: 'monospace',
 
   // Text colors
-  textColor: '#333333',
+  textColor: 'hsla(228,56%,17%,1)',
   textInverseColor: '#FFFFFF',
   textMutedColor: '#666666',
 

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -1,6 +1,7 @@
+import styled from 'styled-components';
 import { theme, toggleHiddenStoryStyle } from './manager';
 import { global } from '@storybook/design-system';
-import { BladeProvider } from '../../src/components/BladeProvider';
+import { BladeProvider, useTheme } from '../../src/components/BladeProvider';
 import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
 import ErrorBoundary from './ErrorBoundary';
 const { GlobalStyle } = global;
@@ -41,9 +42,32 @@ export const parameters = {
   },
 };
 
+const StoryCanvas = styled.div(
+  ({ theme, context }) =>
+    `
+      position: ${context.viewMode === 'story' ? 'absolute' : 'relative'};
+      top: 0;
+      left: 0;
+      border-right: 'none';
+      border: ${theme.border.width.thin}px solid ${theme.colors.surface.border.subtle.lowContrast};
+      right: 0;
+      width: 100%;
+      height: 100%;
+      bottom: 0;
+      overflow: auto;
+      padding: 2rem;
+      border-radius: ${
+        context.viewMode === 'story'
+          ? `${theme.border.radius.none}px`
+          : `${theme.border.radius.medium}px`
+      };
+      background: ${theme.colors.surface.background.level1.lowContrast};
+    `,
+);
+
 export const decorators = [
   (Story, context) => {
-    toggleHiddenStoryStyle(context.globals.showInternalComponents)
+    toggleHiddenStoryStyle(context.globals.showInternalComponents);
     const getThemeTokens = () => {
       if (context.globals.themeTokenName === 'paymentTheme') {
         return paymentTheme;
@@ -52,6 +76,7 @@ export const decorators = [
         return bankingTheme;
       }
     };
+    console.log(paymentTheme);
     return (
       <ErrorBoundary>
         <GlobalStyle />
@@ -60,7 +85,9 @@ export const decorators = [
           themeTokens={getThemeTokens()}
           colorScheme={context.globals.colorScheme}
         >
-          <Story />
+          <StoryCanvas context={context}>
+            <Story />
+          </StoryCanvas>
         </BladeProvider>
       </ErrorBoundary>
     );

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -1,9 +1,11 @@
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
+import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { theme, toggleHiddenStoryStyle } from './manager';
 import { global } from '@storybook/design-system';
-import { BladeProvider, useTheme } from '../../src/components/BladeProvider';
+import { BladeProvider } from '../../src/components/BladeProvider';
 import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
 import ErrorBoundary from './ErrorBoundary';
+import { H1, H2, Paragraph, H3, List } from './docs-components';
 const { GlobalStyle } = global;
 
 export const parameters = {
@@ -39,6 +41,60 @@ export const parameters = {
   },
   docs: {
     theme,
+    components: {
+      h1: H1,
+      h2: H2,
+      h3: H3,
+      p: styled(Paragraph)`
+        margin: 12px 0px;
+      `,
+      li: List,
+      summary: styled.summary`
+        font-family: ${theme.fontBase};
+        font-weight: normal;
+        cursor: pointer;
+      `,
+    },
+    container: ({ children, context }) => {
+      const shouldEnforcePaymentTheme = !context.kind.includes('Tokens');
+
+      const getThemeTokens = () => {
+        if (context.globals.themeTokenName === 'paymentTheme') {
+          return paymentTheme;
+        }
+        if (context.globals.themeTokenName === 'bankingTheme') {
+          return bankingTheme;
+        }
+        return null;
+      };
+
+      const themeTokens = getThemeTokens();
+
+      const GlobalBackground = createGlobalStyle`
+        .sbdocs-wrapper {
+          background-color: ${
+            themeTokens.colors[
+              shouldEnforcePaymentTheme || context.globals.colorScheme === 'light'
+                ? 'onLight'
+                : 'onDark'
+            ].surface.background.level3.lowContrast
+          };
+        }
+      `;
+
+      return (
+        <DocsContainer context={context}>
+          <GlobalBackground />
+          <BladeProvider
+            key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
+            themeTokens={shouldEnforcePaymentTheme ? paymentTheme : themeTokens}
+            colorScheme={shouldEnforcePaymentTheme ? 'light' : context.globals.colorScheme}
+          >
+            {children}
+          </BladeProvider>
+        </DocsContainer>
+      );
+    },
   },
 };
 
@@ -76,7 +132,7 @@ export const decorators = [
         return bankingTheme;
       }
     };
-    console.log(paymentTheme);
+
     return (
       <ErrorBoundary>
         <GlobalStyle />

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -4,9 +4,6 @@ import { Meta } from '@storybook/addon-docs';
 
 # ⚙️ Installation
 
-<br />
-<br />
-
 ## ✍🏻 Pre-requisite
 
 Before you install the package, make sure that you have performed following steps:
@@ -38,9 +35,9 @@ Before you install the package, make sure that you have performed following step
 
 1. Install blade as a dependency. Blade has a peer dependency on `styled-components`, you can skip adding it if you already have it installed in your project.
 
-```shell
-yarn add @razorpay/blade styled-components
-```
+   ```shell
+   yarn add` @razorpay/blade styled-components
+   ```
 
 2. Follow [this guide](#-install-fonts) to install the fonts.
 3. For **React Native** projects, follow [this guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) to support `react-native-reanimated` on Android & iOS which is required by Blade.
@@ -63,9 +60,11 @@ For web projects we can either use google fonts or self hosted fonts. Self hoste
 We recommend to use self hosted fonts. We'll use [Fontsource](https://fontsource.org/) which provides fonts as npm packages.
 
 - Install `Lato` font
+
   ```shell
   yarn add @fontsource/lato
   ```
+
 - Import within your app entry file(eg: `App.tsx`, `entryBrowser.tsx` etc.).
   ```js
   import '@fontsource/lato/400.css';

--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -1,49 +1,48 @@
 import { Meta } from '@storybook/addon-docs';
+import { Heading } from '../../src/components';
 
 <Meta title="Guides/Intro" />
 
-<div style={{ margin: '0 auto', maxWidth: '600px', textAlign: 'center' }}>
+# Blade
 
-<h1 align="center">Blade</h1>
-<p align="center">
+<div>
   <a href="https://github.com/styled-components/styled-components">
     <img
-      src="https://img.shields.io/badge/style-%F0%9F%92%85%20styled--components-orange.svg?colorB=daa357&colorA=db748e"
+      src="https://img.shields.io/badge/%F0%9F%92%85%20style-styled--components-orange.svg?colorB=db748e&colorA=444444&style=flat-square"
       alt="Blade is styled with styled-components"
     />
   </a>
   &nbsp;&nbsp;
   <a href="https://github.com/facebook/jest">
-    <img src="https://jestjs.io/img/jest-badge.svg" alt="Blade is tested with jest" />
+    <img
+      src="https://img.shields.io/badge/tested%20with-jest-15c213.svg?colorA=444444&colorB=15c213&style=flat-square&logo=jest"
+      alt="Blade is tested with jest"
+    />
   </a>
   &nbsp;&nbsp;
   <a href="https://github.com/razorpay/blade/blob/master/LICENSE.md">
     <img
-      src="https://img.shields.io/badge/license-MIT-blue.svg"
+      src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square&colorA=444444"
       alt="Blade is released under the MIT license."
     />
   </a>
-</p>
-
-<h4>
-  <b>The Design System that powers Razorpay</b>
-</h4>
-
 </div>
 
-# 📦 Packages
+<Heading variant="subheading">The Design System that powers Razorpay</Heading>
+
+## 📦 Packages
 
 Blade has 2 packages
 
-## [`@razorpay/blade`](https://github.com/razorpay/blade/tree/master/packages/blade)
+- [**@razorpay/blade**](https://github.com/razorpay/blade/tree/master/packages/blade)
 
-This package is under **active development**. We'll only refer to this version of blade throughout this documentation.
+  This package is under **active development**. We'll only refer to this version of blade throughout this documentation.
 
-## [`@razorpay/blade-old`](https://github.com/razorpay/blade-old#--blade-old)
+- [**@razorpay/blade-old**](https://github.com/razorpay/blade-old#--blade-old)
 
-This package is under **maintenance** and it won't have any major releases. It will be **deprecated** once the newer version (`@razorpay/blade`) is ready for a stable release. The repository is private and only accessible to Razorpay Employees. Documentation for this package can be found [here](https://github.com/razorpay/blade-old#--blade-old)
+  This package is under **maintenance** and it won't have any major releases. It will be **deprecated** once the newer version (`@razorpay/blade`) is ready for a stable release. The repository is private and only accessible to Razorpay Employees. Documentation for this package can be found [here](https://github.com/razorpay/blade-old#--blade-old)
 
-# 📝 Versioning & Publishing
+## 📝 Versioning & Publishing
 
 - The first step in publishing a new version of blade is to first the mention the type of change and bump the version. We are using [`changesets`](https://github.com/atlassian/changesets) to handle automated versioning for us based on the intent of the change we mention in the PR.
 - Once a PR is approved by the authors of blade, based on if the PR needs a new version to be published the author will add a changeset to the PR.
@@ -59,6 +58,6 @@ This package is under **maintenance** and it won't have any major releases. It w
 
 > 🗒 You can read in depth about our shipping strategy [here](https://github.com/razorpay/blade/blob/master/rfcs/2021-06-15-shipping-blade.md)
 
-# ⌛️ Current State
+## ⌛️ Current State
 
 For the current state of things please refer to the left hand sidebar. We're actively working on adding more components, utilities and docs. Please reach us on Slack at `#design-system` for any queries or create an issue on the GitHub repo.

--- a/packages/blade/docs/guides/LocalDevelopment.stories.mdx
+++ b/packages/blade/docs/guides/LocalDevelopment.stories.mdx
@@ -4,8 +4,6 @@ import { Meta } from '@storybook/addon-docs';
 
 # 🧑🏻‍💻 Local Development
 
-<br />
-<br />
 ## Contributing
 
 Check out [CONTRIBUTING.md](https://github.com/razorpay/blade/blob/master/CONTRIBUTING.md) for local installation and setup

--- a/packages/blade/docs/guides/Usage.stories.mdx
+++ b/packages/blade/docs/guides/Usage.stories.mdx
@@ -4,9 +4,6 @@ import { Meta } from '@storybook/addon-docs';
 
 # 👀 How to use blade?
 
-<br />
-<br />
-
 ## Tokens
 
 To start using tokens in your application you can follow these steps:

--- a/packages/blade/docs/tokens/Border.stories.mdx
+++ b/packages/blade/docs/tokens/Border.stories.mdx
@@ -2,35 +2,7 @@ import { Meta, DocsContainer } from '@storybook/addon-docs';
 import { useTheme, BladeProvider } from '../../src/components';
 import { paymentTheme, bankingTheme } from '../../src/tokens';
 
-<Meta
-  title="Tokens/Border"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/Border" />
 
 # ─ Border
 

--- a/packages/blade/docs/tokens/Breakpoints.stories.mdx
+++ b/packages/blade/docs/tokens/Breakpoints.stories.mdx
@@ -2,35 +2,7 @@ import { Meta, DocsContainer } from '@storybook/addon-docs';
 import { useTheme, BladeProvider } from '../../src/components';
 import { paymentTheme, bankingTheme } from '../../src/tokens';
 
-<Meta
-  title="Tokens/Breakpoints"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/Breakpoints" />
 
 # 📏 Breakpoints
 

--- a/packages/blade/docs/tokens/Colors.stories.mdx
+++ b/packages/blade/docs/tokens/Colors.stories.mdx
@@ -3,35 +3,7 @@ import { useTheme, BladeProvider } from '../../src/components';
 import { paymentTheme, bankingTheme, colors } from '../../src/tokens';
 import flat from 'flat';
 
-<Meta
-  title="Tokens/Colors"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/Colors" />
 
 # 🎨 Color Palette
 

--- a/packages/blade/docs/tokens/CssVariables.stories.mdx
+++ b/packages/blade/docs/tokens/CssVariables.stories.mdx
@@ -2,35 +2,7 @@ import { Meta, DocsContainer } from '@storybook/addon-docs';
 import { useTheme, BladeProvider } from '../../src//components';
 import { paymentTheme, bankingTheme } from '../../src//tokens';
 
-<Meta
-  title="Tokens/CSS Variables"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/CSS Variables" />
 
 # ✨ CSS Variables
 

--- a/packages/blade/docs/tokens/Motion.stories.mdx
+++ b/packages/blade/docs/tokens/Motion.stories.mdx
@@ -5,35 +5,7 @@ import { paymentTheme, bankingTheme } from '../../src/tokens';
 import { makeMotionTime } from '../../src/utils';
 import MovingDiv from '../components/MovingDiv';
 
-<Meta
-  title="Tokens/Motion"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/Motion" />
 
 # 🎬 Motion
 

--- a/packages/blade/docs/tokens/Spacing.stories.mdx
+++ b/packages/blade/docs/tokens/Spacing.stories.mdx
@@ -2,35 +2,7 @@ import { Meta, DocsContainer } from '@storybook/addon-docs';
 import { useTheme, BladeProvider } from '../../src/components';
 import { paymentTheme, bankingTheme } from '../../src/tokens';
 
-<Meta
-  title="Tokens/Spacing"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/Spacing" />
 
 # ↔️ Spacing
 

--- a/packages/blade/docs/tokens/Typography.stories.mdx
+++ b/packages/blade/docs/tokens/Typography.stories.mdx
@@ -2,35 +2,7 @@ import { Meta, DocsContainer } from '@storybook/addon-docs';
 import { useTheme, BladeProvider } from '../../src//components';
 import { paymentTheme, bankingTheme } from '../../src//tokens';
 
-<Meta
-  title="Tokens/Typography"
-  parameters={{
-    docs: {
-      container: ({ children, context }) => {
-        const getThemeTokens = () => {
-          if (context.globals.themeTokenName === 'paymentTheme') {
-            return paymentTheme;
-          }
-          if (context.globals.themeTokenName === 'bankingTheme') {
-            return bankingTheme;
-          }
-          return null;
-        };
-        return (
-          <DocsContainer context={context}>
-            <BladeProvider
-              key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
-              themeTokens={getThemeTokens()}
-              colorScheme={context.globals.colorScheme}
-            >
-              {children}
-            </BladeProvider>
-          </DocsContainer>
-        );
-      },
-    },
-  }}
-/>
+<Meta title="Tokens/Typography" />
 
 # 🔡 Typography
 

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -6,7 +6,6 @@ import { Highlight, Link } from '@storybook/design-system';
 import type { AlertProps } from './Alert';
 import { Alert as AlertComponent } from './Alert';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
-import { colors } from '~tokens/global';
 import Box from '~components/Box';
 
 const Page = (): ReactElement => {
@@ -188,7 +187,7 @@ FullWidth.parameters = {
 
 export const Borderless: ComponentStory<typeof AlertComponent> = ({ ...args }) => {
   return (
-    <Box background={colors.neutral.blueGrayLight[100]} height={200} position="relative">
+    <Box height={200} position="relative">
       <Box position="absolute" width="100%">
         <AlertComponent {...args} />
       </Box>


### PR DESCRIPTION
2nd approach for #402. We can override the components of MDX with Blade's components.

The reason I am holding off from this change is because-
- We have to override each and every HTML component including components like `th`, `summary`, and other a bit rare components which is a lot of effort and good chance that I will miss something and we end up with weird non-readable colors. The efforts won't justify the impact.
- Even after this change, we can only change the color of docs container and not the complete storybook so it's looking a bit weird when sidebar has storybook's colors but docs canvas has blade's colors.
- Changing the background color is a bit hacky and can break with new storybook versions.

Overall it was getting more complicated so dropping this for now. We can refer to this branch in future if we come back