### PR TITLE
feat(storybook): add support for theming

### DIFF
--- a/packages/blade/.storybook/react/manager.js
+++ b/packages/blade/.storybook/react/manager.js
@@ -23,7 +23,7 @@ export const theme = create({
   fontCode: 'monospace',
 
   // Text colors
-  textColor: '#333333',
+  textColor: 'rgb(19, 38, 68)',
   textInverseColor: '#FFFFFF',
   textMutedColor: '#666666',
 

--- a/packages/blade/.storybook/react/manager.js
+++ b/packages/blade/.storybook/react/manager.js
@@ -1,10 +1,11 @@
 // .storybook/manager.js
 import React from 'react';
+import { create } from '@storybook/theming';
 import { addons, types } from '@storybook/addons';
 import { useGlobals } from '@storybook/api';
 import { Icons, IconButton } from '@storybook/components';
 
-export const theme = {
+export const theme = create({
   base: 'light',
 
   colorPrimary: '#FF4785',
@@ -40,7 +41,7 @@ export const theme = {
   brandTitle: 'Blade',
   brandUrl: 'https://github.com/razorpay/blade',
   // brandImage: 'https://place-hold.it/350x150',
-};
+});
 
 const ADDON_ID = 'internal-components-addon';
 const TOOL_ID = 'internal-components-tool';
@@ -52,7 +53,7 @@ hiddenStoryStyle.textContent = `
 `;
 document.head.append(hiddenStoryStyle);
 
-export const toggleHiddenStoryStyle = isDisabled => hiddenStoryStyle.disabled = isDisabled
+export const toggleHiddenStoryStyle = (isDisabled) => (hiddenStoryStyle.disabled = isDisabled);
 
 const InternalStoryAddon = () => {
   const [{ showInternalComponents }, updateGlobals] = useGlobals();
@@ -61,7 +62,7 @@ const InternalStoryAddon = () => {
     updateGlobals({
       showInternalComponents: !showInternalComponents,
     });
-    toggleHiddenStoryStyle(!showInternalComponents)
+    toggleHiddenStoryStyle(!showInternalComponents);
   }, [showInternalComponents]);
 
   return (

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -1,6 +1,7 @@
+import styled from 'styled-components';
 import { theme, toggleHiddenStoryStyle } from './manager';
 import { global } from '@storybook/design-system';
-import { BladeProvider } from '../../src/components/BladeProvider';
+import { BladeProvider, useTheme } from '../../src/components/BladeProvider';
 import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
 import ErrorBoundary from './ErrorBoundary';
 const { GlobalStyle } = global;
@@ -41,9 +42,32 @@ export const parameters = {
   },
 };
 
+const StoryCanvas = styled.div(
+  ({ theme, context }) =>
+    `
+      position: ${context.viewMode === 'story' ? 'absolute' : 'relative'};
+      top: 0;
+      left: 0;
+      border-right: 'none';
+      border: ${theme.border.width.thin}px solid ${theme.colors.surface.border.subtle.lowContrast};
+      right: 0;
+      width: 100%;
+      height: 100%;
+      bottom: 0;
+      overflow: auto;
+      padding: 2rem;
+      border-radius: ${
+        context.viewMode === 'story'
+          ? `${theme.border.radius.none}px`
+          : `${theme.border.radius.medium}px`
+      };
+      background: ${theme.colors.surface.background.level1.lowContrast};
+    `,
+);
+
 export const decorators = [
   (Story, context) => {
-    toggleHiddenStoryStyle(context.globals.showInternalComponents)
+    toggleHiddenStoryStyle(context.globals.showInternalComponents);
     const getThemeTokens = () => {
       if (context.globals.themeTokenName === 'paymentTheme') {
         return paymentTheme;
@@ -52,6 +76,7 @@ export const decorators = [
         return bankingTheme;
       }
     };
+    console.log(paymentTheme);
     return (
       <ErrorBoundary>
         <GlobalStyle />
@@ -60,7 +85,9 @@ export const decorators = [
           themeTokens={getThemeTokens()}
           colorScheme={context.globals.colorScheme}
         >
-          <Story />
+          <StoryCanvas context={context}>
+            <Story />
+          </StoryCanvas>
         </BladeProvider>
       </ErrorBoundary>
     );

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import { theme, toggleHiddenStoryStyle } from './manager';
+import { DocsContainer } from '@storybook/addon-docs';
 import { global } from '@storybook/design-system';
-import { BladeProvider, useTheme } from '../../src/components/BladeProvider';
+import { BladeProvider } from '../../src/components/BladeProvider';
 import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
 import ErrorBoundary from './ErrorBoundary';
 const { GlobalStyle } = global;
@@ -39,6 +40,34 @@ export const parameters = {
   },
   docs: {
     theme,
+    components: {
+      summary: styled.summary`
+        font-family: ${theme.fontBase};
+        color: ${theme.textColor};
+        font-weight: normal;
+        cursor: pointer;
+      `,
+      li: styled.li`
+        :not(:first-child) {
+          padding-top: 16px;
+        }
+        font-size: 14px;
+
+        & :not(pre) > code {
+          line-height: 1;
+          margin: 0 2px;
+          padding: 3px 5px;
+          white-space: nowrap;
+          border-radius: 3px;
+          font-size: 13px;
+          border: 1px solid #eeeeee;
+          background-color: #f8f8f8;
+        }
+      `,
+    },
+    container: ({ children, context }) => {
+      return <DocsContainer context={context}>{children}</DocsContainer>;
+    },
   },
 };
 
@@ -76,7 +105,7 @@ export const decorators = [
         return bankingTheme;
       }
     };
-    console.log(paymentTheme);
+
     return (
       <ErrorBoundary>
         <GlobalStyle />

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import { theme, toggleHiddenStoryStyle } from './manager';
-import { DocsContainer } from '@storybook/addon-docs';
 import { global } from '@storybook/design-system';
 import { BladeProvider } from '../../src/components/BladeProvider';
 import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
@@ -64,9 +63,6 @@ export const parameters = {
           background-color: #f8f8f8;
         }
       `,
-    },
-    container: ({ children, context }) => {
-      return <DocsContainer context={context}>{children}</DocsContainer>;
     },
   },
 };

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -16,13 +16,17 @@ Before you install the package, make sure that you have performed following step
 <details>
 <summary>Razorpay Employees have to point @razorpay scope to GitHub Package Registry. Follow the steps below</summary>
 
-- Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages)
-  - Enable SSO by clicking `Authorize` button next to Razorpay logo.
+- Generate a Personal Access Token on GitHub by [visiting this link](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages) (Enable SSO by clicking `Authorize` button next to Razorpay logo.)
 - Run `code ~/.bashrc` or `code ~/.zshrc` in your editor and add this line
+
   ```
   export GITHUB_ACCESS_TOKEN="<YOUR_TOKEN>"
   ```
-  > Note: Replace `<YOUR_TOKEN>` with your actual GitHub Personal Access Token
+
+  > **Note**
+  >
+  > Replace `<YOUR_TOKEN>` with your actual GitHub Personal Access Token
+
 - Run `source ~/.bashrc` or `source ~/.zshrc` based on the file you added your token.
 - Run `code ~/.npmrc` and append the following
   ```bash
@@ -34,13 +38,13 @@ Before you install the package, make sure that you have performed following step
 
 </details>
 
-## ⬇️ Add blade to your application
+## ⬇ Add blade to your application
 
 1. Install blade as a dependency. Blade has a peer dependency on `styled-components`, you can skip adding it if you already have it installed in your project.
 
-```shell
-yarn add @razorpay/blade styled-components
-```
+   ```shell
+   yarn add @razorpay/blade styled-components
+   ```
 
 2. Follow [this guide](#-install-fonts) to install the fonts.
 3. For **React Native** projects, follow [this guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) to support `react-native-reanimated` on Android & iOS which is required by Blade.
@@ -58,14 +62,16 @@ We are using `Lato` font family which is not a system font so we need to perform
 
 For web projects we can either use google fonts or self hosted fonts. Self hosted fonts have certain benefits that you can find [here](https://fontsource.org/docs/introduction)
 
-#### Self Hosted(Recommended)
+#### Self Hosted (Recommended)
 
 We recommend to use self hosted fonts. We'll use [Fontsource](https://fontsource.org/) which provides fonts as npm packages.
 
 - Install `Lato` font
+
   ```shell
   yarn add @fontsource/lato
   ```
+
 - Import within your app entry file(eg: `App.tsx`, `entryBrowser.tsx` etc.).
   ```js
   import '@fontsource/lato/400.css';
@@ -81,6 +87,7 @@ There are downsides to using google fonts which can be found [here](https://font
 - Download `Lato` font from [here](https://fonts.google.com/share?selection.family=Lato:wght@400;700)
 - Copy the font files and paste it under the directory `<project_root>/public/fonts`(**create the directory if it doesn't exist**)
 - Create React Native config file at the root of your project - `<project_root>/react-native.config.js` and add following content to it
+
   ```js
   module.exports = {
     // ... rest of the config
@@ -104,12 +111,15 @@ Follow the next steps mentioned below for configuring fonts to work on android:
   </font-family>
   ```
 - Navigate to `/android/app/src/main/java/com/<your_package_name>/MainApplication.java` and add following contents to it
-  ```java
+
+  ```js
   // add the below import statement after all the import statements
   import com.facebook.react.views.text.ReactFontManager;
   ```
+
   Now search for `onCreate` method and add the following line to it
-  ```java
+
+  ```js
   public void onCreate() {
     // add below line as the first line
     ReactFontManager.getInstance().addCustomFont(this, "Lato", R.font.lato);
@@ -122,6 +132,7 @@ Follow the next steps mentioned below for configuring fonts to work on android:
 Follow the next steps mentioned below for configuring fonts to work on iOS:
 
 - Once you've copied the font files under `<project_root>/public/fonts` you need to link it using following command
+
   ```shell
   npx react-native link --platform ios
   ```

--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -5,45 +5,45 @@ import { Meta } from '@storybook/addon-docs';
 <div style={{ margin: '0 auto', maxWidth: '600px', textAlign: 'center' }}>
 
 <h1 align="center">Blade</h1>
+<h4>The Design System that powers Razorpay</h4>
 <p align="center">
   <a href="https://github.com/styled-components/styled-components">
     <img
-      src="https://img.shields.io/badge/style-%F0%9F%92%85%20styled--components-orange.svg?colorB=daa357&colorA=db748e"
+      src="https://img.shields.io/badge/%F0%9F%92%85%20style-styled--components-orange.svg?colorB=db748e&colorA=444444&style=flat-square"
       alt="Blade is styled with styled-components"
     />
   </a>
   &nbsp;&nbsp;
   <a href="https://github.com/facebook/jest">
-    <img src="https://jestjs.io/img/jest-badge.svg" alt="Blade is tested with jest" />
+    <img
+      src="https://img.shields.io/badge/tested%20with-jest-15c213.svg?colorA=444444&colorB=15c213&style=flat-square&logo=jest"
+      alt="Blade is tested with jest"
+    />
   </a>
   &nbsp;&nbsp;
   <a href="https://github.com/razorpay/blade/blob/master/LICENSE.md">
     <img
-      src="https://img.shields.io/badge/license-MIT-blue.svg"
+      src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square&colorA=444444"
       alt="Blade is released under the MIT license."
     />
   </a>
 </p>
 
-<h4>
-  <b>The Design System that powers Razorpay</b>
-</h4>
-
 </div>
 
-# 📦 Packages
+## 📦 Packages
 
 Blade has 2 packages
 
-## [`@razorpay/blade`](https://github.com/razorpay/blade/tree/master/packages/blade)
+### [@razorpay/blade](https://github.com/razorpay/blade/tree/master/packages/blade)
 
 This package is under **active development**. We'll only refer to this version of blade throughout this documentation.
 
-## [`@razorpay/blade-old`](https://github.com/razorpay/blade-old#--blade-old)
+### [@razorpay/blade-old](https://github.com/razorpay/blade-old#--blade-old)
 
 This package is under **maintenance** and it won't have any major releases. It will be **deprecated** once the newer version (`@razorpay/blade`) is ready for a stable release. The repository is private and only accessible to Razorpay Employees. Documentation for this package can be found [here](https://github.com/razorpay/blade-old#--blade-old)
 
-# 📝 Versioning & Publishing
+## 📝 Versioning & Publishing
 
 - The first step in publishing a new version of blade is to first the mention the type of change and bump the version. We are using [`changesets`](https://github.com/atlassian/changesets) to handle automated versioning for us based on the intent of the change we mention in the PR.
 - Once a PR is approved by the authors of blade, based on if the PR needs a new version to be published the author will add a changeset to the PR.
@@ -59,6 +59,6 @@ This package is under **maintenance** and it won't have any major releases. It w
 
 > 🗒 You can read in depth about our shipping strategy [here](https://github.com/razorpay/blade/blob/master/rfcs/2021-06-15-shipping-blade.md)
 
-# ⌛️ Current State
+## ⌛️ Current State
 
 For the current state of things please refer to the left hand sidebar. We're actively working on adding more components, utilities and docs. Please reach us on Slack at `#design-system` for any queries or create an issue on the GitHub repo.

--- a/packages/blade/docs/guides/LocalDevelopment.stories.mdx
+++ b/packages/blade/docs/guides/LocalDevelopment.stories.mdx
@@ -6,6 +6,7 @@ import { Meta } from '@storybook/addon-docs';
 
 <br />
 <br />
+
 ## Contributing
 
 Check out [CONTRIBUTING.md](https://github.com/razorpay/blade/blob/master/CONTRIBUTING.md) for local installation and setup

--- a/packages/blade/docs/guides/Usage.stories.mdx
+++ b/packages/blade/docs/guides/Usage.stories.mdx
@@ -13,60 +13,60 @@ To start using tokens in your application you can follow these steps:
 
 1. Wrap your App with `BladeProvider` and pass it `paymentTheme` or `bankingTheme` tokens.
 
-```jsx
-// App entry point
-import { BladeProvider } from '@razorpay/blade/components';
-import { paymentTheme } from '@razorpay/blade/tokens';
+   ```jsx
+   // App entry point
+   import { BladeProvider } from '@razorpay/blade/components';
+   import { paymentTheme } from '@razorpay/blade/tokens';
 
-function App(): JSX.Element {
-  return (
-    <React.Fragment>
-      <BladeProvider themeTokens={paymentTheme}>
-        <Card />
-      </BladeProvider>
-    </React.Fragment>
-  );
-}
+   function App(): JSX.Element {
+     return (
+       <React.Fragment>
+         <BladeProvider themeTokens={paymentTheme}>
+           <Card />
+         </BladeProvider>
+       </React.Fragment>
+     );
+   }
 
-export default App;
-```
+   export default App;
+   ```
 
 2. You can also pass an optional `colorScheme` prop to the `BladeProvider` mentioning whether you want the `light`, `dark` or `system`'s default color scheme. The default is `light`.
 
-```jsx
-<BladeProvider themeTokens={paymentTheme} colorScheme="dark">
-  <Card />
-</BladeProvider>
-```
+   ```jsx
+   <BladeProvider themeTokens={paymentTheme} colorScheme="dark">
+     <Card />
+   </BladeProvider>
+   ```
 
-1. After you've wrapped your App with `BladeProvider`, you can use the `useTheme()` hook to get access to the current theme context.
+3. After you've wrapped your App with `BladeProvider`, you can use the `useTheme()` hook to get access to the current theme context.
 
-```jsx
-import { useTheme, Theme } from '@razorpay/blade/components';
+   ```jsx
+   import { useTheme, Theme } from '@razorpay/blade/components';
 
-const Card = (): React.ReactElement => {
-  const { theme } = useTheme();
-  return (
-    <React.Fragment>
-      <DisplayLarge theme={theme}>Cash Advance</DisplayLarge>
-      <StyledCard theme={theme}>
-        <CaptionRegular theme={theme}>
-          This amount will be deducted in 3 installments from your settlement balance between Feb
-          18-20 on a daily basis.
-        </CaptionRegular>
-      </StyledCard>
-    </React.Fragment>
-  );
-};
+   const Card = (): React.ReactElement => {
+     const { theme } = useTheme();
+     return (
+       <React.Fragment>
+         <DisplayLarge theme={theme}>Cash Advance</DisplayLarge>
+         <StyledCard theme={theme}>
+           <CaptionRegular theme={theme}>
+             This amount will be deducted in 3 installments from your settlement balance between Feb
+             18-20 on a daily basis.
+           </CaptionRegular>
+         </StyledCard>
+       </React.Fragment>
+     );
+   };
 
-const StyledCard = styled.div(
-  ({ theme }: { theme: Theme }) => `
-    width: 368px;
-    background-color: ${theme.colors.surface.background.level2.lowContrast};
-    border-radius: ${theme.border.radius.medium}px;
-    padding: ${theme.spacing[5]}px;
-    display: flex;
-    flex-direction: column;
-`,
-);
-```
+   const StyledCard = styled.div(
+     ({ theme }: { theme: Theme }) => `
+       width: 368px;
+       background-color: ${theme.colors.surface.background.level2.lowContrast};
+       border-radius: ${theme.border.radius.medium}px;
+       padding: ${theme.spacing[5]}px;
+       display: flex;
+       flex-direction: column;
+   `,
+   );
+   ```

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -6,7 +6,6 @@ import { Highlight, Link } from '@storybook/design-system';
 import type { AlertProps } from './Alert';
 import { Alert as AlertComponent } from './Alert';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
-import { colors } from '~tokens/global';
 import Box from '~components/Box';
 
 const Page = (): ReactElement => {
@@ -188,7 +187,7 @@ FullWidth.parameters = {
 
 export const Borderless: ComponentStory<typeof AlertComponent> = ({ ...args }) => {
   return (
-    <Box background={colors.neutral.blueGrayLight[100]} height={200} position="relative">
+    <Box height={200} position="relative">
       <Box position="absolute" width="100%">
         <AlertComponent {...args} />
       </Box>


### PR DESCRIPTION
## Description

- Changes the canvas background to background color token. So the background of stories now changes when we change theme.
- Some aesthetic improvements

Try changing themes here - https://61c19ee8d3d282003ac1d81c-brglhsqsoq.chromatic.com/?path=/story/guides-intro--page&globals=measureEnabled:false

> **Note**
>
> This changes the canvas so the chromatic requires approvals for all components. I will do that once the PR is approved.

## Screenshots

### Docs Changes

Things were too cluttered in some places. Improved the spacings a bit. Also changed the intro page badges and some font sizes for the love of aesthetics.

<table>
<tr>
<td>
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/30949385/199929982-7afd8f1e-fd7f-4e4b-86ce-54011fab942b.png">
</td>
<td>
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/30949385/199929904-d524fa31-baa0-4693-a4bf-bedcdf9999df.png">
</td>
</tr>
<tr>
<td>
<img width="1117" alt="image" src="https://user-images.githubusercontent.com/30949385/199929560-580ff111-d807-4854-970a-d1c9140c05cd.png">
</td>
<td>
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/30949385/199929470-8a207f5a-e835-4746-ae2c-add17472380a.png">
</td>
</tr>
</table>

### Theming

https://user-images.githubusercontent.com/30949385/199931619-674f2609-1961-49e5-a73c-d9cd1dda6e5f.mov




