### PR TITLE
feat(storybook): add codesandbox examples and figma embed to all components

### DIFF
--- a/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
+++ b/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
@@ -10,9 +10,15 @@ export type SandboxProps = {
   children: string;
   language?: 'ts' | 'tsx';
   showConsole?: boolean;
+  editorHeight?: number;
 };
 
-function Sandbox({ children, language = 'tsx', showConsole = false }: SandboxProps): JSX.Element {
+function Sandbox({
+  children,
+  language = 'tsx',
+  showConsole = false,
+  editorHeight = 300,
+}: SandboxProps): JSX.Element {
   const {
     // @ts-expect-error globals is available but the typings in storybook are properly defined hence, ignoring it
     globals: { themeTokenName, colorScheme },
@@ -86,6 +92,7 @@ function Sandbox({ children, language = 'tsx', showConsole = false }: SandboxPro
           showInlineErrors: true,
           showConsoleButton: true,
           showConsole,
+          editorHeight,
         }}
       />
       <br />

--- a/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
+++ b/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
@@ -11,6 +11,7 @@ export type SandboxProps = {
   language?: 'ts' | 'tsx';
   showConsole?: boolean;
   editorHeight?: number;
+  editorWidthPercentage?: number;
 };
 
 function Sandbox({
@@ -18,6 +19,7 @@ function Sandbox({
   language = 'tsx',
   showConsole = false,
   editorHeight = 300,
+  editorWidthPercentage = 50,
 }: SandboxProps): JSX.Element {
   const {
     // @ts-expect-error globals is available but the typings in storybook are properly defined hence, ignoring it
@@ -93,6 +95,7 @@ function Sandbox({
           showConsoleButton: true,
           showConsole,
           editorHeight,
+          editorWidthPercentage,
         }}
       />
       <br />

--- a/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
+++ b/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
@@ -38,9 +38,8 @@ function Sandbox({ children, language = 'tsx', showConsole = false }: SandboxPro
             const BackgroundBox = styled.div(
               ({ theme }: { theme: Theme }) => ({
                 backgroundColor: theme.colors.surface.background.level1.lowContrast,
-                height: '100vh',
-                width: '100vw',
-                padding: '12px'
+                minHeight: '100vh',
+                padding: '12px 24px'
               })
             );
 
@@ -68,6 +67,8 @@ function Sandbox({ children, language = 'tsx', showConsole = false }: SandboxPro
               </StrictMode>,
               rootElement
             );
+
+            console.clear(); // There could be some codesandbox warnings, clearing them here on init
             `,
           [`/App.${language}`]: dedent(children),
         }}

--- a/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
+++ b/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
@@ -9,9 +9,10 @@ import Box from '~components/Box';
 export type SandboxProps = {
   children: string;
   language?: 'ts' | 'tsx';
+  showConsole?: boolean;
 };
 
-function Sandbox({ children, language = 'tsx' }: SandboxProps): JSX.Element {
+function Sandbox({ children, language = 'tsx', showConsole = false }: SandboxProps): JSX.Element {
   const {
     // @ts-expect-error globals is available but the typings in storybook are properly defined hence, ignoring it
     globals: { themeTokenName, colorScheme },
@@ -83,6 +84,7 @@ function Sandbox({ children, language = 'tsx' }: SandboxProps): JSX.Element {
         options={{
           showInlineErrors: true,
           showConsoleButton: true,
+          showConsole,
         }}
       />
       <br />

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -1,13 +1,14 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 import type { ReactElement } from 'react';
-import { Highlight, Link } from '@storybook/design-system';
 
 import type { AlertProps } from './Alert';
 import { Alert as AlertComponent } from './Alert';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
 import { colors } from '~tokens/global';
 import Box from '~components/Box';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -35,10 +36,48 @@ const Page = (): ReactElement => {
         explanations inside the system in a prominent way.
       </Subtitle>
       <Title>Usage</Title>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
-      <Highlight language="tsx">{`import { Alert } from '@razorpay/blade/components' \nimport type { AlertProps } from '@razorpay/blade/components'`}</Highlight>
+      <FigmaEmbed title="Alert Figma Designs" src={figmaURL} />
+      <Sandbox>
+        {`
+        import { useState } from 'react';
+        import { Alert, Button } from '@razorpay/blade/components';
+
+        function App() {
+          const [showAlert, setShowAlert] = useState(false);
+          return (
+            <div>
+              <Button onClick={() => setShowAlert(!showAlert)}>Click to be alerted!</Button>
+              <br /><br />
+              <div>
+                { 
+                  showAlert 
+                  ? <Alert 
+                      title="The Button is Clicked 👀" 
+                      description="Click the Button again to hide alert"
+                      actions={{
+                        primary: {
+                          onClick: () => {
+                            alert('Alert from the alert hehe')
+                          },
+                          text: 'Primary Action'
+                        },
+                        secondary: {
+                          href: 'https://razorpay.com',
+                          target: '_blank',
+                          text: 'Go to Razorpay.com'
+                        }
+                      }}
+                    /> 
+                  : null 
+                }
+              </div>
+            </div>
+          )
+        }
+
+        export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>You can change the properties using the controls in the table below.</Subtitle>
       <Primary />

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -35,8 +35,8 @@ const Page = (): ReactElement => {
         Alerts are messages that communicate information to users about any significant changes or
         explanations inside the system in a prominent way.
       </Subtitle>
-      <Title>Usage</Title>
       <FigmaEmbed title="Alert Figma Designs" src={figmaURL} />
+      <Title>Usage</Title>
       <Sandbox>
         {`
         import { useState } from 'react';

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -15,16 +15,16 @@ const Page = (): ReactElement => {
     {
       themeTokenName: 'paymentTheme',
       lightModeURL:
-        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=6824%3A61',
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=6922%3A17789',
       darkModeURL:
-        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=6824%3A61',
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=6922%3A17789',
     },
     {
       themeTokenName: 'bankingTheme',
       lightModeURL:
-        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=6824%3A61',
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11098%3A286031',
       darkModeURL:
-        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=6824%3A61',
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11098%3A286031',
     },
   ]);
 

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -37,7 +37,7 @@ const Page = (): ReactElement => {
       </Subtitle>
       <FigmaEmbed title="Alert Figma Designs" src={figmaURL} />
       <Title>Usage</Title>
-      <Sandbox>
+      <Sandbox editorHeight={500}>
         {`
         import { useState } from 'react';
         import { Alert, Button } from '@razorpay/blade/components';
@@ -46,7 +46,9 @@ const Page = (): ReactElement => {
           const [showAlert, setShowAlert] = useState(false);
           return (
             <div>
-              <Button onClick={() => setShowAlert(!showAlert)}>Click to be alerted!</Button>
+              <Button onClick={() => setShowAlert(!showAlert)}>
+                Click to be alerted!
+              </Button>
               <br /><br />
               <div>
                 { 

--- a/packages/blade/src/components/Button/Button/Button.stories.tsx
+++ b/packages/blade/src/components/Button/Button/Button.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@storybook/addon-docs';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
-import { Highlight, Link } from '@storybook/design-system';
+import { Highlight } from '@storybook/design-system';
 import styled from 'styled-components';
 import type { ButtonProps } from './Button';
 import ButtonComponent from './Button';
@@ -20,6 +20,8 @@ import { Text } from '~components/Typography';
 import iconMap from '~components/Icons/iconMap';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
 import Box from '~components/Box';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -46,13 +48,24 @@ const Page = (): ReactElement => {
         This is the Button component which can be used for various CTAs. It is available in 3
         different variants.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed title="Button Figma Designs" src={figmaURL} />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Button } from '@razorpay/blade/components' \nimport type { ButtonProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox showConsole>
+        {`
+        import { Button } from '@razorpay/blade/components'
+        
+        function App(): JSX.Element {
+          return (
+            // Try changing variant here to secondary
+            <Button variant="primary" onClick={() => console.log('Tadaaaa')}>Click Me!</Button>
+          )
+        }
+
+        export default App;
+      `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>
         This is the default button. You can change the properties of this button using the controls

--- a/packages/blade/src/components/Button/Button/Button.stories.tsx
+++ b/packages/blade/src/components/Button/Button/Button.stories.tsx
@@ -59,7 +59,12 @@ const Page = (): ReactElement => {
         function App(): JSX.Element {
           return (
             // Try changing variant here to secondary
-            <Button variant="primary" onClick={() => console.log('Tadaaaa')}>Click Me!</Button>
+            <Button 
+              variant="primary" 
+              onClick={() => console.log('Tadaaaa')}
+            >
+              Click Me!
+            </Button>
           )
         }
 

--- a/packages/blade/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/blade/src/components/Checkbox/Checkbox.stories.tsx
@@ -20,11 +20,10 @@ const Page = (): React.ReactElement => {
     },
     {
       themeTokenName: 'bankingTheme',
-      // @TODO: replace with banking theme figma URL if it exists
       lightModeURL:
-        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11169%3A230354',
       darkModeURL:
-        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11169%3A230354',
     },
   ]);
 

--- a/packages/blade/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/blade/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,17 +1,26 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { ArgsTable, Primary, PRIMARY_STORY, Stories, Subtitle, Title } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import type { ComponentStory, Meta } from '@storybook/react';
 import React from 'react';
 import { Text } from '../Typography';
 import type { CheckboxProps } from './';
 import { Checkbox as CheckboxComponent } from './';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): React.ReactElement => {
   const figmaURL = useMakeFigmaURL([
     {
       themeTokenName: 'paymentTheme',
+      lightModeURL:
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+      darkModeURL:
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+    },
+    {
+      themeTokenName: 'bankingTheme',
+      // @TODO: replace with banking theme figma URL if it exists
       lightModeURL:
         'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
       darkModeURL:
@@ -26,13 +35,26 @@ const Page = (): React.ReactElement => {
         Checkbox can be used in forms when a user needs to select multiple values from several
         options.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed title="Checkbox Figma Designs" src={figmaURL} />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Checkbox } from '@razorpay/blade/components' \nimport type { CheckboxProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox showConsole>
+        {`
+        import { Checkbox } from '@razorpay/blade/components'
+        
+        function App(): JSX.Element {
+          return (
+            // Check console
+            <Checkbox onChange={(e) => console.log(e.isChecked)}>
+              Toggle Checkbox
+            </Checkbox>
+          )
+        }
+
+        export default App;
+      `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>
         This is the default checkbox. You can change the properties of this button using the

--- a/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
@@ -2,16 +2,24 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import React from 'react';
 import { Title, Subtitle, Primary, ArgsTable, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
-import { Link, Highlight } from '@storybook/design-system';
 import { Text } from '../Typography';
 import { Checkbox as CheckboxComponent, CheckboxGroup as CheckboxGroupComponent } from './';
 import type { CheckboxGroupProps } from './';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): React.ReactElement => {
   const figmaURL = useMakeFigmaURL([
     {
       themeTokenName: 'paymentTheme',
+      lightModeURL:
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+      darkModeURL:
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+    },
+    {
+      themeTokenName: 'bankingTheme',
       lightModeURL:
         'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
       darkModeURL:
@@ -26,13 +34,32 @@ const Page = (): React.ReactElement => {
         CheckboxGroup can be used to group together multiple checkboxes in a forms which provides
         out of the box state management for the multi-checkboxes and other features.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed title="Checkbox Group Figma Designs" src={figmaURL} />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { CheckboxGroup } from '@razorpay/blade/components' \nimport type { CheckboxGroupProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox showConsole>
+        {`
+          import { CheckboxGroup, Checkbox } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <CheckboxGroup 
+                label="Which are your favorite Fruits?"
+                name="fruits" 
+                onChange={({name, values}) => console.log({name, values})}
+                helpText="Select Fruits"
+              >
+                <Checkbox value="apple">Apple</Checkbox>
+                <Checkbox value="mango">Mango</Checkbox>
+                <Checkbox value="orange">Orange</Checkbox>
+              </CheckboxGroup>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>
         This is the default CheckboxGroup. You can change the properties of this button using the

--- a/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
@@ -38,21 +38,27 @@ const Page = (): React.ReactElement => {
       <br />
       <br />
       <Title>Usage</Title>
-      <Sandbox showConsole>
+      <Sandbox showConsole editorHeight={400}>
         {`
           import { CheckboxGroup, Checkbox } from '@razorpay/blade/components';
 
           function App(): JSX.Element {
             return (
               <CheckboxGroup 
-                label="Which are your favorite Fruits?"
-                name="fruits" 
+                label="Where do you want to collect payments?"
+                name="payment-collection" 
                 onChange={({name, values}) => console.log({name, values})}
-                helpText="Select Fruits"
               >
-                <Checkbox value="apple">Apple</Checkbox>
-                <Checkbox value="mango">Mango</Checkbox>
-                <Checkbox value="orange">Orange</Checkbox>
+                <Checkbox value="website">Website</Checkbox>
+                <Checkbox value="android">Android App</Checkbox>
+                <Checkbox value="ios">iOS App</Checkbox>
+                <Checkbox 
+                  value="social-media" 
+                  helpText="Like WhatsApp, Facebook, Instagram"
+                >
+                  Social Media
+                </Checkbox>
+                <Checkbox value="offline-store">Offline Store</Checkbox>
               </CheckboxGroup>
             )
           }

--- a/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
@@ -21,9 +21,9 @@ const Page = (): React.ReactElement => {
     {
       themeTokenName: 'bankingTheme',
       lightModeURL:
-        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11169%3A230590',
       darkModeURL:
-        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13227%3A163026',
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11169%3A230590',
     },
   ]);
 

--- a/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
@@ -38,7 +38,7 @@ const Page = (): React.ReactElement => {
       <br />
       <br />
       <Title>Usage</Title>
-      <Sandbox showConsole editorHeight={400}>
+      <Sandbox showConsole editorHeight={400} editorWidthPercentage={60}>
         {`
           import { CheckboxGroup, Checkbox } from '@razorpay/blade/components';
 

--- a/packages/blade/src/components/Counter/Counter.stories.tsx
+++ b/packages/blade/src/components/Counter/Counter.stories.tsx
@@ -1,12 +1,13 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import type { CounterProps } from './Counter';
 import { Counter as CounterComponent } from './Counter';
 import Box from '~components/Box';
 import { Text as BladeText } from '~components/Typography';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -33,13 +34,24 @@ const Page = (): ReactElement => {
         Counters are visual indicators that contains numerical values, tallies or counts in regards
         to some context. It can be used to show non-interactive numerical data.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed title="Counter Figma Designs" src={figmaURL} />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Counter } from '@razorpay/blade/components'; \nimport type { CounterProps } from '@razorpay/blade/components';`}</Highlight>
+      <Sandbox>
+        {`
+          import { Counter } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              // Change values to anything less than 99 to see change
+              <Counter max={99} value={140} />
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>
         This is the default Counter. You can change the properties of this button using the controls

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
@@ -135,7 +135,10 @@ export default {
               function App(): JSX.Element {
                 return (
                   // Fill OTP and check console
-                  <OTPInput label="Enter OTP" onOTPFilled={(e) => console.log(e)} />
+                  <OTPInput 
+                    label="Enter OTP" 
+                    onOTPFilled={(e) => console.log(e)} 
+                  />
                 )
               }
 

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
@@ -1,9 +1,9 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight } from '@storybook/design-system';
 import React from 'react';
 import type { OTPInputProps } from './OTPInput';
 import { OTPInput as OTPInputComponent } from './OTPInput';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const propsCategory = {
   BASE_PROPS: 'OTPInput Props',
@@ -128,7 +128,20 @@ export default {
             transaction. These are a group of inputs and can be either 4 or 6 characters long.
           </Subtitle>
           <Title>Usage</Title>
-          <Highlight language="tsx">{`import { OTPInput } from '@razorpay/blade/components' \nimport type { OTPInputProps } from '@razorpay/blade/components'`}</Highlight>
+          <Sandbox showConsole>
+            {`
+              import { OTPInput } from '@razorpay/blade/components';
+
+              function App(): JSX.Element {
+                return (
+                  // Fill OTP and check console
+                  <OTPInput label="Enter OTP" onOTPFilled={(e) => console.log(e)} />
+                )
+              }
+
+              export default App;
+            `}
+          </Sandbox>
           <Title>Example</Title>
           <Primary />
           <Title>Properties</Title>

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
@@ -2,11 +2,12 @@ import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
 import type { ReactElement } from 'react';
 import { useState } from 'react';
-import { Highlight, Link } from '@storybook/design-system';
 
 import type { PasswordInputProps } from './PasswordInput';
 import { PasswordInput } from './PasswordInput';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -35,10 +36,20 @@ const Page = (): ReactElement => {
         using an optional reveal button.
       </Subtitle>
       <Title>Usage</Title>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
-      <Highlight language="tsx">{`import { PasswordInput } from '@razorpay/blade/components' \nimport type { PasswordInputProps } from '@razorpay/blade/components'`}</Highlight>
+      <FigmaEmbed title="Password Figma Designs" src={figmaURL} />
+      <Sandbox showConsole>
+        {`
+          import { PasswordInput } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <PasswordInput label="Enter Password" onChange={(e) => console.log(e)} />
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>You can change the properties using the controls in the table below.</Subtitle>
       <Primary />

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
@@ -43,7 +43,10 @@ const Page = (): ReactElement => {
 
           function App(): JSX.Element {
             return (
-              <PasswordInput label="Enter Password" onChange={(e) => console.log(e)} />
+              <PasswordInput 
+                label="Enter Password" 
+                onChange={(e) => console.log(e)} 
+              />
             )
           }
 

--- a/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
@@ -1,10 +1,10 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight } from '@storybook/design-system';
 import React from 'react';
 import type { TextAreaProps } from './TextArea';
 import { TextArea as TextAreaComponent } from './TextArea';
 import Box from '~components/Box';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const propsCategory = {
   BASE_PROPS: 'TextArea Props',
@@ -149,7 +149,24 @@ export default {
             The TextArea component lets you enter long form text which spans over multiple lines.
           </Subtitle>
           <Title>Usage</Title>
-          <Highlight language="tsx">{`import { TextArea } from '@razorpay/blade/components' \nimport type { TextAreaProps } from '@razorpay/blade/components'`}</Highlight>
+          <Sandbox>
+            {`
+              import { TextArea } from '@razorpay/blade/components';
+
+              function App(): JSX.Element {
+                return (
+                  <TextArea 
+                    label="Description" 
+                    placeholder="Enter Description"
+                    helpText="Enter Text Here" 
+                    maxCharacters={100} 
+                  />
+                )
+              }
+
+              export default App;
+            `}
+          </Sandbox>
           <Title>Example</Title>
           <Primary />
           <Title>Properties</Title>

--- a/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable react-native-a11y/has-valid-accessibility-descriptors */
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight } from '@storybook/design-system';
 import React from 'react';
 import type { TextInputProps } from './TextInput';
 import { TextInput as TextInputComponent } from './TextInput';
 import iconMap from '~components/Icons/iconMap';
 import Box from '~components/Box';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const propsCategory = {
   BASE_PROPS: 'Text Input Props',
@@ -192,7 +192,23 @@ export default {
             url, search or plain text.
           </Subtitle>
           <Title>Usage</Title>
-          <Highlight language="tsx">{`import { TextInput } from '@razorpay/blade/components' \nimport type { TextInputProps } from '@razorpay/blade/components'`}</Highlight>
+          <Sandbox showConsole>
+            {`
+              import { TextInput } from '@razorpay/blade/components';
+
+              function App(): JSX.Element {
+                return (
+                  <TextInput 
+                    label="Name" 
+                    placeholder="Enter Name" 
+                    onChange={(e) => console.log(e)} 
+                  />
+                )
+              }
+
+              export default App;
+            `}
+          </Sandbox>
           <Title>Example</Title>
           <Primary />
           <Title>Properties</Title>

--- a/packages/blade/src/components/Link/Link/Link.stories.tsx
+++ b/packages/blade/src/components/Link/Link/Link.stories.tsx
@@ -9,7 +9,6 @@ import {
   Description,
 } from '@storybook/addon-docs';
 import type { ReactElement } from 'react';
-import { Highlight, Link as StorybookLink } from '@storybook/design-system';
 import type { LinkProps } from './Link';
 import LinkComponent from './Link';
 import iconMap from '~components/Icons/iconMap';
@@ -18,6 +17,8 @@ import { BaseText } from '~components/Typography/BaseText';
 import Box from '~components/Box';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
 import { Heading, Text } from '~components/Typography';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -45,13 +46,29 @@ const Page = (): ReactElement => {
         user. The Link component can also be used as an inline button in certain cases with the
         `button` variant
       </Subtitle>
-      <StorybookLink withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </StorybookLink>
+      <FigmaEmbed src={figmaURL} title="Link Figma Designs" />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Link } from '@razorpay/blade/components' \nimport type { LinkProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox>
+        {`
+          import { Link } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <Link 
+                href="https://razorpay.com" 
+                target="_blank" 
+                rel="noopener noreferer"
+              >
+                Go to Razorpay.com
+              </Link>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Description markdown="> **Note:** While using the `Link` component with React Native, please ensure you have gone through platform-specific prerequisites like adding `LSApplicationQueriesSchemes` in `Info.plist` for iOS and adding `intent` queries in `AndroidManifest.xml` for Android. For a detailed guide, follow React Native's [Linking Documentation](https://reactnative.dev/docs/linking#canopenurl)." />
       <Title>Example</Title>
       <Subtitle>

--- a/packages/blade/src/components/Radio/Radio.stories.tsx
+++ b/packages/blade/src/components/Radio/Radio.stories.tsx
@@ -2,12 +2,13 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import React from 'react';
 import { ArgsTable, Primary, PRIMARY_STORY, Stories, Subtitle, Title } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import { Text } from '../Typography';
 import type { RadioGroupProps } from './RadioGroup/RadioGroup';
 import { RadioGroup as RadioGroupComponent } from './RadioGroup/RadioGroup';
 import { Radio as RadioComponent } from './Radio';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): React.ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -18,6 +19,13 @@ const Page = (): React.ReactElement => {
       darkModeURL:
         'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=13133%3A160709',
     },
+    {
+      themeTokenName: 'bankingTheme',
+      lightModeURL:
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11314%3A278927',
+      darkModeURL:
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=11314%3A278927',
+    },
   ]);
 
   return (
@@ -27,13 +35,33 @@ const Page = (): React.ReactElement => {
         Radio & RadioGroup can be used in forms when a user needs to single value from several
         options.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed src={figmaURL} title="Radio Figma Designs" />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Radio, RadioGroup } from '@razorpay/blade/components' \nimport type { RadioProps, RadioGroupProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox showConsole>
+        {`
+          import { RadioGroup, Radio } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <RadioGroup
+                helpText="Select atleast one"
+                label="Fruits"
+                name="fruits"
+                defaultValue="orange"
+                onChange={(e) => console.log(e)}
+              >
+                <Radio value="apple">Apple</Radio>
+                <Radio value="mango">Mango</Radio>
+                <Radio value="orange">Orange</Radio>
+              </RadioGroup>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>
         This is the default radio. You can change the properties of this button using the controls

--- a/packages/blade/src/components/Radio/Radio.stories.tsx
+++ b/packages/blade/src/components/Radio/Radio.stories.tsx
@@ -39,7 +39,7 @@ const Page = (): React.ReactElement => {
       <br />
       <br />
       <Title>Usage</Title>
-      <Sandbox showConsole editorHeight={400}>
+      <Sandbox showConsole editorHeight={400} editorWidthPercentage={60}>
         {`
           import { RadioGroup, Radio } from '@razorpay/blade/components';
 

--- a/packages/blade/src/components/Radio/Radio.stories.tsx
+++ b/packages/blade/src/components/Radio/Radio.stories.tsx
@@ -39,22 +39,29 @@ const Page = (): React.ReactElement => {
       <br />
       <br />
       <Title>Usage</Title>
-      <Sandbox showConsole>
+      <Sandbox showConsole editorHeight={400}>
         {`
           import { RadioGroup, Radio } from '@razorpay/blade/components';
 
           function App(): JSX.Element {
             return (
               <RadioGroup
-                helpText="Select atleast one"
-                label="Fruits"
-                name="fruits"
-                defaultValue="orange"
-                onChange={(e) => console.log(e)}
+                helpText="Select only one"
+                label="Where do you want to collect payments?"
+                name="payment-collection" 
+                onChange={({name, value}) => console.log({name, value})}
+                defaultValue="website"
               >
-                <Radio value="apple">Apple</Radio>
-                <Radio value="mango">Mango</Radio>
-                <Radio value="orange">Orange</Radio>
+                <Radio value="website">Website</Radio>
+                <Radio value="android">Android App</Radio>
+                <Radio value="ios">iOS App</Radio>
+                <Radio 
+                  value="social-media" 
+                  helpText="Like WhatsApp, Facebook, Instagram"
+                >
+                  Social Media
+                </Radio>
+                <Radio value="offline-store">Offline Store</Radio>
               </RadioGroup>
             )
           }

--- a/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
@@ -8,13 +8,13 @@ import {
   PRIMARY_STORY,
   Description,
 } from '@storybook/addon-docs';
-import { Highlight } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import { Button } from '~components/Button';
 import { Link } from '~components/Link';
 import { SkipNavContent, SkipNavLink } from '~components/SkipNav';
 import { Text } from '~components/Typography';
 import Box from '~components/Box';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): ReactElement => {
   return (
@@ -29,7 +29,39 @@ const Page = (): ReactElement => {
       <br />
       <br />
       <StorybookTitle>Usage</StorybookTitle>
-      <Highlight language="tsx">{`import { SkipNavLink, SkipNavContent } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox>
+        {`
+          import { 
+            SkipNavLink, 
+            SkipNavContent, 
+            Text, 
+            Link,
+            Code 
+          } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <div>
+                <Text>Click somewhere on the text here to focus on this window and press <Code>TAB</Code> key to see it in action</Text>
+                <SkipNavLink>Skip to content</SkipNavLink>
+                <nav style={{ marginBottom: '800px' }}>
+                  <ul>
+                    <li><Link href="#">Nav link 1</Link></li>
+                    <li><Link href="#">Nav link 2</Link></li>
+                    <li><Link href="#">Nav link 3</Link></li>
+                  </ul>
+                </nav>
+                <main>
+                  <SkipNavContent />
+                  <Text>Main Content of the Page</Text>
+                </main>
+              </div>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <StorybookTitle>Example</StorybookTitle>
       <Primary />
       <StorybookTitle>Properties</StorybookTitle>

--- a/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
@@ -29,7 +29,7 @@ const Page = (): ReactElement => {
       <br />
       <br />
       <StorybookTitle>Usage</StorybookTitle>
-      <Sandbox>
+      <Sandbox editorHeight={400}>
         {`
           import { 
             SkipNavLink, 

--- a/packages/blade/src/components/Spinner/Spinner/Spinner.stories.tsx
+++ b/packages/blade/src/components/Spinner/Spinner/Spinner.stories.tsx
@@ -1,12 +1,13 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import type { SpinnerProps } from './Spinner';
 import { Spinner as SpinnerComponent } from './Spinner';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
 import Box from '~components/Box';
 import { Text } from '~components/Typography';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -32,13 +33,32 @@ const Page = (): ReactElement => {
       <Subtitle>
         A spinner is an element with a looping animation that indicates loading is in process.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed src={figmaURL} title="Spinner Figma Designs" />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Spinner } from '@razorpay/blade/components'; \nimport type { SpinnerProps } from '@razorpay/blade/components';`}</Highlight>
+      <Sandbox>
+        {`
+          import { useEffect, useState } from 'react';
+          import { Spinner, Text } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            const [isLoading, setIsLoading] = useState(true);
+
+            useEffect(() => {
+              setTimeout(() => {
+                setIsLoading(false)
+              }, 5000)
+            }, [])
+
+            return (
+              isLoading ? <Spinner /> : <Text>Tadaa 🥳 Reload sandbox to see spinner again</Text>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Subtitle>
         This is the default spinner. You can change the properties of this spinner using the

--- a/packages/blade/src/components/Typography/Code/Code.stories.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.stories.tsx
@@ -36,7 +36,7 @@ const Page = (): ReactElement => {
       <br />
       <br />
       <Title>Usage</Title>
-      <Sandbox>
+      <Sandbox editorWidthPercentage={60}>
         {`
           import { Code, Text } from '@razorpay/blade/components';
 

--- a/packages/blade/src/components/Typography/Code/Code.stories.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.stories.tsx
@@ -1,7 +1,63 @@
 import type { ComponentStory, Meta } from '@storybook/react';
+import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
+import type { ReactElement } from 'react';
 import { Text } from '../Text';
 import { Code as CodeComponent } from './Code';
 import Box from '~components/Box';
+import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+
+const Page = (): ReactElement => {
+  const figmaURL = useMakeFigmaURL([
+    {
+      themeTokenName: 'paymentTheme',
+      lightModeURL:
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=11770%3A147140',
+      darkModeURL:
+        'https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=11770%3A147140',
+    },
+    {
+      themeTokenName: 'bankingTheme',
+      lightModeURL:
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=10344%3A189840',
+      darkModeURL:
+        'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?node-id=10344%3A189840',
+    },
+  ]);
+
+  return (
+    <>
+      <Title />
+      <Subtitle>
+        Code component can be used for displaying token, variable names, or inlined code snippets.
+      </Subtitle>
+      <FigmaEmbed src={figmaURL} title="Heading Figma Designs" />
+      <br />
+      <br />
+      <Title>Usage</Title>
+      <Sandbox>
+        {`
+          import { Code, Text } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              // For React Native, you will have to use flex layout to align Code component properly
+              <Text>You can use <Code>Code</Code> component to add inlined Code, token names, variable names, etc</Text>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
+      <Title>Example</Title>
+      <Primary />
+      <Title>Properties</Title>
+      <ArgsTable story={PRIMARY_STORY} />
+      <Stories />
+    </>
+  );
+};
 
 const CodeStoryMeta: Meta = {
   title: 'Components/Typography/Code',
@@ -9,6 +65,11 @@ const CodeStoryMeta: Meta = {
   args: {
     size: 'small',
     children: 'SENTRY_AUTH_TOKEN',
+  },
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
   },
 };
 

--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -1,10 +1,11 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import type { HeadingProps } from './';
 import { Heading as HeadingComponent } from './';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -30,13 +31,23 @@ const Page = (): ReactElement => {
       <Subtitle>
         The Heading Component is usually used for headings of each major section of a page.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed src={figmaURL} title="Heading Figma Designs" />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Heading } from '@razorpay/blade/components' \nimport type { HeadingProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox>
+        {`
+          import { Heading } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <Heading size="large">Blade by Razorpay</Heading>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Primary />
       <Title>Properties</Title>

--- a/packages/blade/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.stories.tsx
@@ -1,10 +1,11 @@
 import type { ComponentStory, Meta } from '@storybook/react';
 import { Title, Subtitle, Primary, ArgsTable, Stories, PRIMARY_STORY } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import type { TextProps } from './';
 import { Text as TextComponent } from './';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -32,13 +33,23 @@ const Page = (): ReactElement => {
         Title or Heading to display content in a hierarchical structure. It applies responsive
         styles automatically based on the device it is being rendered on.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed src={figmaURL} title="Text Figma Designs" />
       <br />
       <br />
       <Title>Usage</Title>
-      <Highlight language="tsx">{`import { Text } from '@razorpay/blade/components' \nimport type { TextProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox>
+        {`
+          import { Text } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <Text>Lorem Ipsum</Text>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <Title>Example</Title>
       <Primary />
       <Title>Properties</Title>

--- a/packages/blade/src/components/Typography/Title/Title.stories.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.stories.tsx
@@ -7,11 +7,12 @@ import {
   Stories,
   PRIMARY_STORY,
 } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import type { TitleProps } from './';
 import { Title as TitleComponent } from './';
 import useMakeFigmaURL from '~src/_helpers/storybook/useMakeFigmaURL';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
+import FigmaEmbed from '~src/_helpers/storybook/FigmaEmbed';
 
 const Page = (): ReactElement => {
   const figmaURL = useMakeFigmaURL([
@@ -39,13 +40,23 @@ const Page = (): ReactElement => {
         goal is visual storytelling. For example, use Title as marketing content on landing pages or
         to capture attention during onboarding.
       </Subtitle>
-      <Link withArrow={true} href={figmaURL} target="_blank" rel="noreferrer noopener">
-        View in Figma
-      </Link>
+      <FigmaEmbed src={figmaURL} title="Title Figma Designs" />
       <br />
       <br />
       <StorybookTitle>Usage</StorybookTitle>
-      <Highlight language="tsx">{`import { Title } from '@razorpay/blade/components' \nimport type { TitleProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox>
+        {`
+          import { Title } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <Title size="large">Blade by Razorpay</Title>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <StorybookTitle>Example</StorybookTitle>
       <Primary />
       <StorybookTitle>Properties</StorybookTitle>

--- a/packages/blade/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/blade/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -8,12 +8,13 @@ import {
   Stories,
   PRIMARY_STORY,
 } from '@storybook/addon-docs';
-import { Highlight, Link } from '@storybook/design-system';
+import { Link } from '@storybook/design-system';
 import type { ReactElement } from 'react';
 import { VisuallyHidden as VisuallyHiddenComponent } from './VisuallyHidden';
 import type { VisuallyHiddenProps } from './types';
 import { Checkbox } from '~components/Checkbox';
 import { Text } from '~components/Typography';
+import Sandbox from '~src/_helpers/storybook/Sandbox';
 
 const Page = (): ReactElement => {
   return (
@@ -34,7 +35,22 @@ const Page = (): ReactElement => {
       <br />
       <br />
       <StorybookTitle>Usage</StorybookTitle>
-      <Highlight language="tsx">{`import { VisuallyHidden } from '@razorpay/blade/components' \nimport type { VisuallyHiddenProps } from '@razorpay/blade/components'`}</Highlight>
+      <Sandbox>
+        {`
+          import { VisuallyHidden, Checkbox, Text } from '@razorpay/blade/components';
+
+          function App(): JSX.Element {
+            return (
+              <div>
+                <Text>If you focus on checkbox below with voice over enabled, you will hear "Hidden Label" announcement</Text>
+                <Checkbox><VisuallyHidden>Hidden Label</VisuallyHidden></Checkbox>
+              </div>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
       <StorybookTitle>Example</StorybookTitle>
       <Primary />
       <StorybookTitle>Properties</StorybookTitle>


### PR DESCRIPTION
In earlier integration PRs, I only made changes to `Badge` stories to keep the PRs focussed and small. This PR adds examples to all the rest of the components.

- Figma Integration #804 
- CodeSandbox Integration #803 

> **Note**
>
> The PR is large but it is repetitive code