### PR TITLE
docs(Icons): add icon grid story

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "14.8.0"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "14.8.0"
-    }
-  }
-}

--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -5,7 +5,6 @@ import iconMap from './iconMap';
 import type { IconProps } from '.';
 import { CreditCardIcon } from '.';
 import Box from '~components/Box';
-import { Text } from '~components/Typography';
 import StoryPageWrapper from '~src/_helpers/storybook/StoryPageWrapper';
 import Sandbox from '~src/_helpers/storybook/Sandbox';
 
@@ -98,7 +97,16 @@ export const AllIcons: ComponentStory<ComponentType<IconProps>> = ({ ...args }) 
             key={key}
           >
             <IconComponent {...args} />
-            <Text size="small">{icon}</Text>
+            <small
+              style={{
+                width: '90%',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                textAlign: 'center',
+              }}
+            >
+              {icon}
+            </small>
           </Box>
         );
       })}

--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -4,6 +4,8 @@ import { Title } from '@storybook/addon-docs';
 import iconMap from './iconMap';
 import type { IconProps } from '.';
 import { CreditCardIcon } from '.';
+import Box from '~components/Box';
+import { Text } from '~components/Typography';
 import StoryPageWrapper from '~src/_helpers/storybook/StoryPageWrapper';
 import Sandbox from '~src/_helpers/storybook/Sandbox';
 
@@ -67,15 +69,38 @@ export default {
   },
 } as Meta<IconProps>;
 
-const IconTemplate: ComponentStory<ComponentType<IconProps & { icon: string }>> = ({
+const IconTemplate: ComponentStory<ComponentType<IconProps & { icon?: string }>> = ({
   icon,
   ...args
 }) => {
-  const IconComponent = iconMap[icon];
-  return <IconComponent {...args} />;
+  if (icon) {
+    const IconComponent = iconMap[icon];
+    return <IconComponent {...args} />;
+  }
+  return (
+    <Box>
+      {Object.keys(iconMap).map((icon, key) => {
+        const IconComponent = iconMap[icon];
+        return (
+          <Box
+            height={95}
+            width={125}
+            display="inline-flex"
+            flexDirection="column"
+            alignItems="center"
+            gap="spacing.6"
+            key={key}
+          >
+            <IconComponent {...args} />
+            <Text size="small">{icon}</Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
 };
 
 export const Icon = IconTemplate.bind({});
 Icon.args = {
-  icon: 'CreditCardIcon',
+  icon: undefined,
 };

--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -97,8 +97,9 @@ export const AllIcons: ComponentStory<ComponentType<IconProps>> = ({ ...args }) 
             key={key}
           >
             <IconComponent {...args} />
-            <small
+            <Box
               style={{
+                fontSize: 12,
                 width: '90%',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -106,7 +107,7 @@ export const AllIcons: ComponentStory<ComponentType<IconProps>> = ({ ...args }) 
               }}
             >
               {icon}
-            </small>
+            </Box>
           </Box>
         );
       })}

--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -69,14 +69,20 @@ export default {
   },
 } as Meta<IconProps>;
 
-const IconTemplate: ComponentStory<ComponentType<IconProps & { icon?: string }>> = ({
+const IconTemplate: ComponentStory<ComponentType<IconProps & { icon: string }>> = ({
   icon,
   ...args
 }) => {
-  if (icon) {
-    const IconComponent = iconMap[icon];
-    return <IconComponent {...args} />;
-  }
+  const IconComponent = iconMap[icon];
+  return <IconComponent {...args} />;
+};
+
+export const Icon = IconTemplate.bind({});
+Icon.args = {
+  icon: 'CreditCardIcon',
+};
+
+export const AllIcons: ComponentStory<ComponentType<IconProps>> = ({ ...args }) => {
   return (
     <Box>
       {Object.keys(iconMap).map((icon, key) => {
@@ -98,9 +104,4 @@ const IconTemplate: ComponentStory<ComponentType<IconProps & { icon?: string }>>
       })}
     </Box>
   );
-};
-
-export const Icon = IconTemplate.bind({});
-Icon.args = {
-  icon: undefined,
 };


### PR DESCRIPTION
**Description**

Closes #669. This is what I came up with. When `icon` is set to `undefined` it shows all available icons with their respective names. To see individual icon, select option can be used. More at https://github.com/razorpay/blade/issues/669#issuecomment-1312676483.