### PR TITLE
fix(Storybook): failing csb previews on master

### DIFF
--- a/.github/workflows/blade-chromatic.yml
+++ b/.github/workflows/blade-chromatic.yml
@@ -32,3 +32,4 @@ jobs:
           exitOnceUploaded: true
         env:
           GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF: ${{ github.ref }}

--- a/packages/blade/.storybook/react/main.js
+++ b/packages/blade/.storybook/react/main.js
@@ -29,6 +29,7 @@ module.exports = {
   env: (config) => ({
     ...config,
     GITHUB_SHA: process.env.GITHUB_SHA,
+    GITHUB_REF: process.env.GITHUB_REF,
   }),
   staticDirs: ['../../public/storybook-site'],
   webpackFinal: async (config, { configType }) => {

--- a/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
+++ b/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
@@ -15,6 +15,7 @@ export type SandboxProps = {
 };
 
 const getBladeVersion = (): string => {
+  console.log(process.env.NODE_ENV);
   const sha = process.env.GITHUB_SHA;
   if (sha) {
     const shortSha = sha.slice(0, 8);

--- a/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
+++ b/packages/blade/src/_helpers/storybook/Sandbox/Sandbox.web.tsx
@@ -15,9 +15,10 @@ export type SandboxProps = {
 };
 
 const getBladeVersion = (): string => {
-  console.log(process.env.NODE_ENV);
+  // We don't publish codesandbox ci on master so version is not present
+  const isMaster = process.env.GITHUB_REF === 'refs/heads/master';
   const sha = process.env.GITHUB_SHA;
-  if (sha) {
+  if (sha && !isMaster) {
     const shortSha = sha.slice(0, 8);
     return `https://pkg.csb.dev/razorpay/blade/commit/${shortSha}/@razorpay/blade`;
   }


### PR DESCRIPTION
Sandpack is failing on master because we don't publish codesandbox ci preview version on master. This PR adds check that sets `*` version on master.

https://razorpay.slack.com/archives/G01B3LQ9H0W/p1668669020171609

