### PR TITLE
feat(IconButton.stories): show console by default

### DIFF
--- a/packages/blade/src/components/Button/IconButton/IconButton.stories.tsx
+++ b/packages/blade/src/components/Button/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const Page = (): ReactElement => {
       }}
     >
       <Title>Usage</Title>
-      <Sandbox editorHeight={500}>
+      <Sandbox showConsole>
         {`
         import { IconButton, CloseIcon } from '@razorpay/blade/components';
 


### PR DESCRIPTION
Since we're console logging on clicks it's a nice quality of life improvement to show console by default