### PR TITLE
feat(FigmaEmbed): add access note for external people

### DIFF
--- a/packages/blade/src/_helpers/storybook/FigmaEmbed.tsx
+++ b/packages/blade/src/_helpers/storybook/FigmaEmbed.tsx
@@ -1,4 +1,5 @@
 import { Description } from '@storybook/addon-docs';
+import dedent from 'dedent';
 
 function FigmaEmbed(props: { src: string; title: string }): JSX.Element {
   return (
@@ -12,7 +13,14 @@ function FigmaEmbed(props: { src: string; title: string }): JSX.Element {
         allowFullScreen
       />
       <Description
-        markdown={`> **Note** <br/>If you're using adblockers, the Figma Embed may not work. <br />You can pause adblocker for this site and allow cross site cookies which might be blocked by your browser. <br/> Or you can [check out the designs on Figma](${props.src}) directly`}
+        markdown={dedent`
+          > **Note**
+          > 
+          > Currently the designs are only accessible to Razorpay Employees.
+          >
+          > For Razorpay Employees,<br/>
+          > Figma Embed may not work with adblockers 😿. You can [View Design on Figma](${props.src}) or pause adblockers for this domain.
+        `}
       />
       <br />
       <br />


### PR DESCRIPTION
The figma is not accessible to external people right now. Added note for that.

Also the note was getting too large so shortened the note for adblockers as well.

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/30949385/203484809-f576e2b8-8776-43af-a96b-94d31af8a812.png">
