### PR TITLE
docs(Icons): docs for adding new icons

### DIFF
--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType, ReactElement } from 'react';
 import type { ComponentStory, Meta } from '@storybook/react';
-import { Title } from '@storybook/addon-docs';
+import { Title, Description } from '@storybook/addon-docs';
 import iconMap from './iconMap';
 import type { IconProps } from '.';
 import { CreditCardIcon } from '.';
@@ -13,7 +13,7 @@ const Page = (): ReactElement => {
     <StoryPageWrapper
       componentDescription="We provide a bunch of icons out-of-the-box for Blade in 6 different sizes. You can choose which size & color fits the best for your use case using the color & size props."
       componentName="Icon"
-      note="For now, we have added only a few icons but you can contribute to Blade by adding more icons that are available on the Figma board as and when a use-case arises"
+      note="For now, we have added only a few icons but you can contribute to Blade by adding more icons that are available on the Figma board as and when a use-case arises. **See the adding icons section below for reference.**"
       imports={`// Replace IconName with actual Icon's name that you would like to use \nimport { IconName } from '@razorpay/blade/components' \n// IconProps are generic Icon props for all icons, don't replace it with your IconName \nimport type { IconProps } from '@razorpay/blade/components'`}
       figmaURL={{
         paymentTheme:
@@ -43,6 +43,51 @@ const Page = (): ReactElement => {
         export default App;
         `}
       </Sandbox>
+      <Title>Adding icons</Title>
+      <Description>
+        Please validate in the all icons story below in case the icon you wish to add is already
+        added. Steps for adding a new icon from Figma:
+      </Description>
+      <ul>
+        <li>
+          <Description>
+            Visit the [icons figma
+            file](https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=57%3A0&t=xzz6HfFC50U8iuJp-0)
+          </Description>
+        </li>
+        <li>
+          <Description>
+            Click the icon you wish to add on Figma. Select the root icon element and not the layer
+            within. Copy this root icon as SVG. **Note**: generally the root svgs have a viewbox of
+            `0 0 24 24`.
+          </Description>
+        </li>
+        <li>
+          <Description>
+            ![](https://user-images.githubusercontent.com/24487274/203279145-1e0b0540-467d-4901-97c8-014f98b3cfca.png)
+          </Description>
+        </li>
+        <li>
+          <Description>
+            Replace the native HTML elements with Blade's components (eg. `svg` becomes `Svg`). You
+            may use a tool such as [SVGR](https://react-svgr.com/playground/?native=true) for the
+            initial transformation. Some properties may still need to be adjusted. Follow an
+            existing icon as a reference.
+          </Description>
+        </li>
+        <li>
+          <Description>
+            Once you're done making changes, run the storybook to verify how the new icon is looking
+            and if it looks inline with rest of the icons. Once you're happy with the results run
+            the tests for web and native to update the snapshots.
+          </Description>
+        </li>
+        <li>
+          <Description>
+            See [this reference PR](https://github.com/razorpay/blade/pull/872).
+          </Description>
+        </li>
+      </ul>
     </StoryPageWrapper>
   );
 };

--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -11,9 +11,9 @@ import { Sandbox } from '~src/_helpers/storybook/Sandbox';
 const Page = (): ReactElement => {
   return (
     <StoryPageWrapper
-      componentDescription="We provide a bunch of icons out-of-the-box for Blade in 6 different sizes. You can choose which size & color fits the best for your use case using the color & size props."
+      componentDescription="Blade provides a bunch of icons out of the box in 6 different sizes. You can choose the size & color that fits best for your use case using the color & size props."
       componentName="Icon"
-      note="For now, we have added only a few icons but you can contribute to Blade by adding more icons that are available on the Figma board as and when a use-case arises. **See the adding icons section below for reference.**"
+      note="Blade consists of a limited set of icons that are commonly used however you can contribute to Blade by adding more icons that are available on the Figma board as and when a use case arises. **See the adding icons section below for reference.**"
       imports={`// Replace IconName with actual Icon's name that you would like to use \nimport { IconName } from '@razorpay/blade/components' \n// IconProps are generic Icon props for all icons, don't replace it with your IconName \nimport type { IconProps } from '@razorpay/blade/components'`}
       figmaURL={{
         paymentTheme:
@@ -45,49 +45,35 @@ const Page = (): ReactElement => {
       </Sandbox>
       <Title>Adding icons</Title>
       <Description>
-        Please validate in the all icons story below in case the icon you wish to add is already
-        added. Steps for adding a new icon from Figma:
+        1. Please validate in the all icons story below in case the icon you wish to add is already
+        present. Steps for adding a new icon from Figma:
       </Description>
-      <ul>
-        <li>
-          <Description>
-            Visit the [icons figma
-            file](https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=57%3A0&t=xzz6HfFC50U8iuJp-0)
-          </Description>
-        </li>
-        <li>
-          <Description>
-            Click the icon you wish to add on Figma. Select the root icon element and not the layer
-            within. Copy this root icon as SVG. **Note**: generally the root svgs have a viewbox of
-            `0 0 24 24`.
-          </Description>
-        </li>
-        <li>
-          <Description>
-            ![](https://user-images.githubusercontent.com/24487274/203279145-1e0b0540-467d-4901-97c8-014f98b3cfca.png)
-          </Description>
-        </li>
-        <li>
-          <Description>
-            Replace the native HTML elements with Blade's components (eg. `svg` becomes `Svg`). You
-            may use a tool such as [SVGR](https://react-svgr.com/playground/?native=true) for the
-            initial transformation. Some properties may still need to be adjusted. Follow an
-            existing icon as a reference.
-          </Description>
-        </li>
-        <li>
-          <Description>
-            Once you're done making changes, run the storybook to verify how the new icon is looking
-            and if it looks inline with rest of the icons. Once you're happy with the results run
-            the tests for web and native to update the snapshots.
-          </Description>
-        </li>
-        <li>
-          <Description>
-            See [this reference PR](https://github.com/razorpay/blade/pull/872).
-          </Description>
-        </li>
-      </ul>
+      <Description>
+        2. Visit the [icons figma
+        file](https://www.figma.com/file/jubmQL9Z8V7881ayUD95ps/Blade---Payment-Light?node-id=57%3A0&t=xzz6HfFC50U8iuJp-0)
+      </Description>
+      <Description>
+        3. Click the icon you wish to add on Figma. Select the root icon element instead of the
+        layer within. Copy this root icon as SVG. **Note**: Generally the root svgs have a viewbox
+        of `0 0 24 24`.
+      </Description>
+      <Description>
+        ![](https://user-images.githubusercontent.com/24487274/203279145-1e0b0540-467d-4901-97c8-014f98b3cfca.png)
+      </Description>
+      <Description>
+        4. Replace the native HTML elements with Blade's components (eg. `svg` becomes `Svg`). You
+        may use a tool such as [SVGR](https://react-svgr.com/playground/?native=true) for the
+        initial transformation. Some properties may still need to be adjusted. Follow an existing
+        icon as a reference.
+      </Description>
+      <Description>
+        5. Once you're done making changes, run the storybook to verify how the new icon looks and
+        if it is inline with rest of the icons. Once you're happy with the results run the tests for
+        web and native to update the snapshots.
+      </Description>
+      <Description>
+        6. See [this reference PR](https://github.com/razorpay/blade/pull/872).
+      </Description>
     </StoryPageWrapper>
   );
 };


### PR DESCRIPTION
We often receive PRs for adding new icons. Adds some docs for reference.

See the [new docs here](https://61c19ee8d3d282003ac1d81c-ffzhqctgvz.chromatic.com/?path=/docs/components-icons--icon&globals=measureEnabled:false)