### PR TITLE
fix(Checkbox): allows Checkbox to accept `childern` prop of type `React.ReactNode`

### DIFF
--- a/.changeset/friendly-oranges-decide.md
+++ b/.changeset/friendly-oranges-decide.md
@@ -1,5 +1,5 @@
 ---
-'@razorpay/blade': minor
+'@razorpay/blade': patch
 ---
 
 fix(Checkbox): allow Checkbox to accept `childern` prop of type `React.ReactNode`

--- a/.changeset/friendly-oranges-decide.md
+++ b/.changeset/friendly-oranges-decide.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': minor
+---
+
+fix(Checkbox): allow Checkbox to accept `childern` prop of type `React.ReactNode`

--- a/packages/blade/src/components/Checkbox/Checkbox.tsx
+++ b/packages/blade/src/components/Checkbox/Checkbox.tsx
@@ -41,9 +41,9 @@ type CheckboxProps = {
    */
   onChange?: OnChange;
   /**
-   * Sets the label text of the checkbox
+   * Sets the label of the checkbox
    */
-  children: string;
+  children: React.ReactNode;
   /**
    * Help text for the checkbox
    */

--- a/packages/blade/src/components/Checkbox/__tests__/Checkbox.web.test.tsx
+++ b/packages/blade/src/components/Checkbox/__tests__/Checkbox.web.test.tsx
@@ -3,16 +3,20 @@
 import userEvents from '@testing-library/user-event';
 import React from 'react';
 import { Checkbox } from '../Checkbox';
+import { Link } from '~components/Link';
 import renderWithTheme from '~src/_helpers/testing/renderWithTheme.web';
 
 describe('<Checkbox />', () => {
   it('should render checkbox with label', () => {
-    const labelText = 'Remember password';
-    const { container, getByText, getByRole } = renderWithTheme(<Checkbox>{labelText}</Checkbox>);
+    const label = (
+      <>
+        I accept <Link>Terms and Conditions</Link>
+      </>
+    );
+
+    const { container, getByRole } = renderWithTheme(<Checkbox>{label}</Checkbox>);
     expect(container).toMatchSnapshot();
-    // the name attribute here is the accessibility label name and not the name of the input
-    expect(getByRole('checkbox', { name: labelText })).toBeInTheDocument();
-    expect(getByText(labelText)).toBeInTheDocument();
+    expect(getByRole('checkbox')).toBeInTheDocument();
   });
 
   it('should render helpText', () => {

--- a/packages/blade/src/components/Checkbox/__tests__/Checkbox.web.test.tsx
+++ b/packages/blade/src/components/Checkbox/__tests__/Checkbox.web.test.tsx
@@ -10,7 +10,7 @@ describe('<Checkbox />', () => {
   it('should render checkbox with label', () => {
     const label = (
       <>
-        I accept <Link>Terms and Conditions</Link>
+        I accept <Link href="#">Terms and Conditions</Link>
       </>
     );
 

--- a/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.web.test.tsx.snap
+++ b/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.web.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
   margin-left: 4px;
 }
 
-.c8 {
+.c10 {
   margin-left: 24px;
 }
 
@@ -70,6 +70,20 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
   line-height: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.c9 {
+  color: hsla(213,89%,56%,1);
+  font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 0.875rem;
+  font-weight: 700;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  text-align: center;
   margin: 0;
   padding: 0;
 }
@@ -108,6 +122,44 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
 .c3:focus + div {
   border-color: hsla(214,18%,69%,1);
   background-color: hsla(216,44%,23%,0.09);
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 70ms;
+  transition-duration: 70ms;
+}
+
+.c8 {
+  padding: 0;
+  background-color: transparent;
+  outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: 2px;
+  -webkit-transition-property: box-shadow;
+  transition-property: box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 70ms;
+  transition-duration: 70ms;
+}
+
+.c8 .content-container {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  border-radius: 2px;
+}
+
+.c8:focus .content-container {
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18);
+}
+
+.c8 * {
+  -webkit-transition-property: color,fill;
+  transition-property: color,fill;
   -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
   -webkit-transition-duration: 70ms;
@@ -182,11 +234,32 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
             font-size="100"
             font-weight="regular"
           >
-            Remember password
+            I accept 
+            <a
+              aria-disabled="false"
+              class="c8"
+              cursor="pointer"
+              data-blade-component="link"
+              role="link"
+            >
+              <div
+                class="c2 content-container"
+                display="flex"
+              >
+                <div
+                  class="c9"
+                  color="action.text.link.default"
+                  font-size="100"
+                  font-weight="bold"
+                >
+                  Terms and Conditions
+                </div>
+              </div>
+            </a>
           </div>
         </div>
         <div
-          class="c8"
+          class="c10"
         />
       </div>
     </label>

--- a/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.web.test.tsx.snap
+++ b/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.web.test.tsx.snap
@@ -240,6 +240,7 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
               class="c8"
               cursor="pointer"
               data-blade-component="link"
+              href="#"
               role="link"
             >
               <div


### PR DESCRIPTION
Currently, Checkbox only accepts `childern` of type `string`
but we have use cases where we may want to pass multiple elements, not just only string, as discussed in #787 

Resolves #787 