### PR TITLE
fix(blade-pr-title-check): use github token instead of ci token

### DIFF
--- a/.github/workflows/blade-pr-title-check.yml
+++ b/.github/workflows/blade-pr-title-check.yml
@@ -1,8 +1,8 @@
 name: Blade PR Title Check
 
-on: 
+on:
   pull_request:
-     types: [open, edited, synchronize]
+    types: [open, edited, synchronize]
 
 concurrency: # cancel previously running workflows when a new workflow is re-run
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,7 +13,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
     env:
-      GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: pr_title_check
@@ -23,19 +23,18 @@ jobs:
         if: always() && (steps.pr_title_check.outputs.error_message != null)
         with:
           header: pr-title-comment
-          message: |            
+          message: |
             ❌ PR title doesn't follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
 
             Details:
-            
+
             ```
             ${{ steps.pr_title_check.outputs.error_message }}
             ```
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.pr_title_check.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@v2
-        with:   
+        with:
           header: pr-title-comment
           recreate: true
           message: '✅ PR title follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).'
-  


### PR DESCRIPTION
It was failing in #887 because CI_TOKEN is not accessible to people outside of Razorpay