### PR TITLE
fix: allows `OTPInput` to accept only numeric values

### DIFF
--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -243,6 +243,7 @@ const OTPInput = ({
             errorText={errorText}
             helpText={helpText}
             hideFormHint={true}
+            type="numeric"
           />
         </Box>,
       );

--- a/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.web.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -369,7 +369,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -406,7 +406,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -443,7 +443,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -480,7 +480,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -517,7 +517,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>


### PR DESCRIPTION
Resolves #786