### PR TITLE
feat: allow masked otp input

### DIFF
--- a/.changeset/cool-pandas-draw.md
+++ b/.changeset/cool-pandas-draw.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat: allow masked otp input

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
@@ -175,6 +175,14 @@ OTPInputHelpText.args = {
   helpText: 'Add a message here',
 };
 
+export const OTPInputMasked = OTPInputTemplate.bind({});
+OTPInputMasked.storyName = 'OTPInput with Masked input';
+OTPInputMasked.args = {
+  isMasked: true,
+  otpLength: 4,
+  label: 'Enter Pin',
+};
+
 export const OTPInputError = OTPInputTemplate.bind({});
 OTPInputError.storyName = 'OTPInput with error';
 OTPInputError.args = {

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -248,7 +248,7 @@ const OTPInput = ({
             errorText={errorText}
             helpText={helpText}
             hideFormHint={true}
-            type={isMasked ? 'password' : 'numeric'}
+            type={isMasked ? 'password' : undefined}
           />
         </Box>,
       );

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -36,6 +36,10 @@ export type OTPInputProps = Pick<
    * The callback function to be invoked when all the values of the OTPInput are filled
    */
   onOTPFilled?: FormInputOnEvent;
+  /**
+   * Masks input characters in all the fields
+   */
+  isMasked?: boolean;
 };
 
 const isReactNative = getPlatformType() === 'react-native';
@@ -76,6 +80,7 @@ const OTPInput = ({
   successText,
   validationState,
   value: inputValue,
+  isMasked,
 }: OTPInputProps): React.ReactElement => {
   const inputRefs: React.RefObject<HTMLInputElement>[] = [];
   const [otpValue, setOtpValue] = useState<string[]>(otpToArray(inputValue));
@@ -243,6 +248,7 @@ const OTPInput = ({
             errorText={errorText}
             helpText={helpText}
             hideFormHint={true}
+            type={isMasked ? 'password' : 'numeric'}
           />
         </Box>,
       );

--- a/packages/blade/src/components/Input/OTPInput/__tests__/OTPInput.native.test.tsx
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/OTPInput.native.test.tsx
@@ -34,6 +34,18 @@ describe('<OTPInput />', () => {
     });
   });
 
+  it('should mask all fields when isMasked is true', () => {
+    const label = 'Enter OTP';
+    const { getAllByLabelText } = renderWithTheme(<OTPInput label={label} isMasked />);
+
+    const allInputs = getAllByLabelText(/character/);
+    allInputs.forEach((input) => {
+      // we assume auto focus is working with this prop in place, no simple way of asserting on focus otherwise
+      // @ts-expect-error TS typings not being picked from library
+      expect(input).toHaveProp('secureTextEntry', true);
+    });
+  });
+
   it('should handle onChange', () => {
     const label = 'Enter OTP';
     const onChange = jest.fn();

--- a/packages/blade/src/components/Input/OTPInput/__tests__/OTPInput.web.test.tsx
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/OTPInput.web.test.tsx
@@ -47,6 +47,16 @@ describe('<OTPInput />', () => {
     });
   });
 
+  it('should mask all fields when isMasked is true', () => {
+    const label = 'Enter OTP';
+    const { getAllByLabelText } = renderWithTheme(<OTPInput label={label} isMasked />);
+
+    const allInputs = getAllByLabelText(/character/);
+    allInputs.forEach((input) => {
+      expect(input).toHaveAttribute('type', 'password');
+    });
+  });
+
   it('should handle onChange', async () => {
     const label = 'Enter OTP';
     const onChange = jest.fn();

--- a/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.web.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -369,7 +369,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -406,7 +406,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -443,7 +443,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -480,7 +480,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>
@@ -517,7 +517,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="text"
+                  type="numeric"
                   value=""
                 />
               </div>

--- a/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.web.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="numeric"
+                  type="text"
                   value=""
                 />
               </div>
@@ -369,7 +369,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="numeric"
+                  type="text"
                   value=""
                 />
               </div>
@@ -406,7 +406,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="numeric"
+                  type="text"
                   value=""
                 />
               </div>
@@ -443,7 +443,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="numeric"
+                  type="text"
                   value=""
                 />
               </div>
@@ -480,7 +480,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="numeric"
+                  type="text"
                   value=""
                 />
               </div>
@@ -517,7 +517,7 @@ exports[`<OTPInput /> should render 1`] = `
                   inputmode="decimal"
                   placeholder=""
                   required=""
-                  type="numeric"
+                  type="text"
                   value=""
                 />
               </div>

--- a/packages/blade/src/components/Input/OTPInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/OTPInput/_decisions/_decisions.md
@@ -47,6 +47,7 @@ This doc talks about the API decisions for `OTPInput`.
 | autoFocus | `boolean` | No | `false` | The autofocus global attribute is a Boolean attribute indicating that an element should be focused on page load. [Web Reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus), [Native Reference](https://reactnative.dev/docs/textinput#autofocus) |
 | keyboardReturnKeyType. [Check this table for full reference](#keyboard-return-key-types-for-web-and-native) | `default`, `go`, `done`, `next`, `search`, `send` | No | Closest based on the `type` attribute | Determines how the return key should look on the keyboard on mobile devices or virtual keyboard |
 | keyboardType | `text`, `search`, `telephone`, `email`, `url`, `decimal` | No | `decimal` | Keyboard to be shown for specific input types |
+| isMasked | `boolean` | No | `undefined` | Masks input characters in all the fields |
 
 ## Keyboard return key types for web and native
 


### PR DESCRIPTION
Adds support for masked input fields in `OTPInput`

**Demo:** 

https://user-images.githubusercontent.com/24487274/204982587-e1400d43-7f01-4bc5-8b85-6072cdb473a9.mov

