### PR TITLE
feat(Alert): update `isFullWidth` to make inline borderless alerts on desktop

### DIFF
--- a/.changeset/proud-boxes-reflect.md
+++ b/.changeset/proud-boxes-reflect.md
@@ -1,0 +1,18 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(Alert): update `isFullWidth` to make inline borderless alerts on desktop
+
+> **Warning**
+>
+> `isBorderless` prop is removed and its usage is now replaced by `isFullWidth`. The layout is updated to match the designs and is now centered on desktop resolutions.
+
+### Steps for migration:
+
+```diff
+<Alert
+- isBorderless
++ isFullWidth
+/>
+```

--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -79,7 +79,6 @@ const meta: Meta<AlertProps> = {
     isDismissable: true,
     contrast: 'low',
     intent: 'information',
-    isBorderless: false,
     actions: {
       primary: {
         text: 'Primary Action',
@@ -189,7 +188,15 @@ PrimaryActionOnly.parameters = {
   },
 };
 
-export const FullWidth = AlertTemplate.bind({});
+export const FullWidth: ComponentStory<typeof AlertComponent> = ({ ...args }) => {
+  return (
+    <Box height={200} position="relative">
+      <Box position="absolute" width="100%">
+        <AlertComponent {...args} />
+      </Box>
+    </Box>
+  );
+};
 FullWidth.args = {
   description: 'Currently you can only accept payments in international currencies using PayPal.',
   intent: 'notice',
@@ -200,31 +207,8 @@ FullWidth.args = {
 FullWidth.parameters = {
   docs: {
     description: {
-      story: 'A full width Alert can be used to span the entire width of its container',
-    },
-  },
-};
-
-export const Borderless: ComponentStory<typeof AlertComponent> = ({ ...args }) => {
-  return (
-    <Box height={200} position="relative">
-      <Box position="absolute" width="100%">
-        <AlertComponent {...args} />
-      </Box>
-    </Box>
-  );
-};
-Borderless.args = {
-  description: 'Use vendor payouts to quickly generate invoices.',
-  actions: undefined,
-  title: undefined,
-  isBorderless: true,
-};
-Borderless.parameters = {
-  docs: {
-    description: {
       story:
-        'A borderless Alert can be used for full-bleed layouts, this automatically makes the alert full width. You can also wrap the alert and adjust layout with absolute positioning if needed.',
+        'A full width Alert can be used to span the entire width of its container. It also makes the Alert borderless and can be used for full-bleed layouts. You can also wrap the alert and adjust layout with absolute positioning if needed.',
     },
   },
 };

--- a/packages/blade/src/components/Alert/Alert.tsx
+++ b/packages/blade/src/components/Alert/Alert.tsx
@@ -81,7 +81,8 @@ type AlertProps = {
   contrast?: ColorContrastTypes;
 
   /**
-   * Makes the Alert span the entire container width, instead of the default max width of `584px`
+   * Makes the Alert span the entire container width, instead of the default max width of `584px`.
+   * This also makes the alert borderless, useful for creating full bleed layouts.
    *
    * @default false
    */
@@ -93,13 +94,6 @@ type AlertProps = {
    * @default neutral
    */
   intent?: Feedback;
-
-  /**
-   * Removes border and border radii, useful for creating full bleed layouts. Automatically sets `isFullWidth` to `true` when enabled.
-   *
-   * @default false
-   */
-  isBorderless?: boolean;
 
   /**
    * Renders a primary action button and a secondary action link button
@@ -139,7 +133,6 @@ const Alert = ({
   contrast = 'low',
   isFullWidth = false,
   intent = 'neutral',
-  isBorderless = false,
   actions,
 }: AlertProps): ReactElement | null => {
   if (!actions?.primary && actions?.secondary) {
@@ -153,25 +146,25 @@ const Alert = ({
 
   const [isVisible, setIsVisible] = useState(true);
   const contrastType = `${contrast}Contrast` as const;
-  const iconSize = isBorderless ? 'large' : 'medium';
-  const textSize = isBorderless ? 'medium' : 'small';
+  const iconSize = isFullWidth ? 'large' : 'medium';
+  const textSize = isFullWidth ? 'medium' : 'small';
 
   const Icon = intentIconMap[intent];
   let iconOffset: DotNotationSpacingStringToken = 'spacing.1';
 
   // certain special cases below needs special care for near perfect alignment
   if (isReactNative) {
-    if (isBorderless && !title) {
+    if (isFullWidth && !title) {
       iconOffset = 'spacing.1';
-    } else if (!isBorderless && !title) {
+    } else if (!isFullWidth && !title) {
       iconOffset = 'spacing.0';
-    } else if (!isBorderless && title) {
+    } else if (!isFullWidth && title) {
       iconOffset = 'spacing.2';
     }
   } else if (isMobile) {
-    if (!isBorderless && title) {
+    if (!isFullWidth && title) {
       iconOffset = 'spacing.2';
-    } else if (isBorderless && !title) {
+    } else if (isFullWidth && !title) {
       iconOffset = 'spacing.2';
     }
   }
@@ -184,7 +177,7 @@ const Alert = ({
 
   const _title = title ? (
     <Box marginBottom="spacing.2">
-      {isBorderless ? (
+      {isFullWidth ? (
         <Heading size="small" contrast={contrast}>
           {title}
         </Heading>
@@ -284,12 +277,11 @@ const Alert = ({
       intent={intent}
       contrastType={contrastType}
       isFullWidth={isFullWidth}
-      isBorderless={isBorderless}
       {...a11yProps}
       {...metaAttribute(MetaConstants.Component, MetaConstants.Alert)}
     >
       {icon}
-      <Box flex={1} paddingLeft={isBorderless ? 'spacing.4' : 'spacing.3'} paddingRight="spacing.2">
+      <Box flex={1} paddingLeft={isFullWidth ? 'spacing.4' : 'spacing.3'} paddingRight="spacing.2">
         {_title}
         {_description}
         {_actions}

--- a/packages/blade/src/components/Alert/Alert.tsx
+++ b/packages/blade/src/components/Alert/Alert.tsx
@@ -114,7 +114,6 @@ type AlertProps = {
 const isReactNative = getPlatformType() === 'react-native';
 
 // Need extra wrappers on React Native only for alignment
-const SecondaryActionWrapper = isReactNative ? Box : Fragment;
 const CloseButtonWrapper = isReactNative ? Box : Fragment;
 
 const intentIconMap = {
@@ -142,7 +141,8 @@ const Alert = ({
   }
   const { theme } = useTheme();
   const { matchedDeviceType } = useBreakpoint({ breakpoints: theme.breakpoints });
-  const isMobile = matchedDeviceType === 'mobile';
+  const isDesktop = matchedDeviceType === 'desktop';
+  const isMobile = !isDesktop;
 
   const [isVisible, setIsVisible] = useState(true);
   const contrastType = `${contrast}Contrast` as const;
@@ -167,6 +167,8 @@ const Alert = ({
     } else if (isFullWidth && !title) {
       iconOffset = 'spacing.2';
     }
+  } else if (isFullWidth) {
+    iconOffset = 'spacing.0';
   }
 
   const icon = (
@@ -228,15 +230,26 @@ const Alert = ({
     secondaryActionParams.rel = actions.secondary.rel;
   }
   const secondaryAction = actions?.secondary ? (
-    <SecondaryActionWrapper>
+    <Box marginRight="spacing.4" display={isReactNative ? 'flex' : 'inline-flex'}>
       <BaseLink size={textSize} contrast={contrast} intent={intent} {...secondaryActionParams}>
         {actions.secondary.text}
       </BaseLink>
-    </SecondaryActionWrapper>
+    </Box>
   ) : null;
 
-  const _actions =
-    primaryAction || secondaryAction ? (
+  // For certain cases we wish to render actions inline with text content
+  const showActionsHorizontal = isFullWidth && isDesktop;
+
+  const actionsHorizontal =
+    showActionsHorizontal && (primaryAction || secondaryAction) ? (
+      <Box flexDirection="row" alignItems="center">
+        {primaryAction}
+        {secondaryAction}
+      </Box>
+    ) : null;
+
+  const actionsVertical =
+    !showActionsHorizontal && (primaryAction || secondaryAction) ? (
       <Box marginTop="spacing.4" flexDirection="row" alignItems="center">
         {primaryAction}
         {secondaryAction}
@@ -277,15 +290,21 @@ const Alert = ({
       intent={intent}
       contrastType={contrastType}
       isFullWidth={isFullWidth}
+      isDesktop={isDesktop}
       {...a11yProps}
       {...metaAttribute(MetaConstants.Component, MetaConstants.Alert)}
     >
       {icon}
-      <Box flex={1} paddingLeft={isFullWidth ? 'spacing.4' : 'spacing.3'} paddingRight="spacing.2">
+      <Box
+        flex={1}
+        paddingLeft={isFullWidth ? 'spacing.4' : 'spacing.3'}
+        paddingRight={showActionsHorizontal ? 'spacing.4' : 'spacing.2'}
+      >
         {_title}
         {_description}
-        {_actions}
+        {actionsVertical}
       </Box>
+      {actionsHorizontal}
       {closeButton}
     </StyledAlert>
   );

--- a/packages/blade/src/components/Alert/__tests__/Alert.native.test.tsx
+++ b/packages/blade/src/components/Alert/__tests__/Alert.native.test.tsx
@@ -24,18 +24,6 @@ describe('<Alert />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should render negative intent and borderless', () => {
-    const { toJSON } = renderWithTheme(
-      <Alert
-        description="Currently you can only accept payments in international currencies using PayPal."
-        intent="negative"
-        isBorderless
-      />,
-    );
-
-    expect(toJSON()).toMatchSnapshot();
-  });
-
   it('should handle onClick on actions', () => {
     const onClickPrimary = jest.fn();
     const onClickSecondary = jest.fn();

--- a/packages/blade/src/components/Alert/__tests__/Alert.web.test.tsx
+++ b/packages/blade/src/components/Alert/__tests__/Alert.web.test.tsx
@@ -25,18 +25,6 @@ describe('<Alert />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render negative intent and borderless', () => {
-    const { container } = renderWithTheme(
-      <Alert
-        description="Currently you can only accept payments in international currencies using PayPal."
-        intent="negative"
-        isBorderless
-      />,
-    );
-
-    expect(container).toMatchSnapshot();
-  });
-
   it('should handle onClick on actions', async () => {
     const user = userEvent.setup();
     const onClickPrimary = jest.fn();

--- a/packages/blade/src/components/Alert/__tests__/__snapshots__/Alert.native.test.tsx.snap
+++ b/packages/blade/src/components/Alert/__tests__/__snapshots__/Alert.native.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Alert /> should render 1`] = `
   accessibilityRole="alert"
   contrastType="lowContrast"
   intent="neutral"
-  isBorderless={false}
+  isDesktop={false}
   isFullWidth={false}
   style={
     Array [
@@ -253,19 +253,19 @@ exports[`<Alert /> should render 1`] = `
 </View>
 `;
 
-exports[`<Alert /> should render negative intent and borderless 1`] = `
+exports[`<Alert /> should render positive intent and full width 1`] = `
 <View
   accessibilityRole="alert"
   contrastType="lowContrast"
-  intent="negative"
-  isBorderless={true}
-  isFullWidth={false}
+  intent="positive"
+  isDesktop={false}
+  isFullWidth={true}
   style={
     Array [
       Object {
         "alignItems": "flex-start",
-        "backgroundColor": "hsla(9, 91%, 56%, 0.09)",
-        "borderColor": "hsla(9, 91%, 56%, 0.32)",
+        "backgroundColor": "hsla(155, 100%, 31%, 0.09)",
+        "borderColor": "hsla(155, 100%, 31%, 0.32)",
         "borderRadius": 0,
         "borderStyle": "solid",
         "borderWidth": 0,
@@ -329,36 +329,40 @@ exports[`<Alert /> should render negative intent and borderless 1`] = `
           ]
         }
       >
-        <RNSVGPath
-          d="M12 7C12.5523 7 13 7.44772 13 8V12C13 12.5523 12.5523 13 12 13C11.4477 13 11 12.5523 11 12V8C11 7.44772 11.4477 7 12 7Z"
-          fill={4291770400}
-          propList={
-            Array [
-              "fill",
-            ]
-          }
-        />
-        <RNSVGPath
-          d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z"
-          fill={4291770400}
-          propList={
-            Array [
-              "fill",
-            ]
-          }
-        />
-        <RNSVGPath
-          clipRule={0}
-          d="M7.15289 1.29289C7.33386 1.11193 7.58386 1 7.86 1H16.14C16.4052 1 16.6596 1.10536 16.8471 1.29289L22.7071 7.15289C22.8946 7.34043 23 7.59478 23 7.86V16.14C23 16.4052 22.8946 16.6596 22.7071 16.8471L16.8471 22.7071C16.6596 22.8946 16.4052 23 16.14 23H7.86C7.59478 23 7.34043 22.8946 7.15289 22.7071L1.29289 16.8471C1.10536 16.6596 1 16.4052 1 16.14V7.86C1 7.59478 1.10536 7.34043 1.29289 7.15289L7.15289 1.29289ZM8.27421 3L3 8.27421V15.7258L8.27421 21H15.7258L21 15.7258V8.27421L15.7258 3H8.27421Z"
-          fill={4291770400}
-          fillRule={0}
-          propList={
-            Array [
-              "fill",
-              "fillRule",
-            ]
-          }
-        />
+        <RNSVGGroup
+          clipPath="clip0_60_208"
+        >
+          <RNSVGPath
+            d="M4.15845 7.14679C6.74812 4.11688 11.0222 3.1512 14.663 4.77343C15.1675 4.99821 15.7586 4.77147 15.9834 4.267C16.2082 3.76253 15.9815 3.17135 15.477 2.94657C11.0272 0.96385 5.80325 2.14413 2.6381 5.84735C-0.527049 9.55057 -0.879431 14.8946 1.77205 18.9813C4.42353 23.0681 9.44725 24.9241 14.1189 23.5429C18.7905 22.1616 21.9972 17.8716 22 13V12.07C22 11.5177 21.5523 11.07 21 11.07C20.4477 11.07 20 11.5177 20 12.07V12.9994C19.9977 16.9852 17.3741 20.4948 13.5518 21.6249C9.72957 22.7551 5.61926 21.2365 3.44986 17.8928C1.28047 14.5491 1.56878 10.1767 4.15845 7.14679Z"
+            fill={4278224216}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+          />
+          <RNSVGPath
+            d="M22.7071 4.70711C23.0976 4.31658 23.0976 3.68342 22.7071 3.29289C22.3166 2.90237 21.6834 2.90237 21.2929 3.29289L11 13.5858L8.70711 11.2929C8.31658 10.9024 7.68342 10.9024 7.29289 11.2929C6.90237 11.6834 6.90237 12.3166 7.29289 12.7071L10.2929 15.7071C10.6834 16.0976 11.3166 16.0976 11.7071 15.7071L22.7071 4.70711Z"
+            fill={4278224216}
+            propList={
+              Array [
+                "fill",
+              ]
+            }
+          />
+        </RNSVGGroup>
+        <RNSVGDefs>
+          <RNSVGClipPath
+            name="clip0_60_208"
+          >
+            <RNSVGRect
+              height="24"
+              width="24"
+              x={0}
+              y={0}
+            />
+          </RNSVGClipPath>
+        </RNSVGDefs>
       </RNSVGGroup>
     </RNSVGSvgView>
   </View>
@@ -481,263 +485,6 @@ exports[`<Alert /> should render negative intent and borderless 1`] = `
         vbHeight={24}
         vbWidth={24}
         width="20px"
-      >
-        <RNSVGGroup
-          fill={null}
-          propList={
-            Array [
-              "fill",
-            ]
-          }
-        >
-          <RNSVGPath
-            d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
-            fill={4288851646}
-            propList={
-              Array [
-                "fill",
-              ]
-            }
-          />
-        </RNSVGGroup>
-      </RNSVGSvgView>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`<Alert /> should render positive intent and full width 1`] = `
-<View
-  accessibilityRole="alert"
-  contrastType="lowContrast"
-  intent="positive"
-  isBorderless={false}
-  isFullWidth={true}
-  style={
-    Array [
-      Object {
-        "alignItems": "flex-start",
-        "backgroundColor": "hsla(155, 100%, 31%, 0.09)",
-        "borderColor": "hsla(155, 100%, 31%, 0.32)",
-        "borderRadius": 4,
-        "borderStyle": "solid",
-        "borderWidth": 1,
-        "display": "flex",
-        "flexDirection": "row",
-        "maxWidth": "auto",
-        "paddingBottom": 12,
-        "paddingLeft": 8,
-        "paddingRight": 8,
-        "paddingTop": 8,
-      },
-    ]
-  }
->
-  <View
-    display="flex"
-    marginTop="spacing.0"
-    style={
-      Array [
-        Object {
-          "display": "flex",
-          "marginTop": 0,
-        },
-      ]
-    }
-  >
-    <RNSVGSvgView
-      accessibilityElementsHidden={true}
-      align="xMidYMid"
-      bbHeight="16px"
-      bbWidth="16px"
-      fill="none"
-      focusable={false}
-      height="16px"
-      importantForAccessibility="no-hide-descendants"
-      meetOrSlice={0}
-      minX={0}
-      minY={0}
-      style={
-        Array [
-          Object {
-            "backgroundColor": "transparent",
-            "borderWidth": 0,
-          },
-          Object {
-            "flex": 0,
-            "height": 16,
-            "width": 16,
-          },
-        ]
-      }
-      vbHeight={24}
-      vbWidth={24}
-      width="16px"
-    >
-      <RNSVGGroup
-        fill={null}
-        propList={
-          Array [
-            "fill",
-          ]
-        }
-      >
-        <RNSVGGroup
-          clipPath="clip0_60_208"
-        >
-          <RNSVGPath
-            d="M4.15845 7.14679C6.74812 4.11688 11.0222 3.1512 14.663 4.77343C15.1675 4.99821 15.7586 4.77147 15.9834 4.267C16.2082 3.76253 15.9815 3.17135 15.477 2.94657C11.0272 0.96385 5.80325 2.14413 2.6381 5.84735C-0.527049 9.55057 -0.879431 14.8946 1.77205 18.9813C4.42353 23.0681 9.44725 24.9241 14.1189 23.5429C18.7905 22.1616 21.9972 17.8716 22 13V12.07C22 11.5177 21.5523 11.07 21 11.07C20.4477 11.07 20 11.5177 20 12.07V12.9994C19.9977 16.9852 17.3741 20.4948 13.5518 21.6249C9.72957 22.7551 5.61926 21.2365 3.44986 17.8928C1.28047 14.5491 1.56878 10.1767 4.15845 7.14679Z"
-            fill={4278224216}
-            propList={
-              Array [
-                "fill",
-              ]
-            }
-          />
-          <RNSVGPath
-            d="M22.7071 4.70711C23.0976 4.31658 23.0976 3.68342 22.7071 3.29289C22.3166 2.90237 21.6834 2.90237 21.2929 3.29289L11 13.5858L8.70711 11.2929C8.31658 10.9024 7.68342 10.9024 7.29289 11.2929C6.90237 11.6834 6.90237 12.3166 7.29289 12.7071L10.2929 15.7071C10.6834 16.0976 11.3166 16.0976 11.7071 15.7071L22.7071 4.70711Z"
-            fill={4278224216}
-            propList={
-              Array [
-                "fill",
-              ]
-            }
-          />
-        </RNSVGGroup>
-        <RNSVGDefs>
-          <RNSVGClipPath
-            name="clip0_60_208"
-          >
-            <RNSVGRect
-              height="24"
-              width="24"
-              x={0}
-              y={0}
-            />
-          </RNSVGClipPath>
-        </RNSVGDefs>
-      </RNSVGGroup>
-    </RNSVGSvgView>
-  </View>
-  <View
-    flex={1}
-    paddingLeft="spacing.3"
-    paddingRight="spacing.2"
-    style={
-      Array [
-        Object {
-          "flexBasis": 0,
-          "flexGrow": 1,
-          "flexShrink": 1,
-          "paddingLeft": 8,
-          "paddingRight": 4,
-        },
-      ]
-    }
-  >
-    <View
-      marginTop="spacing.0"
-      style={
-        Array [
-          Object {
-            "marginTop": 0,
-          },
-        ]
-      }
-    >
-      <Text
-        color="surface.text.normal.lowContrast"
-        fontFamily="text"
-        fontSize={75}
-        fontStyle="normal"
-        fontWeight="regular"
-        lineHeight="s"
-        style={
-          Array [
-            Object {
-              "color": "hsla(217, 56%, 17%, 1)",
-              "fontFamily": "Lato",
-              "fontSize": 12,
-              "fontStyle": "normal",
-              "fontWeight": "400",
-              "lineHeight": 16,
-              "marginBottom": 0,
-              "marginLeft": 0,
-              "marginRight": 0,
-              "marginTop": 0,
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "textDecorationLine": "none",
-            },
-            Object {},
-          ]
-        }
-      >
-        Currently you can only accept payments in international currencies using PayPal.
-      </Text>
-    </View>
-  </View>
-  <View
-    style={
-      Array [
-        Object {},
-      ]
-    }
-  >
-    <View
-      accessibilityLabel="Dismiss alert"
-      accessibilityRole="button"
-      accessible={true}
-      collapsable={false}
-      contrast="low"
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        Array [
-          Object {
-            "alignSelf": "center",
-          },
-        ]
-      }
-    >
-      <RNSVGSvgView
-        accessibilityElementsHidden={true}
-        align="xMidYMid"
-        bbHeight="16px"
-        bbWidth="16px"
-        fill="none"
-        focusable={false}
-        height="16px"
-        importantForAccessibility="no-hide-descendants"
-        meetOrSlice={0}
-        minX={0}
-        minY={0}
-        style={
-          Array [
-            Object {
-              "backgroundColor": "transparent",
-              "borderWidth": 0,
-            },
-            Object {
-              "flex": 0,
-              "height": 16,
-              "width": 16,
-            },
-          ]
-        }
-        vbHeight={24}
-        vbWidth={24}
-        width="16px"
       >
         <RNSVGGroup
           fill={null}

--- a/packages/blade/src/components/Alert/__tests__/__snapshots__/Alert.web.test.tsx.snap
+++ b/packages/blade/src/components/Alert/__tests__/__snapshots__/Alert.web.test.tsx.snap
@@ -173,12 +173,12 @@ exports[`<Alert /> should render 1`] = `
 </div>
 `;
 
-exports[`<Alert /> should render negative intent and borderless 1`] = `
+exports[`<Alert /> should render positive intent and full width 1`] = `
 .c0 {
-  background: hsla(9,91%,56%,0.09);
+  background: hsla(155,100%,31%,0.09);
   padding: 12px 16px;
   border-radius: 0px;
-  border-color: hsla(9,91%,56%,0.32);
+  border-color: hsla(155,100%,31%,0.32);
   border-width: 0px;
   border-style: solid;
   display: -webkit-box;
@@ -189,10 +189,10 @@ exports[`<Alert /> should render negative intent and borderless 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   max-width: auto;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c5 {
@@ -241,7 +241,7 @@ exports[`<Alert /> should render negative intent and borderless 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  margin-top: 2px;
+  margin-top: 0px;
 }
 
 .c2 {
@@ -249,7 +249,7 @@ exports[`<Alert /> should render negative intent and borderless 1`] = `
   -ms-flex: 1;
   flex: 1;
   padding-left: 12px;
-  padding-right: 4px;
+  padding-right: 12px;
 }
 
 .c3 {
@@ -273,179 +273,6 @@ exports[`<Alert /> should render negative intent and borderless 1`] = `
   <div
     class="c0"
     data-blade-component="alert"
-    role="alert"
-  >
-    <div
-      class="c1"
-      display="flex"
-    >
-      <svg
-        aria-hidden="true"
-        data-blade-component="icon"
-        fill="none"
-        height="20px"
-        viewBox="0 0 24 24"
-        width="20px"
-      >
-        <path
-          d="M12 7C12.5523 7 13 7.44772 13 8V12C13 12.5523 12.5523 13 12 13C11.4477 13 11 12.5523 11 12V8C11 7.44772 11.4477 7 12 7Z"
-          fill="hsla(8, 73%, 47%, 1)"
-        />
-        <path
-          d="M12 17C12.5523 17 13 16.5523 13 16C13 15.4477 12.5523 15 12 15C11.4477 15 11 15.4477 11 16C11 16.5523 11.4477 17 12 17Z"
-          fill="hsla(8, 73%, 47%, 1)"
-        />
-        <path
-          clip-rule="evenodd"
-          d="M7.15289 1.29289C7.33386 1.11193 7.58386 1 7.86 1H16.14C16.4052 1 16.6596 1.10536 16.8471 1.29289L22.7071 7.15289C22.8946 7.34043 23 7.59478 23 7.86V16.14C23 16.4052 22.8946 16.6596 22.7071 16.8471L16.8471 22.7071C16.6596 22.8946 16.4052 23 16.14 23H7.86C7.59478 23 7.34043 22.8946 7.15289 22.7071L1.29289 16.8471C1.10536 16.6596 1 16.4052 1 16.14V7.86C1 7.59478 1.10536 7.34043 1.29289 7.15289L7.15289 1.29289ZM8.27421 3L3 8.27421V15.7258L8.27421 21H15.7258L21 15.7258V8.27421L15.7258 3H8.27421Z"
-          fill="hsla(8, 73%, 47%, 1)"
-          fill-rule="evenodd"
-        />
-      </svg>
-    </div>
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-      >
-        <p
-          class="c4 Text__StyledText-wkh56f-0"
-          color="surface.text.normal.lowContrast"
-          data-blade-component="text"
-          font-family="text"
-          font-size="100"
-          font-style="normal"
-          font-weight="regular"
-        >
-          Currently you can only accept payments in international currencies using PayPal.
-        </p>
-      </div>
-    </div>
-    <button
-      aria-label="Dismiss alert"
-      class="c5"
-      data-blade-component="icon-button"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        data-blade-component="icon"
-        fill="none"
-        height="20px"
-        viewBox="0 0 24 24"
-        width="20px"
-      >
-        <path
-          d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
-          fill="currentColor"
-        />
-      </svg>
-    </button>
-  </div>
-</div>
-`;
-
-exports[`<Alert /> should render positive intent and full width 1`] = `
-.c0 {
-  background: hsla(155,100%,31%,0.09);
-  padding: 8px 8px 12px 8px;
-  border-radius: 4px;
-  border-color: hsla(155,100%,31%,0.32);
-  border-width: 1px;
-  border-style: solid;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  max-width: auto;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-}
-
-.c5 {
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  border-radius: 2px;
-  background: transparent;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  color: hsla(214,18%,69%,1);
-  -webkit-transition-property: color,box-shadow;
-  transition-property: color,box-shadow;
-  -webkit-transition-duration: 150ms;
-  transition-duration: 150ms;
-  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
-  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
-}
-
-.c5:hover {
-  color: hsla(217,18%,45%,1);
-}
-
-.c5:focus {
-  outline: none;
-  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18);
-  color: hsla(217,18%,45%,1);
-}
-
-.c5:active {
-  color: hsla(217,18%,45%,1);
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  margin-top: 2px;
-}
-
-.c2 {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  padding-left: 8px;
-  padding-right: 4px;
-}
-
-.c3 {
-  margin-top: 2px;
-}
-
-.c4 {
-  color: hsla(217,56%,17%,1);
-  font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 0.75rem;
-  font-weight: 400;
-  font-style: normal;
-  -webkit-text-decoration-line: none;
-  text-decoration-line: none;
-  line-height: 1rem;
-  margin: 0;
-  padding: 0;
-}
-
-<div>
-  <div
-    class="c0"
-    data-blade-component="alert"
     role="status"
   >
     <div
@@ -456,9 +283,9 @@ exports[`<Alert /> should render positive intent and full width 1`] = `
         aria-hidden="true"
         data-blade-component="icon"
         fill="none"
-        height="16px"
+        height="20px"
         viewBox="0 0 24 24"
-        width="16px"
+        width="20px"
       >
         <g
           clip-path="url(#clip0_60_208)"
@@ -496,7 +323,7 @@ exports[`<Alert /> should render positive intent and full width 1`] = `
           color="surface.text.normal.lowContrast"
           data-blade-component="text"
           font-family="text"
-          font-size="75"
+          font-size="100"
           font-style="normal"
           font-weight="regular"
         >
@@ -514,9 +341,9 @@ exports[`<Alert /> should render positive intent and full width 1`] = `
         aria-hidden="true"
         data-blade-component="icon"
         fill="none"
-        height="16px"
+        height="20px"
         viewBox="0 0 24 24"
-        width="16px"
+        width="20px"
       >
         <path
           d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"

--- a/packages/blade/src/components/Alert/_decisions/decisions.md
+++ b/packages/blade/src/components/Alert/_decisions/decisions.md
@@ -40,17 +40,16 @@ import { Alert, Link } from '@razorpay/blade';
 
 We'll expose an `Alert` component with the following API:
 
-| Prop          | Type                                                        | Default       | Description                                                                                             | Required |
-| ------------- | ----------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------- | -------- |
-| description   | `string`, `JSX`                                             | `undefined`   | Body content                                                                                            | ✅       |
-| title         | `string`                                                    | `undefined`   | A brief heading                                                                                         |          |
-| isDismissable | `boolean`                                                   | `true`        | Shows a dismiss button                                                                                  |          |
-| onDismiss     | `function`                                                  | `undefined`   | Callback when the dismiss button is pressed                                                             |          |
-| contrast      | `high`, `low`                                               | `low`         | Can be set to `high` for more prominent look _(not related to a11y)_                                    |          |
-| isFullWidth   | `boolean`                                                   | `false`       | Spans the entire width of container, otherwise max width is restricted to 584px by default              |          |
-| intent        | `information`, `positive`, `notice`, `negative`             | `information` | Sets the color tone of entire alert. Icon is set automatically based on intent                          |          |
-| isBorderless  | `boolean`                                                   | `false`       | Removes borders and border radii, useful for creating a full bleed layout, sets `isFullWidth` to `true` |          |
-| actions       | `{ primary: PrimaryAction, secondary: SecondaryAction }` \* | `{}`          | Renders a primary action button and a secondary action link button                                      |          |
+| Prop          | Type                                                        | Default       | Description                                                                                                           | Required |
+| ------------- | ----------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- | -------- |
+| description   | `string`, `JSX`                                             | `undefined`   | Body content                                                                                                          | ✅       |
+| title         | `string`                                                    | `undefined`   | A brief heading                                                                                                       |          |
+| isDismissable | `boolean`                                                   | `true`        | Shows a dismiss button                                                                                                |          |
+| onDismiss     | `function`                                                  | `undefined`   | Callback when the dismiss button is pressed                                                                           |          |
+| contrast      | `high`, `low`                                               | `low`         | Can be set to `high` for more prominent look _(not related to a11y)_                                                  |          |
+| isFullWidth   | `boolean`                                                   | `false`       | Spans the entire width of container and makes alert borderless, otherwise max width is restricted to 584px by default |          |
+| intent        | `information`, `positive`, `notice`, `negative`             | `information` | Sets the color tone of entire alert. Icon is set automatically based on intent                                        |          |
+| actions       | `{ primary: PrimaryAction, secondary: SecondaryAction }` \* | `{}`          | Renders a primary action button and a secondary action link button                                                    |          |
 
 `PrimaryAction` and `SecondaryAction` will accept objects with the following keys:
 
@@ -116,14 +115,14 @@ Some example usage patterns of `Alert`.
 >
 > Design update pending to remove all borders and border radii
 
-This full bleed layout works for all desktop, mobile and native when the `isBorderless` prop is passed. The alert behaves like `isFullWidth` set to `true` when `isBorderless` is enabled.
+This full bleed layout works for all desktop, mobile and native when the `isFullWidth` prop is passed. It also gets rid of all borders.
 
 <img src="./alert-mobile-full-bleed.png" alt="" width="520">
 
 ```jsx
 <Alert
   title="International Payments Only"
-  isBorderless
+  isFullWidth
   description={
     <>
       Use vendor payouts to quickly generate invoices.{' '}
@@ -155,7 +154,7 @@ This full bleed layout works for all desktop, mobile and native when the `isBord
 
 **A5.** To be taken up separately as an enhancement.
 
-**Q6.** Should `isFullWidth`, `isBorderless` be decoupled or not? Should borderless be a variant instead?
+**Q6.** Should `isFullWidth`, `isBorderless` be decoupled or not? Should borderless be a variant instead? _(Outdated)_
 
 **A6.** We would need both `isFullWidth` and `isBorderless` to exist, because there are usecases of alerts to span the full width of the container (which might be more than the default max-width of 584px). However, since `isBorderless` alert is only supposed to be used in full bleed layouts, it would automatically set `isFullWidth` to `true`. Also, since we can't think of future variants right now I'm leaning towards not making borderless as sole variant. Another alternative is to instead have a `variant` prop that can be `default` | `fullwidth` | `fullwidth-borderless` but so far we haven’t used variant in this sense.
 
@@ -197,6 +196,10 @@ However there are certain issues with this API:
 - The order of passing compound components doesn't has any impact on final rendering order
 - More error prone, users can pass unexpected wrappers in children or in between compound components
 - It's harder to define constraints for example - secondary action should only exist in the presence of a primary action
+
+## Changelog
+
+- Removed `isBorderless`. Now all borderless specific properties will be controlled by `isFullWidth`
 
 ## References
 

--- a/packages/blade/src/components/Alert/styles.ts
+++ b/packages/blade/src/components/Alert/styles.ts
@@ -6,7 +6,7 @@ import { makeBorderSize, makeSize, makeSpace } from '~utils';
 const MAX_WIDTH = 584;
 
 export const getCommonStyles = (props: StyledProps<StyledAlertProps>): CSSObject => {
-  const { theme, contrastType, intent, isFullWidth } = props;
+  const { theme, contrastType, intent, isFullWidth, isDesktop } = props;
 
   const feedbackColors = theme.colors.feedback;
 
@@ -26,6 +26,6 @@ export const getCommonStyles = (props: StyledProps<StyledAlertProps>): CSSObject
     display: 'flex',
     flexDirection: 'row',
     maxWidth: isFullWidth ? 'auto' : makeSize(MAX_WIDTH),
-    alignItems: 'flex-start',
+    alignItems: isFullWidth && isDesktop ? 'center' : 'flex-start',
   };
 };

--- a/packages/blade/src/components/Alert/styles.ts
+++ b/packages/blade/src/components/Alert/styles.ts
@@ -6,28 +6,26 @@ import { makeBorderSize, makeSize, makeSpace } from '~utils';
 const MAX_WIDTH = 584;
 
 export const getCommonStyles = (props: StyledProps<StyledAlertProps>): CSSObject => {
-  const { theme, contrastType, intent, isFullWidth, isBorderless } = props;
+  const { theme, contrastType, intent, isFullWidth } = props;
 
-  // a borderless alert is automatically set to full width
-  const _isFullWidth = isFullWidth || isBorderless;
   const feedbackColors = theme.colors.feedback;
 
   return {
     background: feedbackColors.background[intent][contrastType],
-    padding: isBorderless
+    padding: isFullWidth
       ? `${makeSpace(theme.spacing[4])} ${makeSpace(theme.spacing[5])}`
       : `${makeSpace(theme.spacing[3])} ${makeSpace(theme.spacing[3])} ${makeSpace(
           theme.spacing[4],
         )} ${makeSpace(theme.spacing[3])}`,
     borderRadius: makeBorderSize(
-      isBorderless ? theme.border.radius.none : theme.border.radius.medium,
+      isFullWidth ? theme.border.radius.none : theme.border.radius.medium,
     ),
     borderColor: feedbackColors.border[intent][contrastType],
-    borderWidth: makeBorderSize(isBorderless ? theme.border.width.none : theme.border.width.thin),
+    borderWidth: makeBorderSize(isFullWidth ? theme.border.width.none : theme.border.width.thin),
     borderStyle: 'solid',
     display: 'flex',
     flexDirection: 'row',
-    maxWidth: _isFullWidth ? 'auto' : makeSize(MAX_WIDTH),
+    maxWidth: isFullWidth ? 'auto' : makeSize(MAX_WIDTH),
     alignItems: 'flex-start',
   };
 };

--- a/packages/blade/src/components/Alert/types.ts
+++ b/packages/blade/src/components/Alert/types.ts
@@ -7,4 +7,5 @@ export type StyledAlertProps = {
   contrastType: keyof ColorContrast;
   intent: Feedback;
   isFullWidth: boolean;
+  isDesktop: boolean;
 };

--- a/packages/blade/src/components/Alert/types.ts
+++ b/packages/blade/src/components/Alert/types.ts
@@ -7,5 +7,4 @@ export type StyledAlertProps = {
   contrastType: keyof ColorContrast;
   intent: Feedback;
   isFullWidth: boolean;
-  isBorderless: boolean;
 };


### PR DESCRIPTION
## Details

Now `isFullWidth` prop is rewired to cause these effects:
- Makes the alert borderless (same UI as earlier with `isBorderless` on mobile and native)
- Makes the actions inline (appear horizontal) with the content besides the above change (only on desktop). Note that actions always appear vertically on mobile and react native.

## Screenshots

Tested various combinations, some screenshots:

![Screen Shot 2022-12-09 at 18 06 37](https://user-images.githubusercontent.com/6682655/206706197-965d61f1-6a3e-4d3a-8812-6a61432ac05d.png)

![Screen Shot 2022-12-09 at 18 07 32](https://user-images.githubusercontent.com/6682655/206706223-11390931-60fb-42e4-ae67-d5f85317dfdf.png)

![Screen Shot 2022-12-09 at 18 08 10](https://user-images.githubusercontent.com/6682655/206706227-34ebbf78-50e3-4076-b690-eed950020492.png)

![Screen Shot 2022-12-09 at 18 09 56](https://user-images.githubusercontent.com/6682655/206706231-544b918a-e724-4f3c-876d-fbdcf7b8e58d.png)

![Screen Shot 2022-12-09 at 18 10 50](https://user-images.githubusercontent.com/6682655/206706237-dd862948-0a84-4275-88b2-905945c95943.png)

![Screen Shot 2022-12-09 at 18 11 10](https://user-images.githubusercontent.com/6682655/206706245-57b67d2e-26c8-4a6b-b741-2f0dba3e5884.png)

And... oh well, here's a meme 😅 

![image](https://user-images.githubusercontent.com/6682655/206705623-0b05a12f-9099-4a76-93b3-42261a60bd59.png)
