### PR TITLE
fix: storybook internal component addon

### DIFF
--- a/packages/blade/.storybook/react/constants.js
+++ b/packages/blade/.storybook/react/constants.js
@@ -1,0 +1,1 @@
+export const INTERNAL_STORY_ADDON_PARAM = 'showInternalComponents';

--- a/packages/blade/.storybook/react/manager.js
+++ b/packages/blade/.storybook/react/manager.js
@@ -4,6 +4,7 @@ import { create } from '@storybook/theming';
 import { addons, types } from '@storybook/addons';
 import { useGlobals } from '@storybook/api';
 import { Icons, IconButton } from '@storybook/components';
+import { INTERNAL_STORY_ADDON_PARAM } from './constants';
 
 export const theme = create({
   base: 'light',
@@ -56,19 +57,22 @@ document.head.append(hiddenStoryStyle);
 export const toggleHiddenStoryStyle = (isDisabled) => (hiddenStoryStyle.disabled = isDisabled);
 
 const InternalStoryAddon = () => {
-  const [{ showInternalComponents }, updateGlobals] = useGlobals();
+  const [globals, updateGlobals] = useGlobals();
+
+  const isActive = globals[INTERNAL_STORY_ADDON_PARAM] || false;
+  toggleHiddenStoryStyle(isActive);
 
   const toggleVisibility = React.useCallback(() => {
     updateGlobals({
-      showInternalComponents: !showInternalComponents,
+      [INTERNAL_STORY_ADDON_PARAM]: !isActive,
     });
-    toggleHiddenStoryStyle(!showInternalComponents);
-  }, [showInternalComponents]);
+    toggleHiddenStoryStyle(!isActive);
+  }, [isActive]);
 
   return (
     <IconButton
       key={TOOL_ID}
-      active={showInternalComponents}
+      active={isActive}
       title="Show internal components"
       onClick={toggleVisibility}
     >
@@ -82,7 +86,7 @@ addons.register(ADDON_ID, () => {
     type: types.TOOL,
     title: 'Toggle Visibility Of Internal Components',
     match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
-    render: InternalStoryAddon,
+    render: () => <InternalStoryAddon />,
   });
 });
 

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -4,6 +4,7 @@ import { global } from '@storybook/design-system';
 import { BladeProvider } from '../../src/components/BladeProvider';
 import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
 import ErrorBoundary from './ErrorBoundary';
+import { INTERNAL_STORY_ADDON_PARAM } from './constants';
 const { GlobalStyle } = global;
 
 export const parameters = {
@@ -151,4 +152,8 @@ export const globalTypes = {
       showName: true,
     },
   },
+};
+
+export const globals = {
+  [INTERNAL_STORY_ADDON_PARAM]: false,
 };


### PR DESCRIPTION
fixes https://github.com/razorpay/blade/issues/828

Previously storybook wasn't able to load the global variable `showInternalComponents` on initial load of the addon. Thus even when URL was shared with the global parameter storybook wasn't rendering the story. 