### PR TITLE
docs(Alert): add full width example with actions

### DIFF
--- a/packages/blade/src/components/Alert/Alert.stories.tsx
+++ b/packages/blade/src/components/Alert/Alert.stories.tsx
@@ -213,4 +213,27 @@ FullWidth.parameters = {
   },
 };
 
+export const FullWidthWithActions: ComponentStory<typeof AlertComponent> = ({ ...args }) => {
+  return (
+    <Box height={200} position="relative">
+      <Box position="absolute" width="100%">
+        <AlertComponent {...args} />
+      </Box>
+    </Box>
+  );
+};
+FullWidthWithActions.args = {
+  description: 'Currently you can only accept payments in international currencies using PayPal.',
+  intent: 'negative',
+  isFullWidth: true,
+};
+FullWidthWithActions.parameters = {
+  docs: {
+    description: {
+      story:
+        'A full width Alert with `actions` will render them inline if there is enough space and responsively wrap them to the next line in smaller displays.',
+    },
+  },
+};
+
 export default meta;


### PR DESCRIPTION
Adds the missing story for the new full width variation.

## Screenshots

| Desktop | Mobile |
| - | - |
|  <img width="961" alt="image" src="https://user-images.githubusercontent.com/6682655/208637462-eec8264b-4922-4088-acb7-4ad158c06e4e.png"> | <img width="418" alt="image" src="https://user-images.githubusercontent.com/6682655/208637515-28647574-5904-4a8f-ada1-2aa44afe3285.png"> |
