### PR TITLE
fix(blade): restrict childrens in Card component

### DIFF
--- a/packages/blade/src/components/Card/Card.tsx
+++ b/packages/blade/src/components/Card/Card.tsx
@@ -40,7 +40,7 @@ export type CardProps = {
    * - Docs: https://blade.razorpay.com/?path=/docs/tokens-colors--page#-theme-tokens
    * - Figma: https://shorturl.at/fsvwK
    */
-  surfaceLevel: 2 | 3;
+  surfaceLevel?: 2 | 3;
 };
 
 const Card = ({ children, surfaceLevel = 3 }: CardProps): React.ReactElement => {

--- a/packages/blade/src/components/Card/Card.tsx
+++ b/packages/blade/src/components/Card/Card.tsx
@@ -1,8 +1,25 @@
 import React from 'react';
 import { CardSurface } from './CardSurface';
-import { CardProvider, useVerifyInsideCard } from './CardContext';
+import { CardProvider, useVerifyInsideCard, useVerifyOnlyAllowedComponents } from './CardContext';
 import Box from '~components/Box';
+import type { WithComponentId } from '~utils';
 import { metaAttribute, MetaConstants } from '~utils';
+
+export const ComponentIds = {
+  CardHeader: 'CardHeader',
+  CardHeaderTrailing: 'CardHeaderTrailing',
+  CardHeaderLeading: 'CardHeaderLeading',
+  CardFooter: 'CardFooter',
+  CardFooterTrailing: 'CardFooterTrailing',
+  CardFooterLeading: 'CardFooterLeading',
+  CardBody: 'CardBody',
+  CardHeaderIcon: 'CardHeaderIcon',
+  CardHeaderCounter: 'CardHeaderCounter',
+  CardHeaderBadge: 'CardHeaderBadge',
+  CardHeaderText: 'CardHeaderText',
+  CardHeaderLink: 'CardHeaderLink',
+  CardHeaderIconButton: 'CardHeaderIconButton',
+};
 
 export type CardProps = {
   /**
@@ -27,6 +44,12 @@ export type CardProps = {
 };
 
 const Card = ({ children, surfaceLevel = 3 }: CardProps): React.ReactElement => {
+  useVerifyOnlyAllowedComponents(children, 'Card', [
+    ComponentIds.CardHeader,
+    ComponentIds.CardBody,
+    ComponentIds.CardFooter,
+  ]);
+
   return (
     <CardProvider>
       <CardSurface
@@ -48,10 +71,11 @@ type CardBodyProps = {
   children: React.ReactNode;
 };
 
-const CardBody = ({ children }: CardBodyProps): React.ReactElement => {
+const CardBody: WithComponentId<CardBodyProps> = ({ children }) => {
   useVerifyInsideCard('CardBody');
 
   return <Box {...metaAttribute(MetaConstants.Component, MetaConstants.CardBody)}>{children}</Box>;
 };
+CardBody.componentId = ComponentIds.CardBody;
 
 export { Card, CardBody };

--- a/packages/blade/src/components/Card/Card.tsx
+++ b/packages/blade/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CardSurface } from './CardSurface';
-import { CardProvider, useVerifyInsideCard, useVerifyOnlyAllowedComponents } from './CardContext';
+import { CardProvider, useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
 import Box from '~components/Box';
 import type { WithComponentId } from '~utils';
 import { metaAttribute, MetaConstants } from '~utils';
@@ -44,7 +44,7 @@ export type CardProps = {
 };
 
 const Card = ({ children, surfaceLevel = 3 }: CardProps): React.ReactElement => {
-  useVerifyOnlyAllowedComponents(children, 'Card', [
+  useVerifyAllowedComponents(children, 'Card', [
     ComponentIds.CardHeader,
     ComponentIds.CardBody,
     ComponentIds.CardFooter,

--- a/packages/blade/src/components/Card/CardContext.tsx
+++ b/packages/blade/src/components/Card/CardContext.tsx
@@ -15,7 +15,7 @@ const useVerifyInsideCard = (componentName: string): CardContextType => {
 /**
  * Verify if the passed childrens are only of allowedComponents list
  */
-const useVerifyOnlyAllowedComponents = (
+const useVerifyAllowedComponents = (
   children: React.ReactNode,
   componentName: string,
   allowedComponents: string[],
@@ -26,7 +26,7 @@ const useVerifyOnlyAllowedComponents = (
       throw new Error(
         `[Blade Card]: Only one of \`${allowedComponents.join(
           ', ',
-        )}\` component is accepted in ${componentName} children`,
+        )}\` component is accepted as ${componentName} children`,
       );
     }
   });
@@ -37,4 +37,4 @@ const CardProvider = ({ children }: CardProviderProps): React.ReactElement => {
   return <CardContext.Provider value={true}>{children}</CardContext.Provider>;
 };
 
-export { useVerifyInsideCard, useVerifyOnlyAllowedComponents, CardProvider };
+export { useVerifyInsideCard, useVerifyAllowedComponents, CardProvider };

--- a/packages/blade/src/components/Card/CardContext.tsx
+++ b/packages/blade/src/components/Card/CardContext.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getComponentId } from '~utils';
 
 type CardContextType = true | null;
 const CardContext = React.createContext<CardContextType>(null);
@@ -11,9 +12,29 @@ const useVerifyInsideCard = (componentName: string): CardContextType => {
   return true;
 };
 
+/**
+ * Verify if the passed childrens are only of allowedComponents list
+ */
+const useVerifyOnlyAllowedComponents = (
+  children: React.ReactNode,
+  componentName: string,
+  allowedComponents: string[],
+): void => {
+  React.Children.forEach(children, (child) => {
+    const isValidChild = child && allowedComponents.includes(getComponentId(child)!);
+    if (!isValidChild) {
+      throw new Error(
+        `[Blade Card]: Only one of \`${allowedComponents.join(
+          ', ',
+        )}\` component is accepted in ${componentName} children`,
+      );
+    }
+  });
+};
+
 type CardProviderProps = { children: React.ReactNode };
 const CardProvider = ({ children }: CardProviderProps): React.ReactElement => {
   return <CardContext.Provider value={true}>{children}</CardContext.Provider>;
 };
 
-export { useVerifyInsideCard, CardProvider };
+export { useVerifyInsideCard, useVerifyOnlyAllowedComponents, CardProvider };

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -1,11 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+import React from 'react';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
 import { Divider } from './Divider';
-import { useVerifyInsideCard } from './CardContext';
+import { useVerifyInsideCard, useVerifyOnlyAllowedComponents } from './CardContext';
+import { ComponentIds } from './Card';
 import Box from '~components/Box';
 import { Text } from '~components/Typography';
+import type { WithComponentId } from '~utils';
 import { metaAttribute, MetaConstants, useBreakpoint } from '~utils';
+
 import { useTheme } from '~components/BladeProvider';
 
 export type CardFooterAction = Pick<
@@ -27,9 +31,13 @@ const useIsMobile = (): boolean => {
   return matchedDeviceType === 'mobile';
 };
 
-const CardFooter = ({ children }: CardFooterProps): React.ReactElement => {
+const CardFooter: WithComponentId<CardFooterProps> = ({ children }) => {
   const isMobile = useIsMobile();
   useVerifyInsideCard('CardFooter');
+  useVerifyOnlyAllowedComponents(children, 'CardFooter', [
+    ComponentIds.CardFooterLeading,
+    ComponentIds.CardFooterTrailing,
+  ]);
 
   return (
     <Box marginTop="auto" {...metaAttribute(MetaConstants.Component, MetaConstants.CardFooter)}>
@@ -47,12 +55,13 @@ const CardFooter = ({ children }: CardFooterProps): React.ReactElement => {
     </Box>
   );
 };
+CardFooter.componentId = ComponentIds.CardFooter;
 
 type CardFooterLeadingProps = {
   title?: string;
   subtitle?: string;
 };
-const CardFooterLeading = ({ title, subtitle }: CardFooterLeadingProps): React.ReactElement => {
+const CardFooterLeading: WithComponentId<CardFooterLeadingProps> = ({ title, subtitle }) => {
   useVerifyInsideCard('CardFooterLeading');
 
   return (
@@ -70,6 +79,7 @@ const CardFooterLeading = ({ title, subtitle }: CardFooterLeadingProps): React.R
     </Box>
   );
 };
+CardFooterLeading.componentId = ComponentIds.CardFooterLeading;
 
 type CardFooterTrailingProps = {
   actions?: {
@@ -77,7 +87,7 @@ type CardFooterTrailingProps = {
     secondary?: CardFooterAction;
   };
 };
-const CardFooterTrailing = ({ actions }: CardFooterTrailingProps): React.ReactElement => {
+const CardFooterTrailing: WithComponentId<CardFooterTrailingProps> = ({ actions }) => {
   const isMobile = useIsMobile();
   useVerifyInsideCard('CardFooterTrailing');
 
@@ -107,5 +117,6 @@ const CardFooterTrailing = ({ actions }: CardFooterTrailingProps): React.ReactEl
     </Box>
   );
 };
+CardFooterTrailing.componentId = ComponentIds.CardFooterTrailing;
 
 export { CardFooter, CardFooterLeading, CardFooterTrailing };

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
 import { Divider } from './Divider';
-import { useVerifyInsideCard, useVerifyOnlyAllowedComponents } from './CardContext';
+import { useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
 import { ComponentIds } from './Card';
 import Box from '~components/Box';
 import { Text } from '~components/Typography';
@@ -34,7 +34,7 @@ const useIsMobile = (): boolean => {
 const CardFooter: WithComponentId<CardFooterProps> = ({ children }) => {
   const isMobile = useIsMobile();
   useVerifyInsideCard('CardFooter');
-  useVerifyOnlyAllowedComponents(children, 'CardFooter', [
+  useVerifyAllowedComponents(children, 'CardFooter', [
     ComponentIds.CardFooterLeading,
     ComponentIds.CardFooterTrailing,
   ]);

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -7,7 +7,7 @@ import { Link } from '../Link';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
 import { Divider } from './Divider';
-import { useVerifyInsideCard, useVerifyOnlyAllowedComponents } from './CardContext';
+import { useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
 import { ComponentIds } from './Card';
 import Box from '~components/Box';
 import type { TextProps, TextVariant } from '~components/Typography';
@@ -84,7 +84,7 @@ type CardHeaderProps = {
 
 const CardHeader: WithComponentId<CardHeaderProps> = ({ children }) => {
   useVerifyInsideCard('CardHeader');
-  useVerifyOnlyAllowedComponents(children, 'CardHeader', [
+  useVerifyAllowedComponents(children, 'CardHeader', [
     ComponentIds.CardHeaderLeading,
     ComponentIds.CardHeaderTrailing,
   ]);

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -7,7 +7,8 @@ import { Link } from '../Link';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
 import { Divider } from './Divider';
-import { useVerifyInsideCard } from './CardContext';
+import { useVerifyInsideCard, useVerifyOnlyAllowedComponents } from './CardContext';
+import { ComponentIds } from './Card';
 import Box from '~components/Box';
 import type { TextProps, TextVariant } from '~components/Typography';
 import { Heading, Text } from '~components/Typography';
@@ -23,15 +24,6 @@ import {
   isValidAllowedChildren,
   makeSpace,
 } from '~utils';
-
-const ComponentIds = {
-  CardHeaderIcon: 'CardHeaderIcon',
-  CardHeaderCounter: 'CardHeaderCounter',
-  CardHeaderBadge: 'CardHeaderBadge',
-  CardHeaderText: 'CardHeaderText',
-  CardHeaderLink: 'CardHeaderLink',
-  CardHeaderIconButton: 'CardHeaderIconButton',
-};
 
 const CardHeaderIcon: WithComponentId<{ icon: IconComponent }> = ({ icon: Icon }) => {
   useVerifyInsideCard('CardHeaderIcon');
@@ -90,8 +82,12 @@ type CardHeaderProps = {
   children?: React.ReactNode;
 };
 
-const CardHeader = ({ children }: CardHeaderProps): React.ReactElement => {
+const CardHeader: WithComponentId<CardHeaderProps> = ({ children }) => {
   useVerifyInsideCard('CardHeader');
+  useVerifyOnlyAllowedComponents(children, 'CardHeader', [
+    ComponentIds.CardHeaderLeading,
+    ComponentIds.CardHeaderTrailing,
+  ]);
 
   return (
     <Box
@@ -110,6 +106,7 @@ const CardHeader = ({ children }: CardHeaderProps): React.ReactElement => {
     </Box>
   );
 };
+CardHeader.componentId = ComponentIds.CardHeader;
 
 type CardHeaderLeadingProps = {
   title: string;
@@ -127,12 +124,12 @@ type CardHeaderLeadingProps = {
    */
   suffix?: React.ReactNode;
 };
-const CardHeaderLeading = ({
+const CardHeaderLeading: WithComponentId<CardHeaderLeadingProps> = ({
   title,
   subtitle,
   prefix,
   suffix,
-}: CardHeaderLeadingProps): React.ReactElement => {
+}) => {
   useVerifyInsideCard('CardHeaderLeading');
 
   if (prefix && !isValidAllowedChildren(prefix, ComponentIds.CardHeaderIcon)) {
@@ -166,6 +163,7 @@ const CardHeaderLeading = ({
     </Box>
   );
 };
+CardHeaderLeading.componentId = ComponentIds.CardHeaderLeading;
 
 type CardHeaderTrailingProps = {
   /**
@@ -183,7 +181,7 @@ const headerTrailingAllowedComponents = [
   ComponentIds.CardHeaderBadge,
 ];
 
-const CardHeaderTrailing = ({ visual }: CardHeaderTrailingProps): React.ReactElement => {
+const CardHeaderTrailing: WithComponentId<CardHeaderTrailingProps> = ({ visual }) => {
   useVerifyInsideCard('CardHeaderTrailing');
 
   if (visual && !headerTrailingAllowedComponents.includes(getComponentId(visual)!)) {
@@ -196,6 +194,7 @@ const CardHeaderTrailing = ({ visual }: CardHeaderTrailingProps): React.ReactEle
 
   return <Box alignSelf="center">{visual}</Box>;
 };
+CardHeaderTrailing.componentId = ComponentIds.CardHeaderTrailing;
 
 export {
   CardHeader,

--- a/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
@@ -171,4 +171,55 @@ describe('<Card />', () => {
       '[Blade Card]: CardFooterTrailing cannot be used outside of Card component',
     );
   });
+
+  it('should restrict childrens & only allow CardHeader, CardBody & CardFooter in Card', () => {
+    expect(() =>
+      renderWithTheme(
+        <Card>
+          <div>some random div</div>
+          <CardHeader />
+          <CardBody>Plain Card</CardBody>
+          <CardFooter />
+        </Card>,
+      ),
+    ).toThrow(
+      '[Blade Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted in Card children',
+    );
+  });
+
+  it('should restrict childrens in CardHeader', () => {
+    expect(() =>
+      renderWithTheme(
+        <Card>
+          <CardHeader>
+            <CardHeaderLeading title="" />
+            <div>some random children</div>
+            <CardHeaderTrailing />
+          </CardHeader>
+          <CardBody>Plain Card</CardBody>
+          <CardFooter />
+        </Card>,
+      ),
+    ).toThrow(
+      '[Blade Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted in CardHeader children',
+    );
+  });
+
+  it('should restrict childrens in CardFooter', () => {
+    expect(() =>
+      renderWithTheme(
+        <Card>
+          <CardHeader />
+          <CardBody>Plain Card</CardBody>
+          <CardFooter>
+            <CardFooterLeading />
+            <CardFooterTrailing />
+            <div>some random children</div>
+          </CardFooter>
+        </Card>,
+      ),
+    ).toThrow(
+      '[Blade Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted in CardFooter children',
+    );
+  });
 });

--- a/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
@@ -184,7 +184,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted in Card children',
+      '[Blade Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted as Card children',
     );
   });
 
@@ -202,7 +202,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted in CardHeader children',
+      '[Blade Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted as CardHeader children',
     );
   });
 
@@ -220,7 +220,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted in CardFooter children',
+      '[Blade Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted as CardFooter children',
     );
   });
 });

--- a/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
@@ -18,6 +18,7 @@ import { InfoIcon } from '~components/Icons';
 import { Text } from '~components/Typography';
 import { Counter } from '~components/Counter';
 import { Badge } from '~components/Badge';
+import Box from '~components/Box';
 
 beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
 afterAll(() => jest.restoreAllMocks());
@@ -176,7 +177,7 @@ describe('<Card />', () => {
     expect(() =>
       renderWithTheme(
         <Card>
-          <div>some random div</div>
+          <Box>some random Box</Box>
           <CardHeader />
           <CardBody>Plain Card</CardBody>
           <CardFooter />
@@ -193,7 +194,7 @@ describe('<Card />', () => {
         <Card>
           <CardHeader>
             <CardHeaderLeading title="" />
-            <div>some random children</div>
+            <Box>some random children</Box>
             <CardHeaderTrailing />
           </CardHeader>
           <CardBody>Plain Card</CardBody>
@@ -214,7 +215,7 @@ describe('<Card />', () => {
           <CardFooter>
             <CardFooterLeading />
             <CardFooterTrailing />
-            <div>some random children</div>
+            <Box>some random children</Box>
           </CardFooter>
         </Card>,
       ),

--- a/packages/blade/src/components/Card/__tests__/Card.web.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.web.test.tsx
@@ -172,6 +172,57 @@ describe('<Card />', () => {
     );
   });
 
+  it('should restrict childrens & only allow CardHeader, CardBody & CardFooter in Card', () => {
+    expect(() =>
+      renderWithTheme(
+        <Card>
+          <div>some random div</div>
+          <CardHeader />
+          <CardBody>Plain Card</CardBody>
+          <CardFooter />
+        </Card>,
+      ),
+    ).toThrow(
+      '[Blade Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted in Card children',
+    );
+  });
+
+  it('should restrict childrens in CardHeader', () => {
+    expect(() =>
+      renderWithTheme(
+        <Card>
+          <CardHeader>
+            <CardHeaderLeading title="" />
+            <div>some random children</div>
+            <CardHeaderTrailing />
+          </CardHeader>
+          <CardBody>Plain Card</CardBody>
+          <CardFooter />
+        </Card>,
+      ),
+    ).toThrow(
+      '[Blade Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted in CardHeader children',
+    );
+  });
+
+  it('should restrict childrens in CardFooter', () => {
+    expect(() =>
+      renderWithTheme(
+        <Card>
+          <CardHeader />
+          <CardBody>Plain Card</CardBody>
+          <CardFooter>
+            <CardFooterLeading />
+            <CardFooterTrailing />
+            <div>some random children</div>
+          </CardFooter>
+        </Card>,
+      ),
+    ).toThrow(
+      '[Blade Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted in CardFooter children',
+    );
+  });
+
   it('should not have accessibility violations', async () => {
     const cardTitle = 'Card Header';
     const cardSubtitle = 'Card subtitle';

--- a/packages/blade/src/components/Card/__tests__/Card.web.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.web.test.tsx
@@ -183,7 +183,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted in Card children',
+      '[Blade Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted as Card children',
     );
   });
 
@@ -201,7 +201,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted in CardHeader children',
+      '[Blade Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted as CardHeader children',
     );
   });
 
@@ -219,7 +219,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted in CardFooter children',
+      '[Blade Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted as CardFooter children',
     );
   });
 

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.stories.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.stories.tsx
@@ -4,6 +4,7 @@ import { Highlight } from '@storybook/design-system';
 import React from 'react';
 import type { BaseInputProps } from './BaseInput';
 import { BaseInput as BaseInputComponent } from './BaseInput';
+import BaseInputLayoutImage from './_decisions/base-inputfield-layout.png';
 import iconMap from '~components/Icons/iconMap';
 import Box from '~components/Box';
 import { CharacterCounter } from '~components/Form/CharacterCounter';
@@ -232,6 +233,7 @@ export default {
             The BaseInput component is a component that will be used as a base to build all the
             other input fields like TextInput, PasswordInput, CardInput, OTPInput
           </Subtitle>
+          <img src={BaseInputLayoutImage} alt="Base Input Layout" />
           <Title>Usage</Title>
           <Highlight language="tsx">{`import { BaseInput } from '@razorpay/blade/components' \nimport type { BaseInputProps } from '@razorpay/blade/components'`}</Highlight>
           <Title>Example</Title>


### PR DESCRIPTION
This PR adds: 

- Restricted childrens components in Card to be one of CardHeader, CardBody, CardFooter
- Restricted childrens components in CardHeader to be one of CardHeaderLeading, CardHeaderTrailing
- Restricted childrens components in CardFooter to be one of CardFooterLeading, CardFooterTrailing