### PR TITLE
docs: fix react-native link command

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -138,5 +138,5 @@ Follow the next steps mentioned below for configuring fonts to work on iOS:
 - Once you've copied the font files under `<project_root>/public/fonts` you need to link it using following command
 
   ```shell
-  npx react-native link --platform ios
+  npx react-native link --platforms ios
   ```


### PR DESCRIPTION
`--platform` is not a valid arg. `--platforms` is valid.

<img width="953" alt="Screenshot 2022-12-28 at 11 20 06 AM" src="https://user-images.githubusercontent.com/46647141/209764461-dc327607-8269-43a9-9f01-d150e17eeebb.png">
<img width="984" alt="Screenshot 2022-12-28 at 11 20 14 AM" src="https://user-images.githubusercontent.com/46647141/209764474-98aa33b9-7a5f-4f4e-9b23-05810bb38e98.png">
