### PR TITLE
feat(Code): use new alpha color in background

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -138,5 +138,5 @@ Follow the next steps mentioned below for configuring fonts to work on iOS:
 - Once you've copied the font files under `<project_root>/public/fonts` you need to link it using following command
 
   ```shell
-  npx react-native link --platform ios
+  npx react-native link --platforms ios
   ```

--- a/packages/blade/src/components/Typography/Code/Code.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.tsx
@@ -41,7 +41,7 @@ const CodeContainer = styled(Box)<CodeContainerProps>((props) => {
   const padding = `${makeSpace(props.theme.spacing[0])} ${makeSpace(props.theme.spacing[2])}`;
   return {
     padding,
-    backgroundColor: props.theme.colors.brand.gray[400].lowContrast,
+    backgroundColor: props.theme.colors.brand.gray.a50.lowContrast,
     borderRadius: props.theme.border.radius.medium,
     display: isPlatformWeb ? 'inline-block' : undefined,
     // Removing the line height of container to remove extra surrounding space in background

--- a/packages/blade/src/components/Typography/Code/__tests__/__snapshots__/Code.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Code/__tests__/__snapshots__/Code.native.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Code /> should render Code with default properties 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "hsla(216, 19%, 89%, 1)",
+        "backgroundColor": "hsla(216, 44%, 23%, 0.09)",
         "borderRadius": 4,
         "lineHeight": 16,
         "paddingBottom": 0,
@@ -54,7 +54,7 @@ exports[`<Code /> should render medium Code 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "hsla(216, 19%, 89%, 1)",
+        "backgroundColor": "hsla(216, 44%, 23%, 0.09)",
         "borderRadius": 4,
         "lineHeight": 16,
         "paddingBottom": 0,
@@ -102,7 +102,7 @@ exports[`<Code /> should render small Code 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": "hsla(216, 19%, 89%, 1)",
+        "backgroundColor": "hsla(216, 44%, 23%, 0.09)",
         "borderRadius": 4,
         "lineHeight": 16,
         "paddingBottom": 0,

--- a/packages/blade/src/components/Typography/Code/__tests__/__snapshots__/Code.web.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Code/__tests__/__snapshots__/Code.web.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<Code /> should render Code with default properties 1`] = `
 
 .c0 {
   padding: 0px 4px;
-  background-color: hsla(216,19%,89%,1);
+  background-color: hsla(216,44%,23%,0.09);
   border-radius: 4px;
   display: inline-block;
   line-height: 1rem;
@@ -55,7 +55,7 @@ exports[`<Code /> should render medium Code 1`] = `
 
 .c0 {
   padding: 0px 4px;
-  background-color: hsla(216,19%,89%,1);
+  background-color: hsla(216,44%,23%,0.09);
   border-radius: 4px;
   display: inline-block;
   line-height: 1rem;
@@ -94,7 +94,7 @@ exports[`<Code /> should render small Code 1`] = `
 
 .c0 {
   padding: 0px 4px;
-  background-color: hsla(216,19%,89%,1);
+  background-color: hsla(216,44%,23%,0.09);
   border-radius: 4px;
   display: inline-block;
   line-height: 1rem;


### PR DESCRIPTION
changes the background color from gray.400 to gray.a50 

(we earlier went with `gray.400` because alpha shades were unavailable.