### PR TITLE
fix(blade): TextInput clear button state

### DIFF
--- a/.changeset/shaggy-pigs-warn.md
+++ b/.changeset/shaggy-pigs-warn.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): TextInput clear button state on initial render

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -70,9 +70,11 @@ const TextArea = ({
 }: TextAreaProps): React.ReactElement => {
   const inputRef = React.useRef<HTMLInputElement | TextInputReactNative>(null);
 
-  const [shouldShowClearButton, setShouldShowClearButton] = React.useState<boolean>(
-    Boolean(showClearButton && (value?.length || defaultValue?.length)),
-  );
+  const [shouldShowClearButton, setShouldShowClearButton] = React.useState(false);
+
+  React.useEffect(() => {
+    setShouldShowClearButton(Boolean(showClearButton && (value?.length || defaultValue?.length)));
+  }, [showClearButton, defaultValue, value]);
 
   const renderInteractionElement = (): React.ReactNode => {
     if (shouldShowClearButton) {

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -180,9 +180,11 @@ export const TextInput = ({
   autoCompleteSuggestionType,
 }: TextInputProps): ReactElement => {
   const textInputRef = React.useRef<HTMLInputElement | TextInputReactNative>(null);
-  const [shouldShowClearButton, setShouldShowClearButton] = useState(
-    Boolean(defaultValue ?? value) ?? false,
-  );
+  const [shouldShowClearButton, setShouldShowClearButton] = useState(false);
+
+  React.useEffect(() => {
+    setShouldShowClearButton(Boolean(showClearButton && (defaultValue ?? value)));
+  }, [showClearButton, defaultValue, value]);
 
   const renderInteractionElement = (): ReactNode => {
     if (isLoading) {

--- a/packages/blade/src/components/Input/TextInput/__tests__/TextInput.native.test.tsx
+++ b/packages/blade/src/components/Input/TextInput/__tests__/TextInput.native.test.tsx
@@ -266,6 +266,26 @@ describe('<TextInput />', () => {
     expect(getByDisplayValue(valueInitial)).toBeTruthy();
   });
 
+  it('should not show clear button on initial render if showClearButton is false', () => {
+    const label = 'Enter name';
+    const valueInitial = '123';
+    const onClearButtonClick = jest.fn();
+
+    const { getByDisplayValue, queryByRole } = renderWithTheme(
+      <TextInput
+        label={label}
+        defaultValue={valueInitial}
+        showClearButton={false}
+        onClearButtonClick={onClearButtonClick}
+      />,
+    );
+    const input = getByDisplayValue(valueInitial);
+    expect(input).toBeTruthy();
+
+    const clearButton = queryByRole('button');
+    expect(clearButton).toBeFalsy();
+  });
+
   it('should pass a11y', () => {
     // todo: tests should be updated for improved a11y after https://github.com/razorpay/blade/issues/696
     const placeholder = 'First Last';

--- a/packages/blade/src/components/Input/TextInput/__tests__/TextInput.web.test.tsx
+++ b/packages/blade/src/components/Input/TextInput/__tests__/TextInput.web.test.tsx
@@ -292,6 +292,27 @@ describe('<TextInput />', () => {
     expect(input).toHaveValue('');
   });
 
+  it('should not show clear button on initial render if showClearButton is false', () => {
+    const label = 'Enter name';
+    const onClearButtonClick = jest.fn();
+    const valueInitial = '123';
+
+    const { getByLabelText, queryByRole } = renderWithTheme(
+      <TextInput
+        label={label}
+        defaultValue={valueInitial}
+        showClearButton={false}
+        onClearButtonClick={onClearButtonClick}
+      />,
+    );
+
+    const input = getByLabelText(label);
+    expect(input).toHaveValue(valueInitial);
+
+    const clearButton = queryByRole('button');
+    expect(clearButton).not.toBeInTheDocument();
+  });
+
   it('should pass a11y', async () => {
     const { getByRole } = renderWithTheme(
       <TextInput


### PR DESCRIPTION
Fixes a bug where TextInput shows clear button even when showClearButton is false with initialValue set. 

![image](https://user-images.githubusercontent.com/35374649/210552696-510abb89-be32-4943-a5c5-16e4ca942ca8.png)


Fixes: https://app.asana.com/0/1200620439276878/1203628642944573/f

