### PR TITLE
fix: package types exports for ESM projects

### DIFF
--- a/.changeset/pretty-swans-perform.md
+++ b/.changeset/pretty-swans-perform.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': major
+---
+
+fix: add types field to package exports for ESM TypeScript projects

--- a/.changeset/pretty-swans-perform.md
+++ b/.changeset/pretty-swans-perform.md
@@ -1,5 +1,5 @@
 ---
-'@razorpay/blade': major
+'@razorpay/blade': patch
 ---
 
 fix: add types field to package exports for ESM TypeScript projects

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -28,8 +28,14 @@
   ],
   "exports": {
     "./components": {
-      "react-native": "./build/components/index.native.js",
-      "default": "./build/components/index.web.js"
+      "react-native": {
+        "import": "./build/components/index.native.js",
+        "types": "./build/components/index.native.d.ts"
+      },
+      "default": {
+        "import": "./build/components/index.web.js",
+        "types": "./build/components/index.d.ts"
+      }
     },
     "./tokens": {
       "react-native": "./build/tokens/index.native.js",

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -38,12 +38,24 @@
       }
     },
     "./tokens": {
-      "react-native": "./build/tokens/index.native.js",
-      "default": "./build/tokens/index.web.js"
+      "react-native": {
+        "import": "./build/tokens/index.native.js",
+        "types": "./build/tokens/index.native.d.ts"
+      },
+      "default": {
+        "import": "./build/tokens/index.web.js",
+        "types": "./build/tokens/index.d.ts"
+      }
     },
     "./utils": {
-      "react-native": "./build/utils/index.native.js",
-      "default": "./build/utils/index.web.js"
+      "react-native": {
+        "import": "./build/utils/index.native.js",
+        "types": "./build/utils/index.native.d.ts"
+      },
+      "default": {
+        "import": "./build/utils/index.web.js",
+        "types": "./build/utils/index.d.ts"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
Fixes #960 

## Description

TypeScript requires types to be declared in the `"types"` property under `"exports"` section of `package.json` of npm packages to detect declaration files in a project setup that outputs ESM. 
(combination of `type:module` in project's `package.json` and `module:NodeNext` in `tsconfig.json`)

I've added the missing fields. These fields are only used by TypeScript in an ESM setup so backwards compatibility shouldn't be affected.

**Note:** An alternate shorter solution is to rename the generated types files for web from `index.d.ts` to `index.web.d.ts`. While that would work for the above config, it will break types for `moduleResolution:node`. Since the automatic detection of TypeScript varies based on the moduleResolution used, it's better to tell TypeScript explicitly where the types are for each export instead of relying on automatic detection. Renaming the generated file will also cause a backwards compatibility issue as pointed out by this code comment:

https://github.com/razorpay/blade/blob/master/packages/blade/rollup.config.js#L127

## Testing

Tested the below combinations in a web project.

|typescript|module|moduleResolution|
|-|-|-|
| 4.9.4 | NodeNext | NodeNext |
| 4.9.4 | es6 | node |
| 4.6.4 | es6 | node |

**Note:** Haven't tested this solution for a react-native project.

## Screenshots

|Before|
|:-:|
| ![Screenshot 2023-01-21 at 2 48 07 PM](https://user-images.githubusercontent.com/29686866/213861834-e4c0d80a-1cc3-4b7e-9bf4-00203ffdadd9.png) |
| After |
| ![Screenshot 2023-01-21 at 3 40 06 PM](https://user-images.githubusercontent.com/29686866/213862239-66cfa7cd-3c02-4da0-8acb-09eecf0e71da.png) |

## References

- https://www.typescriptlang.org/docs/handbook/esm-node.html
- https://webpack.js.org/guides/package-exports/
