### PR TITLE
chore: added component status table

### DIFF
--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -6,6 +6,7 @@ import { paymentTheme, bankingTheme } from '../../src/tokens/theme';
 import ErrorBoundary from './ErrorBoundary';
 import { INTERNAL_STORY_ADDON_PARAM } from './constants';
 const { GlobalStyle } = global;
+import { DocsContainer } from '@storybook/addon-docs/blocks';
 
 export const parameters = {
   previewTabs: {
@@ -39,6 +40,27 @@ export const parameters = {
     },
   },
   docs: {
+    container: ({ children, context }) => {
+      const getThemeTokens = () => {
+        if (context.globals.themeTokenName === 'paymentTheme') {
+          return paymentTheme;
+        }
+        if (context.globals.themeTokenName === 'bankingTheme') {
+          return bankingTheme;
+        }
+      };
+      return (
+        <DocsContainer context={context}>
+          <BladeProvider
+            key={`${context.globals.themeTokenName}-${context.globals.colorScheme}`}
+            themeTokens={getThemeTokens()}
+            colorScheme={context.globals.colorScheme}
+          >
+            {children}
+          </BladeProvider>
+        </DocsContainer>
+      );
+    },
     theme,
     components: {
       summary: styled.summary`

--- a/packages/blade/docs/guides/ComponentStatus.stories.mdx
+++ b/packages/blade/docs/guides/ComponentStatus.stories.mdx
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/addon-docs';
+import { ComponentStatusTable } from '../../src/_helpers/storybook/ComponentStatusTable';
+
+<Meta title="Guides/Component Status" />
+
+# ⚙️ Component Status
+
+<br />
+<br />
+
+<ComponentStatusTable />

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import styled from 'styled-components';
 import type { IconComponent } from '../../components/Icons';
 import {
-  AlertCircleIcon,
   EditIcon,
   CheckIcon,
   ClockIcon,
   LoaderIcon,
+  AlertCircleIcon,
 } from '../../components/Icons';
+import { LinkToStorybook } from './LinkToStorybook';
 import { Text } from '~components/Typography';
 import { makeSpace } from '~utils';
 import Box from '~components/Box';
@@ -27,6 +28,7 @@ type ComponentStatusData = {
   name: string;
   status: ComponentStatuses;
   releasedIn?: string;
+  storybookLink: string;
 }[];
 
 const componentData: ComponentStatusData = [
@@ -34,116 +36,146 @@ const componentData: ComponentStatusData = [
     name: 'Alert',
     status: 'released',
     releasedIn: '1.1.0',
+    storybookLink: 'Components/Alert',
   },
   {
     name: 'Badge',
     status: 'released',
     releasedIn: '1.0.0',
+    storybookLink: 'Components/Badge',
   },
   {
     name: 'Button',
     status: 'released',
     releasedIn: '0.11.0',
+    storybookLink: 'Components/Button',
   },
   {
     name: 'Card',
     status: 'released',
     releasedIn: '5.3.0',
+    storybookLink: 'Components/Card',
   },
   {
     name: 'Checkbox',
     status: 'released',
     releasedIn: '0.13.0',
+    storybookLink: 'Components/Checkbox/Checkbox',
   },
   {
-    name: 'Code',
+    name: 'CheckboxGroup',
     status: 'released',
-    releasedIn: '3.0.0',
+    releasedIn: '0.13.0',
+    storybookLink: 'Components/Checkbox/CheckboxGroup',
   },
   {
     name: 'Counter',
     status: 'released',
     releasedIn: '3.6.0',
-  },
-  {
-    name: 'Heading',
-    status: 'released',
-    releasedIn: '0.6.0',
+    storybookLink: 'Components/Counter',
   },
   {
     name: 'IconButton',
     status: 'released',
     releasedIn: '3.6.2',
+    storybookLink: 'Components/IconButton',
   },
   {
     name: 'Indicator',
     status: 'released',
     releasedIn: '3.7.0',
+    storybookLink: 'Components/Indicator',
   },
   {
     name: 'Link',
     status: 'released',
     releasedIn: '0.13.0',
+    storybookLink: 'Components/Link',
   },
-  {
-    name: 'OTPInput',
-    status: 'released',
-    releasedIn: '3.1.0',
-  },
-  {
-    name: 'PasswordInput',
-    status: 'released',
-    releasedIn: '2.5.0',
-  },
+
   {
     name: 'ProgressBar',
     status: 'released',
     releasedIn: '5.4.0',
-  },
-  {
-    name: 'Radio',
-    status: 'released',
-    releasedIn: '1.0.0',
-  },
-  {
-    name: 'RadioGroup',
-    status: 'released',
-    releasedIn: '1.0.0',
-  },
-  {
-    name: 'SkipNav',
-    status: 'released',
-    releasedIn: '0.9.0',
+    storybookLink: 'Components/ProgressBar',
   },
   {
     name: 'Spinner',
     status: 'released',
     releasedIn: '2.2.0',
-  },
-  {
-    name: 'Text',
-    status: 'released',
-    releasedIn: '0.4.0',
-  },
-  {
-    name: 'TextArea',
-    status: 'released',
-    releasedIn: '2.3.0',
+    storybookLink: 'Components/Spinner',
   },
   {
     name: 'TextInput',
     status: 'released',
     releasedIn: '2.1.0',
+    storybookLink: 'Components/Input/TextInput',
+  },
+  {
+    name: 'TextArea',
+    status: 'released',
+    releasedIn: '2.3.0',
+    storybookLink: 'Components/Input/TextArea',
+  },
+  {
+    name: 'OTPInput',
+    status: 'released',
+    releasedIn: '3.1.0',
+    storybookLink: 'Components/Input/OTPInput',
+  },
+  {
+    name: 'PasswordInput',
+    status: 'released',
+    releasedIn: '2.5.0',
+    storybookLink: 'Components/Input/PasswordInput',
+  },
+  {
+    name: 'Radio',
+    status: 'released',
+    releasedIn: '1.0.0',
+    storybookLink: 'Components/Radio & RadioGroup',
+  },
+  {
+    name: 'RadioGroup',
+    status: 'released',
+    releasedIn: '1.0.0',
+    storybookLink: 'Components/Radio & RadioGroup',
+  },
+  {
+    name: 'Text',
+    status: 'released',
+    releasedIn: '0.4.0',
+    storybookLink: 'Components/Typography/Text',
+  },
+  {
+    name: 'Heading',
+    status: 'released',
+    releasedIn: '0.6.0',
+    storybookLink: 'Components/Typography/Heading',
   },
   {
     name: 'Title',
     status: 'released',
     releasedIn: '0.5.0',
+    storybookLink: 'Components/Typography/Title',
+  },
+  {
+    name: 'Code',
+    status: 'released',
+    releasedIn: '3.0.0',
+    storybookLink: 'Components/Typography/Code',
+  },
+  {
+    name: 'SkipNav',
+    status: 'released',
+    releasedIn: '0.9.0',
+    storybookLink: 'Components/Accessibility/SkipNav',
   },
   {
     name: 'VisuallyHidden',
     status: 'released',
     releasedIn: '0.9.0',
+    storybookLink: 'Components/Accessibility/VisuallyHidden',
   },
 ];
 
@@ -192,14 +224,14 @@ const ComponentStatusBadge = ({ status }: { status: ComponentStatuses }): React.
 
 const ReleasedInLink = ({ version }: { version?: string }): React.ReactElement => {
   const ghUrl = 'https://github.com/razorpay/blade/releases/tag/%40razorpay%2Fblade%40';
-  return version ? <Link href={`${ghUrl}${version}`}>{`v${version}`}</Link> : <Text>-</Text>;
+  return version ? (
+    <Link href={`${ghUrl}${version}`} target="_blank">{`v${version}`}</Link>
+  ) : (
+    <Text>-</Text>
+  );
 };
 
 const ComponentStatusTable = (): React.ReactElement => {
-  const sortedComponentData = componentData.sort((prev, next) => {
-    return prev.name.localeCompare(next.name);
-  });
-
   return (
     <Box>
       <Table>
@@ -217,11 +249,17 @@ const ComponentStatusTable = (): React.ReactElement => {
           </tr>
         </thead>
         <tbody>
-          {sortedComponentData.map((data) => {
+          {componentData.map((data) => {
+            const [category, folder, storyName] = data.storybookLink.split('/');
+            const kind = storyName === undefined ? category : `${category}/${folder}`;
+            const story = storyName === undefined ? folder : storyName;
+
             return (
               <tr key={data.name}>
                 <td align="left">
-                  <Text>{data.name}</Text>
+                  <LinkToStorybook kind={kind} story={story}>
+                    {data.name}
+                  </LinkToStorybook>
                 </td>
                 <td align="left">
                   <ComponentStatusBadge status={data.status} />

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -27,6 +27,7 @@ type ComponentStatuses =
 type ComponentStatusData = {
   name: string;
   status: ComponentStatuses;
+  description: string;
   releasedIn?: string;
   storybookLink?: string;
 }[];
@@ -37,189 +38,254 @@ const componentData: ComponentStatusData = [
     status: 'released',
     releasedIn: '1.1.0',
     storybookLink: 'Components/Alert',
+    description:
+      'Alerts are messages that communicate information to users about any significant changes or explanations inside the system in a prominent way.',
   },
   {
     name: 'Badge',
     status: 'released',
     releasedIn: '1.0.0',
     storybookLink: 'Components/Badge',
+    description:
+      'Badges are used to show small amount of color coded metadata, which are ideal for getting user attention.',
   },
   {
     name: 'Button',
     status: 'released',
     releasedIn: '0.11.0',
     storybookLink: 'Components/Button',
+    description:
+      'Button component which can be used for various CTAs. It is available in 3 different variants.',
   },
   {
     name: 'Card',
     status: 'released',
     releasedIn: '5.3.0',
     storybookLink: 'Components/Card',
+    description:
+      'Cards are used to group similar concepts and tasks together to make easier for merchants to scan, read, and get things done.',
   },
   {
     name: 'Checkbox',
     status: 'released',
     releasedIn: '0.13.0',
     storybookLink: 'Components/Checkbox/Checkbox',
+    description:
+      'Checkbox can be used in forms when a user needs to select multiple values from several options.',
   },
   {
     name: 'CheckboxGroup',
     status: 'released',
     releasedIn: '0.13.0',
     storybookLink: 'Components/Checkbox/CheckboxGroup',
+    description:
+      'CheckboxGroup can be used to group together multiple checkboxes in a forms which provides out of the box state management for the multi-checkboxes and other features.',
   },
   {
     name: 'Counter',
     status: 'released',
     releasedIn: '3.6.0',
     storybookLink: 'Components/Counter',
+    description:
+      'Counters are visual indicators that contains numerical values, tallies or counts in regards to some context. It can be used to show non-interactive numerical data.',
   },
   {
     name: 'IconButton',
     status: 'released',
     releasedIn: '3.6.2',
     storybookLink: 'Components/IconButton',
+    description:
+      'Useful for making clickable icons. For example - close button for modals, inputs, etc.',
   },
   {
     name: 'Indicator',
     status: 'released',
     releasedIn: '3.7.0',
     storybookLink: 'Components/Indicator',
+    description:
+      'Indicators describe the condition of an entity. They can be used to convey semantic meaning, such as statuses and semantical-categories.',
   },
   {
     name: 'Link',
     status: 'released',
     releasedIn: '0.13.0',
     storybookLink: 'Components/Link',
+    description:
+      'Link component can be used for showing external or internal Links to the user. The Link component can also be used as an inline button in certain cases with the `button` variant.',
   },
-
   {
     name: 'ProgressBar',
     status: 'released',
     releasedIn: '5.4.0',
     storybookLink: 'Components/ProgressBar',
+    description:
+      'Progress bar is generally a branded element that indicates progress of process or task',
   },
   {
     name: 'Spinner',
     status: 'released',
     releasedIn: '2.2.0',
     storybookLink: 'Components/Spinner',
+    description:
+      'Spinner component is an element with a looping animation that indicates loading is in process.',
   },
   {
     name: 'TextInput',
     status: 'released',
     releasedIn: '2.1.0',
     storybookLink: 'Components/Input/TextInput',
+    description:
+      'TextInput component is a component that can be used to input name, email, telephone, url, search or plain text.',
   },
   {
     name: 'TextArea',
     status: 'released',
     releasedIn: '2.3.0',
     storybookLink: 'Components/Input/TextArea',
+    description:
+      'TextArea component lets you enter long form text which spans over multiple lines.',
   },
   {
     name: 'OTPInput',
     status: 'released',
     releasedIn: '3.1.0',
     storybookLink: 'Components/Input/OTPInput',
+    description:
+      'A one-time password (OTP), also known as a one-time PIN, one-time authorization code (OTAC) or dynamic password, is a password that is valid for only one login session or a transaction. These are a group of inputs and can be either 4 or 6 characters long.',
   },
   {
     name: 'PasswordInput',
     status: 'released',
     releasedIn: '2.5.0',
     storybookLink: 'Components/Input/PasswordInput',
+    description:
+      'PasswordInput is an input field for entering passwords. The input is masked by default. On mobile devices the last typed letter is shown for a brief moment. The masking can be toggled using an optional reveal button.',
   },
   {
     name: 'Radio',
     status: 'released',
     releasedIn: '1.0.0',
     storybookLink: 'Components/Radio & RadioGroup',
+    description:
+      'Radio & RadioGroup can be used in forms when a user needs to single value from several options.',
   },
   {
     name: 'RadioGroup',
     status: 'released',
     releasedIn: '1.0.0',
     storybookLink: 'Components/Radio & RadioGroup',
+    description:
+      'RadioGroup can be used to group together multiple radios in a forms which provides out of the box state management for the multi-radio and other features.',
   },
   {
     name: 'Text',
     status: 'released',
     releasedIn: '0.4.0',
     storybookLink: 'Components/Typography/Text',
+    description:
+      'Text component is used to display main content of the page. It is often clubbed with Title or Heading to display content in a hierarchical structure. It applies responsive styles automatically based on the device it is being rendered on.',
   },
   {
     name: 'Heading',
     status: 'released',
     releasedIn: '0.6.0',
     storybookLink: 'Components/Typography/Heading',
+    description: 'Heading Component is usually used for headings of each major section of a page.',
   },
   {
     name: 'Title',
     status: 'released',
     releasedIn: '0.5.0',
     storybookLink: 'Components/Typography/Title',
+    description:
+      'Title Component makes a bold visual statement. Use them to create impact when the main goal is visual storytelling. For example, use Title as marketing content on landing pages or to capture attention during onboarding.',
   },
   {
     name: 'Code',
     status: 'released',
     releasedIn: '3.0.0',
     storybookLink: 'Components/Typography/Code',
+    description:
+      'Code component can be used for displaying token, variable names, or inlined code snippets.',
   },
   {
     name: 'SkipNav',
     status: 'released',
     releasedIn: '0.9.0',
     storybookLink: 'Components/Accessibility/SkipNav',
+    description:
+      'SkipNav component lets users skip the navigation and jump to the main content of the page. Useful when you have navbars at the top and the user wants to jump directly to the main content.',
   },
   {
     name: 'VisuallyHidden',
     status: 'released',
     releasedIn: '0.9.0',
     storybookLink: 'Components/Accessibility/VisuallyHidden',
+    description:
+      'VisuallyHidden component makes content hidden from sighted users but available for screen reader users.',
   },
   {
     name: 'ListView',
     status: 'in-development',
+    description:
+      'Lists display a set of related items that are composed of text/links. Each list item begins with a bullet or a number.',
   },
   {
     name: 'DropDown',
     status: 'in-development',
+    description:
+      'Dropdown Menu displays a list of choices on temporary surfaces. They allow users to make a selection from multiple options. They appear when users interact with a button, action, or other control.',
   },
   {
     name: 'Select',
     status: 'in-development',
+    description:
+      'Select displays a list of choices on temporary surfaces. They allows users pick a value from predefined options',
   },
   {
     name: 'Layout',
     status: 'in-api-spec',
+    description: 'Layout components/primitives are used to build complex layouts.',
   },
   {
     name: 'BottomSheet',
     status: 'planned-Q4',
+    description:
+      'Bottom sheets are surfaces containing supplementary content that are anchored to the bottom of the screen.',
   },
   {
     name: 'Tags',
     status: 'planned-Q4',
+    description: 'A tag labels UI objects for quick recognition and navigation.',
   },
   {
     name: 'Toggle',
     status: 'planned-Q4',
+    description:
+      'Toggle component is used as an alternative for the checkbox component, It can be used to switch between two states: often on or off.',
   },
   {
     name: 'Amount',
     status: 'planned-Q4',
+    description: 'Amount component is used to display & format various currencies',
   },
   {
     name: 'Accordion',
     status: 'planned-Q4',
+    description:
+      'Accordion component allows the user to show and hide sections of related content on a page',
   },
   {
     name: 'Modal',
     status: 'planned-Q4',
+    description:
+      "Modal is a dialog that focuses the user's attention exclusively on an information via a window that is overlaid on primary content.",
   },
   {
     name: 'Tooltip',
     status: 'planned-Q4',
+    description:
+      'Tooltip is a brief, informative message that appears when a user interacts with an element.',
   },
 ];
 
@@ -230,6 +296,7 @@ const Table = styled.table`
 
   th,
   td {
+    width: 20%;
     padding: ${({ theme }) => makeSpace(theme.spacing[4])};
     padding-inline: ${({ theme }) => makeSpace(theme.spacing[7])};
   }
@@ -298,6 +365,9 @@ const ComponentStatusTable = (): React.ReactElement => {
             <th align="left">
               <Text weight="bold">Status</Text>
             </th>
+            <th style={{ width: '50%' }} align="left">
+              <Text weight="bold">Description</Text>
+            </th>
             <th align="right">
               <Text weight="bold">Released In</Text>
             </th>
@@ -316,6 +386,11 @@ const ComponentStatusTable = (): React.ReactElement => {
                 </td>
                 <td align="left">
                   <ComponentStatusBadge status={data.status} />
+                </td>
+                <td align="left">
+                  <Text size="medium" color="surface.text.subtle.lowContrast">
+                    {data.description}
+                  </Text>
                 </td>
                 <td align="right">
                   <ReleasedInLink version={data.releasedIn} />

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import styled from 'styled-components';
+import type { IconComponent } from '../../components/Icons';
+import {
+  AlertCircleIcon,
+  EditIcon,
+  CheckIcon,
+  ClockIcon,
+  LoaderIcon,
+} from '../../components/Icons';
+import { Text } from '~components/Typography';
+import { makeSpace } from '~utils';
+import Box from '~components/Box';
+import type { BadgeProps } from '~components/Badge';
+import { Badge } from '~components/Badge';
+import { Link } from '~components/Link';
+
+type ComponentStatuses =
+  | 'released'
+  | 'in-api-spec'
+  | 'in-development'
+  | 'in-design'
+  | 'deprecated'
+  | `planned-Q${1 | 2 | 3 | 4}`;
+
+type ComponentStatusData = {
+  name: string;
+  status: ComponentStatuses;
+  releasedIn?: string;
+}[];
+
+const componentData: ComponentStatusData = [
+  {
+    name: 'Alert',
+    status: 'released',
+    releasedIn: '1.1.0',
+  },
+  {
+    name: 'Badge',
+    status: 'released',
+    releasedIn: '1.0.0',
+  },
+  {
+    name: 'Button',
+    status: 'released',
+    releasedIn: '0.11.0',
+  },
+  {
+    name: 'Card',
+    status: 'released',
+    releasedIn: '5.3.0',
+  },
+  {
+    name: 'Checkbox',
+    status: 'released',
+    releasedIn: '0.13.0',
+  },
+  {
+    name: 'Code',
+    status: 'released',
+    releasedIn: '3.0.0',
+  },
+  {
+    name: 'Counter',
+    status: 'released',
+    releasedIn: '3.6.0',
+  },
+  {
+    name: 'Heading',
+    status: 'released',
+    releasedIn: '0.6.0',
+  },
+  {
+    name: 'IconButton',
+    status: 'released',
+    releasedIn: '3.6.2',
+  },
+  {
+    name: 'Indicator',
+    status: 'released',
+    releasedIn: '3.7.0',
+  },
+  {
+    name: 'Link',
+    status: 'released',
+    releasedIn: '0.13.0',
+  },
+  {
+    name: 'OTPInput',
+    status: 'released',
+    releasedIn: '3.1.0',
+  },
+  {
+    name: 'PasswordInput',
+    status: 'released',
+    releasedIn: '2.5.0',
+  },
+  {
+    name: 'ProgressBar',
+    status: 'released',
+    releasedIn: '5.4.0',
+  },
+  {
+    name: 'Radio',
+    status: 'released',
+    releasedIn: '1.0.0',
+  },
+  {
+    name: 'RadioGroup',
+    status: 'released',
+    releasedIn: '1.0.0',
+  },
+  {
+    name: 'SkipNav',
+    status: 'released',
+    releasedIn: '0.9.0',
+  },
+  {
+    name: 'Spinner',
+    status: 'released',
+    releasedIn: '2.2.0',
+  },
+  {
+    name: 'Text',
+    status: 'released',
+    releasedIn: '0.4.0',
+  },
+  {
+    name: 'TextArea',
+    status: 'released',
+    releasedIn: '2.3.0',
+  },
+  {
+    name: 'TextInput',
+    status: 'released',
+    releasedIn: '2.1.0',
+  },
+  {
+    name: 'Title',
+    status: 'released',
+    releasedIn: '0.5.0',
+  },
+  {
+    name: 'VisuallyHidden',
+    status: 'released',
+    releasedIn: '0.9.0',
+  },
+];
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+
+  th,
+  td {
+    padding: ${({ theme }) => makeSpace(theme.spacing[4])};
+    padding-inline: ${({ theme }) => makeSpace(theme.spacing[7])};
+  }
+
+  tr:nth-child(odd) {
+    background-color: ${({ theme }) => theme.colors.brand.gray[200].lowContrast};
+  }
+
+  tr:nth-child(even) {
+    background-color: ${({ theme }) => theme.colors.brand.gray[300].lowContrast};
+  }
+`;
+
+const ComponentStatusBadge = ({ status }: { status: ComponentStatuses }): React.ReactElement => {
+  const badgeVariants: Record<
+    ComponentStatuses,
+    { label: string; variant: BadgeProps['variant']; icon: IconComponent }
+  > = {
+    released: { label: 'Released', variant: 'positive', icon: CheckIcon },
+    deprecated: { label: 'Deprecated', variant: 'negative', icon: AlertCircleIcon },
+    'in-design': { label: 'In Design', variant: 'notice', icon: LoaderIcon },
+    'in-api-spec': { label: 'API In Progress', variant: 'notice', icon: EditIcon },
+    'in-development': { label: 'In Development', variant: 'notice', icon: LoaderIcon },
+    'planned-Q1': { label: 'Planned: Q1', variant: 'information', icon: ClockIcon },
+    'planned-Q2': { label: 'Planned: Q2', variant: 'information', icon: ClockIcon },
+    'planned-Q3': { label: 'Planned: Q3', variant: 'information', icon: ClockIcon },
+    'planned-Q4': { label: 'Planned: Q4', variant: 'information', icon: ClockIcon },
+  };
+
+  return (
+    <Badge variant={badgeVariants[status].variant} icon={badgeVariants[status].icon}>
+      {badgeVariants[status].label}
+    </Badge>
+  );
+};
+
+const ReleasedInLink = ({ version }: { version?: string }): React.ReactElement => {
+  const ghUrl = 'https://github.com/razorpay/blade/releases/tag/%40razorpay%2Fblade%40';
+  return version ? <Link href={`${ghUrl}${version}`}>{`v${version}`}</Link> : <Text>-</Text>;
+};
+
+const ComponentStatusTable = (): React.ReactElement => {
+  const sortedComponentData = componentData.sort((prev, next) => {
+    return prev.name.localeCompare(next.name);
+  });
+
+  return (
+    <Box>
+      <Table>
+        <thead>
+          <tr>
+            <th align="left">
+              <Text weight="bold">Component</Text>
+            </th>
+            <th align="left">
+              <Text weight="bold">Status</Text>
+            </th>
+            <th align="right">
+              <Text weight="bold">Released In</Text>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedComponentData.map((data) => {
+            return (
+              <tr key={data.name}>
+                <td align="left">
+                  <Text>{data.name}</Text>
+                </td>
+                <td align="left">
+                  <ComponentStatusBadge status={data.status} />
+                </td>
+                <td align="right">
+                  <ReleasedInLink version={data.releasedIn} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export { ComponentStatusTable };

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -225,7 +225,11 @@ const ComponentStatusBadge = ({ status }: { status: ComponentStatuses }): React.
 const ReleasedInLink = ({ version }: { version?: string }): React.ReactElement => {
   const ghUrl = 'https://github.com/razorpay/blade/releases/tag/%40razorpay%2Fblade%40';
   return version ? (
-    <Link href={`${ghUrl}${version}`} target="_blank">{`v${version}`}</Link>
+    <Link
+      href={`${ghUrl}${version}`}
+      rel="noopener noreferrer"
+      target="_blank"
+    >{`v${version}`}</Link>
   ) : (
     <Text>-</Text>
   );

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -28,7 +28,7 @@ type ComponentStatusData = {
   name: string;
   status: ComponentStatuses;
   releasedIn?: string;
-  storybookLink: string;
+  storybookLink?: string;
 }[];
 
 const componentData: ComponentStatusData = [
@@ -177,6 +177,46 @@ const componentData: ComponentStatusData = [
     releasedIn: '0.9.0',
     storybookLink: 'Components/Accessibility/VisuallyHidden',
   },
+  {
+    name: 'ListView',
+    status: 'in-development',
+  },
+  {
+    name: 'DropDown',
+    status: 'in-development',
+  },
+  {
+    name: 'Layout',
+    status: 'in-api-spec',
+  },
+  {
+    name: 'BottomSheet',
+    status: 'planned-Q4',
+  },
+  {
+    name: 'Tags',
+    status: 'planned-Q4',
+  },
+  {
+    name: 'Toggle',
+    status: 'planned-Q4',
+  },
+  {
+    name: 'Amount',
+    status: 'planned-Q4',
+  },
+  {
+    name: 'Accordion',
+    status: 'planned-Q4',
+  },
+  {
+    name: 'Modal',
+    status: 'planned-Q4',
+  },
+  {
+    name: 'Tooltip',
+    status: 'planned-Q4',
+  },
 ];
 
 const Table = styled.table`
@@ -254,16 +294,14 @@ const ComponentStatusTable = (): React.ReactElement => {
         </thead>
         <tbody>
           {componentData.map((data) => {
-            const [category, folder, storyName] = data.storybookLink.split('/');
-            const kind = storyName === undefined ? category : `${category}/${folder}`;
-            const story = storyName === undefined ? folder : storyName;
-
             return (
               <tr key={data.name}>
                 <td align="left">
-                  <LinkToStorybook kind={kind} story={story}>
-                    {data.name}
-                  </LinkToStorybook>
+                  {data.storybookLink ? (
+                    <LinkToStorybook url={data.storybookLink}>{data.name}</LinkToStorybook>
+                  ) : (
+                    <Text>{data.name}</Text>
+                  )}
                 </td>
                 <td align="left">
                   <ComponentStatusBadge status={data.status} />

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -280,6 +280,13 @@ const ReleasedInLink = ({ version }: { version?: string }): React.ReactElement =
 };
 
 const ComponentStatusTable = (): React.ReactElement => {
+  const sortedData = componentData.sort((a, b) => {
+    if (!a.releasedIn || !b.releasedIn) {
+      return a.status.localeCompare(b.status);
+    }
+    return a.name.localeCompare(b.name);
+  });
+
   return (
     <Box>
       <Table>
@@ -297,7 +304,7 @@ const ComponentStatusTable = (): React.ReactElement => {
           </tr>
         </thead>
         <tbody>
-          {componentData.map((data) => {
+          {sortedData.map((data) => {
             return (
               <tr key={data.name}>
                 <td align="left">

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -22,7 +22,7 @@ type ComponentStatuses =
   | 'in-development'
   | 'in-design'
   | 'deprecated'
-  | `planned-Q${1 | 2 | 3 | 4}`;
+  | `planned-Q${1 | 2 | 3 | 4}-${'dev' | 'design'}`;
 
 type ComponentStatusData = {
   name: string;
@@ -249,41 +249,41 @@ const componentData: ComponentStatusData = [
   },
   {
     name: 'BottomSheet',
-    status: 'planned-Q4',
+    status: 'planned-Q4-dev',
     description:
       'Bottom sheets are surfaces containing supplementary content that are anchored to the bottom of the screen.',
   },
   {
     name: 'Tags',
-    status: 'planned-Q4',
+    status: 'planned-Q4-design',
     description: 'A tag labels UI objects for quick recognition and navigation.',
   },
   {
     name: 'Toggle',
-    status: 'planned-Q4',
+    status: 'planned-Q4-dev',
     description:
       'Toggle component is used as an alternative for the checkbox component, It can be used to switch between two states: often on or off.',
   },
   {
     name: 'Amount',
-    status: 'planned-Q4',
+    status: 'planned-Q4-dev',
     description: 'Amount component is used to display & format various currencies',
   },
   {
     name: 'Accordion',
-    status: 'planned-Q4',
+    status: 'planned-Q4-design',
     description:
       'Accordion component allows the user to show and hide sections of related content on a page',
   },
   {
     name: 'Modal',
-    status: 'planned-Q4',
+    status: 'planned-Q4-design',
     description:
       "Modal is a dialog that focuses the user's attention exclusively on an information via a window that is overlaid on primary content.",
   },
   {
     name: 'Tooltip',
-    status: 'planned-Q4',
+    status: 'planned-Q4-design',
     description:
       'Tooltip is a brief, informative message that appears when a user interacts with an element.',
   },
@@ -320,10 +320,14 @@ const ComponentStatusBadge = ({ status }: { status: ComponentStatuses }): React.
     'in-design': { label: 'In Design', variant: 'notice', icon: LoaderIcon },
     'in-api-spec': { label: 'API In Progress', variant: 'notice', icon: EditIcon },
     'in-development': { label: 'In Development', variant: 'notice', icon: LoaderIcon },
-    'planned-Q1': { label: 'Planned: Q1', variant: 'information', icon: ClockIcon },
-    'planned-Q2': { label: 'Planned: Q2', variant: 'information', icon: ClockIcon },
-    'planned-Q3': { label: 'Planned: Q3', variant: 'information', icon: ClockIcon },
-    'planned-Q4': { label: 'Planned: Q4', variant: 'information', icon: ClockIcon },
+    'planned-Q1-dev': { label: 'Planned: Q1 Dev', variant: 'information', icon: ClockIcon },
+    'planned-Q2-dev': { label: 'Planned: Q2 Dev', variant: 'information', icon: ClockIcon },
+    'planned-Q3-dev': { label: 'Planned: Q3 Dev', variant: 'information', icon: ClockIcon },
+    'planned-Q4-dev': { label: 'Planned: Q4 Dev', variant: 'information', icon: ClockIcon },
+    'planned-Q1-design': { label: 'Planned: Q1 Design', variant: 'information', icon: ClockIcon },
+    'planned-Q2-design': { label: 'Planned: Q2 Design', variant: 'information', icon: ClockIcon },
+    'planned-Q3-design': { label: 'Planned: Q3 Design', variant: 'information', icon: ClockIcon },
+    'planned-Q4-design': { label: 'Planned: Q4 Design', variant: 'information', icon: ClockIcon },
   };
 
   return (

--- a/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/_helpers/storybook/ComponentStatusTable.tsx
@@ -186,6 +186,10 @@ const componentData: ComponentStatusData = [
     status: 'in-development',
   },
   {
+    name: 'Select',
+    status: 'in-development',
+  },
+  {
     name: 'Layout',
     status: 'in-api-spec',
   },

--- a/packages/blade/src/_helpers/storybook/LinkToStorybook.tsx
+++ b/packages/blade/src/_helpers/storybook/LinkToStorybook.tsx
@@ -18,14 +18,16 @@ const cancelled = (e: React.MouseEvent<HTMLAnchorElement>, cb = (_e: unknown) =>
 };
 
 const LinkToStorybook = ({
-  kind,
-  story,
+  url,
   children,
 }: {
-  kind: string;
-  story: string;
+  url: string;
   children: string;
 }): React.ReactElement => {
+  const [category, folder, storyName] = url.split('/');
+  const kind = storyName === undefined ? category : `${category}/${folder}`;
+  const story = storyName === undefined ? folder : storyName;
+
   const [href, setHref] = React.useState('');
 
   const updateHref = async (): Promise<void> => {
@@ -40,7 +42,7 @@ const LinkToStorybook = ({
   React.useEffect(() => {
     void updateHref();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [kind, story]);
+  }, [kind, story, url]);
 
   return (
     // eslint-disable-next-line

--- a/packages/blade/src/_helpers/storybook/LinkToStorybook.tsx
+++ b/packages/blade/src/_helpers/storybook/LinkToStorybook.tsx
@@ -44,7 +44,7 @@ const LinkToStorybook = ({
 
   return (
     // eslint-disable-next-line
-    <Link href={href} onClick={(e) => cancelled(e as any, handleClick)}>
+    <Link href={href} rel="noopener noreferrer" onClick={(e) => cancelled(e as any, handleClick)}>
       {children}
     </Link>
   );

--- a/packages/blade/src/_helpers/storybook/LinkToStorybook.tsx
+++ b/packages/blade/src/_helpers/storybook/LinkToStorybook.tsx
@@ -1,0 +1,53 @@
+// Taken from:
+// https://github.com/storybookjs/storybook/blob/main/addons/links/src/react/components/link.tsx
+import React from 'react';
+import { hrefTo, navigate } from '@storybook/addon-links';
+import { Link } from '~components/Link';
+
+// Cmd/Ctrl/Shift/Alt + Click should trigger default browser behaviour. Same applies to non-left clicks
+const LEFT_BUTTON = 0;
+const isPlainLeftClick = (e: React.MouseEvent<HTMLAnchorElement>): boolean =>
+  e.button === LEFT_BUTTON && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const cancelled = (e: React.MouseEvent<HTMLAnchorElement>, cb = (_e: unknown) => {}): void => {
+  if (isPlainLeftClick(e)) {
+    e.preventDefault();
+    cb(e);
+  }
+};
+
+const LinkToStorybook = ({
+  kind,
+  story,
+  children,
+}: {
+  kind: string;
+  story: string;
+  children: string;
+}): React.ReactElement => {
+  const [href, setHref] = React.useState('');
+
+  const updateHref = async (): Promise<void> => {
+    const href = await hrefTo(kind, story);
+    setHref(href);
+  };
+
+  const handleClick = (): void => {
+    navigate({ kind, story });
+  };
+
+  React.useEffect(() => {
+    void updateHref();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [kind, story]);
+
+  return (
+    // eslint-disable-next-line
+    <Link href={href} onClick={(e) => cancelled(e as any, handleClick)}>
+      {children}
+    </Link>
+  );
+};
+
+export { LinkToStorybook };


### PR DESCRIPTION
This PR adds component status table in storybook to show which components are ready/in-progress/planned

[Link to storybook](https://61c19ee8d3d282003ac1d81c-hhcipvslio.chromatic.com/?path=/docs/guides-component-status--page)


<img width="1054" alt="image" src="https://user-images.githubusercontent.com/35374649/214040662-c868c64a-86ea-4efc-8713-724762082d6e.png">
