### PR TITLE
fix: mark react-native dependencies as optional

### DIFF
--- a/.changeset/chilled-radios-greet.md
+++ b/.changeset/chilled-radios-greet.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix: mark react-native peerDependencies as optional

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -175,6 +175,14 @@
     "react-native-svg": "^12.3.0",
     "styled-components": "^5"
   },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "react-native-reanimated": {
+      "optional": true
+    }
+  },
   "resolutions": {
     "@storybook/**/react-dom": "17.0.2",
     "@storybook/**/react": "17.0.2",


### PR DESCRIPTION
[Jira][1] | Fixes #957 

Users of Blade are forced to use the `--legacy-peer-deps` flag for installing packages because starting from v7, npm install fails if all peer dependencies specified by a package are not installed by the host project. This is a problem because this means Blade's peerDependencies config will force all web projects to install react-native unless they use the above flag.

Screenshot from the dashboard project:

<img width="595" alt="Screenshot 2023-01-19 at 2 12 50 PM" src="https://user-images.githubusercontent.com/29686866/214344066-aa5fbfe2-4479-4a06-bff5-90c129999c63.png">

The `peerDependenciesMeta` field of `package.json` is used for solving exactly this problem. This will inform npm that it needs to check the version of react-native peerDependencies of Blade only for projects that already have react-native installed on the host. 

Refer: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta

[1]: https://razorpay.atlassian.net/browse/OM-16