### PR TITLE
chore: remove viewmode from storybook config

### DIFF
--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -12,10 +12,6 @@ export const parameters = {
     'storybook/docs/panel': { index: 0 },
     canvas: { title: 'Stories', index: 1 },
   },
-  // setting default view mode to story when development
-  // otherwise while changing component code storybook resets view to story mode
-  // which hampers productivity
-  viewMode: process.env.NODE_ENV === 'development' ? 'story' : 'docs',
   actions: { argTypesRegex: '^on[A-Z].*' },
   options: {
     storySort: {


### PR DESCRIPTION
Right now if you visit `blade.razorpay.com` select a story & any story variants it will show you the `docs` page, but even if you select `story` tab and try navigating the stories it will redirect you to the `docs` tab, so to quickly check the story variants you need to each time select `story` tab. 


before: 

https://user-images.githubusercontent.com/35374649/214499131-bc72ac2b-8aaf-420e-ae36-0a13dbd9c734.mov

after: 


https://user-images.githubusercontent.com/35374649/214499499-67ecf93d-d2ce-4a91-9193-39cc11742634.mov

