### PR TITLE
fix(Dropdown): ignore flicker in Select when clicking items

### DIFF
--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -206,6 +206,7 @@ const ActionListItem: WithComponentId<ActionListItemProps> = (props): JSX.Elemen
     onOptionClick,
     selectedIndices,
     setShouldIgnoreBlur,
+    setShouldIgnoreBlurAnimation,
     selectionType,
     dropdownTriggerer,
     isKeydownPressed,
@@ -258,6 +259,10 @@ const ActionListItem: WithComponentId<ActionListItemProps> = (props): JSX.Elemen
         {...metaAttribute(MetaConstants.Component, MetaConstants.ActionListItem)}
         onMouseDown={() => {
           setShouldIgnoreBlur(true);
+          setShouldIgnoreBlurAnimation(true);
+        }}
+        onMouseUp={() => {
+          setShouldIgnoreBlurAnimation(false);
         }}
         data-value={props.value}
         data-index={props._index}

--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -259,9 +259,12 @@ const ActionListItem: WithComponentId<ActionListItemProps> = (props): JSX.Elemen
         {...metaAttribute(MetaConstants.Component, MetaConstants.ActionListItem)}
         onMouseDown={() => {
           setShouldIgnoreBlur(true);
+          // We want to keep focus on Dropdown's trigger while option is being clicked
+          // So We set this flag that ignores the blur animation to avoid the flicker between focus out + focus in
           setShouldIgnoreBlurAnimation(true);
         }}
         onMouseUp={() => {
+          // (Contd from above comment...) We set this flag back to false since blur of SelectInput is done calling by this time
           setShouldIgnoreBlurAnimation(false);
         }}
         data-value={props.value}

--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -207,7 +207,6 @@ const ActionListItem: WithComponentId<ActionListItemProps> = (props): JSX.Elemen
     selectedIndices,
     setShouldIgnoreBlur,
     selectionType,
-    triggererRef,
     dropdownTriggerer,
     isKeydownPressed,
   } = useDropdown();
@@ -257,12 +256,6 @@ const ActionListItem: WithComponentId<ActionListItemProps> = (props): JSX.Elemen
           props.onClick?.({ name: props.value, value: isSelected });
         })}
         {...metaAttribute(MetaConstants.Component, MetaConstants.ActionListItem)}
-        onFocus={() => {
-          // We don't want to keep the browser's focus on option item. We move it to selectInput
-          if (!isReactNative()) {
-            triggererRef.current?.focus();
-          }
-        }}
         onMouseDown={() => {
           setShouldIgnoreBlur(true);
         }}

--- a/packages/blade/src/components/Dropdown/Dropdown.tsx
+++ b/packages/blade/src/components/Dropdown/Dropdown.tsx
@@ -48,6 +48,7 @@ const Dropdown: WithComponentId<DropdownProps> = ({
   >([]);
   const [activeIndex, setActiveIndex] = React.useState(-1);
   const [shouldIgnoreBlur, setShouldIgnoreBlur] = React.useState(false);
+  const [shouldIgnoreBlurAnimation, setShouldIgnoreBlurAnimation] = React.useState(false);
   const triggererRef = React.useRef<HTMLButtonElement>(null);
   const actionListRef = React.useRef<HTMLDivElement>(null);
   const [hasFooterAction, setHasFooterAction] = React.useState(false);
@@ -86,6 +87,8 @@ const Dropdown: WithComponentId<DropdownProps> = ({
       setActiveIndex,
       shouldIgnoreBlur,
       setShouldIgnoreBlur,
+      shouldIgnoreBlurAnimation,
+      setShouldIgnoreBlurAnimation,
       isKeydownPressed,
       setIsKeydownPressed,
       dropdownBaseId,
@@ -103,6 +106,7 @@ const Dropdown: WithComponentId<DropdownProps> = ({
       options,
       activeIndex,
       shouldIgnoreBlur,
+      shouldIgnoreBlurAnimation,
       selectionType,
       hasFooterAction,
       isKeydownPressed,

--- a/packages/blade/src/components/Dropdown/useDropdown.ts
+++ b/packages/blade/src/components/Dropdown/useDropdown.ts
@@ -16,7 +16,6 @@ import type {
   FormInputHandleOnEvent,
   FormInputHandleOnKeyDownEvent,
 } from '~components/Form/FormTypes';
-import { isReactNative } from '~utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
@@ -255,9 +254,6 @@ const useDropdown = (): UseDropdownReturnValue => {
       onOptionChange(actionType, index);
     }
     selectOption(index);
-    if (!isReactNative()) {
-      rest.triggererRef.current?.focus();
-    }
   };
 
   /**
@@ -317,10 +313,6 @@ const useDropdown = (): UseDropdownReturnValue => {
         onComboType,
         selectCurrentOption: () => {
           selectOption(activeIndex);
-          if (rest.hasFooterAction && !isReactNative()) {
-            rest.triggererRef.current?.focus();
-          }
-
           const anchorLink = options[activeIndex]?.href;
           if (anchorLink) {
             window.location.href = anchorLink;

--- a/packages/blade/src/components/Dropdown/useDropdown.ts
+++ b/packages/blade/src/components/Dropdown/useDropdown.ts
@@ -42,6 +42,12 @@ type DropdownContextType = {
   /** Used to ignore blur on certains events. E.g. to ignore blur of dropdown when click is inside the dropdown */
   shouldIgnoreBlur: boolean;
   setShouldIgnoreBlur: (value: boolean) => void;
+  /**
+   * Sometimes we want to ignore the blur event to keep dropdown open but not ignore the blur animation from selectinput
+   * E.g. When someone clicks on Footer, we just want to ignore the blur event and not the blur animation
+   */
+  shouldIgnoreBlurAnimation: boolean;
+  setShouldIgnoreBlurAnimation: (value: boolean) => void;
   /** Tells you if keyboard was used. Its false by default and turns into true when keydown is called  */
   isKeydownPressed: boolean;
   setIsKeydownPressed: (value: boolean) => void;
@@ -72,6 +78,8 @@ const DropdownContext = React.createContext<DropdownContextType>({
   setActiveIndex: noop,
   shouldIgnoreBlur: false,
   setShouldIgnoreBlur: noop,
+  shouldIgnoreBlurAnimation: false,
+  setShouldIgnoreBlurAnimation: noop,
   hasFooterAction: false,
   setHasFooterAction: noop,
   isKeydownPressed: false,

--- a/packages/blade/src/components/Dropdown/useDropdown.ts
+++ b/packages/blade/src/components/Dropdown/useDropdown.ts
@@ -16,6 +16,7 @@ import type {
   FormInputHandleOnEvent,
   FormInputHandleOnKeyDownEvent,
 } from '~components/Form/FormTypes';
+import { isReactNative } from '~utils';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = (): void => {};
@@ -254,6 +255,9 @@ const useDropdown = (): UseDropdownReturnValue => {
       onOptionChange(actionType, index);
     }
     selectOption(index);
+    if (!isReactNative()) {
+      rest.triggererRef.current?.focus();
+    }
   };
 
   /**
@@ -313,6 +317,10 @@ const useDropdown = (): UseDropdownReturnValue => {
         onComboType,
         selectCurrentOption: () => {
           selectOption(activeIndex);
+          if (rest.hasFooterAction && !isReactNative()) {
+            rest.triggererRef.current?.focus();
+          }
+
           const anchorLink = options[activeIndex]?.href;
           if (anchorLink) {
             window.location.href = anchorLink;

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -88,11 +88,11 @@ export type BaseInputProps = FormInputLabelProps &
      */
     onBlur?: FormInputOnEvent;
     /**
-     * Ignores the next blur event
+     * Ignores the blur event animation (Used in Select to ignore blur animation when item in option is clicked)
      */
     shouldIgnoreBlurAnimation?: boolean;
     /**
-     * Used to set the shouldIgnoreBlurAnimation flag back to false after blur is ignored
+     * Used to set the shouldIgnoreBlurAnimation flag back to false after blur is ignored so we only ignore 1 event
      */
     setShouldIgnoreBlurAnimation?: (shouldIgnoreBlurAnimation: boolean) => void;
     /**

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -88,6 +88,14 @@ export type BaseInputProps = FormInputLabelProps &
      */
     onBlur?: FormInputOnEvent;
     /**
+     * Ignores the next blur event
+     */
+    shouldIgnoreBlur?: boolean;
+    /**
+     * Used to set the shouldIgnoreBlur flag back to false after blur is ignored
+     */
+    setShouldIgnoreBlur?: (shouldIgnoreBlur: boolean) => void;
+    /**
      * Used to turn the input field to controlled so user can control the value
      */
     value?: string;
@@ -498,6 +506,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
       hasPopup,
       popupId,
       isPopupExpanded,
+      shouldIgnoreBlur,
+      setShouldIgnoreBlur,
     },
     ref,
   ) => {
@@ -635,6 +645,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
               numberOfLines={numberOfLines}
               isTextArea={isTextArea}
               hasPopup={hasPopup}
+              shouldIgnoreBlur={shouldIgnoreBlur}
+              setShouldIgnoreBlur={setShouldIgnoreBlur}
             />
             <BaseInputVisuals
               interactionElement={interactionElement}

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -90,11 +90,11 @@ export type BaseInputProps = FormInputLabelProps &
     /**
      * Ignores the next blur event
      */
-    shouldIgnoreBlur?: boolean;
+    shouldIgnoreBlurAnimation?: boolean;
     /**
-     * Used to set the shouldIgnoreBlur flag back to false after blur is ignored
+     * Used to set the shouldIgnoreBlurAnimation flag back to false after blur is ignored
      */
-    setShouldIgnoreBlur?: (shouldIgnoreBlur: boolean) => void;
+    setShouldIgnoreBlurAnimation?: (shouldIgnoreBlurAnimation: boolean) => void;
     /**
      * Used to turn the input field to controlled so user can control the value
      */
@@ -506,8 +506,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
       hasPopup,
       popupId,
       isPopupExpanded,
-      shouldIgnoreBlur,
-      setShouldIgnoreBlur,
+      shouldIgnoreBlurAnimation,
+      setShouldIgnoreBlurAnimation,
     },
     ref,
   ) => {
@@ -645,8 +645,8 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
               numberOfLines={numberOfLines}
               isTextArea={isTextArea}
               hasPopup={hasPopup}
-              shouldIgnoreBlur={shouldIgnoreBlur}
-              setShouldIgnoreBlur={setShouldIgnoreBlur}
+              shouldIgnoreBlurAnimation={shouldIgnoreBlurAnimation}
+              setShouldIgnoreBlurAnimation={setShouldIgnoreBlurAnimation}
             />
             <BaseInputVisuals
               interactionElement={interactionElement}

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -92,10 +92,6 @@ export type BaseInputProps = FormInputLabelProps &
      */
     shouldIgnoreBlurAnimation?: boolean;
     /**
-     * Used to set the shouldIgnoreBlurAnimation flag back to false after blur is ignored so we only ignore 1 event
-     */
-    setShouldIgnoreBlurAnimation?: (shouldIgnoreBlurAnimation: boolean) => void;
-    /**
      * Used to turn the input field to controlled so user can control the value
      */
     value?: string;
@@ -507,7 +503,6 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
       popupId,
       isPopupExpanded,
       shouldIgnoreBlurAnimation,
-      setShouldIgnoreBlurAnimation,
     },
     ref,
   ) => {
@@ -646,7 +641,6 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
               isTextArea={isTextArea}
               hasPopup={hasPopup}
               shouldIgnoreBlurAnimation={shouldIgnoreBlurAnimation}
-              setShouldIgnoreBlurAnimation={setShouldIgnoreBlurAnimation}
             />
             <BaseInputVisuals
               interactionElement={interactionElement}

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -144,6 +144,16 @@ export const StyledBaseInput = React.forwardRef<
     ref,
   ) => {
     const buttonValue = props.value ? props.value : props.defaultValue;
+    const commonProps = {
+      onBlur: (): void => {
+        if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
+          setShouldIgnoreBlurAnimation(false);
+          return;
+        }
+        setCurrentInteraction('default');
+      },
+      isFocused: currentInteraction === 'active',
+    };
 
     return hasPopup ? (
       <StyledNativeBaseButton
@@ -153,18 +163,11 @@ export const StyledBaseInput = React.forwardRef<
         onPress={(): void => {
           handleOnClick?.({ name, value: buttonValue });
         }}
-        isFocused={currentInteraction === 'active'}
         onFocus={(): void => {
           handleOnFocus?.({ name, value: buttonValue });
           setCurrentInteraction('active');
         }}
-        onBlur={(): void => {
-          if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
-            setShouldIgnoreBlurAnimation(false);
-            return;
-          }
-          setCurrentInteraction('default');
-        }}
+        {...commonProps}
         {...props}
         {...accessibilityProps}
       >
@@ -179,19 +182,11 @@ export const StyledBaseInput = React.forwardRef<
         ref={ref as any}
         multiline={isTextArea}
         numberOfLines={numberOfLines}
-        isFocused={currentInteraction === 'active'}
         editable={!isDisabled}
         maxLength={maxCharacters}
         onFocus={(event): void => {
           handleOnFocus?.({ name, value: event?.nativeEvent.text });
           setCurrentInteraction('active');
-        }}
-        onBlur={(): void => {
-          if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
-            setShouldIgnoreBlurAnimation(false);
-            return;
-          }
-          setCurrentInteraction('default');
         }}
         onChangeText={(text): void => {
           handleOnChange?.({ name, value: text });
@@ -223,6 +218,7 @@ export const StyledBaseInput = React.forwardRef<
             ? autoCompleteSuggestionTypeIOS[autoCompleteSuggestionType]
             : undefined
         }
+        {...commonProps}
         {...props}
         {...accessibilityProps}
       />

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -137,8 +137,8 @@ export const StyledBaseInput = React.forwardRef<
       numberOfLines,
       isTextArea,
       hasPopup,
-      shouldIgnoreBlur,
-      setShouldIgnoreBlur,
+      shouldIgnoreBlurAnimation,
+      setShouldIgnoreBlurAnimation,
       ...props
     },
     ref,
@@ -159,8 +159,8 @@ export const StyledBaseInput = React.forwardRef<
           setCurrentInteraction('active');
         }}
         onBlur={(): void => {
-          if (shouldIgnoreBlur && setShouldIgnoreBlur) {
-            setShouldIgnoreBlur(false);
+          if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
+            setShouldIgnoreBlurAnimation(false);
             return;
           }
           setCurrentInteraction('default');
@@ -187,8 +187,8 @@ export const StyledBaseInput = React.forwardRef<
           setCurrentInteraction('active');
         }}
         onBlur={(): void => {
-          if (shouldIgnoreBlur && setShouldIgnoreBlur) {
-            setShouldIgnoreBlur(false);
+          if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
+            setShouldIgnoreBlurAnimation(false);
             return;
           }
           setCurrentInteraction('default');

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -138,7 +138,6 @@ export const StyledBaseInput = React.forwardRef<
       isTextArea,
       hasPopup,
       shouldIgnoreBlurAnimation,
-      setShouldIgnoreBlurAnimation,
       ...props
     },
     ref,
@@ -148,11 +147,9 @@ export const StyledBaseInput = React.forwardRef<
       onBlur: (): void => {
         // In certain cases like SelectInput, we want to ignore the blur animation when option item is clicked.
         // The selectinput should always look like it is in focus otherwise it triggers blur + focus again which can cause flicker
-        if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
-          setShouldIgnoreBlurAnimation(false);
-          return;
+        if (!shouldIgnoreBlurAnimation) {
+          setCurrentInteraction('default');
         }
-        setCurrentInteraction('default');
       },
       isFocused: currentInteraction === 'active',
     };

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -146,6 +146,8 @@ export const StyledBaseInput = React.forwardRef<
     const buttonValue = props.value ? props.value : props.defaultValue;
     const commonProps = {
       onBlur: (): void => {
+        // In certain cases like SelectInput, we want to ignore the blur animation when option item is clicked.
+        // The selectinput should always look like it is in focus otherwise it triggers blur + focus again which can cause flicker
         if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
           setShouldIgnoreBlurAnimation(false);
           return;

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -137,6 +137,8 @@ export const StyledBaseInput = React.forwardRef<
       numberOfLines,
       isTextArea,
       hasPopup,
+      shouldIgnoreBlur,
+      setShouldIgnoreBlur,
       ...props
     },
     ref,
@@ -157,6 +159,10 @@ export const StyledBaseInput = React.forwardRef<
           setCurrentInteraction('active');
         }}
         onBlur={(): void => {
+          if (shouldIgnoreBlur && setShouldIgnoreBlur) {
+            setShouldIgnoreBlur(false);
+            return;
+          }
           setCurrentInteraction('default');
         }}
         {...props}
@@ -181,6 +187,10 @@ export const StyledBaseInput = React.forwardRef<
           setCurrentInteraction('active');
         }}
         onBlur={(): void => {
+          if (shouldIgnoreBlur && setShouldIgnoreBlur) {
+            setShouldIgnoreBlur(false);
+            return;
+          }
           setCurrentInteraction('default');
         }}
         onChangeText={(text): void => {

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
@@ -104,19 +104,19 @@ export const StyledBaseInput = React.forwardRef<
       numberOfLines,
       type,
       hasPopup,
-      shouldIgnoreBlur,
-      setShouldIgnoreBlur,
+      shouldIgnoreBlurAnimation,
+      setShouldIgnoreBlurAnimation,
       ...props
     },
     ref,
   ) => {
     const commonProps = {
       onBlur: (event: React.ChangeEvent<HTMLInputElement>): void => {
-        if (shouldIgnoreBlur && setShouldIgnoreBlur) {
-          setShouldIgnoreBlur(false);
-          return;
+        if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
+          setShouldIgnoreBlurAnimation(false);
+        } else {
+          setCurrentInteraction('default');
         }
-        setCurrentInteraction('default');
         handleOnBlur?.({ name, value: event });
       },
       onFocus: (event: React.ChangeEvent<HTMLInputElement>): void => {

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
@@ -104,12 +104,18 @@ export const StyledBaseInput = React.forwardRef<
       numberOfLines,
       type,
       hasPopup,
+      shouldIgnoreBlur,
+      setShouldIgnoreBlur,
       ...props
     },
     ref,
   ) => {
     const commonProps = {
       onBlur: (event: React.ChangeEvent<HTMLInputElement>): void => {
+        if (shouldIgnoreBlur && setShouldIgnoreBlur) {
+          setShouldIgnoreBlur(false);
+          return;
+        }
         setCurrentInteraction('default');
         handleOnBlur?.({ name, value: event });
       },

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
@@ -105,7 +105,6 @@ export const StyledBaseInput = React.forwardRef<
       type,
       hasPopup,
       shouldIgnoreBlurAnimation,
-      setShouldIgnoreBlurAnimation,
       ...props
     },
     ref,
@@ -114,9 +113,7 @@ export const StyledBaseInput = React.forwardRef<
       onBlur: (event: React.ChangeEvent<HTMLInputElement>): void => {
         // In certain cases like SelectInput, we want to ignore the blur animation when option item is clicked.
         // The selectinput should always look like it is in focus otherwise it triggers blur + focus again which can cause flicker
-        if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
-          setShouldIgnoreBlurAnimation(false);
-        } else {
+        if (!shouldIgnoreBlurAnimation) {
           setCurrentInteraction('default');
         }
         handleOnBlur?.({ name, value: event });

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
@@ -112,6 +112,8 @@ export const StyledBaseInput = React.forwardRef<
   ) => {
     const commonProps = {
       onBlur: (event: React.ChangeEvent<HTMLInputElement>): void => {
+        // In certain cases like SelectInput, we want to ignore the blur animation when option item is clicked.
+        // The selectinput should always look like it is in focus otherwise it triggers blur + focus again which can cause flicker
         if (shouldIgnoreBlurAnimation && setShouldIgnoreBlurAnimation) {
           setShouldIgnoreBlurAnimation(false);
         } else {

--- a/packages/blade/src/components/Input/BaseInput/types.ts
+++ b/packages/blade/src/components/Input/BaseInput/types.ts
@@ -47,7 +47,7 @@ export type StyledBaseInputProps = {
   | 'hasPopup'
   | 'popupId'
   | 'isPopupExpanded'
-  | 'shouldIgnoreBlur'
-  | 'setShouldIgnoreBlur'
+  | 'shouldIgnoreBlurAnimation'
+  | 'setShouldIgnoreBlurAnimation'
 >;
 export { StyledBaseInput } from './StyledBaseInput.web';

--- a/packages/blade/src/components/Input/BaseInput/types.ts
+++ b/packages/blade/src/components/Input/BaseInput/types.ts
@@ -47,5 +47,7 @@ export type StyledBaseInputProps = {
   | 'hasPopup'
   | 'popupId'
   | 'isPopupExpanded'
+  | 'shouldIgnoreBlur'
+  | 'setShouldIgnoreBlur'
 >;
 export { StyledBaseInput } from './StyledBaseInput.web';

--- a/packages/blade/src/components/Input/BaseInput/types.ts
+++ b/packages/blade/src/components/Input/BaseInput/types.ts
@@ -48,6 +48,5 @@ export type StyledBaseInputProps = {
   | 'popupId'
   | 'isPopupExpanded'
   | 'shouldIgnoreBlurAnimation'
-  | 'setShouldIgnoreBlurAnimation'
 >;
 export { StyledBaseInput } from './StyledBaseInput.web';

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -51,8 +51,7 @@ const _SelectInput = (
     triggererRef,
     hasFooterAction,
     dropdownTriggerer,
-    shouldIgnoreBlur,
-    setShouldIgnoreBlur,
+    shouldIgnoreBlurAnimation,
   } = useDropdown();
 
   const inputRef = useBladeInnerRef(ref);
@@ -98,8 +97,7 @@ const _SelectInput = (
         onBlur={onTriggerBlur}
         activeDescendant={activeIndex >= 0 ? `${dropdownBaseId}-${activeIndex}` : undefined}
         popupId={`${dropdownBaseId}-actionlist`}
-        shouldIgnoreBlurAnimation={shouldIgnoreBlur}
-        setShouldIgnoreBlurAnimation={setShouldIgnoreBlur}
+        shouldIgnoreBlurAnimation={shouldIgnoreBlurAnimation}
         interactionElement={
           <SelectChevronIcon
             onClick={() => {

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -48,12 +48,14 @@ const _SelectInput = (
     onTriggerBlur,
     dropdownBaseId,
     activeIndex,
-    triggererRef,
     hasFooterAction,
     dropdownTriggerer,
+    shouldIgnoreBlur,
+    setShouldIgnoreBlur,
   } = useDropdown();
 
   const inputRef = useBladeInnerRef(ref);
+  const triggerRef = React.useRef<HTMLInputElement>(null);
 
   const { icon, onChange, ...baseInputProps } = props;
 
@@ -83,7 +85,7 @@ const _SelectInput = (
         {...baseInputProps}
         as="button"
         componentName={MetaConstants.SelectInput}
-        ref={!isReactNative() ? (triggererRef as React.MutableRefObject<HTMLInputElement>) : null}
+        ref={!isReactNative() ? triggerRef : null}
         textAlign="left"
         value={displayValue ? displayValue : 'Select Option'}
         id={`${dropdownBaseId}-trigger`}
@@ -96,12 +98,14 @@ const _SelectInput = (
         onBlur={onTriggerBlur}
         activeDescendant={activeIndex >= 0 ? `${dropdownBaseId}-${activeIndex}` : undefined}
         popupId={`${dropdownBaseId}-actionlist`}
+        shouldIgnoreBlur={shouldIgnoreBlur}
+        setShouldIgnoreBlur={setShouldIgnoreBlur}
         interactionElement={
           <SelectChevronIcon
             onClick={() => {
               // Icon onClicks to the SelectInput itself
               if (!isReactNative()) {
-                triggererRef.current?.focus();
+                triggerRef.current?.focus();
               }
               onTriggerClick();
             }}

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -48,6 +48,7 @@ const _SelectInput = (
     onTriggerBlur,
     dropdownBaseId,
     activeIndex,
+    triggererRef,
     hasFooterAction,
     dropdownTriggerer,
     shouldIgnoreBlur,
@@ -55,7 +56,6 @@ const _SelectInput = (
   } = useDropdown();
 
   const inputRef = useBladeInnerRef(ref);
-  const triggerRef = React.useRef<HTMLInputElement>(null);
 
   const { icon, onChange, ...baseInputProps } = props;
 
@@ -85,7 +85,7 @@ const _SelectInput = (
         {...baseInputProps}
         as="button"
         componentName={MetaConstants.SelectInput}
-        ref={!isReactNative() ? triggerRef : null}
+        ref={!isReactNative() ? (triggererRef as React.MutableRefObject<HTMLInputElement>) : null}
         textAlign="left"
         value={displayValue ? displayValue : 'Select Option'}
         id={`${dropdownBaseId}-trigger`}
@@ -96,16 +96,19 @@ const _SelectInput = (
         onClick={onTriggerClick}
         onKeyDown={onTriggerKeydown}
         onBlur={onTriggerBlur}
+        onFocus={() => {
+          setShouldIgnoreBlur(false);
+        }}
         activeDescendant={activeIndex >= 0 ? `${dropdownBaseId}-${activeIndex}` : undefined}
         popupId={`${dropdownBaseId}-actionlist`}
-        shouldIgnoreBlur={shouldIgnoreBlur}
-        setShouldIgnoreBlur={setShouldIgnoreBlur}
+        shouldIgnoreBlurAnimation={shouldIgnoreBlur}
+        setShouldIgnoreBlurAnimation={setShouldIgnoreBlur}
         interactionElement={
           <SelectChevronIcon
             onClick={() => {
               // Icon onClicks to the SelectInput itself
               if (!isReactNative()) {
-                triggerRef.current?.focus();
+                triggererRef.current?.focus();
               }
               onTriggerClick();
             }}

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -96,9 +96,6 @@ const _SelectInput = (
         onClick={onTriggerClick}
         onKeyDown={onTriggerKeydown}
         onBlur={onTriggerBlur}
-        onFocus={() => {
-          setShouldIgnoreBlur(false);
-        }}
         activeDescendant={activeIndex >= 0 ? `${dropdownBaseId}-${activeIndex}` : undefined}
         popupId={`${dropdownBaseId}-actionlist`}
         shouldIgnoreBlurAnimation={shouldIgnoreBlur}


### PR DESCRIPTION
fixes #989 

- I passed `shouldIgnoreBlur` and `setShouldIgnoreBlur` to `BaseInput` so that we can ignore the blur event when we don't really want to call the blur out animation.
- ~I also removed the `triggererRef` from the Dropdown context because we only needed it to reput the focus on select which is not needed anymore as we just ignore the blur.~ We're only ignoring blur animation and not the blur itself so we still need to manage focus.
