### PR TITLE
feat(Dropdown): benchmarks [not to be merged]

### DIFF
--- a/packages/examples/basic/src/App.tsx
+++ b/packages/examples/basic/src/App.tsx
@@ -1,4 +1,25 @@
-import { BladeProvider, Button } from '@razorpay/blade/components';
+import {
+  BladeProvider,
+  Dropdown,
+  DropdownOverlay,
+  SelectInput,
+  ActionList,
+  // ActionListFooter,
+  // ActionListFooterIcon,
+  // ActionListHeader,
+  ActionListItem,
+  // ActionListHeaderIcon,
+  // ActionListSection,
+  // ActionListItemAsset,
+  ActionListItemIcon,
+  // Button,
+  // HistoryIcon,
+  ArrowRightIcon,
+  SettingsIcon,
+  // DownloadIcon,
+  // SearchIcon,
+  HomeIcon,
+} from '@razorpay/blade/components';
 import { paymentTheme } from '@razorpay/blade/tokens';
 import '@fontsource/lato/400.css';
 import '@fontsource/lato/400-italic.css';
@@ -8,7 +29,53 @@ import '@fontsource/lato/700-italic.css';
 function App(): JSX.Element {
   return (
     <BladeProvider themeTokens={paymentTheme} colorScheme="light">
-      <Button onClick={() => console.log('hi')}>Hello</Button>
+      <Dropdown>
+        <SelectInput
+          label="Select Action"
+          onChange={({ name, values }) => {
+            console.log(name, values);
+          }}
+        />
+        <DropdownOverlay>
+          <ActionList>
+            {/* <ActionListHeader
+              title="Recent Searches"
+              leading={<ActionListHeaderIcon icon={HistoryIcon} />}
+            /> */}
+            <ActionListItem
+              leading={<ActionListItemIcon icon={HomeIcon} />}
+              trailing={<ActionListItemIcon icon={ArrowRightIcon} />}
+              title="Home"
+              value="home"
+              description="Home sweet home"
+            />
+            <ActionListItem
+              leading={<ActionListItemIcon icon={SettingsIcon} />}
+              title="Settings"
+              value="settings"
+              isDisabled={true}
+            />
+            {/* <ActionListSection title="Options">
+              
+              <ActionListItem
+                leading={<ActionListItemIcon icon={DownloadIcon} />}
+                title="Download"
+                value="download"
+              />
+            </ActionListSection> */}
+            {/* <ActionListItem
+              leading={<ActionListItemAsset src="https://flagcdn.com/w20/in.png" alt="india" />}
+              title="Pricing"
+              value="pricing"
+            /> */}
+            {/* <ActionListFooter
+              title="Search"
+              leading={<ActionListFooterIcon icon={SearchIcon} />}
+              trailing={<Button onClick={console.log}>Apply</Button>}
+            /> */}
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>
     </BladeProvider>
   );
 }

--- a/packages/examples/basic/src/App.tsx
+++ b/packages/examples/basic/src/App.tsx
@@ -11,14 +11,14 @@ import {
   // ActionListHeaderIcon,
   // ActionListSection,
   // ActionListItemAsset,
-  ActionListItemIcon,
+  // ActionListItemIcon,
   // Button,
   // HistoryIcon,
-  ArrowRightIcon,
-  SettingsIcon,
+  // ArrowRightIcon,
+  // SettingsIcon,
   // DownloadIcon,
   // SearchIcon,
-  HomeIcon,
+  // HomeIcon,
 } from '@razorpay/blade/components';
 import { paymentTheme } from '@razorpay/blade/tokens';
 import '@fontsource/lato/400.css';
@@ -43,14 +43,14 @@ function App(): JSX.Element {
               leading={<ActionListHeaderIcon icon={HistoryIcon} />}
             /> */}
             <ActionListItem
-              leading={<ActionListItemIcon icon={HomeIcon} />}
-              trailing={<ActionListItemIcon icon={ArrowRightIcon} />}
+              // leading={<ActionListItemIcon icon={HomeIcon} />}
+              // trailing={<ActionListItemIcon icon={ArrowRightIcon} />}
               title="Home"
               value="home"
               description="Home sweet home"
             />
             <ActionListItem
-              leading={<ActionListItemIcon icon={SettingsIcon} />}
+              // leading={<ActionListItemIcon icon={SettingsIcon} />}
               title="Settings"
               value="settings"
               isDisabled={true}


### PR DESCRIPTION
Example used to benchmark the dropdown bundlesize in announcement

**Benchmarks:**

| Dropdown Version                                                                   | Bundle Size (gzip)                        |
|------------------------------------------------------------------------------------|-------------------------------------------|
| [Simple Dropdown with items and leading icons](https://blade.razorpay.com/?path=/story/components-dropdown-with-select--with-single-select&globals=measureEnabled:false) (most common usecase across Razorpay) | 10.6kb (9.9kb without ActionListItemIcon) |
| [Complex Dropdown with footers, headers, assets, icons, and sections](https://blade.razorpay.com/?path=/story/components-dropdown-with-select--with-header-footer&args=selectionType:multiple&globals=measureEnabled:false)                | 13.2kb                                    |


They were compared with `Select` components from different design systems and component libraries (gzipped versions)

Chakra
<img width="305" alt="image" src="https://user-images.githubusercontent.com/30949385/218379641-63cea1c1-868c-44b1-afd0-e9b3d73ab51d.png">

`@mui/material`
<img width="294" alt="image" src="https://user-images.githubusercontent.com/30949385/218379908-1e22a7ab-4aa9-4c2e-96d5-d256910d60fd.png">

