### PR TITLE
fix(Dropdown): change footer title to avoid confusion

### DIFF
--- a/packages/blade/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/blade/src/components/Dropdown/Dropdown.stories.tsx
@@ -22,7 +22,7 @@ import {
   InfoIcon,
   ArrowRightIcon,
   HistoryIcon,
-  SearchIcon,
+  FileTextIcon,
 } from '~components/Icons';
 import Box from '~components/Box';
 import { Sandbox } from '~src/_helpers/storybook/Sandbox';
@@ -72,7 +72,7 @@ const Page = (): ReactElement => {
       }}
     >
       <Title>Usage</Title>
-      <Sandbox editorHeight={600}>
+      <Sandbox showConsole editorHeight={600}>
         {`
           import { 
             Dropdown, 
@@ -92,7 +92,7 @@ const Page = (): ReactElement => {
             SettingsIcon,
             DownloadIcon,
             InfoIcon,
-            SearchIcon,
+            FileTextIcon,
             Button
           } from '@razorpay/blade/components';
 
@@ -136,8 +136,8 @@ const Page = (): ReactElement => {
                       />
                     </ActionListSection>
                     <ActionListFooter
-                      title="Search"
-                      leading={<ActionListFooterIcon icon={SearchIcon} />}
+                      title="Search Tips"
+                      leading={<ActionListFooterIcon icon={FileTextIcon} />}
                       trailing={
                         <Button onClick={() => {
                           console.log('Apply button clicked')
@@ -382,8 +382,8 @@ export const WithHeaderFooter = (args: AllDropdownProps): JSX.Element => {
               value="pricing"
             />
             <ActionListFooter
-              title="Search"
-              leading={<ActionListFooterIcon icon={SearchIcon} />}
+              title="Search Tips"
+              leading={<ActionListFooterIcon icon={FileTextIcon} />}
               trailing={<Button onClick={console.log}>Apply</Button>}
             />
           </ActionList>
@@ -482,8 +482,8 @@ export const WithScrollbar = (args: AllDropdownProps): JSX.Element => {
               value="pricing"
             />
             <ActionListFooter
-              title="Search"
-              leading={<ActionListFooterIcon icon={SearchIcon} />}
+              title="Search Tips"
+              leading={<ActionListFooterIcon icon={FileTextIcon} />}
               trailing={<Button onClick={console.log}>Apply</Button>}
             />
           </ActionList>


### PR DESCRIPTION
Search with search icon on footer makes it feel like its input with search. Changing the footer title and icon as Abhishek suggested
https://razorpay.slack.com/archives/C01H13RTF8V/p1676280664087239?thread_ts=1676278793.897139&cid=C01H13RTF8V