### PR TITLE
fix: codesandbox ci example URL

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -3,5 +3,5 @@
   "packages": ["packages/blade"],
   "//": "we don't want to build since post install and prepublish our build automatically runs",
   "buildCommand": false,
-  "sandboxes": ["packages/examples/basic/"]
+  "sandboxes": ["/packages/examples/basic/"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -3,6 +3,5 @@
   "packages": ["packages/blade"],
   "//": "we don't want to build since post install and prepublish our build automatically runs",
   "buildCommand": false,
-  "//": "it's weird that the react sandbox name is 'new'😅",
-  "sandboxes": ["/examples/basic/"]
+  "sandboxes": ["packages/examples/basic/"]
 }


### PR DESCRIPTION
examples is moved inside packages now so the codesandbox CI was unable to detect the example while building. this should fix the preview codesandbox now.