### PR TITLE
feat: support string array in children

### DIFF
--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -25,4 +25,31 @@ type DotNotationMotionStringToken<TokenType> = {
 
 type DotNotationSpacingStringToken = `spacing.${keyof Spacing}`;
 
-export { DotNotationColorStringToken, DotNotationMotionStringToken, DotNotationSpacingStringToken };
+/**
+ * Use this when you want children to be string.
+ *
+ * This covers scenarios like
+ * ```jsx
+ * <Title>Hi</Title>
+ * <Title>{dynamicVariable} something</Title>
+ * ```
+ *
+ *
+ * ### Usage
+ *
+ * ```ts
+ * import type { StringChildrenType } from '~helpers/types';
+ *
+ * type MyProps = {
+ *  children: StringChildrenType;
+ * }
+ * ```
+ */
+type StringChildrenType = string | string[];
+
+export {
+  DotNotationColorStringToken,
+  DotNotationMotionStringToken,
+  DotNotationSpacingStringToken,
+  StringChildrenType,
+};

--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import type { Spacing } from '~tokens/global';
 import type { EasingFunctionFactory } from '~tokens/global/motion';
 
@@ -45,7 +46,7 @@ type DotNotationSpacingStringToken = `spacing.${keyof Spacing}`;
  * }
  * ```
  */
-type StringChildrenType = string | string[];
+type StringChildrenType = React.ReactText | React.ReactText[];
 
 export {
   DotNotationColorStringToken,

--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -19,6 +19,7 @@ import { isReactNative, makeAccessible, makeSize, metaAttribute, MetaConstants }
 import type { WithComponentId } from '~utils';
 import { Checkbox } from '~components/Checkbox';
 import { useTheme } from '~components/BladeProvider';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 type ActionListItemProps = {
   title: string;
@@ -149,7 +150,7 @@ const ActionListItemIcon: WithComponentId<{ icon: IconComponent }> = ({ icon }):
 
 ActionListItemIcon.componentId = componentIds.ActionListItemIcon;
 
-const ActionListItemText: WithComponentId<{ children: string }> = ({ children }) => {
+const ActionListItemText: WithComponentId<{ children: StringChildrenType }> = ({ children }) => {
   const { isDisabled } = React.useContext(ActionListItemContext);
 
   return (

--- a/packages/blade/src/components/Badge/Badge.tsx
+++ b/packages/blade/src/components/Badge/Badge.tsx
@@ -8,13 +8,15 @@ import type { Feedback } from '~tokens/theme/theme';
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
 import { Text } from '~components/Typography';
 import { metaAttribute, MetaConstants } from '~utils';
+import type { StringChildrenType } from '~src/_helpers/types';
+import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
 
 type BadgeProps = {
   /**
    * Sets the label for the badge.
    *
    */
-  children: string;
+  children: StringChildrenType;
   /**
    * Sets the variant of the badge.
    *
@@ -90,7 +92,8 @@ const Badge = ({
   size = 'medium',
   variant = 'neutral',
 }: BadgeProps): ReactElement => {
-  if (!children?.trim()) {
+  const childrenString = getStringChildrenFromArray(children);
+  if (!childrenString?.trim()) {
     throw new Error('[Blade: Badge]: Text as children is required for Badge.');
   }
   const { backgroundColor, iconColor, textColor } = getColorProps({

--- a/packages/blade/src/components/Badge/Badge.tsx
+++ b/packages/blade/src/components/Badge/Badge.tsx
@@ -9,7 +9,7 @@ import type { BaseTextProps } from '~components/Typography/BaseText/types';
 import { Text } from '~components/Typography';
 import { metaAttribute, MetaConstants } from '~utils';
 import type { StringChildrenType } from '~src/_helpers/types';
-import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
+import { getStringFromReactText } from '~src/utils/getStringChildren';
 
 type BadgeProps = {
   /**
@@ -92,7 +92,7 @@ const Badge = ({
   size = 'medium',
   variant = 'neutral',
 }: BadgeProps): ReactElement => {
-  const childrenString = getStringChildrenFromArray(children);
+  const childrenString = getStringFromReactText(children);
   if (!childrenString?.trim()) {
     throw new Error('[Blade: Badge]: Text as children is required for Badge.');
   }

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -35,10 +35,11 @@ import { announce } from '~components/LiveAnnouncer';
 import type { BaseSpinnerProps } from '~components/Spinner/BaseSpinner';
 import { BaseSpinner } from '~components/Spinner/BaseSpinner';
 import BaseBox from '~components/Box/BaseBox';
-import type { DotNotationSpacingStringToken } from '~src/_helpers/types';
+import type { DotNotationSpacingStringToken, StringChildrenType } from '~src/_helpers/types';
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
 import { useBladeInnerRef } from '~src/hooks/useBladeInnerRef';
+import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
 
 type BaseButtonCommonProps = {
   size?: 'xsmall' | 'small' | 'medium' | 'large';
@@ -62,7 +63,7 @@ Mandatory children prop when icon is not provided
 */
 type BaseButtonWithoutIconProps = BaseButtonCommonProps & {
   icon?: undefined;
-  children: string;
+  children: StringChildrenType;
 };
 
 /*
@@ -70,7 +71,7 @@ type BaseButtonWithoutIconProps = BaseButtonCommonProps & {
 */
 type BaseButtonWithIconProps = BaseButtonCommonProps & {
   icon: IconComponent;
-  children?: string;
+  children?: StringChildrenType;
 };
 
 /*
@@ -293,10 +294,11 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
   },
   ref,
 ) => {
+  const childrenString = getStringChildrenFromArray(children);
   const buttonRef = useBladeInnerRef(ref);
   const disabled = isLoading || isDisabled;
   const { theme } = useTheme();
-  if (!Icon && !children?.trim()) {
+  if (!Icon && !childrenString?.trim()) {
     throw new Error(
       `[Blade: BaseButton]: At least one of icon or text is required to render a button.`,
     );
@@ -339,7 +341,7 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
     motionEasing,
   } = getProps({
     buttonTypographyTokens: buttonTypography,
-    children,
+    children: childrenString,
     isDisabled: disabled,
     size,
     variant,

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -39,7 +39,7 @@ import type { DotNotationSpacingStringToken, StringChildrenType } from '~src/_he
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
 import { useBladeInnerRef } from '~src/hooks/useBladeInnerRef';
-import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
+import { getStringFromReactText } from '~src/utils/getStringChildren';
 
 type BaseButtonCommonProps = {
   size?: 'xsmall' | 'small' | 'medium' | 'large';
@@ -294,7 +294,7 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
   },
   ref,
 ) => {
-  const childrenString = getStringChildrenFromArray(children);
+  const childrenString = getStringFromReactText(children);
   const buttonRef = useBladeInnerRef(ref);
   const disabled = isLoading || isDisabled;
   const { theme } = useTheme();

--- a/packages/blade/src/components/Button/Button/Button.stories.tsx
+++ b/packages/blade/src/components/Button/Button/Button.stories.tsx
@@ -93,6 +93,8 @@ const ButtonTemplate: ComponentStory<typeof ButtonComponent> = ({
   return <ButtonComponent {...args}>{children}</ButtonComponent>;
 };
 
+const count = 1;
+
 const StyledBaseText = styled(BaseText)({ padding: '8px 0px' });
 const ButtonWithSizeTemplate: ComponentStory<typeof ButtonComponent> = ({
   children = 'Button',

--- a/packages/blade/src/components/Button/Button/Button.stories.tsx
+++ b/packages/blade/src/components/Button/Button/Button.stories.tsx
@@ -93,8 +93,6 @@ const ButtonTemplate: ComponentStory<typeof ButtonComponent> = ({
   return <ButtonComponent {...args}>{children}</ButtonComponent>;
 };
 
-const count = 1;
-
 const StyledBaseText = styled(BaseText)({ padding: '8px 0px' });
 const ButtonWithSizeTemplate: ComponentStory<typeof ButtonComponent> = ({
   children = 'Button',

--- a/packages/blade/src/components/Button/Button/Button.tsx
+++ b/packages/blade/src/components/Button/Button/Button.tsx
@@ -4,6 +4,7 @@ import BaseButton from '../BaseButton';
 import type { IconComponent } from '~components/Icons';
 import type { Platform } from '~utils';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 type ButtonCommonProps = {
   variant?: 'primary' | 'secondary' | 'tertiary';
@@ -25,7 +26,7 @@ type ButtonCommonProps = {
   */
 type ButtonWithoutIconProps = ButtonCommonProps & {
   icon?: undefined;
-  children: string;
+  children: StringChildrenType;
 };
 
 /*
@@ -33,7 +34,7 @@ type ButtonWithoutIconProps = ButtonCommonProps & {
   */
 type ButtonWithIconProps = ButtonCommonProps & {
   icon: IconComponent;
-  children?: string;
+  children?: StringChildrenType;
 };
 
 export type ButtonProps = ButtonWithoutIconProps | ButtonWithIconProps;

--- a/packages/blade/src/components/Indicator/Indicator.tsx
+++ b/packages/blade/src/components/Indicator/Indicator.tsx
@@ -5,7 +5,7 @@ import BaseBox from '~components/Box/BaseBox';
 import Svg from '~components/Icons/_Svg';
 import Circle from '~components/Icons/_Svg/Circle';
 import { Text } from '~components/Typography';
-import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
+import { getStringFromReactText } from '~src/utils/getStringChildren';
 import type { StringChildrenType } from '~src/_helpers/types';
 
 import type { Feedback } from '~tokens/theme/theme';
@@ -65,7 +65,7 @@ const Indicator = ({
   intent = 'neutral',
 }: IndicatorProps): ReactElement => {
   const { theme } = useTheme();
-  const childrenString = getStringChildrenFromArray(children);
+  const childrenString = getStringFromReactText(children);
 
   const fillColor = theme.colors.feedback.background[intent].highContrast;
   const strokeColor = theme.colors.brand.gray.a100.highContrast;

--- a/packages/blade/src/components/Indicator/Indicator.tsx
+++ b/packages/blade/src/components/Indicator/Indicator.tsx
@@ -5,6 +5,8 @@ import BaseBox from '~components/Box/BaseBox';
 import Svg from '~components/Icons/_Svg';
 import Circle from '~components/Icons/_Svg/Circle';
 import { Text } from '~components/Typography';
+import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 import type { Feedback } from '~tokens/theme/theme';
 import { metaAttribute, getPlatformType, makeAccessible, MetaConstants } from '~utils';
@@ -29,7 +31,7 @@ type IndicatorWithoutA11yLabel = {
   /**
    * A text label to show alongside the indicator dot
    */
-  children: string;
+  children: StringChildrenType;
 
   /**
    * a11y label for screen readers
@@ -46,7 +48,7 @@ type IndicatorWithA11yLabel = {
   /**
    * A text label to show alongside the indicator dot
    */
-  children?: string;
+  children?: StringChildrenType;
 };
 
 type IndicatorProps = IndicatorCommonProps & (IndicatorWithA11yLabel | IndicatorWithoutA11yLabel);
@@ -63,6 +65,7 @@ const Indicator = ({
   intent = 'neutral',
 }: IndicatorProps): ReactElement => {
   const { theme } = useTheme();
+  const childrenString = getStringChildrenFromArray(children);
 
   const fillColor = theme.colors.feedback.background[intent].highContrast;
   const strokeColor = theme.colors.brand.gray.a100.highContrast;
@@ -81,7 +84,7 @@ const Indicator = ({
   const isReactNative = getPlatformType() === 'react-native';
   const isWeb = !isReactNative;
   const a11yProps = makeAccessible({
-    label: accessibilityLabel ?? children,
+    label: accessibilityLabel ?? childrenString,
     ...(isWeb && { role: 'status' }),
   });
 

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -15,7 +15,7 @@ import { makeAccessible, getIn, metaAttribute, MetaConstants } from '~utils';
 import type { LinkActionStates } from '~tokens/theme/theme';
 import type { DurationString, EasingString } from '~tokens/global/motion';
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
-import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
+import { getStringFromReactText } from '~src/utils/getStringChildren';
 
 type BaseLinkCommonProps = {
   intent?: 'positive' | 'negative' | 'notice' | 'information' | 'neutral';
@@ -214,7 +214,7 @@ const BaseLink = ({
   size = 'medium',
 }: BaseLinkProps): ReactElement => {
   const [isVisited, setIsVisited] = useState(false);
-  const childrenString = getStringChildrenFromArray(children);
+  const childrenString = getStringFromReactText(children);
   const { currentInteraction, setCurrentInteraction, ...syntheticEvents } = useInteraction();
   const { theme } = useTheme();
   if (!Icon && !childrenString?.trim()) {

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -10,11 +10,12 @@ import type { Theme } from '~components/BladeProvider';
 import { useTheme } from '~components/BladeProvider';
 import BaseBox from '~components/Box/BaseBox';
 import { BaseText } from '~components/Typography/BaseText';
-import type { DotNotationSpacingStringToken } from '~src/_helpers/types';
+import type { DotNotationSpacingStringToken, StringChildrenType } from '~src/_helpers/types';
 import { makeAccessible, getIn, metaAttribute, MetaConstants } from '~utils';
 import type { LinkActionStates } from '~tokens/theme/theme';
 import type { DurationString, EasingString } from '~tokens/global/motion';
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
+import { getStringChildrenFromArray } from '~src/utils/getStringChildren';
 
 type BaseLinkCommonProps = {
   intent?: 'positive' | 'negative' | 'notice' | 'information' | 'neutral';
@@ -37,7 +38,7 @@ type BaseLinkCommonProps = {
 */
 type BaseLinkWithoutIconProps = BaseLinkCommonProps & {
   icon?: undefined;
-  children: string;
+  children: StringChildrenType;
 };
 
 /*
@@ -45,7 +46,7 @@ type BaseLinkWithoutIconProps = BaseLinkCommonProps & {
 */
 type BaseLinkWithIconProps = BaseLinkCommonProps & {
   icon: IconComponent;
-  children?: string;
+  children?: StringChildrenType;
 };
 
 /*
@@ -213,9 +214,10 @@ const BaseLink = ({
   size = 'medium',
 }: BaseLinkProps): ReactElement => {
   const [isVisited, setIsVisited] = useState(false);
+  const childrenString = getStringChildrenFromArray(children);
   const { currentInteraction, setCurrentInteraction, ...syntheticEvents } = useInteraction();
   const { theme } = useTheme();
-  if (!Icon && !children?.trim()) {
+  if (!Icon && !childrenString?.trim()) {
     throw new Error(
       `[Blade: BaseLink]: At least one of icon or text is required to render a link.`,
     );
@@ -241,7 +243,7 @@ const BaseLink = ({
     theme,
     variant,
     currentInteraction,
-    children,
+    children: childrenString,
     isDisabled,
     intent,
     contrast,

--- a/packages/blade/src/components/Link/Link/Link.tsx
+++ b/packages/blade/src/components/Link/Link/Link.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement, SyntheticEvent } from 'react';
 import { BaseLink } from '../BaseLink';
 import type { IconComponent } from '~components/Icons';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 type LinkCommonProps = {
   variant?: 'anchor' | 'button';
@@ -25,7 +26,7 @@ type LinkCommonProps = {
 */
 type LinkWithoutIconProps = LinkCommonProps & {
   icon?: undefined;
-  children: string;
+  children: StringChildrenType;
 };
 
 /*
@@ -33,7 +34,7 @@ type LinkWithoutIconProps = LinkCommonProps & {
 */
 type LinkWithIconProps = LinkCommonProps & {
   icon: IconComponent;
-  children?: string;
+  children?: StringChildrenType;
 };
 
 /*

--- a/packages/blade/src/components/Radio/Radio.tsx
+++ b/packages/blade/src/components/Radio/Radio.tsx
@@ -12,12 +12,13 @@ import { SelectorSupportText } from '~components/Form/Selector/SelectorSupportTe
 import { SelectorInput } from '~components/Form/Selector/SelectorInput';
 import { getPlatformType } from '~utils';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 type RadioProps = {
   /**
    * Sets the label text of the Radio
    */
-  children: string;
+  children: StringChildrenType;
   /**
    * Help text for the Radio
    */

--- a/packages/blade/src/components/SkipNav/SkipNav.native.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.native.tsx
@@ -1,6 +1,8 @@
+import type { StringChildrenType } from '~src/_helpers/types';
+
 type SkipNavLinkProps = {
   id?: string;
-  children?: string;
+  children?: StringChildrenType;
 };
 
 const SkipNavLink = (_props: SkipNavLinkProps): never => {

--- a/packages/blade/src/components/SkipNav/SkipNav.web.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.web.tsx
@@ -3,11 +3,12 @@ import styled from 'styled-components';
 import { metaAttribute, MetaConstants, testID } from '~utils';
 import { screenReaderStyles } from '~components/VisuallyHidden/ScreenReaderStyles';
 import { BaseLink } from '~components/Link/BaseLink';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 const fallbackId = 'blade-skip-nav';
 type SkipNavLinkProps = {
   id?: string;
-  children?: string;
+  children?: StringChildrenType;
 };
 
 const StyledLink = styled(BaseLink)(({ theme }) => ({

--- a/packages/blade/src/components/Typography/Code/Code.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.tsx
@@ -9,9 +9,10 @@ import {
   MetaConstants,
 } from '~utils';
 import type { FontSize } from '~tokens/global/typography';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 export type CodeProps = {
-  children: string;
+  children: StringChildrenType;
   /**
    * Decides the fontSize and padding of Code
    *

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -5,6 +5,7 @@ import type { BaseTextProps } from '../BaseText/types';
 import type { ColorContrast, ColorContrastTypes, TextTypes } from '~tokens/theme/theme';
 import { getPlatformType } from '~utils';
 import type { Theme } from '~components/BladeProvider';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 type HeadingVariant = 'regular' | 'subheading';
 type HeadingSize = 'small' | 'medium' | 'large';
@@ -12,7 +13,7 @@ type HeadingSize = 'small' | 'medium' | 'large';
 type HeadingCommonProps = {
   type?: TextTypes;
   contrast?: ColorContrastTypes;
-  children: string;
+  children: StringChildrenType;
 };
 
 type HeadingNormalVariant = HeadingCommonProps & {

--- a/packages/blade/src/components/Typography/Title/Title.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.tsx
@@ -3,12 +3,13 @@ import { BaseText } from '../BaseText';
 import type { BaseTextProps } from '../BaseText/types';
 import type { ColorContrast, ColorContrastTypes, TextTypes } from '~tokens/theme/theme';
 import { getPlatformType } from '~utils';
+import type { StringChildrenType } from '~src/_helpers/types';
 
 export type TitleProps = {
   size?: 'small' | 'medium' | 'large';
   contrast?: ColorContrastTypes;
   type?: TextTypes;
-  children: string;
+  children: StringChildrenType;
 };
 
 const getProps = ({

--- a/packages/blade/src/utils/getStringChildren/getStringChildren.ts
+++ b/packages/blade/src/utils/getStringChildren/getStringChildren.ts
@@ -1,0 +1,13 @@
+import type { StringChildrenType } from '~src/_helpers/types';
+
+const getStringChildrenFromArray = (
+  childrenArray: StringChildrenType | undefined,
+): string | undefined => {
+  if (Array.isArray(childrenArray)) {
+    return childrenArray.join('');
+  }
+
+  return childrenArray;
+};
+
+export { getStringChildrenFromArray };

--- a/packages/blade/src/utils/getStringChildren/getStringChildren.ts
+++ b/packages/blade/src/utils/getStringChildren/getStringChildren.ts
@@ -1,9 +1,10 @@
+import { isEmpty } from 'lodash';
 import type { StringChildrenType } from '~src/_helpers/types';
 
 const getStringFromReactText = (
   childReactText: StringChildrenType | undefined,
 ): string | undefined => {
-  if (!childReactText) {
+  if (isEmpty(childReactText)) {
     return undefined;
   }
 

--- a/packages/blade/src/utils/getStringChildren/getStringChildren.ts
+++ b/packages/blade/src/utils/getStringChildren/getStringChildren.ts
@@ -1,13 +1,17 @@
 import type { StringChildrenType } from '~src/_helpers/types';
 
-const getStringChildrenFromArray = (
-  childrenArray: StringChildrenType | undefined,
+const getStringFromReactText = (
+  childReactText: StringChildrenType | undefined,
 ): string | undefined => {
-  if (Array.isArray(childrenArray)) {
-    return childrenArray.join('');
+  if (!childReactText) {
+    return undefined;
   }
 
-  return childrenArray;
+  if (Array.isArray(childReactText)) {
+    return childReactText.join('');
+  }
+
+  return String(childReactText);
 };
 
-export { getStringChildrenFromArray };
+export { getStringFromReactText };

--- a/packages/blade/src/utils/getStringChildren/index.ts
+++ b/packages/blade/src/utils/getStringChildren/index.ts
@@ -1,0 +1,1 @@
+export * from './getStringChildren';


### PR DESCRIPTION
The following code now works with this PR-

```jsx
<Button>{someVariable} hello</Button>
```

Fixes the issue from this comment https://github.com/razorpay/blade/issues/811#issuecomment-1318289632

Slack Thread: https://razorpay.slack.com/archives/G01B3LQ9H0W/p1669028285672599

~Just changing it to `string | string[]` instead of `ReactText | ReactText[]` since we have several checks for strings which I didn't want to break.~ Changed it to `ReactText | ReactText[]`