### PR TITLE
fix: change import to default in package exports

### DIFF
--- a/.changeset/two-carrots-provide.md
+++ b/.changeset/two-carrots-provide.md
@@ -2,6 +2,6 @@
 '@razorpay/blade': patch
 ---
 
-fix: jest cannot import Blade
+fix: change import to default in package exports
 
-Jest does not support the "import" condition in exports. Changed "import" to "default".
+Jest does not support the "import" condition in exports. This was causing tests to fail for Blade consumers. Changed "import" to "default" which is supported by all tools. Since Blade is not exporting a dual package, we don't need the "import" condition.

--- a/.changeset/two-carrots-provide.md
+++ b/.changeset/two-carrots-provide.md
@@ -2,4 +2,6 @@
 '@razorpay/blade': patch
 ---
 
-revert: remove types field from package exports
+fix: jest cannot import Blade
+
+Jest does not support the "import" condition in exports. Changed "import" to "default".

--- a/.changeset/two-carrots-provide.md
+++ b/.changeset/two-carrots-provide.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+revert: remove types field from package exports

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -28,16 +28,34 @@
   ],
   "exports": {
     "./components": {
-      "react-native": "./build/components/index.native.js",
-      "default": "./build/components/index.web.js"
+      "react-native": {
+        "types": "./build/components/index.native.d.ts",
+        "default": "./build/components/index.native.js"
+      },
+      "default": {
+        "types": "./build/components/index.d.ts",
+        "default": "./build/components/index.web.js"
+      }
     },
     "./tokens": {
-      "react-native": "./build/tokens/index.native.js",
-      "default": "./build/tokens/index.web.js"
+      "react-native": {
+        "types": "./build/tokens/index.native.d.ts",
+        "default": "./build/tokens/index.native.js"
+      },
+      "default": {
+        "types": "./build/tokens/index.d.ts",
+        "default": "./build/tokens/index.web.js"
+      }
     },
     "./utils": {
-      "react-native": "./build/utils/index.native.js",
-      "default": "./build/utils/index.web.js"
+      "react-native": {
+        "types": "./build/utils/index.native.d.ts",
+        "default": "./build/utils/index.native.js"
+      },
+      "default": {
+        "types": "./build/utils/index.d.ts",
+        "default": "./build/utils/index.web.js"
+      }
     }
   },
   "scripts": {

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -28,34 +28,16 @@
   ],
   "exports": {
     "./components": {
-      "react-native": {
-        "import": "./build/components/index.native.js",
-        "types": "./build/components/index.native.d.ts"
-      },
-      "default": {
-        "import": "./build/components/index.web.js",
-        "types": "./build/components/index.d.ts"
-      }
+      "react-native": "./build/components/index.native.js",
+      "default": "./build/components/index.web.js"
     },
     "./tokens": {
-      "react-native": {
-        "import": "./build/tokens/index.native.js",
-        "types": "./build/tokens/index.native.d.ts"
-      },
-      "default": {
-        "import": "./build/tokens/index.web.js",
-        "types": "./build/tokens/index.d.ts"
-      }
+      "react-native": "./build/tokens/index.native.js",
+      "default": "./build/tokens/index.web.js"
     },
     "./utils": {
-      "react-native": {
-        "import": "./build/utils/index.native.js",
-        "types": "./build/utils/index.native.d.ts"
-      },
-      "default": {
-        "import": "./build/utils/index.web.js",
-        "types": "./build/utils/index.d.ts"
-      }
+      "react-native": "./build/utils/index.native.js",
+      "default": "./build/utils/index.web.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
The changes made in #970 caused Jest tests to [break][1] for Blade consumers.
This is because Jest [does not support][2] the "import" condition in package exports.

Proper support for the exports field for Jest is still an open issue:
https://github.com/browserify/resolve/issues/222

But we can fix this just by providing a "default" field which Jest does recognise. Since we're not exporting a dual package build which requires explicit `import`/`require` conditions, the default field is sufficient for all tools consuming Blade.

I've also moved the "types" to be defined first as is recommended by TypeScript. It still works right now in `master` because of a [bug in TypeScript][3]. Refer: https://arethetypeswrong.github.io/

[1]: https://razorpay.slack.com/archives/C02S42DDKU3/p1677557736749599
[2]: https://github.com/okta/okta-auth-js/issues/1268
[3]: https://github.com/microsoft/TypeScript/issues/50762
