### PR TITLE
feat(theme): add name property to watch over theme changes

### DIFF
--- a/.changeset/swift-dolphins-wink.md
+++ b/.changeset/swift-dolphins-wink.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(theme): add `name` property in `theme` to watch on theme changes

--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -74,6 +74,7 @@ type StringChildrenType = React.ReactText | React.ReactText[];
  * This will show paymentTheme and bankingTheme in autocomplete but also allow any other string as value.
  *
  * More details - https://github.com/razorpay/blade/pull/1031/commits/86b6ee0facf45e7556739efcbfa5396b11b1b3c9#r1121298293
+ * Related TS Issue - https://github.com/microsoft/TypeScript/issues/29729
  *
  */
 type StringWithAutocomplete = string & Record<never, never>;

--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -61,6 +61,23 @@ type KeysRequired<T> = AllowUndefinedValue<Required<T>>;
  */
 type StringChildrenType = React.ReactText | React.ReactText[];
 
+/**
+ *
+ * When combined with union, this type utility will give you autocomplete of union while still supporting any string value as input
+ *
+ * ### Usage
+ *
+ * ```ts
+ * type ThemeName = 'paymentTheme' | 'bankingTheme' | StringWithAutocomplete;
+ * ```
+ *
+ * This will show paymentTheme and bankingTheme in autocomplete but also allow any other string as value.
+ *
+ * More details - https://github.com/razorpay/blade/pull/1031/commits/86b6ee0facf45e7556739efcbfa5396b11b1b3c9#r1121298293
+ *
+ */
+type StringWithAutocomplete = string & Record<never, never>;
+
 type TestID = {
   testID?: string;
 };
@@ -71,5 +88,6 @@ export {
   DotNotationSpacingStringToken,
   KeysRequired,
   StringChildrenType,
+  StringWithAutocomplete,
   TestID,
 };

--- a/packages/blade/src/components/BladeProvider/__tests__/paymentLightTheme/paymentLightTheme.web.ts
+++ b/packages/blade/src/components/BladeProvider/__tests__/paymentLightTheme/paymentLightTheme.web.ts
@@ -2,6 +2,7 @@ import type { Theme } from '~components/BladeProvider';
 import { paymentTheme } from '~tokens/theme';
 
 const paymentLightTheme: Theme = {
+  name: 'paymentTheme',
   colors: { ...paymentTheme.colors.onLight },
   border: { ...paymentTheme.border },
   motion: { ...paymentTheme.motion },

--- a/packages/blade/src/components/BladeProvider/index.ts
+++ b/packages/blade/src/components/BladeProvider/index.ts
@@ -1,4 +1,4 @@
-import type { Colors, Shadows, ShadowLevels } from '~tokens/theme/theme';
+import type { Colors, Shadows, ShadowLevels, ThemeTokens } from '~tokens/theme/theme';
 import type { Border } from '~tokens/global/border';
 import type { Breakpoints } from '~tokens/global/breakpoints';
 import type { Motion } from '~tokens/global/motion';
@@ -9,6 +9,7 @@ export * from './BladeProvider';
 export { default as useTheme } from './useTheme';
 
 export type Theme = {
+  name: ThemeTokens['name'];
   border: Border;
   breakpoints: Breakpoints;
   colors: Colors;

--- a/packages/blade/src/components/Box/BaseBox/useMemoizedStyles.web.ts
+++ b/packages/blade/src/components/Box/BaseBox/useMemoizedStyles.web.ts
@@ -12,7 +12,7 @@ const getMemoDependency = (props: BaseBoxProps & { theme?: Theme }): string | Ba
     // I know this looks illegal but Dan approves it - https://twitter.com/dan_abramov/status/1104414272753487872?s=20
     // A lot of times passing object to dependency prop isn't efficient and mostly won't work
     // Hence we JSON.strinfigy and pass the string as dependency prop. React handles this way better.
-    dependencyPropString = JSON.stringify(rest);
+    dependencyPropString = `${JSON.stringify(rest)}-${theme?.name}`;
   } catch (err: unknown) {
     console.warn(
       '[Blade - BaseBox]: stringification of props failed in BaseBox so falling back to re-calculations on all changes\n\n If you see this warning, please create issue on https://github.com/razorpay/blade as this could degrade runtime styling performance',

--- a/packages/blade/src/components/Box/BaseBox/useMemoizedStyles.web.ts
+++ b/packages/blade/src/components/Box/BaseBox/useMemoizedStyles.web.ts
@@ -4,16 +4,19 @@ import { getBaseBoxStyles } from './baseBoxStyles';
 import type { BaseBoxProps } from './types';
 import type { Theme } from '~components/BladeProvider';
 import { useTheme } from '~components/BladeProvider';
+import type { ColorSchemeNames } from '~tokens/theme';
 
-const getMemoDependency = (props: BaseBoxProps & { theme?: Theme }): string | BaseBoxProps => {
+const getMemoDependency = (
+  props: BaseBoxProps & { theme?: Theme } & { colorScheme: ColorSchemeNames },
+): string | BaseBoxProps => {
   // These are the props that change nothing in the getBaseBoxStyles calculations
-  const { theme, children, className, id, ...rest } = props;
+  const { theme, colorScheme, children, className, id, ...rest } = props;
   let dependencyPropString: string | BaseBoxProps = '';
   try {
     // I know this looks illegal but Dan approves it - https://twitter.com/dan_abramov/status/1104414272753487872?s=20
     // A lot of times passing object to dependency prop isn't efficient and mostly won't work
     // Hence we JSON.strinfigy and pass the string as dependency prop. React handles this way better.
-    dependencyPropString = `${JSON.stringify(rest)}-${theme?.name}`;
+    dependencyPropString = `${JSON.stringify(rest)}-${theme?.name}-${colorScheme}`;
   } catch (err: unknown) {
     console.warn(
       '[Blade - BaseBox]: stringification of props failed in BaseBox so falling back to re-calculations on all changes\n\n If you see this warning, please create issue on https://github.com/razorpay/blade as this could degrade runtime styling performance',
@@ -37,12 +40,12 @@ const getMemoDependency = (props: BaseBoxProps & { theme?: Theme }): string | Ba
  * Checkout: https://github.com/razorpay/blade/pull/1009#discussion_r1113767442 for benchmarks
  */
 const useMemoizedStyles = (boxProps: BaseBoxProps & { theme: Theme }): CSSObject => {
-  const boxPropsMemoDependency = getMemoDependency(boxProps);
   const { colorScheme } = useTheme();
+  const boxPropsMemoDependency = getMemoDependency({ ...boxProps, colorScheme });
   const boxPropsCSSObject = React.useMemo(
     () => getBaseBoxStyles({ ...boxProps, theme: boxProps.theme }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [boxPropsMemoDependency, colorScheme],
+    [boxPropsMemoDependency],
   );
 
   return boxPropsCSSObject;

--- a/packages/blade/src/components/Box/BaseBox/useMemoizedStyles.web.ts
+++ b/packages/blade/src/components/Box/BaseBox/useMemoizedStyles.web.ts
@@ -3,6 +3,7 @@ import type { CSSObject } from 'styled-components';
 import { getBaseBoxStyles } from './baseBoxStyles';
 import type { BaseBoxProps } from './types';
 import type { Theme } from '~components/BladeProvider';
+import { useTheme } from '~components/BladeProvider';
 
 const getMemoDependency = (props: BaseBoxProps & { theme?: Theme }): string | BaseBoxProps => {
   // These are the props that change nothing in the getBaseBoxStyles calculations
@@ -37,10 +38,11 @@ const getMemoDependency = (props: BaseBoxProps & { theme?: Theme }): string | Ba
  */
 const useMemoizedStyles = (boxProps: BaseBoxProps & { theme: Theme }): CSSObject => {
   const boxPropsMemoDependency = getMemoDependency(boxProps);
+  const { colorScheme } = useTheme();
   const boxPropsCSSObject = React.useMemo(
     () => getBaseBoxStyles({ ...boxProps, theme: boxProps.theme }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [boxPropsMemoDependency],
+    [boxPropsMemoDependency, colorScheme],
   );
 
   return boxPropsCSSObject;

--- a/packages/blade/src/components/Box/__tests__/useMemoizedStyles.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/useMemoizedStyles.web.test.tsx
@@ -12,9 +12,11 @@ describe('getDependencyProp', () => {
         className: 'hi',
         children: 'wuuhuuu',
         // @ts-expect-error: we don't have to care about actual theme object. It is ignored in this function
-        theme: { something: 'something' },
+        theme: { name: 'paymentTheme', something: 'something' },
       }),
-    ).toMatchInlineSnapshot(`"{\\"paddingLeft\\":\\"12px\\",\\"display\\":\\"block\\"}"`);
+    ).toMatchInlineSnapshot(
+      `"{\\"paddingLeft\\":\\"12px\\",\\"display\\":\\"block\\"}-paymentTheme"`,
+    );
   });
 });
 

--- a/packages/blade/src/components/Box/__tests__/useMemoizedStyles.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/useMemoizedStyles.web.test.tsx
@@ -1,6 +1,16 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { getMemoDependency, useMemoizedStyles } from '../BaseBox/useMemoizedStyles';
 import paymentLightTheme from '~components/BladeProvider/__tests__/paymentLightTheme/paymentLightTheme.web';
+import { BladeProvider } from '~components/BladeProvider';
+import { paymentTheme } from '~tokens/theme';
+
+const BladeThemeProvider = ({ children }: { children: React.ReactNode }): JSX.Element => {
+  return (
+    <BladeProvider themeTokens={paymentTheme} colorScheme="light">
+      {children}
+    </BladeProvider>
+  );
+};
 
 describe('getDependencyProp', () => {
   it('should return react usememo dependency prop', () => {
@@ -22,12 +32,16 @@ describe('getDependencyProp', () => {
 
 describe('useMemoizedStyles', () => {
   it('should return correct CSS styles', () => {
-    const { result } = renderHook(() =>
-      useMemoizedStyles({
-        padding: 'spacing.10',
-        margin: ['spacing.1', 'spacing.2'],
-        theme: paymentLightTheme,
-      }),
+    const { result } = renderHook(
+      () =>
+        useMemoizedStyles({
+          padding: 'spacing.10',
+          margin: ['spacing.1', 'spacing.2'],
+          theme: paymentLightTheme,
+        }),
+      {
+        wrapper: BladeThemeProvider,
+      },
     );
 
     expect(JSON.stringify(result.current)).toMatchInlineSnapshot(

--- a/packages/blade/src/components/Box/__tests__/useMemoizedStyles.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/useMemoizedStyles.web.test.tsx
@@ -23,9 +23,10 @@ describe('getDependencyProp', () => {
         children: 'wuuhuuu',
         // @ts-expect-error: we don't have to care about actual theme object. It is ignored in this function
         theme: { name: 'paymentTheme', something: 'something' },
+        colorScheme: 'light',
       }),
     ).toMatchInlineSnapshot(
-      `"{\\"paddingLeft\\":\\"12px\\",\\"display\\":\\"block\\"}-paymentTheme"`,
+      `"{\\"paddingLeft\\":\\"12px\\",\\"display\\":\\"block\\"}-paymentTheme-light"`,
     );
   });
 });

--- a/packages/blade/src/tokens/theme/bankingTheme.ts
+++ b/packages/blade/src/tokens/theme/bankingTheme.ts
@@ -2203,6 +2203,7 @@ const shadows: Shadows = {
 };
 
 const bankingTheme: ThemeTokens = {
+  name: 'bankingTheme',
   border,
   breakpoints,
   colors,

--- a/packages/blade/src/tokens/theme/paymentTheme.ts
+++ b/packages/blade/src/tokens/theme/paymentTheme.ts
@@ -2203,6 +2203,7 @@ const shadows: Shadows = {
 };
 
 const paymentTheme: ThemeTokens = {
+  name: 'paymentTheme',
   border,
   breakpoints,
   colors,

--- a/packages/blade/src/tokens/theme/theme.d.ts
+++ b/packages/blade/src/tokens/theme/theme.d.ts
@@ -1,3 +1,4 @@
+import type { StringWithAutocomplete } from '~src/_helpers/types';
 import type { Border } from '~tokens/global/border';
 import type { Breakpoints } from '~tokens/global/breakpoints';
 import type { Motion } from '~tokens/global/motion';
@@ -155,6 +156,7 @@ export type Colors = {
 export type ColorsWithModes = Record<ColorSchemeModes, Colors>;
 
 export type ThemeTokens = {
+  name: 'paymentTheme' | 'bankingTheme' | StringWithAutocomplete; // Can be used to watch over state changes between theme without watching over entire theme object
   border: Border;
   breakpoints: Breakpoints;
   colors: ColorsWithModes;


### PR DESCRIPTION
> **Note**
>
> Will merge this PR separately after Layouts. Not that important right now and it can wait. You can review the PR though.

Working Sandbox: https://codesandbox.io/s/blade-theme-change-r736xm

Imagine a usecase where you want to watch when theme is changed. 

This is how you will currently do it.
```ts
const { theme } = useTheme();
React.useMemo(() => {/* something when theme is switched */}, [theme]);
```

This will likely not work as expected in most of the usecases because theme is a deep object.

The proposed solution is this -
```ts
const { theme } = useTheme();
React.useMemo(() => {/* something when theme is switched */}, [theme.name]);
```

So now you only watch when theme itself is switched from state. 

Also helpful for doing any conditional checks in the code like-
```ts
const { theme } = useTheme();
let assets = paymentAssets;
if (theme.name === 'bankingTheme') {
  assets = bankingAssets;
}
```


Although we don't have an actual usecase of switching themes right now. This is something we've been using in our Dashboard recipe in storybook. And the theme switch might not work as expected with something like useMemo that we use in Box. We can add theme object directly to useMemo but the JSON.stringify can get expensive with that.
