### PR TITLE
feat(Text): add `textAlign` prop

### DIFF
--- a/.changeset/yellow-countries-smoke.md
+++ b/.changeset/yellow-countries-smoke.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(Text): add `textAlign` prop

--- a/.changeset/yellow-countries-smoke.md
+++ b/.changeset/yellow-countries-smoke.md
@@ -1,5 +1,5 @@
 ---
-"@razorpay/blade": patch
+"@razorpay/blade": minor
 ---
 
 feat(Text): add `textAlign` prop

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -17,6 +17,7 @@ type TextCommonProps = {
    * **For Internal use only**:  Sets the color of the Text component
    */
   color?: BaseTextProps['color'];
+  textAlign?: BaseTextProps['textAlign'];
 };
 
 export type TextVariant = 'body' | 'caption';
@@ -55,7 +56,8 @@ const getTextProps = <T extends { variant: TextVariant }>({
   weight,
   size,
   contrast,
-}: Pick<TextProps<T>, 'type' | 'variant' | 'weight' | 'size' | 'contrast'>): Omit<
+  textAlign,
+}: Pick<TextProps<T>, 'type' | 'variant' | 'weight' | 'size' | 'contrast' | 'textAlign'>): Omit<
   BaseTextProps,
   'children'
 > &
@@ -71,6 +73,7 @@ const getTextProps = <T extends { variant: TextVariant }>({
     fontFamily: 'text',
     forwardedAs: isPlatformWeb ? 'p' : undefined,
     componentName: 'text',
+    textAlign,
   };
 
   if (variant === 'body') {
@@ -122,10 +125,11 @@ const Text = <T extends { variant: TextVariant }>({
   truncateAfterLines,
   children,
   color,
+  textAlign,
 }: TextProps<T>): ReactElement => {
   const props: Omit<BaseTextProps, 'children'> & TextForwardedAs = {
     truncateAfterLines,
-    ...getTextProps({ variant, type, weight, size, contrast }),
+    ...getTextProps({ variant, type, weight, size, contrast, textAlign }),
     ...(color ? { color } : {}),
   };
   return <StyledText {...props}>{children}</StyledText>;

--- a/packages/blade/src/components/Typography/Text/__tests__/Text.native.test.tsx
+++ b/packages/blade/src/components/Typography/Text/__tests__/Text.native.test.tsx
@@ -57,6 +57,13 @@ describe('<Text />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  it('should render Text with center textAlign', () => {
+    const displayText = 'Displaying some text';
+    const { toJSON, getByText } = renderWithTheme(<Text textAlign="center">{displayText}</Text>);
+    expect(getByText('Displaying some text')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
   it('should throw error when variant is "caption" and size "small" is passed', () => {
     const displayText = 'Displaying some text';
     expect(() =>

--- a/packages/blade/src/components/Typography/Text/__tests__/Text.web.test.tsx
+++ b/packages/blade/src/components/Typography/Text/__tests__/Text.web.test.tsx
@@ -52,6 +52,12 @@ describe('<Text />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should render Text with center textAlign', () => {
+    const displayText = 'Displaying some text';
+    const { container } = renderWithTheme(<Text textAlign="center">{displayText}</Text>);
+    expect(container).toMatchSnapshot();
+  });
+
   it('should throw error when variant is "caption" and size "small" is passed', () => {
     const displayText = 'Displaying some text';
     expect(() =>

--- a/packages/blade/src/components/Typography/Text/__tests__/__snapshots__/Text.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Text/__tests__/__snapshots__/Text.native.test.tsx.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Text /> should render Text with center textAlign 1`] = `
+<Text
+  color="surface.text.normal.lowContrast"
+  fontFamily="text"
+  fontSize={100}
+  fontStyle="normal"
+  fontWeight="regular"
+  lineHeight="l"
+  style={
+    Array [
+      Object {
+        "color": "hsla(217, 56%, 17%, 1)",
+        "fontFamily": "Lato",
+        "fontSize": 15,
+        "fontStyle": "normal",
+        "fontWeight": "400",
+        "lineHeight": 24,
+        "marginBottom": 0,
+        "marginLeft": 0,
+        "marginRight": 0,
+        "marginTop": 0,
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+        "textAlign": "center",
+        "textDecorationLine": "none",
+      },
+      Object {},
+    ]
+  }
+  textAlign="center"
+>
+  Displaying some text
+</Text>
+`;
+
 exports[`<Text /> should render Text with default properties 1`] = `
 <Text
   color="surface.text.normal.lowContrast"

--- a/packages/blade/src/components/Typography/Text/__tests__/__snapshots__/Text.web.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Text/__tests__/__snapshots__/Text.web.test.tsx.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Text /> should render Text with center textAlign 1`] = `
+.c0 {
+  color: hsla(217,56%,17%,1);
+  font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+<div>
+  <p
+    class="c0 Text__StyledText-wkh56f-0"
+    color="surface.text.normal.lowContrast"
+    data-blade-component="text"
+    font-family="text"
+    font-size="100"
+    font-style="normal"
+    font-weight="regular"
+  >
+    Displaying some text
+  </p>
+</div>
+`;
+
 exports[`<Text /> should render Text with default properties 1`] = `
 .c0 {
   color: hsla(217,56%,17%,1);


### PR DESCRIPTION
Need to add textAlign support to center align text in certain cases on native

(ignore the other styling changes in screenshot, one is using blade components and other is without blade)

|  without  |  with |
| --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-01 at 12 21 55](https://user-images.githubusercontent.com/24487274/223083771-5157b101-59ac-4c0a-9a70-bbbf663ab7a0.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-01 at 12 18 41](https://user-images.githubusercontent.com/24487274/223083778-2b0d674a-9e0f-4d69-be5e-b6582b53e70f.png) |

