### PR TITLE
chore: fix wrong link in integration docs

### DIFF
--- a/packages/blade/docs/guides/IntegrationExamples.stories.mdx
+++ b/packages/blade/docs/guides/IntegrationExamples.stories.mdx
@@ -6,5 +6,5 @@ import { Meta } from '@storybook/addon-docs';
 
 You may checkout some examples on integrating `blade` in your project:
 
-- [Basic example](https://github.com/razorpay/blade/tree/master/examples/basic)
-- [With multiple theme providers](https://github.com/razorpay/blade/tree/master/examples/with-multiple-theme-providers)
+- [Basic example](https://github.com/razorpay/blade/tree/master/packages/examples/basic)
+- [With multiple theme providers](https://github.com/razorpay/blade/tree/master/packages/examples/with-multiple-theme-providers)


### PR DESCRIPTION
Since we moved examples folder inside packages, the integration guide page on story book was pointing to the wrong path which was resulting in a broken experience. 