### PR TITLE
fix: lodash bundle-size

### DIFF
--- a/.changeset/fifty-penguins-tickle.md
+++ b/.changeset/fifty-penguins-tickle.md
@@ -1,5 +1,5 @@
 ---
-"@razorpay/blade": patch
+'@razorpay/blade': patch
 ---
 
-fix: lodash tree shaking. Reduce lodash bundle size from 47kb -> 23kb
+fix: lodash tree shaking to reduce effective bundle-size.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,6 +147,19 @@ module.exports = {
         '@typescript-eslint/no-shadow': ['off'],
         '@typescript-eslint/explicit-module-boundary-types': ['off'],
         'no-only-tests/no-only-tests': 'error',
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'lodash',
+                message:
+                  "Named export from lodash is restricted. Use path exports like `import get from 'lodash/get';` instead",
+              },
+            ],
+            patterns: ['!lodash/*'],
+          },
+        ],
       },
     },
     {

--- a/packages/blade/src/utils/getStringChildren/getStringChildren.ts
+++ b/packages/blade/src/utils/getStringChildren/getStringChildren.ts
@@ -1,5 +1,5 @@
-import { isEmpty } from 'lodash';
 import type { StringChildrenType } from '~src/_helpers/types';
+import { isEmpty } from '~utils';
 
 const getStringFromReactText = (
   childReactText: StringChildrenType | undefined,


### PR DESCRIPTION
This import was adding entire lodash bundle. There are some issues with tree-shaking which I am figuring out but this was a quickfix

### Before - 47kb

<img width="590" alt="image" src="https://user-images.githubusercontent.com/30949385/224019002-d9b5a5d9-5695-4d75-9f89-03c8a1692798.png">

### After - 23kb

<img width="485" alt="image" src="https://user-images.githubusercontent.com/30949385/224019131-55010702-4888-4035-8cf7-fbc3537976e7.png">

