### PR TITLE
feat: add box-sizing border-box for alert

### DIFF
--- a/.changeset/red-badgers-tease.md
+++ b/.changeset/red-badgers-tease.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fea(Alert): add box-sizing border-box to ensure Alert stays inside outer box

--- a/packages/blade/src/components/Alert/styles.ts
+++ b/packages/blade/src/components/Alert/styles.ts
@@ -28,6 +28,7 @@ export const getCommonStyles = (props: StyledProps<StyledAlertProps>): CSSObject
     flexDirection: 'row',
     maxWidth: isFullWidth ? 'auto' : makeSize(MAX_WIDTH),
     width: isFullWidth ? '100%' : undefined,
+    boxSizing: 'border-box',
     alignItems: isFullWidth && isDesktop ? 'center' : 'flex-start',
   };
 };


### PR DESCRIPTION
We added `width: 100%` for isFullWidth with position="fixed" on Alert. But we'll also need boxSizing border-box to make sure Alert stays inside the outer box. https://razorpay.slack.com/archives/G01B3LQ9H0W/p1677822733203969

Normally apps are adding `* { box-sizing: border-box }` to their global styles. This is for apps that forget to add that global style.


