### PR TITLE
fix: CardHeader title alignment when subtitle is not present

### DIFF
--- a/.changeset/stale-crabs-add.md
+++ b/.changeset/stale-crabs-add.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-fix(Card): ChardHeader title alignment when subtitle is not present
+fix(Card): CardHeader title alignment when subtitle is not present

--- a/.changeset/stale-crabs-add.md
+++ b/.changeset/stale-crabs-add.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Card): ChardHeader title alignment when subtitle is not present

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -157,9 +157,11 @@ const CardHeaderLeading: WithComponentId<CardHeaderLeadingProps> = ({
           </Heading>
           <BaseBox marginLeft="spacing.3">{suffix}</BaseBox>
         </BaseBox>
-        <Text variant="body" size="small" weight="regular">
-          {subtitle}
-        </Text>
+        {subtitle && (
+          <Text variant="body" size="small" weight="regular">
+            {subtitle}
+          </Text>
+        )}
       </BaseBox>
     </BaseBox>
   );


### PR DESCRIPTION
React Native's text reserves space for empty text here. Tried it with Native text instead of ours as well, same results.


(Notice the "Profile Information" alignment)
## **Before:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-17 at 15 26 36](https://user-images.githubusercontent.com/24487274/225873043-afadf5ca-5af5-4555-9c06-b20f61564979.png)


## **After:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-17 at 15 26 49](https://user-images.githubusercontent.com/24487274/225873067-2728cb2a-b68f-4df7-976e-444b2bb9b8d1.png)
