### PR TITLE
fix: ListItemLink alignment

### DIFF
--- a/.changeset/soft-melons-eat.md
+++ b/.changeset/soft-melons-eat.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: ListItemLink alignment

--- a/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.web.test.tsx.snap
+++ b/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.web.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -186,7 +186,7 @@ const getProps = ({
       isVisited,
     }) as IconProps['color'],
     fontSize: size === 'medium' ? 100 : 75,
-    lineHeight: size === 'medium' ? 'm' : 's',
+    lineHeight: size === 'medium' ? 'l' : 's',
     iconSize: size,
     iconPadding: children?.trim() ? 'spacing.2' : 'spacing.0',
     textColor: getColorToken({

--- a/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.native.test.tsx.snap
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.native.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`<BaseLink /> should change the link to a visited state after click 1`] 
       color="action.text.link.visited"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -68,7 +68,7 @@ exports[`<BaseLink /> should change the link to a visited state after click 1`] 
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -150,7 +150,7 @@ exports[`<BaseLink /> should not change the button to a visited state after clic
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -159,7 +159,7 @@ exports[`<BaseLink /> should not change the button to a visited state after clic
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -241,7 +241,7 @@ exports[`<BaseLink /> should render button variant of link 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -250,7 +250,7 @@ exports[`<BaseLink /> should render button variant of link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -332,7 +332,7 @@ exports[`<BaseLink /> should render disabled button variant of link 1`] = `
       color="action.text.link.disabled"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -341,7 +341,7 @@ exports[`<BaseLink /> should render disabled button variant of link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -423,7 +423,7 @@ exports[`<BaseLink /> should render disabled information intent high contrast li
       color="feedback.information.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -432,7 +432,7 @@ exports[`<BaseLink /> should render disabled information intent high contrast li
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -514,7 +514,7 @@ exports[`<BaseLink /> should render disabled information intent low contrast lin
       color="feedback.information.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -523,7 +523,7 @@ exports[`<BaseLink /> should render disabled information intent low contrast lin
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -605,7 +605,7 @@ exports[`<BaseLink /> should render disabled negative intent high contrast link 
       color="feedback.negative.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -614,7 +614,7 @@ exports[`<BaseLink /> should render disabled negative intent high contrast link 
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -696,7 +696,7 @@ exports[`<BaseLink /> should render disabled negative intent low contrast link 1
       color="feedback.negative.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -705,7 +705,7 @@ exports[`<BaseLink /> should render disabled negative intent low contrast link 1
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -787,7 +787,7 @@ exports[`<BaseLink /> should render disabled neutral intent high contrast link 1
       color="feedback.neutral.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -796,7 +796,7 @@ exports[`<BaseLink /> should render disabled neutral intent high contrast link 1
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -878,7 +878,7 @@ exports[`<BaseLink /> should render disabled neutral intent low contrast link 1`
       color="feedback.neutral.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -887,7 +887,7 @@ exports[`<BaseLink /> should render disabled neutral intent low contrast link 1`
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -969,7 +969,7 @@ exports[`<BaseLink /> should render disabled notice intent high contrast link 1`
       color="feedback.notice.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -978,7 +978,7 @@ exports[`<BaseLink /> should render disabled notice intent high contrast link 1`
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1060,7 +1060,7 @@ exports[`<BaseLink /> should render disabled notice intent low contrast link 1`]
       color="feedback.notice.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1069,7 +1069,7 @@ exports[`<BaseLink /> should render disabled notice intent low contrast link 1`]
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1151,7 +1151,7 @@ exports[`<BaseLink /> should render disabled positive intent high contrast link 
       color="feedback.positive.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1160,7 +1160,7 @@ exports[`<BaseLink /> should render disabled positive intent high contrast link 
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1242,7 +1242,7 @@ exports[`<BaseLink /> should render disabled positive intent low contrast link 1
       color="feedback.positive.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1251,7 +1251,7 @@ exports[`<BaseLink /> should render disabled positive intent low contrast link 1
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1419,7 +1419,7 @@ exports[`<BaseLink /> should render icon only link 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1428,7 +1428,7 @@ exports[`<BaseLink /> should render icon only link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1508,7 +1508,7 @@ exports[`<BaseLink /> should render information intent high contrast link 1`] = 
       color="feedback.information.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1517,7 +1517,7 @@ exports[`<BaseLink /> should render information intent high contrast link 1`] = 
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1599,7 +1599,7 @@ exports[`<BaseLink /> should render information intent low contrast link 1`] = `
       color="feedback.information.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1608,7 +1608,7 @@ exports[`<BaseLink /> should render information intent low contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1690,7 +1690,7 @@ exports[`<BaseLink /> should render link with default properties 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1699,7 +1699,7 @@ exports[`<BaseLink /> should render link with default properties 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -1867,7 +1867,7 @@ exports[`<BaseLink /> should render link with icon with default iconPosition 1`]
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -1876,7 +1876,7 @@ exports[`<BaseLink /> should render link with icon with default iconPosition 1`]
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2044,7 +2044,7 @@ exports[`<BaseLink /> should render link with icon with left iconPosition 1`] = 
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2053,7 +2053,7 @@ exports[`<BaseLink /> should render link with icon with left iconPosition 1`] = 
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2135,7 +2135,7 @@ exports[`<BaseLink /> should render link with icon with right iconPosition 1`] =
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2144,7 +2144,7 @@ exports[`<BaseLink /> should render link with icon with right iconPosition 1`] =
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2312,7 +2312,7 @@ exports[`<BaseLink /> should render negative intent high contrast link 1`] = `
       color="feedback.negative.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2321,7 +2321,7 @@ exports[`<BaseLink /> should render negative intent high contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2403,7 +2403,7 @@ exports[`<BaseLink /> should render negative intent low contrast link 1`] = `
       color="feedback.negative.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2412,7 +2412,7 @@ exports[`<BaseLink /> should render negative intent low contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2494,7 +2494,7 @@ exports[`<BaseLink /> should render neutral intent high contrast link 1`] = `
       color="feedback.neutral.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2503,7 +2503,7 @@ exports[`<BaseLink /> should render neutral intent high contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2585,7 +2585,7 @@ exports[`<BaseLink /> should render neutral intent low contrast link 1`] = `
       color="feedback.neutral.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2594,7 +2594,7 @@ exports[`<BaseLink /> should render neutral intent low contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2676,7 +2676,7 @@ exports[`<BaseLink /> should render notice intent high contrast link 1`] = `
       color="feedback.notice.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2685,7 +2685,7 @@ exports[`<BaseLink /> should render notice intent high contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2767,7 +2767,7 @@ exports[`<BaseLink /> should render notice intent low contrast link 1`] = `
       color="feedback.notice.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2776,7 +2776,7 @@ exports[`<BaseLink /> should render notice intent low contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2858,7 +2858,7 @@ exports[`<BaseLink /> should render positive intent high contrast link 1`] = `
       color="feedback.positive.action.text.link.default.highContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2867,7 +2867,7 @@ exports[`<BaseLink /> should render positive intent high contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -2949,7 +2949,7 @@ exports[`<BaseLink /> should render positive intent low contrast link 1`] = `
       color="feedback.positive.action.text.link.default.lowContrast"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -2958,7 +2958,7 @@ exports[`<BaseLink /> should render positive intent low contrast link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,

--- a/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<BaseLink /> should render link with a default rel set when target is _blank 1`] = `"<div id=\\"root\\" data-reactroot=\\"\\"><a data-blade-component=\\"link\\" href=\\"https://www.google.com/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" cursor=\\"pointer\\" class=\\"StyledBaseLinkweb__StyledLink-sc-1yj1z8h-0 kzvYbf\\" role=\\"link\\" aria-disabled=\\"false\\"><div display=\\"flex\\" class=\\"BaseBoxweb__BaseBox-sc-1icfu8j-0 ePjSmf content-container\\"><div color=\\"action.text.link.default\\" font-size=\\"100\\" font-weight=\\"bold\\" class=\\"BaseTextweb__StyledBaseText-sc-1ob51ew-0 cqtXx\\">Learn More</div></div></a></div>"`;
+exports[`<BaseLink /> should render link with a default rel set when target is _blank 1`] = `"<div id=\\"root\\" data-reactroot=\\"\\"><a data-blade-component=\\"link\\" href=\\"https://www.google.com/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" cursor=\\"pointer\\" class=\\"StyledBaseLinkweb__StyledLink-sc-1yj1z8h-0 kzvYbf\\" role=\\"link\\" aria-disabled=\\"false\\"><div display=\\"flex\\" class=\\"BaseBoxweb__BaseBox-sc-1icfu8j-0 ePjSmf content-container\\"><div color=\\"action.text.link.default\\" font-size=\\"100\\" font-weight=\\"bold\\" class=\\"BaseTextweb__StyledBaseText-sc-1ob51ew-0 bWvucQ\\">Learn More</div></div></a></div>"`;
 
 exports[`<BaseLink /> should render link with a default rel set when target is _blank 2`] = `
 <div
@@ -22,7 +22,7 @@ exports[`<BaseLink /> should render link with a default rel set when target is _
       display="flex"
     >
       <div
-        class="BaseTextweb__StyledBaseText-sc-1ob51ew-0 cqtXx"
+        class="BaseTextweb__StyledBaseText-sc-1ob51ew-0 bWvucQ"
         color="action.text.link.default"
         font-size="100"
         font-weight="bold"

--- a/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.web.test.tsx.snap
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/__snapshots__/BaseLink.web.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`<BaseLink /> should change the link to a visited state after click 1`] 
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -156,7 +156,7 @@ exports[`<BaseLink /> should not change the button to a visited state after clic
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -249,7 +249,7 @@ exports[`<BaseLink /> should render button variant of link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -342,7 +342,7 @@ exports[`<BaseLink /> should render disabled button variant of link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -436,7 +436,7 @@ exports[`<BaseLink /> should render disabled information intent high contrast li
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -528,7 +528,7 @@ exports[`<BaseLink /> should render disabled information intent low contrast lin
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -620,7 +620,7 @@ exports[`<BaseLink /> should render disabled negative intent high contrast link 
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -712,7 +712,7 @@ exports[`<BaseLink /> should render disabled negative intent low contrast link 1
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -804,7 +804,7 @@ exports[`<BaseLink /> should render disabled neutral intent high contrast link 1
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -896,7 +896,7 @@ exports[`<BaseLink /> should render disabled neutral intent low contrast link 1`
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -988,7 +988,7 @@ exports[`<BaseLink /> should render disabled notice intent high contrast link 1`
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1080,7 +1080,7 @@ exports[`<BaseLink /> should render disabled notice intent low contrast link 1`]
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1172,7 +1172,7 @@ exports[`<BaseLink /> should render disabled positive intent high contrast link 
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1264,7 +1264,7 @@ exports[`<BaseLink /> should render disabled positive intent low contrast link 1
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1368,7 +1368,7 @@ exports[`<BaseLink /> should render icon only link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1487,7 +1487,7 @@ exports[`<BaseLink /> should render information intent high contrast link 1`] = 
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1579,7 +1579,7 @@ exports[`<BaseLink /> should render information intent low contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1671,7 +1671,7 @@ exports[`<BaseLink /> should render link with default properties 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1775,7 +1775,7 @@ exports[`<BaseLink /> should render link with icon with default iconPosition 1`]
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -1908,7 +1908,7 @@ exports[`<BaseLink /> should render link with icon with left iconPosition 1`] = 
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2041,7 +2041,7 @@ exports[`<BaseLink /> should render link with icon with right iconPosition 1`] =
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2162,7 +2162,7 @@ exports[`<BaseLink /> should render negative intent high contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2254,7 +2254,7 @@ exports[`<BaseLink /> should render negative intent low contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2346,7 +2346,7 @@ exports[`<BaseLink /> should render neutral intent high contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2438,7 +2438,7 @@ exports[`<BaseLink /> should render neutral intent low contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2530,7 +2530,7 @@ exports[`<BaseLink /> should render notice intent high contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2622,7 +2622,7 @@ exports[`<BaseLink /> should render notice intent low contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2714,7 +2714,7 @@ exports[`<BaseLink /> should render positive intent high contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -2806,7 +2806,7 @@ exports[`<BaseLink /> should render positive intent low contrast link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.native.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.native.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`<Link /> should render button variant of link 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -68,7 +68,7 @@ exports[`<Link /> should render button variant of link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -150,7 +150,7 @@ exports[`<Link /> should render disabled button variant of link 1`] = `
       color="action.text.link.disabled"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -159,7 +159,7 @@ exports[`<Link /> should render disabled button variant of link 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -241,7 +241,7 @@ exports[`<Link /> should render link with default properties 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -250,7 +250,7 @@ exports[`<Link /> should render link with default properties 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -418,7 +418,7 @@ exports[`<Link /> should render link with icon with default iconPosition 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -427,7 +427,7 @@ exports[`<Link /> should render link with icon with default iconPosition 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -595,7 +595,7 @@ exports[`<Link /> should render link with icon with left iconPosition 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -604,7 +604,7 @@ exports[`<Link /> should render link with icon with left iconPosition 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -686,7 +686,7 @@ exports[`<Link /> should render link with icon with right iconPosition 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -695,7 +695,7 @@ exports[`<Link /> should render link with icon with right iconPosition 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,
@@ -949,7 +949,7 @@ exports[`<Link /> should render link with icon without text 1`] = `
       color="action.text.link.default"
       fontSize={100}
       fontWeight="bold"
-      lineHeight="m"
+      lineHeight="l"
       style={
         Array [
           Object {
@@ -958,7 +958,7 @@ exports[`<Link /> should render link with icon without text 1`] = `
             "fontSize": 15,
             "fontStyle": "normal",
             "fontWeight": "700",
-            "lineHeight": 18,
+            "lineHeight": 24,
             "marginBottom": 0,
             "marginLeft": 0,
             "marginRight": 0,

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Link /> should render link with a default rel set when target is _blank 1`] = `"<div id=\\"root\\" data-reactroot=\\"\\"><a data-blade-component=\\"link\\" href=\\"https://www.google.com/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" cursor=\\"pointer\\" class=\\"StyledBaseLinkweb__StyledLink-sc-1yj1z8h-0 kzvYbf\\" role=\\"link\\" aria-disabled=\\"false\\"><div display=\\"flex\\" class=\\"BaseBoxweb__BaseBox-sc-1icfu8j-0 ePjSmf content-container\\"><div color=\\"action.text.link.default\\" font-size=\\"100\\" font-weight=\\"bold\\" class=\\"BaseTextweb__StyledBaseText-sc-1ob51ew-0 cqtXx\\">Learn More</div></div></a></div>"`;
+exports[`<Link /> should render link with a default rel set when target is _blank 1`] = `"<div id=\\"root\\" data-reactroot=\\"\\"><a data-blade-component=\\"link\\" href=\\"https://www.google.com/\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" cursor=\\"pointer\\" class=\\"StyledBaseLinkweb__StyledLink-sc-1yj1z8h-0 kzvYbf\\" role=\\"link\\" aria-disabled=\\"false\\"><div display=\\"flex\\" class=\\"BaseBoxweb__BaseBox-sc-1icfu8j-0 ePjSmf content-container\\"><div color=\\"action.text.link.default\\" font-size=\\"100\\" font-weight=\\"bold\\" class=\\"BaseTextweb__StyledBaseText-sc-1ob51ew-0 bWvucQ\\">Learn More</div></div></a></div>"`;
 
 exports[`<Link /> should render link with a default rel set when target is _blank 2`] = `
 <div
@@ -22,7 +22,7 @@ exports[`<Link /> should render link with a default rel set when target is _blan
       display="flex"
     >
       <div
-        class="BaseTextweb__StyledBaseText-sc-1ob51ew-0 cqtXx"
+        class="BaseTextweb__StyledBaseText-sc-1ob51ew-0 bWvucQ"
         color="action.text.link.default"
         font-size="100"
         font-weight="bold"

--- a/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.web.test.tsx.snap
+++ b/packages/blade/src/components/Link/Link/__tests__/__snapshots__/Link.web.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`<Link /> should render button variant of link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -154,7 +154,7 @@ exports[`<Link /> should render disabled button variant of link 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -248,7 +248,7 @@ exports[`<Link /> should render link with default properties 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -352,7 +352,7 @@ exports[`<Link /> should render link with icon with default iconPosition 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -485,7 +485,7 @@ exports[`<Link /> should render link with icon with left iconPosition 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -618,7 +618,7 @@ exports[`<Link /> should render link with icon with right iconPosition 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;
@@ -751,7 +751,7 @@ exports[`<Link /> should render link with icon without text 1`] = `
   font-style: normal;
   -webkit-text-decoration-line: none;
   text-decoration-line: none;
-  line-height: 1rem;
+  line-height: 1.25rem;
   text-align: center;
   margin: 0;
   padding: 0;

--- a/packages/blade/src/components/List/ListItem.tsx
+++ b/packages/blade/src/components/List/ListItem.tsx
@@ -66,7 +66,7 @@ const ListItemContentChildren = ({
   children,
   size,
 }: {
-  children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[];
+  children: React.ReactNode[];
   size: NonNullable<ListProps['size']>;
 }): JSX.Element => {
   /* Having a <View><Text>...</Text><View/> inside <Text /> breaks vertical alignment. Issue: https://github.com/facebook/react-native/issues/31955

--- a/packages/blade/src/components/List/ListItem.tsx
+++ b/packages/blade/src/components/List/ListItem.tsx
@@ -19,6 +19,7 @@ import BaseBox from '~components/Box/BaseBox';
 import {
   getComponentId,
   getIn,
+  getPlatformType,
   isValidAllowedChildren,
   metaAttribute,
   MetaConstants,
@@ -59,6 +60,33 @@ const StyledListItem = styled(ListItemElement)<{
       )
     : 0,
 }));
+
+const ListItemContentChildren = ({
+  children,
+  size,
+}: {
+  children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[];
+  size: NonNullable<ListProps['size']>;
+}): JSX.Element => {
+  return getPlatformType() === 'react-native' ? (
+    <BaseBox display="flex" flexDirection="row">
+      {children.map((child) => {
+        if (typeof child === 'string') {
+          return (
+            <Text variant="body" size={size}>
+              {child}
+            </Text>
+          );
+        }
+        return child;
+      })}
+    </BaseBox>
+  ) : (
+    <Text variant="body" size={size}>
+      {children}
+    </Text>
+  );
+};
 
 const ListItem = ({
   children,
@@ -152,9 +180,7 @@ const ListItem = ({
             </Text>
           </BaseBox>
         )}
-        <Text variant="body" size={size}>
-          {validChildItem}
-        </Text>
+        <ListItemContentChildren size={size}>{validChildItem}</ListItemContentChildren>
       </BaseBox>
       {childList}
     </StyledListItem>

--- a/packages/blade/src/components/List/ListItem.tsx
+++ b/packages/blade/src/components/List/ListItem.tsx
@@ -68,6 +68,9 @@ const ListItemContentChildren = ({
   children: (React.ReactChild | React.ReactFragment | React.ReactPortal)[];
   size: NonNullable<ListProps['size']>;
 }): JSX.Element => {
+  /* Having a <View><Text>...</Text><View/> inside <Text /> breaks vertical alignment. Issue: https://github.com/facebook/react-native/issues/31955
+    As a workaround, we wrap individual strings in their own <Text /> and handle alignment with a parent <View> (BaseBox).
+   */
   return getPlatformType() === 'react-native' ? (
     <BaseBox display="flex" flexDirection="row" flexWrap="wrap">
       {children.map((child) => {

--- a/packages/blade/src/components/List/ListItem.tsx
+++ b/packages/blade/src/components/List/ListItem.tsx
@@ -69,7 +69,7 @@ const ListItemContentChildren = ({
   size: NonNullable<ListProps['size']>;
 }): JSX.Element => {
   return getPlatformType() === 'react-native' ? (
-    <BaseBox display="flex" flexDirection="row">
+    <BaseBox display="flex" flexDirection="row" flexWrap="wrap">
       {children.map((child) => {
         if (typeof child === 'string') {
           return (

--- a/packages/blade/src/components/List/__tests__/__snapshots__/List.native.test.tsx.snap
+++ b/packages/blade/src/components/List/__tests__/__snapshots__/List.native.test.tsx.snap
@@ -114,38 +114,53 @@ exports[`<List /> should render List with default properties 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
       <View
         style={
@@ -257,38 +272,53 @@ exports[`<List /> should render List with default properties 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Text
-                color="surface.text.normal.lowContrast"
-                fontFamily="text"
-                fontSize={100}
-                fontStyle="normal"
-                fontWeight="regular"
-                lineHeight="l"
+              <View
+                display="flex"
+                flexDirection="row"
+                flexWrap="wrap"
                 style={
                   Array [
                     Object {
-                      "color": "hsla(217, 56%, 17%, 1)",
-                      "fontFamily": "Lato",
-                      "fontSize": 15,
-                      "fontStyle": "normal",
-                      "fontWeight": "400",
-                      "lineHeight": 24,
-                      "marginBottom": 0,
-                      "marginLeft": 0,
-                      "marginRight": 0,
-                      "marginTop": 0,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "textDecorationLine": "none",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "wrap",
                     },
-                    Object {},
                   ]
                 }
               >
-                Level 2
-              </Text>
+                <Text
+                  color="surface.text.normal.lowContrast"
+                  fontFamily="text"
+                  fontSize={100}
+                  fontStyle="normal"
+                  fontWeight="regular"
+                  lineHeight="l"
+                  style={
+                    Array [
+                      Object {
+                        "color": "hsla(217, 56%, 17%, 1)",
+                        "fontFamily": "Lato",
+                        "fontSize": 15,
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
+                        "lineHeight": 24,
+                        "marginBottom": 0,
+                        "marginLeft": 0,
+                        "marginRight": 0,
+                        "marginTop": 0,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "textDecorationLine": "none",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Level 2
+                </Text>
+              </View>
             </View>
             <View
               style={
@@ -402,38 +432,53 @@ exports[`<List /> should render List with default properties 1`] = `
                         </RNSVGGroup>
                       </RNSVGSvgView>
                     </View>
-                    <Text
-                      color="surface.text.normal.lowContrast"
-                      fontFamily="text"
-                      fontSize={100}
-                      fontStyle="normal"
-                      fontWeight="regular"
-                      lineHeight="l"
+                    <View
+                      display="flex"
+                      flexDirection="row"
+                      flexWrap="wrap"
                       style={
                         Array [
                           Object {
-                            "color": "hsla(217, 56%, 17%, 1)",
-                            "fontFamily": "Lato",
-                            "fontSize": 15,
-                            "fontStyle": "normal",
-                            "fontWeight": "400",
-                            "lineHeight": 24,
-                            "marginBottom": 0,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "marginTop": 0,
-                            "paddingBottom": 0,
-                            "paddingLeft": 0,
-                            "paddingRight": 0,
-                            "paddingTop": 0,
-                            "textDecorationLine": "none",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
                           },
-                          Object {},
                         ]
                       }
                     >
-                      Level 3
-                    </Text>
+                      <Text
+                        color="surface.text.normal.lowContrast"
+                        fontFamily="text"
+                        fontSize={100}
+                        fontStyle="normal"
+                        fontWeight="regular"
+                        lineHeight="l"
+                        style={
+                          Array [
+                            Object {
+                              "color": "hsla(217, 56%, 17%, 1)",
+                              "fontFamily": "Lato",
+                              "fontSize": 15,
+                              "fontStyle": "normal",
+                              "fontWeight": "400",
+                              "lineHeight": 24,
+                              "marginBottom": 0,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "marginTop": 0,
+                              "paddingBottom": 0,
+                              "paddingLeft": 0,
+                              "paddingRight": 0,
+                              "paddingTop": 0,
+                              "textDecorationLine": "none",
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Level 3
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -560,37 +605,52 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1 
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1 
+          </Text>
           <View
             size="small"
             style={
@@ -636,7 +696,7 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
               Google
             </Text>
           </View>
-        </Text>
+        </View>
       </View>
     </View>
     <View
@@ -734,38 +794,53 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 2
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 2
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -886,37 +961,52 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
           <View
             accessibilityRole="link"
             accessibilityState={
@@ -975,7 +1065,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
                 color="action.text.link.default"
                 fontSize={100}
                 fontWeight="bold"
-                lineHeight="m"
+                lineHeight="l"
                 style={
                   Array [
                     Object {
@@ -984,7 +1074,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
                       "fontSize": 15,
                       "fontStyle": "normal",
                       "fontWeight": "700",
-                      "lineHeight": 18,
+                      "lineHeight": 24,
                       "marginBottom": 0,
                       "marginLeft": 0,
                       "marginRight": 0,
@@ -1005,7 +1095,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
               </Text>
             </View>
           </View>
-        </Text>
+        </View>
       </View>
     </View>
     <View
@@ -1103,38 +1193,53 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 2
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 2
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -1244,38 +1349,53 @@ exports[`<List /> should render medium ordered List 1`] = `
             1.
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
       <View
         style={
@@ -1387,38 +1507,53 @@ exports[`<List /> should render medium ordered List 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Text
-                color="surface.text.normal.lowContrast"
-                fontFamily="text"
-                fontSize={100}
-                fontStyle="normal"
-                fontWeight="regular"
-                lineHeight="l"
+              <View
+                display="flex"
+                flexDirection="row"
+                flexWrap="wrap"
                 style={
                   Array [
                     Object {
-                      "color": "hsla(217, 56%, 17%, 1)",
-                      "fontFamily": "Lato",
-                      "fontSize": 15,
-                      "fontStyle": "normal",
-                      "fontWeight": "400",
-                      "lineHeight": 24,
-                      "marginBottom": 0,
-                      "marginLeft": 0,
-                      "marginRight": 0,
-                      "marginTop": 0,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "textDecorationLine": "none",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "wrap",
                     },
-                    Object {},
                   ]
                 }
               >
-                Level 2
-              </Text>
+                <Text
+                  color="surface.text.normal.lowContrast"
+                  fontFamily="text"
+                  fontSize={100}
+                  fontStyle="normal"
+                  fontWeight="regular"
+                  lineHeight="l"
+                  style={
+                    Array [
+                      Object {
+                        "color": "hsla(217, 56%, 17%, 1)",
+                        "fontFamily": "Lato",
+                        "fontSize": 15,
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
+                        "lineHeight": 24,
+                        "marginBottom": 0,
+                        "marginLeft": 0,
+                        "marginRight": 0,
+                        "marginTop": 0,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "textDecorationLine": "none",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Level 2
+                </Text>
+              </View>
             </View>
             <View
               style={
@@ -1532,38 +1667,53 @@ exports[`<List /> should render medium ordered List 1`] = `
                         </RNSVGGroup>
                       </RNSVGSvgView>
                     </View>
-                    <Text
-                      color="surface.text.normal.lowContrast"
-                      fontFamily="text"
-                      fontSize={100}
-                      fontStyle="normal"
-                      fontWeight="regular"
-                      lineHeight="l"
+                    <View
+                      display="flex"
+                      flexDirection="row"
+                      flexWrap="wrap"
                       style={
                         Array [
                           Object {
-                            "color": "hsla(217, 56%, 17%, 1)",
-                            "fontFamily": "Lato",
-                            "fontSize": 15,
-                            "fontStyle": "normal",
-                            "fontWeight": "400",
-                            "lineHeight": 24,
-                            "marginBottom": 0,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "marginTop": 0,
-                            "paddingBottom": 0,
-                            "paddingLeft": 0,
-                            "paddingRight": 0,
-                            "paddingTop": 0,
-                            "textDecorationLine": "none",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
                           },
-                          Object {},
                         ]
                       }
                     >
-                      Level 3
-                    </Text>
+                      <Text
+                        color="surface.text.normal.lowContrast"
+                        fontFamily="text"
+                        fontSize={100}
+                        fontStyle="normal"
+                        fontWeight="regular"
+                        lineHeight="l"
+                        style={
+                          Array [
+                            Object {
+                              "color": "hsla(217, 56%, 17%, 1)",
+                              "fontFamily": "Lato",
+                              "fontSize": 15,
+                              "fontStyle": "normal",
+                              "fontWeight": "400",
+                              "lineHeight": 24,
+                              "marginBottom": 0,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "marginTop": 0,
+                              "paddingBottom": 0,
+                              "paddingLeft": 0,
+                              "paddingRight": 0,
+                              "paddingTop": 0,
+                              "textDecorationLine": "none",
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Level 3
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -1683,38 +1833,53 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
             1
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -1805,38 +1970,53 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
             2
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 2
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 2
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -1927,38 +2107,53 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
             3
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 3
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 3
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -2077,38 +2272,53 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="l"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 15,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 24,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="l"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 15,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
       <View
         style={
@@ -2218,38 +2428,53 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Text
-                color="surface.text.normal.lowContrast"
-                fontFamily="text"
-                fontSize={100}
-                fontStyle="normal"
-                fontWeight="regular"
-                lineHeight="l"
+              <View
+                display="flex"
+                flexDirection="row"
+                flexWrap="wrap"
                 style={
                   Array [
                     Object {
-                      "color": "hsla(217, 56%, 17%, 1)",
-                      "fontFamily": "Lato",
-                      "fontSize": 15,
-                      "fontStyle": "normal",
-                      "fontWeight": "400",
-                      "lineHeight": 24,
-                      "marginBottom": 0,
-                      "marginLeft": 0,
-                      "marginRight": 0,
-                      "marginTop": 0,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "textDecorationLine": "none",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "wrap",
                     },
-                    Object {},
                   ]
                 }
               >
-                Level 2
-              </Text>
+                <Text
+                  color="surface.text.normal.lowContrast"
+                  fontFamily="text"
+                  fontSize={100}
+                  fontStyle="normal"
+                  fontWeight="regular"
+                  lineHeight="l"
+                  style={
+                    Array [
+                      Object {
+                        "color": "hsla(217, 56%, 17%, 1)",
+                        "fontFamily": "Lato",
+                        "fontSize": 15,
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
+                        "lineHeight": 24,
+                        "marginBottom": 0,
+                        "marginLeft": 0,
+                        "marginRight": 0,
+                        "marginTop": 0,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "textDecorationLine": "none",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Level 2
+                </Text>
+              </View>
             </View>
             <View
               style={
@@ -2363,38 +2588,53 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                         </RNSVGGroup>
                       </RNSVGSvgView>
                     </View>
-                    <Text
-                      color="surface.text.normal.lowContrast"
-                      fontFamily="text"
-                      fontSize={100}
-                      fontStyle="normal"
-                      fontWeight="regular"
-                      lineHeight="l"
+                    <View
+                      display="flex"
+                      flexDirection="row"
+                      flexWrap="wrap"
                       style={
                         Array [
                           Object {
-                            "color": "hsla(217, 56%, 17%, 1)",
-                            "fontFamily": "Lato",
-                            "fontSize": 15,
-                            "fontStyle": "normal",
-                            "fontWeight": "400",
-                            "lineHeight": 24,
-                            "marginBottom": 0,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "marginTop": 0,
-                            "paddingBottom": 0,
-                            "paddingLeft": 0,
-                            "paddingRight": 0,
-                            "paddingTop": 0,
-                            "textDecorationLine": "none",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
                           },
-                          Object {},
                         ]
                       }
                     >
-                      Level 3
-                    </Text>
+                      <Text
+                        color="surface.text.normal.lowContrast"
+                        fontFamily="text"
+                        fontSize={100}
+                        fontStyle="normal"
+                        fontWeight="regular"
+                        lineHeight="l"
+                        style={
+                          Array [
+                            Object {
+                              "color": "hsla(217, 56%, 17%, 1)",
+                              "fontFamily": "Lato",
+                              "fontSize": 15,
+                              "fontStyle": "normal",
+                              "fontWeight": "400",
+                              "lineHeight": 24,
+                              "marginBottom": 0,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "marginTop": 0,
+                              "paddingBottom": 0,
+                              "paddingLeft": 0,
+                              "paddingRight": 0,
+                              "paddingTop": 0,
+                              "textDecorationLine": "none",
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Level 3
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -2510,38 +2750,53 @@ exports[`<List /> should render small ordered List 1`] = `
             1.
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={75}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="s"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 12,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 16,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="s"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 16,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
       <View
         style={
@@ -2653,38 +2908,53 @@ exports[`<List /> should render small ordered List 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Text
-                color="surface.text.normal.lowContrast"
-                fontFamily="text"
-                fontSize={75}
-                fontStyle="normal"
-                fontWeight="regular"
-                lineHeight="s"
+              <View
+                display="flex"
+                flexDirection="row"
+                flexWrap="wrap"
                 style={
                   Array [
                     Object {
-                      "color": "hsla(217, 56%, 17%, 1)",
-                      "fontFamily": "Lato",
-                      "fontSize": 12,
-                      "fontStyle": "normal",
-                      "fontWeight": "400",
-                      "lineHeight": 16,
-                      "marginBottom": 0,
-                      "marginLeft": 0,
-                      "marginRight": 0,
-                      "marginTop": 0,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "textDecorationLine": "none",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "wrap",
                     },
-                    Object {},
                   ]
                 }
               >
-                Level 2
-              </Text>
+                <Text
+                  color="surface.text.normal.lowContrast"
+                  fontFamily="text"
+                  fontSize={75}
+                  fontStyle="normal"
+                  fontWeight="regular"
+                  lineHeight="s"
+                  style={
+                    Array [
+                      Object {
+                        "color": "hsla(217, 56%, 17%, 1)",
+                        "fontFamily": "Lato",
+                        "fontSize": 12,
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
+                        "lineHeight": 16,
+                        "marginBottom": 0,
+                        "marginLeft": 0,
+                        "marginRight": 0,
+                        "marginTop": 0,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "textDecorationLine": "none",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Level 2
+                </Text>
+              </View>
             </View>
             <View
               style={
@@ -2798,38 +3068,53 @@ exports[`<List /> should render small ordered List 1`] = `
                         </RNSVGGroup>
                       </RNSVGSvgView>
                     </View>
-                    <Text
-                      color="surface.text.normal.lowContrast"
-                      fontFamily="text"
-                      fontSize={75}
-                      fontStyle="normal"
-                      fontWeight="regular"
-                      lineHeight="s"
+                    <View
+                      display="flex"
+                      flexDirection="row"
+                      flexWrap="wrap"
                       style={
                         Array [
                           Object {
-                            "color": "hsla(217, 56%, 17%, 1)",
-                            "fontFamily": "Lato",
-                            "fontSize": 12,
-                            "fontStyle": "normal",
-                            "fontWeight": "400",
-                            "lineHeight": 16,
-                            "marginBottom": 0,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "marginTop": 0,
-                            "paddingBottom": 0,
-                            "paddingLeft": 0,
-                            "paddingRight": 0,
-                            "paddingTop": 0,
-                            "textDecorationLine": "none",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
                           },
-                          Object {},
                         ]
                       }
                     >
-                      Level 3
-                    </Text>
+                      <Text
+                        color="surface.text.normal.lowContrast"
+                        fontFamily="text"
+                        fontSize={75}
+                        fontStyle="normal"
+                        fontWeight="regular"
+                        lineHeight="s"
+                        style={
+                          Array [
+                            Object {
+                              "color": "hsla(217, 56%, 17%, 1)",
+                              "fontFamily": "Lato",
+                              "fontSize": 12,
+                              "fontStyle": "normal",
+                              "fontWeight": "400",
+                              "lineHeight": 16,
+                              "marginBottom": 0,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "marginTop": 0,
+                              "paddingBottom": 0,
+                              "paddingLeft": 0,
+                              "paddingRight": 0,
+                              "paddingTop": 0,
+                              "textDecorationLine": "none",
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Level 3
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -2949,38 +3234,53 @@ exports[`<List /> should render small ordered-filled List 1`] = `
             1
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={75}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="s"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 12,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 16,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="s"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 16,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -3071,38 +3371,53 @@ exports[`<List /> should render small ordered-filled List 1`] = `
             2
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={75}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="s"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 12,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 16,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 2
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="s"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 16,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 2
+          </Text>
+        </View>
       </View>
     </View>
     <View
@@ -3193,38 +3508,53 @@ exports[`<List /> should render small ordered-filled List 1`] = `
             3
           </Text>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={75}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="s"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 12,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 16,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 3
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="s"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 16,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 3
+          </Text>
+        </View>
       </View>
     </View>
   </View>
@@ -3343,38 +3673,53 @@ exports[`<List /> should render small unordered List with icon 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={75}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="s"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 12,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 16,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="s"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 16,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
       <View
         style={
@@ -3484,38 +3829,53 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Text
-                color="surface.text.normal.lowContrast"
-                fontFamily="text"
-                fontSize={75}
-                fontStyle="normal"
-                fontWeight="regular"
-                lineHeight="s"
+              <View
+                display="flex"
+                flexDirection="row"
+                flexWrap="wrap"
                 style={
                   Array [
                     Object {
-                      "color": "hsla(217, 56%, 17%, 1)",
-                      "fontFamily": "Lato",
-                      "fontSize": 12,
-                      "fontStyle": "normal",
-                      "fontWeight": "400",
-                      "lineHeight": 16,
-                      "marginBottom": 0,
-                      "marginLeft": 0,
-                      "marginRight": 0,
-                      "marginTop": 0,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "textDecorationLine": "none",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "wrap",
                     },
-                    Object {},
                   ]
                 }
               >
-                Level 2
-              </Text>
+                <Text
+                  color="surface.text.normal.lowContrast"
+                  fontFamily="text"
+                  fontSize={75}
+                  fontStyle="normal"
+                  fontWeight="regular"
+                  lineHeight="s"
+                  style={
+                    Array [
+                      Object {
+                        "color": "hsla(217, 56%, 17%, 1)",
+                        "fontFamily": "Lato",
+                        "fontSize": 12,
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
+                        "lineHeight": 16,
+                        "marginBottom": 0,
+                        "marginLeft": 0,
+                        "marginRight": 0,
+                        "marginTop": 0,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "textDecorationLine": "none",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Level 2
+                </Text>
+              </View>
             </View>
             <View
               style={
@@ -3629,38 +3989,53 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                         </RNSVGGroup>
                       </RNSVGSvgView>
                     </View>
-                    <Text
-                      color="surface.text.normal.lowContrast"
-                      fontFamily="text"
-                      fontSize={75}
-                      fontStyle="normal"
-                      fontWeight="regular"
-                      lineHeight="s"
+                    <View
+                      display="flex"
+                      flexDirection="row"
+                      flexWrap="wrap"
                       style={
                         Array [
                           Object {
-                            "color": "hsla(217, 56%, 17%, 1)",
-                            "fontFamily": "Lato",
-                            "fontSize": 12,
-                            "fontStyle": "normal",
-                            "fontWeight": "400",
-                            "lineHeight": 16,
-                            "marginBottom": 0,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "marginTop": 0,
-                            "paddingBottom": 0,
-                            "paddingLeft": 0,
-                            "paddingRight": 0,
-                            "paddingTop": 0,
-                            "textDecorationLine": "none",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
                           },
-                          Object {},
                         ]
                       }
                     >
-                      Level 3
-                    </Text>
+                      <Text
+                        color="surface.text.normal.lowContrast"
+                        fontFamily="text"
+                        fontSize={75}
+                        fontStyle="normal"
+                        fontWeight="regular"
+                        lineHeight="s"
+                        style={
+                          Array [
+                            Object {
+                              "color": "hsla(217, 56%, 17%, 1)",
+                              "fontFamily": "Lato",
+                              "fontSize": 12,
+                              "fontStyle": "normal",
+                              "fontWeight": "400",
+                              "lineHeight": 16,
+                              "marginBottom": 0,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "marginTop": 0,
+                              "paddingBottom": 0,
+                              "paddingLeft": 0,
+                              "paddingRight": 0,
+                              "paddingTop": 0,
+                              "textDecorationLine": "none",
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Level 3
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
@@ -3787,38 +4162,53 @@ exports[`<List /> should render unordered List of small size 1`] = `
             </RNSVGGroup>
           </RNSVGSvgView>
         </View>
-        <Text
-          color="surface.text.normal.lowContrast"
-          fontFamily="text"
-          fontSize={75}
-          fontStyle="normal"
-          fontWeight="regular"
-          lineHeight="s"
+        <View
+          display="flex"
+          flexDirection="row"
+          flexWrap="wrap"
           style={
             Array [
               Object {
-                "color": "hsla(217, 56%, 17%, 1)",
-                "fontFamily": "Lato",
-                "fontSize": 12,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "lineHeight": 16,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
+                "display": "flex",
+                "flexDirection": "row",
+                "flexWrap": "wrap",
               },
-              Object {},
             ]
           }
         >
-          Level 1
-        </Text>
+          <Text
+            color="surface.text.normal.lowContrast"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            lineHeight="s"
+            style={
+              Array [
+                Object {
+                  "color": "hsla(217, 56%, 17%, 1)",
+                  "fontFamily": "Lato",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "lineHeight": 16,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+                Object {},
+              ]
+            }
+          >
+            Level 1
+          </Text>
+        </View>
       </View>
       <View
         style={
@@ -3930,38 +4320,53 @@ exports[`<List /> should render unordered List of small size 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Text
-                color="surface.text.normal.lowContrast"
-                fontFamily="text"
-                fontSize={75}
-                fontStyle="normal"
-                fontWeight="regular"
-                lineHeight="s"
+              <View
+                display="flex"
+                flexDirection="row"
+                flexWrap="wrap"
                 style={
                   Array [
                     Object {
-                      "color": "hsla(217, 56%, 17%, 1)",
-                      "fontFamily": "Lato",
-                      "fontSize": 12,
-                      "fontStyle": "normal",
-                      "fontWeight": "400",
-                      "lineHeight": 16,
-                      "marginBottom": 0,
-                      "marginLeft": 0,
-                      "marginRight": 0,
-                      "marginTop": 0,
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
-                      "textDecorationLine": "none",
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "wrap",
                     },
-                    Object {},
                   ]
                 }
               >
-                Level 2
-              </Text>
+                <Text
+                  color="surface.text.normal.lowContrast"
+                  fontFamily="text"
+                  fontSize={75}
+                  fontStyle="normal"
+                  fontWeight="regular"
+                  lineHeight="s"
+                  style={
+                    Array [
+                      Object {
+                        "color": "hsla(217, 56%, 17%, 1)",
+                        "fontFamily": "Lato",
+                        "fontSize": 12,
+                        "fontStyle": "normal",
+                        "fontWeight": "400",
+                        "lineHeight": 16,
+                        "marginBottom": 0,
+                        "marginLeft": 0,
+                        "marginRight": 0,
+                        "marginTop": 0,
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                        "textDecorationLine": "none",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  Level 2
+                </Text>
+              </View>
             </View>
             <View
               style={
@@ -4075,38 +4480,53 @@ exports[`<List /> should render unordered List of small size 1`] = `
                         </RNSVGGroup>
                       </RNSVGSvgView>
                     </View>
-                    <Text
-                      color="surface.text.normal.lowContrast"
-                      fontFamily="text"
-                      fontSize={75}
-                      fontStyle="normal"
-                      fontWeight="regular"
-                      lineHeight="s"
+                    <View
+                      display="flex"
+                      flexDirection="row"
+                      flexWrap="wrap"
                       style={
                         Array [
                           Object {
-                            "color": "hsla(217, 56%, 17%, 1)",
-                            "fontFamily": "Lato",
-                            "fontSize": 12,
-                            "fontStyle": "normal",
-                            "fontWeight": "400",
-                            "lineHeight": 16,
-                            "marginBottom": 0,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "marginTop": 0,
-                            "paddingBottom": 0,
-                            "paddingLeft": 0,
-                            "paddingRight": 0,
-                            "paddingTop": 0,
-                            "textDecorationLine": "none",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexWrap": "wrap",
                           },
-                          Object {},
                         ]
                       }
                     >
-                      Level 3
-                    </Text>
+                      <Text
+                        color="surface.text.normal.lowContrast"
+                        fontFamily="text"
+                        fontSize={75}
+                        fontStyle="normal"
+                        fontWeight="regular"
+                        lineHeight="s"
+                        style={
+                          Array [
+                            Object {
+                              "color": "hsla(217, 56%, 17%, 1)",
+                              "fontFamily": "Lato",
+                              "fontSize": 12,
+                              "fontStyle": "normal",
+                              "fontWeight": "400",
+                              "lineHeight": 16,
+                              "marginBottom": 0,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "marginTop": 0,
+                              "paddingBottom": 0,
+                              "paddingLeft": 0,
+                              "paddingRight": 0,
+                              "paddingTop": 0,
+                              "textDecorationLine": "none",
+                            },
+                            Object {},
+                          ]
+                        }
+                      >
+                        Level 3
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>


### PR DESCRIPTION
React native has a vertical alignment bug that causes nested text which also has its own view inside to cause misalignment. This PR wraps all the children of list item (text and view) in a flex and aligns them. 

Ref: https://github.com/facebook/react-native/issues/31955

**Before this PR:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-28 at 11 07 59](https://user-images.githubusercontent.com/24487274/228138970-85fb5cb5-464a-4b38-bf28-7948aee63de1.png)

**After this PR:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-28 at 11 09 24](https://user-images.githubusercontent.com/24487274/228138987-eb14a5d7-107c-497b-9020-c7bed11a7839.png)
