### PR TITLE
feat(package.json): add main field 

### DIFF
--- a/.changeset/nervous-eyes-lie.md
+++ b/.changeset/nervous-eyes-lie.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(package.json): add "main" field to package.json

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -30,6 +30,7 @@
     "razorpay",
     "blade"
   ],
+  "main": "./build/components/index.web.js",
   "exports": {
     "./components": {
       "react-native": {


### PR DESCRIPTION
Trying to see if this fixes bundlephobia for blade.


May or may not resolve #586. According to google search answers it should. Will need to test after creating npm release. I referred to this PR that came in google search https://github.com/nirtz89/crumbsjs/issues/5


<img width="300" alt="image" src="https://user-images.githubusercontent.com/30949385/231134524-45221a33-7152-411f-b597-5f98119677c8.png">

Shouldn't break anything in existing setup because -

> If both exports and main are defined, the exports field takes precedence over main in supported versions of Node.js.
>
> ~ https://nodejs.org/api/packages.html#package-entry-points


