### PR TITLE
fix: ref breakage on react native

### DIFF
--- a/.changeset/khaki-planets-shake.md
+++ b/.changeset/khaki-planets-shake.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: ref breakage on react native

--- a/packages/blade/src/hooks/useBladeInnerRef.ts
+++ b/packages/blade/src/hooks/useBladeInnerRef.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { TextInput as TextInputReactNative, View } from 'react-native';
+import { getPlatformType } from '~utils';
 
 type BladeElementRef = Pick<HTMLElement, 'focus' | 'scrollIntoView'> | Pick<View, 'focus'>;
 
@@ -23,7 +24,7 @@ const useBladeInnerRef = (
     targetRef,
     (): BladeElementRef => {
       const element = innerRef.current;
-      if (element instanceof HTMLElement) {
+      if (getPlatformType() !== 'react-native' && element instanceof HTMLElement) {
         return {
           focus: (opts) => (handlers?.onFocus ? handlers.onFocus(opts) : element.focus(opts)),
           scrollIntoView: (opts) => element.scrollIntoView(opts),


### PR DESCRIPTION
Fixes: #1013 #1090

`instanceof HTMLElement` tries to use HTMLElement as a value which is not available for react native. Added a platform check to ensure 
`instanceof HTMLElement` doesn't run. 
