### PR TITLE
fix(Box): react-native style types

### DIFF
--- a/.changeset/cool-students-study.md
+++ b/.changeset/cool-students-study.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Box): add correct prop types in react native Box

--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -87,14 +87,6 @@ type TestID = {
 };
 
 /**
- * Returns the object as it is in web and sets all properties of object to type `never` in react native
- */
-type MakeObjectWebOnly<T> = Platform.Select<{
-  web: T;
-  native: Record<keyof T, never>;
-}>;
-
-/**
  * Similar to `Pick` except this returns `never` when value doesn't exist (native `Pick` returns `unknown`).
  *
  * You might have to ts-ignore the non-existing type error while using this. This is done so that you can get jsdoc from actual type.
@@ -120,8 +112,8 @@ type PickIfExist<T, K extends keyof T> = {
  * // On Native --> This will be just `flex` and `none`
  * ```
  */
-type PickCSSByPlatform<T extends keyof CSSObject | keyof ViewStyle> = Platform.Select<{
-  web: Pick<CSSObject, T>;
+type PickCSSByPlatform<T extends keyof React.CSSProperties | keyof ViewStyle> = Platform.Select<{
+  web: PickIfExist<CSSObject, T>;
   // @ts-expect-error: T passed here may not neccessarily exist. We return `never` type when it doesn't
   native: PickIfExist<ViewStyle, T>;
 }>;
@@ -134,7 +126,6 @@ export {
   StringChildrenType,
   StringWithAutocomplete,
   TestID,
-  MakeObjectWebOnly,
   PickIfExist,
   PickCSSByPlatform,
 };

--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -1,6 +1,9 @@
 import type React from 'react';
+import type { ViewStyle } from 'react-native';
+import type { CSSObject } from 'styled-components';
 import type { Spacing } from '~tokens/global';
 import type { EasingFunctionFactory } from '~tokens/global/motion';
+import type { Platform } from '~utils';
 
 /**
  * @template TokenType token type generic
@@ -83,6 +86,46 @@ type TestID = {
   testID?: string;
 };
 
+/**
+ * Returns the object as it is in web and sets all properties of object to type `never` in react native
+ */
+type MakeObjectWebOnly<T> = Platform.Select<{
+  web: T;
+  native: Record<keyof T, never>;
+}>;
+
+/**
+ * Similar to `Pick` except this returns `never` when value doesn't exist (native `Pick` returns `unknown`).
+ *
+ * You might have to ts-ignore the non-existing type error while using this. This is done so that you can get jsdoc from actual type.
+ *
+ * E.g. This will pick from ViewStyle prop if value exists else returns undefined.
+ *
+ * ```ts
+ * // @ts-expect-error: T passed here may not neccessarily exist. We return `never` type when it doesn't
+ * native: PickIfExist<ViewStyle, T>;
+ * ```
+ */
+type PickIfExist<T, K extends keyof T> = {
+  [P in K]: P extends keyof T ? T[P] : never;
+};
+
+/**
+ * Picks the types based on the platform (web / native).
+ *
+ * E.g.
+ * ```ts
+ * type CSSObject = PickCSSByPlatform<'display'>
+ * // On Web --> This will be all possible web display properties like `block`, `flex`, `inline`, and more.
+ * // On Native --> This will be just `flex` and `none`
+ * ```
+ */
+type PickCSSByPlatform<T extends keyof CSSObject | keyof ViewStyle> = Platform.Select<{
+  web: Pick<CSSObject, T>;
+  // @ts-expect-error: T passed here may not neccessarily exist. We return `never` type when it doesn't
+  native: PickIfExist<ViewStyle, T>;
+}>;
+
 export {
   DotNotationColorStringToken,
   DotNotationMotionStringToken,
@@ -91,4 +134,7 @@ export {
   StringChildrenType,
   StringWithAutocomplete,
   TestID,
+  MakeObjectWebOnly,
+  PickIfExist,
+  PickCSSByPlatform,
 };

--- a/packages/blade/src/components/Box/BaseBox/baseBoxStyles.ts
+++ b/packages/blade/src/components/Box/BaseBox/baseBoxStyles.ts
@@ -215,7 +215,6 @@ const getAllProps = (
     // Visual props
     backgroundColor: getBackgroundValue(props.backgroundColor, props.theme, breakpoint),
     borderRadius: getBorderRadiusValue(props.borderRadius, props.theme, breakpoint),
-    transform: getResponsiveValue(props.transform, breakpoint),
     lineHeight: getSpacingValue(props.lineHeight, props.theme, breakpoint),
     border: getResponsiveValue(props.border, breakpoint),
     borderTop: getResponsiveValue(props.borderTop, breakpoint),

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -1,14 +1,8 @@
-import type { CSSObject } from 'styled-components';
 import type { MarginProps, PaddingProps, SpacingValueType } from './spacingTypes';
 import type { MakeObjectResponsive } from './responsiveTypes';
 import type { Theme } from '~components/BladeProvider';
 import type { Border } from '~tokens/global';
-import type {
-  DotNotationColorStringToken,
-  MakeObjectWebOnly,
-  PickCSSByPlatform,
-  TestID,
-} from '~src/_helpers/types';
+import type { DotNotationColorStringToken, PickCSSByPlatform, TestID } from '~src/_helpers/types';
 
 type LayoutProps = MakeObjectResponsive<
   {
@@ -76,26 +70,23 @@ type PositionProps = MakeObjectResponsive<
   } & PickCSSByPlatform<'position' | 'zIndex'>
 >;
 
-type GridProps = MakeObjectWebOnly<
-  MakeObjectResponsive<
-    Pick<
-      CSSObject,
-      | 'grid'
-      | 'gridColumn'
-      | 'gridRow'
-      | 'gridRowStart'
-      | 'gridRowEnd'
-      | 'gridColumnStart'
-      | 'gridColumnEnd'
-      | 'gridArea'
-      | 'gridAutoFlow'
-      | 'gridAutoRows'
-      | 'gridAutoColumns'
-      | 'gridTemplate'
-      | 'gridTemplateAreas'
-      | 'gridTemplateColumns'
-      | 'gridTemplateRows'
-    >
+type GridProps = MakeObjectResponsive<
+  PickCSSByPlatform<
+    | 'grid'
+    | 'gridColumn'
+    | 'gridRow'
+    | 'gridRowStart'
+    | 'gridRowEnd'
+    | 'gridColumnStart'
+    | 'gridColumnEnd'
+    | 'gridArea'
+    | 'gridAutoFlow'
+    | 'gridAutoRows'
+    | 'gridAutoColumns'
+    | 'gridTemplate'
+    | 'gridTemplateAreas'
+    | 'gridTemplateColumns'
+    | 'gridTemplateRows'
   >
 >;
 

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -127,9 +127,7 @@ type BaseBoxVisualProps = MakeObjectResponsive<
       | BackgroundColorString<'action'>
       | (string & Record<never, never>);
     lineHeight: SpacingValueType;
-  } & PickCSSByPlatform<
-    'transform' | 'border' | 'borderLeft' | 'borderRight' | 'borderTop' | 'borderBottom'
-  >
+  } & PickCSSByPlatform<'border' | 'borderLeft' | 'borderRight' | 'borderTop' | 'borderBottom'>
 >;
 
 type BoxVisualProps = MakeObjectResponsive<{
@@ -141,19 +139,22 @@ type BoxVisualProps = MakeObjectResponsive<{
 };
 
 type StyledPropsBlade = Partial<
-  MarginProps &
-    Pick<FlexboxProps, 'alignSelf' | 'justifySelf' | 'placeSelf' | 'order'> &
-    PositionProps &
-    Pick<
-      GridProps,
-      | 'gridColumn'
-      | 'gridRow'
-      | 'gridRowStart'
-      | 'gridRowEnd'
-      | 'gridColumnStart'
-      | 'gridColumnEnd'
-      | 'gridArea'
-    >
+  Omit<
+    MarginProps &
+      Pick<FlexboxProps, 'alignSelf' | 'justifySelf' | 'placeSelf' | 'order'> &
+      PositionProps &
+      Pick<
+        GridProps,
+        | 'gridColumn'
+        | 'gridRow'
+        | 'gridRowStart'
+        | 'gridRowEnd'
+        | 'gridColumnStart'
+        | 'gridColumnEnd'
+        | 'gridArea'
+      >,
+    '__brand__'
+  >
 >;
 
 type BoxProps = Partial<

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -3,12 +3,12 @@ import type { MarginProps, PaddingProps, SpacingValueType } from './spacingTypes
 import type { MakeObjectResponsive } from './responsiveTypes';
 import type { Theme } from '~components/BladeProvider';
 import type { Border } from '~tokens/global';
-import type { DotNotationColorStringToken, TestID } from '~src/_helpers/types';
-import type { Platform } from '~src/utils/platform/platform';
-
-type MakeObjectWebOnly<T> = {
-  [P in keyof T]: Platform.Select<{ web: T[P]; native: never }>;
-};
+import type {
+  DotNotationColorStringToken,
+  MakeObjectWebOnly,
+  PickCSSByPlatform,
+  TestID,
+} from '~src/_helpers/types';
 
 type LayoutProps = MakeObjectResponsive<
   {
@@ -18,30 +18,7 @@ type LayoutProps = MakeObjectResponsive<
     width: SpacingValueType;
     minWidth: SpacingValueType;
     maxWidth: SpacingValueType;
-  } & Pick<CSSObject, 'overflow' | 'overflowX' | 'overflowY'> &
-    Platform.Select<{
-      web: {
-        /**
-         *
-         * On Web, The **`display`** CSS property sets whether an element is treated as a block or inline element and the layout used for its children, such as flow layout, grid or flex.
-         *
-         * @see https://developer.mozilla.org/docs/Web/CSS/display
-         */
-        display: CSSObject['display'];
-      };
-      native: {
-        /**
-         *
-         *
-         * On React Native, **`display`** property sets whether an element can be `flex` or `none`
-         *
-         * @see https://reactnative.dev/docs/layout-props.html#display
-         *
-         * @default 'flex'
-         */
-        display: 'none' | 'flex';
-      };
-    }>
+  } & PickCSSByPlatform<'display' | 'overflow' | 'overflowX' | 'overflowY'>
 >;
 
 type FlexboxProps = MakeObjectResponsive<
@@ -67,9 +44,13 @@ type FlexboxProps = MakeObjectResponsive<
      * @see https://caniuse.com/?search=column-gap
      */
     columnGap: SpacingValueType;
-  } & Pick<
-    CSSObject,
-    | 'flex'
+    /**
+     * The **`flex`** CSS shorthand property sets how a flex _item_ will grow or shrink to fit the space available in its flex container.
+     *
+     * @see https://developer.mozilla.org/docs/Web/CSS/flex
+     */
+    flex: string | number;
+  } & PickCSSByPlatform<
     | 'flexWrap'
     | 'flexDirection'
     | 'flexGrow'
@@ -92,7 +73,7 @@ type PositionProps = MakeObjectResponsive<
     right: SpacingValueType;
     bottom: SpacingValueType;
     left: SpacingValueType;
-  } & Pick<CSSObject, 'position' | 'zIndex'>
+  } & PickCSSByPlatform<'position' | 'zIndex'>
 >;
 
 type GridProps = MakeObjectWebOnly<
@@ -146,8 +127,7 @@ type BaseBoxVisualProps = MakeObjectResponsive<
       | BackgroundColorString<'action'>
       | (string & Record<never, never>);
     lineHeight: SpacingValueType;
-  } & Pick<
-    CSSObject,
+  } & PickCSSByPlatform<
     'transform' | 'border' | 'borderLeft' | 'borderRight' | 'borderTop' | 'borderBottom'
   >
 >;

--- a/packages/blade/src/components/Box/BaseBox/types/responsiveTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/responsiveTypes.ts
@@ -19,12 +19,16 @@ import type { Breakpoints } from '~tokens/global';
  * ```
  *
  */
-type MakeValueResponsive<T> =
-  | T
-  | {
-      // Using this instead of Record to maintain the jsdoc from breakpoints.ts
-      [P in keyof Breakpoints]?: T;
-    };
+// When type is `never`, we just want to return `never` rather than { base: never, ...etc } since that prop is intended to be never used
+// Explaination of [T] extends [never] -> https://stackoverflow.com/questions/65492464/typescript-never-type-condition
+type MakeValueResponsive<T> = [T] extends [never]
+  ? never
+  :
+      | T
+      | {
+          // Using this instead of Record to maintain the jsdoc from breakpoints.ts
+          [P in keyof Breakpoints]?: T;
+        };
 
 /**
  * Turns all the values in object into responsive object.

--- a/packages/blade/src/components/Box/styledProps/getStyledProps.ts
+++ b/packages/blade/src/components/Box/styledProps/getStyledProps.ts
@@ -31,7 +31,8 @@ const removeUndefinedStyledProps = (obj: StyledPropsInputType): StyledPropsInput
   const onlyDefinedStyledProps: StyledPropsBlade = {};
   for (const key in obj) {
     if (obj[key as keyof StyledPropsBlade] !== undefined) {
-      // @ts-expect-error: complex type error
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
+      // @ts-ignore: complex type error
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       onlyDefinedStyledProps[key as keyof StyledPropsBlade] = obj[key as keyof StyledPropsBlade];
     }


### PR DESCRIPTION
fixes #1112 and bunch of other types in Box and styled-props

## Changes

- Created `PickCSSByPlatform` type utility which picks from `CSSObject` type in web and `ViewStyle` in react native and automatically returns `never` when prop doesn't exist on react native.

We won't have to explicitly handle types anymore.

### Types on React Native
<img src="https://user-images.githubusercontent.com/30949385/231355030-46ec65b5-3ff9-4b9b-b7fb-1e225d134f87.png" width="300" />

<img src="https://user-images.githubusercontent.com/30949385/231355062-7af6406f-8113-4ea9-ac43-07c065cf96fe.png" width="300" />

<img src="https://user-images.githubusercontent.com/30949385/231355081-8c40d0bb-523c-4fcc-9731-821776e24e9b.png" width="300" />

### Types on Web

<img src="https://user-images.githubusercontent.com/30949385/231355103-2c6845e6-d023-45fb-9c10-016e469eecfa.png" width="300" />

<img src="https://user-images.githubusercontent.com/30949385/231355116-0dc3d626-8040-4cd4-a065-88396782140c.png" width="300" />
