### PR TITLE
feat: add `htmlTitle` prop support for Link component on web

### DIFF
--- a/.changeset/clever-kings-cover.md
+++ b/.changeset/clever-kings-cover.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat: add `title` prop support for Link component on web

--- a/.changeset/clever-kings-cover.md
+++ b/.changeset/clever-kings-cover.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-feat: add `title` prop support for Link component on web
+feat: add `htmlTitle` prop support for Link component on web

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -51,7 +51,7 @@ type BaseLinkCommonProps = {
   /**
    * The title of the link which is displayed as a tooltip. This is a web only prop and has no effect on react-native.
    */
-  title?: string;
+  htmlTitle?: string;
 } & TestID &
   StyledPropsBlade;
 
@@ -252,7 +252,7 @@ const BaseLink = ({
   size = 'medium',
   testID,
   hitSlop,
-  title,
+  htmlTitle,
   ...styledProps
 }: BaseLinkProps): ReactElement => {
   const [isVisited, setIsVisited] = useState(false);
@@ -328,7 +328,7 @@ const BaseLink = ({
       className={className}
       style={style}
       hitSlop={hitSlop}
-      title={title}
+      title={htmlTitle}
     >
       <BaseBox display="flex" flexDirection="row" className="content-container" alignItems="center">
         {Icon && iconPosition == 'left' ? (

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -48,6 +48,10 @@ type BaseLinkCommonProps = {
         left?: number;
       }
     | number;
+  /**
+   * The title of the link which is displayed as a tooltip. This is a web only prop and has no effect on react-native.
+   */
+  title?: string;
 } & TestID &
   StyledPropsBlade;
 
@@ -248,6 +252,7 @@ const BaseLink = ({
   size = 'medium',
   testID,
   hitSlop,
+  title,
   ...styledProps
 }: BaseLinkProps): ReactElement => {
   const [isVisited, setIsVisited] = useState(false);
@@ -323,6 +328,7 @@ const BaseLink = ({
       className={className}
       style={style}
       hitSlop={hitSlop}
+      title={title}
     >
       <BaseBox display="flex" flexDirection="row" className="content-container" alignItems="center">
         {Icon && iconPosition == 'left' ? (

--- a/packages/blade/src/components/Link/BaseLink/__tests__/BaseLink.web.test.tsx
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/BaseLink.web.test.tsx
@@ -20,7 +20,7 @@ describe('<BaseLink />', () => {
     const linkText = 'Learn More';
     const { getByRole } = renderWithTheme(
       // nosemgrep
-      <BaseLink href="https://www.google.com/" target="_blank" rel="noreferrer" title="Google">
+      <BaseLink href="https://www.google.com/" target="_blank" rel="noreferrer" htmlTitle="Google">
         {linkText}
       </BaseLink>,
     );

--- a/packages/blade/src/components/Link/BaseLink/__tests__/BaseLink.web.test.tsx
+++ b/packages/blade/src/components/Link/BaseLink/__tests__/BaseLink.web.test.tsx
@@ -16,17 +16,18 @@ describe('<BaseLink />', () => {
     expect(getByText('Learn More')).toBeInTheDocument();
   });
 
-  it('should render link with an href, target and rel', () => {
+  it('should render link with an href, target, rel, and title', () => {
     const linkText = 'Learn More';
     const { getByRole } = renderWithTheme(
       // nosemgrep
-      <BaseLink href="https://www.google.com/" target="_blank" rel="noreferrer">
+      <BaseLink href="https://www.google.com/" target="_blank" rel="noreferrer" title="Google">
         {linkText}
       </BaseLink>,
     );
     expect(getByRole('link')).toHaveAttribute('href', 'https://www.google.com/');
     expect(getByRole('link')).toHaveAttribute('target', '_blank');
     expect(getByRole('link')).toHaveAttribute('rel', 'noreferrer');
+    expect(getByRole('link')).toHaveAttribute('title', 'Google');
   });
 
   it('should render link with a default rel set when target is _blank', () => {

--- a/packages/blade/src/components/Link/Link/Link.tsx
+++ b/packages/blade/src/components/Link/Link/Link.tsx
@@ -36,12 +36,20 @@ type LinkCommonProps = {
             left?: number;
           }
         | number;
+      /**
+       * This is a web only prop and has no effect on react-native.
+       */
+      title?: undefined;
     };
     web: {
       /**
        * This is a react-native only prop and has no effect on web.
        */
       hitSlop?: undefined;
+      /**
+       * The title of the link which is displayed as a tooltip.
+       */
+      title?: string;
     };
   }>;
 

--- a/packages/blade/src/components/Link/Link/Link.tsx
+++ b/packages/blade/src/components/Link/Link/Link.tsx
@@ -39,7 +39,7 @@ type LinkCommonProps = {
       /**
        * This is a web only prop and has no effect on react-native.
        */
-      title?: undefined;
+      htmlTitle?: undefined;
     };
     web: {
       /**
@@ -49,7 +49,7 @@ type LinkCommonProps = {
       /**
        * The title of the link which is displayed as a tooltip.
        */
-      title?: string;
+      htmlTitle?: string;
     };
   }>;
 
@@ -115,6 +115,7 @@ const Link = ({
   size = 'medium',
   testID,
   hitSlop,
+  htmlTitle,
   ...styledProps
 }: LinkProps): ReactElement => {
   return (
@@ -127,6 +128,7 @@ const Link = ({
       size={size}
       testID={testID}
       hitSlop={hitSlop}
+      htmlTitle={htmlTitle}
       {...styledProps}
     />
   );

--- a/packages/blade/src/components/Link/Link/__tests__/Link.web.test.tsx
+++ b/packages/blade/src/components/Link/Link/__tests__/Link.web.test.tsx
@@ -26,16 +26,22 @@ describe('<Link />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should render link with an href, target and rel', () => {
+  it('should render link with an href, target, rel and title', () => {
     const linkText = 'Learn More';
     const { getByRole } = renderWithTheme(
-      <Link href="https://www.google.com/" target="_blank" rel="noreferrer noopener">
+      <Link
+        href="https://www.google.com/"
+        target="_blank"
+        rel="noreferrer noopener"
+        htmlTitle="Google"
+      >
         {linkText}
       </Link>,
     );
     expect(getByRole('link')).toHaveAttribute('href', 'https://www.google.com/');
     expect(getByRole('link')).toHaveAttribute('target', '_blank');
     expect(getByRole('link')).toHaveAttribute('rel', 'noreferrer noopener');
+    expect(getByRole('link')).toHaveAttribute('title', 'Google');
   });
 
   it('should render link with icon without text', () => {


### PR DESCRIPTION
Adds support for `title` attribute on web. Does nothing on native since there is no counterpart for showing a tooltip on links on native. We could add this as a feature later on where long pressing the link shows a Toast with the `title` but that would be when we build the Toast component. 

On hover:
<img width="194" alt="Screenshot 2023-04-12 at 11 02 04 AM" src="https://user-images.githubusercontent.com/24487274/231359956-301d0fcc-7130-4b81-bca4-cb844795729b.png">
