### PR TITLE
fix(colors): incorrect value of ashGrayLight.1200

### DIFF
--- a/.changeset/fifty-dryers-grin.md
+++ b/.changeset/fifty-dryers-grin.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(colors): incorrect value of ashGrayLight.1200
+
+There was a typo earlier in the value of the token.

--- a/packages/blade/src/tokens/global/colors.ts
+++ b/packages/blade/src/tokens/global/colors.ts
@@ -296,7 +296,7 @@ const colors: Color = {
       900: `hsla(218, 9%, 36%, ${opacity[9]})`,
       1000: `hsla(219, 12%, 28%, ${opacity[9]})`,
       1100: `hsla(214, 15%, 18%, ${opacity[9]})`,
-      1200: `hsla(216, 15, 13%, ${opacity[9]})`,
+      1200: `hsla(216, 15%, 13%, ${opacity[9]})`,
       1300: `hsla(214, 24%, 6%, ${opacity[9]})`,
       a00: `hsla(214, 15%, 18%, ${opacity[0]})`,
       a50: `hsla(214, 15%, 18%, ${opacity[1]})`,


### PR DESCRIPTION
[Slack][1]

The value of `ashGrayLight.1200` is broken:
https://blade.razorpay.com/?path=/docs/tokens-colors--page#neutral-colors

[1]: https://razorpay.slack.com/archives/CMQ3RBHEU/p1681440228714499
