### PR TITLE
fix(cardFooter): alignment issue

### DIFF
--- a/.changeset/swift-dogs-teach.md
+++ b/.changeset/swift-dogs-teach.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(cardFooter): alignment issue

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -46,7 +46,7 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
     footerChildrensArray.length && footerChildrensArray.length === 2
       ? 'space-between'
       : React.isValidElement(footerChildrensArray[0]) && footerChildrensArray[0]?.props?.actions // FooterTrailing component receives actions as props
-      ? 'end'
+      ? 'flex-end'
       : 'space-between';
 
   return (

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -45,6 +45,10 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
     throw new Error(`Invalid React Element ${footerChildrensArray}`);
   }
 
+  // the reason why we are checking for actions here is, because we want the footerTrailing
+  // to always be aligned to the right
+  // if we don't check for action here, and if we do not have footerTrailing and only footerLeading
+  // then the content of footerLeading will be justified to the end.
   const baseBoxJustifyContent =
     footerChildrensArray.length === 2 || !footerChildrensArray[0]?.props?.actions
       ? 'space-between'

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -40,6 +40,15 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
     ComponentIds.CardFooterTrailing,
   ]);
 
+  const footerChildrensArray = React.Children.toArray(children);
+
+  const baseBoxJustifyContent =
+    footerChildrensArray.length && footerChildrensArray.length === 2
+      ? 'space-between'
+      : React.isValidElement(footerChildrensArray[0]) && footerChildrensArray[0]?.props?.actions // FooterTrailing component receives actions as props
+      ? 'end'
+      : 'space-between';
+
   return (
     <BaseBox marginTop="auto" {...metaAttribute({ name: MetaConstants.CardFooter, testID })}>
       <BaseBox marginTop="spacing.7" />
@@ -48,7 +57,7 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
         marginTop="spacing.7"
         display="flex"
         flexDirection={isMobile ? 'column' : 'row'}
-        justifyContent="space-between"
+        justifyContent={baseBoxJustifyContent}
         alignItems={isMobile ? 'stretch' : 'center'}
       >
         {children}

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -41,13 +41,14 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
   ]);
 
   const footerChildrensArray = React.Children.toArray(children);
+  if (!React.isValidElement(footerChildrensArray[0])) {
+    throw new Error(`Invalid React Element ${footerChildrensArray}`);
+  }
 
   const baseBoxJustifyContent =
-    footerChildrensArray.length && footerChildrensArray.length === 2
+    footerChildrensArray.length === 2 || !footerChildrensArray[0]?.props?.actions
       ? 'space-between'
-      : React.isValidElement(footerChildrensArray[0]) && footerChildrensArray[0]?.props?.actions // FooterTrailing component receives actions as props
-      ? 'flex-end'
-      : 'space-between';
+      : 'end';
 
   return (
     <BaseBox marginTop="auto" {...metaAttribute({ name: MetaConstants.CardFooter, testID })}>

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -48,7 +48,7 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
   const baseBoxJustifyContent =
     footerChildrensArray.length === 2 || !footerChildrensArray[0]?.props?.actions
       ? 'space-between'
-      : 'end';
+      : 'flex-end';
 
   return (
     <BaseBox marginTop="auto" {...metaAttribute({ name: MetaConstants.CardFooter, testID })}>


### PR DESCRIPTION
Resolves #1140 

When we do not provide either `footerTrailing` or `footerLeading` component to the `cardFooter` component, then it's always aligned to the right.

More information on this [issue](https://github.com/razorpay/blade/issues/1140)

Added a fix, so that the `footerTrailing` is alway aligned to the right.

> I did not provide the `footerLeading` component

<img width="1646" alt="Screenshot 2023-05-04 at 2 44 15 PM" src="https://user-images.githubusercontent.com/29303618/236161657-57c7da8e-a721-4201-8010-dbc18d2e716c.png">
