### PR TITLE
fix(blade): ensure that the BottomSheet's lower snappoint will have a buffer

### DIFF
--- a/.changeset/plenty-cougars-smoke.md
+++ b/.changeset/plenty-cougars-smoke.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-fix(blade): ensure that the BottomSheet's lower snappoint will have a buffer
+fix(BottomSheet): ensure that the BottomSheet's lower snappoint will have a buffer

--- a/.changeset/plenty-cougars-smoke.md
+++ b/.changeset/plenty-cougars-smoke.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): ensure that the BottomSheet's lower snappoint will have a buffer

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -10,7 +10,7 @@ import { clearAllBodyScrollLocks } from 'body-scroll-lock';
 import { BottomSheetGrabHandle, BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetBody } from './BottomSheetBody';
 import type { SnapPoints } from './utils';
-import { computeMaxContent, computeSnapPointBounds } from './utils';
+import { nearlyEqual, computeMaxContent, computeSnapPointBounds } from './utils';
 import { BottomSheetBackdrop } from './BottomSheetBackdrop';
 import { BottomSheetContext, useBottomSheetAndDropdownGlue } from './BottomSheetContext';
 import { ComponentIds } from './componentIds';
@@ -297,7 +297,16 @@ const _BottomSheet = ({
         preventScrollingRef.current = newY < upperSnapPoint;
       }
 
-      const shouldClose = newY < lowerSnapPoint;
+      // This ensure that the lower snapPoint will always have atleast headerHeight's buffer
+      // When the bottomsheet total height is less than the lower snapPoint
+      // Video walkthrough: https://www.loom.com/share/a9a8db7688d64194b13df8b3e25859ae
+      const totalHeight = headerHeight + grabHandleHeight + contentHeight + footerHeight;
+      const dynamicLowerSnapPoint =
+        totalHeight < lowerSnapPoint || nearlyEqual(totalHeight, lowerSnapPoint, headerHeight)
+          ? contentHeight
+          : lowerSnapPoint;
+
+      const shouldClose = newY < dynamicLowerSnapPoint;
       if (shouldClose) {
         setIsDragging(false);
         close();
@@ -434,8 +443,6 @@ const _BottomSheet = ({
 
   return (
     <BottomSheetContext.Provider value={contextValue}>
-      {/* This has to be isVisible */}
-      {/* TODO: fix opactiy flicker */}
       <BottomSheetBackdrop zIndex={zIndex} />
       <BottomSheetSurface
         data-surface

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -10,7 +10,7 @@ import { clearAllBodyScrollLocks } from 'body-scroll-lock';
 import { BottomSheetGrabHandle, BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetBody } from './BottomSheetBody';
 import type { SnapPoints } from './utils';
-import { nearlyEqual, computeMaxContent, computeSnapPointBounds } from './utils';
+import { computeMaxContent, computeSnapPointBounds } from './utils';
 import { BottomSheetBackdrop } from './BottomSheetBackdrop';
 import { BottomSheetContext, useBottomSheetAndDropdownGlue } from './BottomSheetContext';
 import { ComponentIds } from './componentIds';
@@ -297,16 +297,14 @@ const _BottomSheet = ({
         preventScrollingRef.current = newY < upperSnapPoint;
       }
 
-      // This ensure that the lower snapPoint will always have atleast headerHeight's buffer
+      // This ensure that the lower snapPoint will always have atleast some buffer
       // When the bottomsheet total height is less than the lower snapPoint
       // Video walkthrough: https://www.loom.com/share/a9a8db7688d64194b13df8b3e25859ae
+      const lowerPointBuffer = 60;
       const totalHeight = headerHeight + grabHandleHeight + contentHeight + footerHeight;
-      const dynamicLowerSnapPoint =
-        totalHeight < lowerSnapPoint || nearlyEqual(totalHeight, lowerSnapPoint, headerHeight)
-          ? contentHeight
-          : lowerSnapPoint;
+      const lowerestSnap = Math.min(lowerSnapPoint, totalHeight) - lowerPointBuffer;
 
-      const shouldClose = newY < dynamicLowerSnapPoint;
+      const shouldClose = newY < lowerestSnap;
       if (shouldClose) {
         setIsDragging(false);
         close();

--- a/packages/blade/src/components/BottomSheet/utils.ts
+++ b/packages/blade/src/components/BottomSheet/utils.ts
@@ -54,4 +54,11 @@ function computeMaxContent(
   );
 }
 
-export { SnapPoints, computeMaxContent, computeMinContent, computeSnapPointBounds };
+/**
+ * Checkes if two numbers are close to reach other
+ */
+const nearlyEqual = (value1: number, value2: number, epsilon: number) => {
+  return Math.abs(value1 - value2) < epsilon;
+};
+
+export { SnapPoints, computeMaxContent, computeMinContent, computeSnapPointBounds, nearlyEqual };

--- a/packages/blade/src/components/BottomSheet/utils.ts
+++ b/packages/blade/src/components/BottomSheet/utils.ts
@@ -54,11 +54,4 @@ function computeMaxContent(
   );
 }
 
-/**
- * Checkes if two numbers are close to reach other
- */
-const nearlyEqual = (value1: number, value2: number, epsilon: number) => {
-  return Math.abs(value1 - value2) < epsilon;
-};
-
-export { SnapPoints, computeMaxContent, computeMinContent, computeSnapPointBounds, nearlyEqual };
+export { SnapPoints, computeMaxContent, computeMinContent, computeSnapPointBounds };


### PR DESCRIPTION
Changes: 

- Made the lower snapPoint dynamic based on the content of the height, to ensure we will always have some buffer between the lower snapPoint and the contentHeight. 

Explanation:

https://www.loom.com/share/a9a8db7688d64194b13df8b3e25859ae 