### PR TITLE
fix: css vars build script with new elevation tokens

### DIFF
--- a/.changeset/nine-kids-march.md
+++ b/.changeset/nine-kids-march.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: css vars build script with new elevation tokens

--- a/packages/blade/scripts/generateCssThemeVariables.js
+++ b/packages/blade/scripts/generateCssThemeVariables.js
@@ -2,8 +2,6 @@ const { getLeaves } = require('any-leaf');
 const StyleDictionary = require('style-dictionary');
 const set = require('lodash/set');
 const cloneDeep = require('lodash/cloneDeep');
-const chalk = require('chalk');
-const figures = require('figures');
 
 const { paymentTheme, bankingTheme } = require('../build/js-bundle-for-css/tokensBundle');
 const {
@@ -180,13 +178,7 @@ const getThemeFromTokensCSSTokens = () => {
       }),
     ).buildAllPlatforms();
   } catch (error) {
-    console.log(
-      '\n',
-      chalk.red(`${figures.cross} error while generating CSS theme variables`),
-      '\n',
-      chalk.red(error),
-      '\n',
-    );
+    throw new Error(`Error while generating CSS theme variables:`, error);
   }
 };
 

--- a/packages/blade/scripts/generateCssThemeVariables.js
+++ b/packages/blade/scripts/generateCssThemeVariables.js
@@ -18,10 +18,7 @@ const getThemeFromTokens = ({ onColorMode, onDeviceType, themeTokens }) => {
   return {
     ...themeTokens,
     colors: themeTokens.colors[onColorMode],
-    shadows: {
-      ...themeTokens.shadows,
-      color: themeTokens.shadows.color[onColorMode],
-    },
+    elevation: themeTokens.elevation[onColorMode],
     typography: themeTokens.typography[onDeviceType],
   };
 };


### PR DESCRIPTION
Our shadow tokens changed to elevation tokens but we missed to update the CSS vars generating script. Since the script logged the error instead of throwing an error, we missed catching this on CI