### PR TITLE
build: fix npm publish by generating .npmrc in monorepo root

### DIFF
--- a/packages/blade/scripts/publishToNpm.js
+++ b/packages/blade/scripts/publishToNpm.js
@@ -20,8 +20,8 @@ const path = require('path');
 const execa = require('execa');
 
 const BLADE_ROOT = path.join(__dirname, '..');
-const NPMRC_PATH = path.join(BLADE_ROOT, '.npmrc');
 const MONOREPO_ROOT = path.join(BLADE_ROOT, '../..');
+const NPMRC_PATH = path.join(MONOREPO_ROOT, '.npmrc');
 
 const npmRcContent = `@razorpay:registry=https://registry.npmjs.org/
 //registry.npmjs.org/:always-auth=true


### PR DESCRIPTION
Node `v16.14.2` with npm `8.5.0` introduced a feature that automatically resolves the workspace root and uses the `.npmrc` from there. We were generating our npmrc for publishing to npm inside our blade package within the workspace and not at the workspace root. It was working while we were on Node `v14` but as soon as we upgraded to `v18`, this stopped working as expected.

This PR generates the `.npmrc` at root instead of within the package. I haven't tried to publishing to npm after this change but I did try to check with `npm view @razorpay/blade time`. Without this change `npm view` shows 8.2.1 as latest available package (which is incorrect since its showing the latest available on github registry & not on npm registry) but after this change `npm view` shows `8.1.0` as the latest available package which is correct on npm registry.