### PR TITLE
Fix issue #1220

### DIFF
--- a/packages/blade/jest-setup.native.js
+++ b/packages/blade/jest-setup.native.js
@@ -3,7 +3,9 @@
  **/
 
 Object.defineProperty(global.navigator, 'product', {
-  value: 'ReactNative',
+  get() {
+    return 'ReactNative';
+  },
 });
 require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();
 jest.mock('react-native-reanimated', () => ({

--- a/packages/blade/jest-setup.native.js
+++ b/packages/blade/jest-setup.native.js
@@ -2,11 +2,9 @@
  * For browser we have `window`, for node we have `process` as globals, for React Native it's `global.navigator.product: ReactNative`
  **/
 
-Object.defineProperty(global.navigator, 'product', {
-  get() {
-    return 'ReactNative';
-  },
-});
+global.navigator = {
+  product: 'ReactNative',
+};
 require('react-native-reanimated/lib/reanimated2/jestUtils').setUpTests();
 jest.mock('react-native-reanimated', () => ({
   ...require('react-native-reanimated/mock'),


### PR DESCRIPTION
Hello,

I have made the necessary code changes to address the issue. The updated code modifies the `jest-setup.native.js` file in the project to configure `global.navigator.product` for Jest testing. This change ensures that the tests run as expected for consumers using React Native.

By setting `global.navigator.product` to `'ReactNative'`, Jest will have the same configuration as React Native in a production environment, resolving the inconsistency encountered during testing.

Please review the changes and let me know if any further modifications or adjustments are required. I believe these modifications will resolve the issue and enable the tests to run successfully for React Native consumers.

Thank you!
