### PR TITLE
fix: update migrate-typography script

### DIFF
--- a/.changeset/dry-beers-greet.md
+++ b/.changeset/dry-beers-greet.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: update migrate-typography script

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -7,7 +7,7 @@
     "node": ">=18.12.1"
   },
   "bin": {
-    "migrate-typography": "./codemods/migrate-typography/cli.js"
+    "migrate-typography": "./codemods/migrate-typography/transformers/migrate-typography.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the path to codemod. We will also need to release this fix to previous versions of blade.