### PR TITLE
fix: jsdoc for components with refs

### DIFF
--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -117,6 +117,23 @@ type PickCSSByPlatform<T extends keyof React.CSSProperties | keyof ViewStyle> = 
   native: PickIfExist<ViewStyle, T>;
 }>;
 
+/**
+ * JSDoc sometimes break unless return type of forwardRef is not explicitly defines
+ * (It tries to redefine the types in object rather than just pointing to existing type
+ *  and strips away jsdoc from it for some reason)
+ *
+ * This can be fixed using explicitly defining the prop type before exporting with -
+ * ```jsx
+ * const TextArea: ForwardRefReturnType<TextAreaProps, BladeElementRef> = React.forwardRef(_TextArea);
+ * ```
+ */
+type ForwardRefReturnType<
+  BladeElementPropsType,
+  BladeElementRefType
+> = React.ForwardRefExoticComponent<
+  BladeElementPropsType & React.RefAttributes<BladeElementRefType>
+>;
+
 export {
   DotNotationColorStringToken,
   DotNotationMotionStringToken,
@@ -127,4 +144,5 @@ export {
   TestID,
   PickIfExist,
   PickCSSByPlatform,
+  ForwardRefReturnType,
 };

--- a/packages/blade/src/_helpers/types.ts
+++ b/packages/blade/src/_helpers/types.ts
@@ -118,11 +118,11 @@ type PickCSSByPlatform<T extends keyof React.CSSProperties | keyof ViewStyle> = 
 }>;
 
 /**
- * JSDoc sometimes break unless return type of forwardRef is not explicitly defines
- * (It tries to redefine the types in object rather than just pointing to existing type
- *  and strips away jsdoc from it for some reason)
+ * JSDoc sometimes break unless return type of forwardRef is not explicitly defined
+ * (It tries to redefine the types again rather than just pointing to existing type variable
+ *  and strips away jsdoc while redefining)
  *
- * This can be fixed using explicitly defining the prop type before exporting with -
+ * This can be fixed by explicitly defining the prop type before exporting using this type utility -
  * ```jsx
  * const TextArea: ForwardRefReturnType<TextAreaProps, BladeElementRef> = React.forwardRef(_TextArea);
  * ```

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import BaseBox from './BaseBox';
 import type { BoxProps, BoxRefType, MakeValueResponsive } from './BaseBox/types';
 import { validBoxAsValues } from './BaseBox/types/propsTypes';
-import type { KeysRequired } from '~src/_helpers/types';
+import type { ForwardRefReturnType, KeysRequired } from '~src/_helpers/types';
 import { assignWithoutSideEffects, isReactNative, metaAttribute, MetaConstants } from '~utils';
 
 const validateBackgroundString = (stringBackgroundColorValue: string): void => {
@@ -202,10 +202,11 @@ const _Box: React.ForwardRefRenderFunction<BoxRefType, BoxProps> = (props, ref) 
  * Checkout {@link https://blade.razorpay.com/?path=/docs/components-box Box Documentation}
  * 
  */
-const Box: React.ForwardRefExoticComponent<
-  BoxProps & React.RefAttributes<BoxRefType>
-> = assignWithoutSideEffects(React.forwardRef(_Box), {
-  displayName: 'Box',
-});
+const Box: ForwardRefReturnType<BoxProps, BoxRefType> = assignWithoutSideEffects(
+  React.forwardRef(_Box),
+  {
+    displayName: 'Box',
+  },
+);
 
 export { Box, makeBoxProps };

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -136,6 +136,37 @@ const makeBoxProps = (props: BoxProps): KeysRequired<Omit<BoxProps, 'testID' | '
   };
 };
 
+const _Box: React.ForwardRefRenderFunction<BoxRefType, BoxProps> = (props, ref) => {
+  React.useEffect(() => {
+    validateBackgroundProp(props.backgroundColor);
+  }, [props.backgroundColor]);
+
+  React.useEffect(() => {
+    if (props.as) {
+      if (isReactNative()) {
+        throw new Error('[Blade - Box]: `as` prop is not supported on React Native');
+      }
+
+      if (!validBoxAsValues.includes(props.as)) {
+        throw new Error(
+          `[Blade - Box]: Invalid \`as\` prop value - ${props.as}. Only ${validBoxAsValues.join(
+            ', ',
+          )} are valid values`,
+        );
+      }
+    }
+  }, [props.as]);
+
+  return (
+    <BaseBox
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref={ref as any}
+      {...metaAttribute({ name: MetaConstants.Box, testID: props.testID })}
+      {...makeBoxProps(props)}
+    />
+  );
+};
+
 /**
  * ## Box
  * 
@@ -171,38 +202,9 @@ const makeBoxProps = (props: BoxProps): KeysRequired<Omit<BoxProps, 'testID' | '
  * Checkout {@link https://blade.razorpay.com/?path=/docs/components-box Box Documentation}
  * 
  */
-const _Box: React.ForwardRefRenderFunction<BoxRefType, BoxProps> = (props, ref) => {
-  React.useEffect(() => {
-    validateBackgroundProp(props.backgroundColor);
-  }, [props.backgroundColor]);
-
-  React.useEffect(() => {
-    if (props.as) {
-      if (isReactNative()) {
-        throw new Error('[Blade - Box]: `as` prop is not supported on React Native');
-      }
-
-      if (!validBoxAsValues.includes(props.as)) {
-        throw new Error(
-          `[Blade - Box]: Invalid \`as\` prop value - ${props.as}. Only ${validBoxAsValues.join(
-            ', ',
-          )} are valid values`,
-        );
-      }
-    }
-  }, [props.as]);
-
-  return (
-    <BaseBox
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ref={ref as any}
-      {...metaAttribute({ name: MetaConstants.Box, testID: props.testID })}
-      {...makeBoxProps(props)}
-    />
-  );
-};
-
-const Box = assignWithoutSideEffects(React.forwardRef(_Box), {
+const Box: React.ForwardRefExoticComponent<
+  BoxProps & React.RefAttributes<BoxRefType>
+> = assignWithoutSideEffects(React.forwardRef(_Box), {
   displayName: 'Box',
 });
 

--- a/packages/blade/src/components/Checkbox/Checkbox.tsx
+++ b/packages/blade/src/components/Checkbox/Checkbox.tsx
@@ -16,7 +16,7 @@ import { SelectorSupportText } from '~components/Form/Selector/SelectorSupportTe
 import { SelectorInput } from '~components/Form/Selector/SelectorInput';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
 import { assignWithoutSideEffects } from '~src/utils/assignWithoutSideEffects';
-import type { TestID } from '~src/_helpers/types';
+import type { ForwardRefReturnType, TestID } from '~src/_helpers/types';
 
 type OnChange = ({
   isChecked,
@@ -249,8 +249,11 @@ const _Checkbox: React.ForwardRefRenderFunction<BladeElementRef, CheckboxProps> 
   );
 };
 
-const Checkbox = assignWithoutSideEffects(React.forwardRef(_Checkbox), {
-  displayName: 'Checkbox',
-});
+const Checkbox: ForwardRefReturnType<CheckboxProps, BladeElementRef> = assignWithoutSideEffects(
+  React.forwardRef(_Checkbox),
+  {
+    displayName: 'Checkbox',
+  },
+);
 
 export { Checkbox, CheckboxProps };

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
@@ -9,6 +9,7 @@ import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
 import { useBladeInnerRef } from '~src/hooks/useBladeInnerRef';
 import { assignWithoutSideEffects } from '~src/utils/assignWithoutSideEffects';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
+import type { ForwardRefReturnType } from '~src/_helpers/types';
 
 type PasswordInputExtraProps = {
   /**
@@ -169,7 +170,10 @@ const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordIn
 };
 
 // nosemgrep
-const PasswordInput = assignWithoutSideEffects(React.forwardRef(_PasswordInput), {
+const PasswordInput: ForwardRefReturnType<
+  PasswordInputProps,
+  BladeElementRef
+> = assignWithoutSideEffects(React.forwardRef(_PasswordInput), {
   displayName: 'PasswordInput',
 });
 

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -172,7 +172,9 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
   );
 };
 
-const TextArea = assignWithoutSideEffects(React.forwardRef(_TextArea), {
+const TextArea: React.ForwardRefExoticComponent<
+  TextAreaProps & React.RefAttributes<BladeElementRef>
+> = assignWithoutSideEffects(React.forwardRef(_TextArea), {
   displayName: 'TextArea',
 });
 

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -12,6 +12,7 @@ import { CharacterCounter } from '~components/Form/CharacterCounter';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
 import { useBladeInnerRef } from '~src/hooks/useBladeInnerRef';
 import { assignWithoutSideEffects } from '~src/utils/assignWithoutSideEffects';
+import type { ForwardRefReturnType } from '~src/_helpers/types';
 
 type TextAreaProps = Pick<
   BaseInputProps,
@@ -172,10 +173,11 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
   );
 };
 
-const TextArea: React.ForwardRefExoticComponent<
-  TextAreaProps & React.RefAttributes<BladeElementRef>
-> = assignWithoutSideEffects(React.forwardRef(_TextArea), {
-  displayName: 'TextArea',
-});
+const TextArea: ForwardRefReturnType<TextAreaProps, BladeElementRef> = assignWithoutSideEffects(
+  React.forwardRef(_TextArea),
+  {
+    displayName: 'TextArea',
+  },
+);
 
 export { TextArea, TextAreaProps };

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -14,6 +14,7 @@ import { Spinner } from '~components/Spinner';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
 import { useBladeInnerRef } from '~src/hooks/useBladeInnerRef';
 import { assignWithoutSideEffects } from '~src/utils/assignWithoutSideEffects';
+import type { ForwardRefReturnType } from '~src/_helpers/types';
 
 // Users should use PasswordInput for input type password
 type Type = Exclude<BaseInputProps['type'], 'password'>;
@@ -314,8 +315,11 @@ const _TextInput: React.ForwardRefRenderFunction<BladeElementRef, TextInputProps
   );
 };
 
-const TextInput = assignWithoutSideEffects(React.forwardRef(_TextInput), {
-  displayName: 'TextInput',
-});
+const TextInput: ForwardRefReturnType<TextInputProps, BladeElementRef> = assignWithoutSideEffects(
+  React.forwardRef(_TextInput),
+  {
+    displayName: 'TextInput',
+  },
+);
 
 export { TextInput, TextInputProps };

--- a/packages/blade/src/components/Radio/Radio.tsx
+++ b/packages/blade/src/components/Radio/Radio.tsx
@@ -123,6 +123,8 @@ const _Radio: React.ForwardRefRenderFunction<BladeElementRef, RadioProps> = (
   );
 };
 
-const Radio = assignWithoutSideEffects(React.forwardRef(_Radio), { displayName: 'Radio' });
+const Radio: React.ForwardRefExoticComponent<
+  RadioProps & React.RefAttributes<BladeElementRef>
+> = assignWithoutSideEffects(React.forwardRef(_Radio), { displayName: 'Radio' });
 
 export { Radio, RadioProps };

--- a/packages/blade/src/components/Radio/Radio.tsx
+++ b/packages/blade/src/components/Radio/Radio.tsx
@@ -15,7 +15,7 @@ import { getStyledProps } from '~components/Box/styledProps';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import { getPlatformType } from '~utils';
 import type { BladeElementRef } from '~src/hooks/useBladeInnerRef';
-import type { StringChildrenType, TestID } from '~src/_helpers/types';
+import type { ForwardRefReturnType, StringChildrenType, TestID } from '~src/_helpers/types';
 import { assignWithoutSideEffects } from '~src/utils/assignWithoutSideEffects';
 
 type RadioProps = {
@@ -123,8 +123,9 @@ const _Radio: React.ForwardRefRenderFunction<BladeElementRef, RadioProps> = (
   );
 };
 
-const Radio: React.ForwardRefExoticComponent<
-  RadioProps & React.RefAttributes<BladeElementRef>
+const Radio: ForwardRefReturnType<
+  RadioProps,
+  BladeElementRef
 > = assignWithoutSideEffects(React.forwardRef(_Radio), { displayName: 'Radio' });
 
 export { Radio, RadioProps };


### PR DESCRIPTION
Suuuper weird issue but when we had types like -
```ts
type StyledProps = {
  /** margin jsdoc */
  marginX: ''
}

type CheckBoxProps = {
  /** hello from jsdoc */
  myCheckBoxProps: number;
} & StyledProps;


const CheckBox = React.forwardRef(_CheckBox);
```

Then the output `.d.ts` file was this where instead of just pointing to CheckBoxProps and StyledProps types variables, it defined those again (badly). The ones that were statically available like `myCheckBoxProps` continued to have jsdoc but ones that were defined in variable like `StyledProps` or `testID` had their jsdocs stripped for some reason -
```ts
declare const CheckBox: React__default.ForwardRefExoticComponent<{
    /** hello from jsdoc */
  myCheckBoxProps: number;
} & {
  marginX: ''
}>
```


## Solution

Explicitly defining the export variable's type by pointing it to actual props seems to help solve the issue. JSDoc is working now as expected -
![image](https://github.com/razorpay/blade/assets/30949385/eee19519-8626-45b1-bec2-b9f285bd06e6)


Definitely an additional overhead on top of existing components. Not sure how to solve this 😢 