### PR TITLE
feat(Accordion): add base toggle functionality

### DIFF
--- a/packages/blade/src/components/Accordion/Accordion.stories.internal.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.stories.internal.tsx
@@ -1,0 +1,73 @@
+import type { ComponentStory, Meta } from '@storybook/react';
+import { Title } from '@storybook/addon-docs';
+import type { ReactElement } from 'react';
+
+import type { AccordionProps } from './Accordion';
+import { Accordion as AccordionComponent } from './Accordion';
+import { AccordionItem } from './AccordionItem';
+import { Sandbox } from '~src/_helpers/storybook/Sandbox';
+import StoryPageWrapper from '~src/_helpers/storybook/StoryPageWrapper';
+import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
+
+// TODO: udpate
+const Page = (): ReactElement => {
+  return (
+    <StoryPageWrapper
+      componentName="Collapsible"
+      componentDescription="Collapsible is used to allow users to toggle the visibility of hidden content within a container."
+      figmaURL={{
+        paymentTheme:
+          'https://www.figma.com/file/LSG77hEeVYDk7j7WV7OMJE/Blade-DSL---Components-Guideline?type=design&node-id=79-629874&t=sVxH3DOnx3L3F9rO-0',
+        bankingTheme:
+          'https://www.figma.com/file/sAdplk2uYnI2ILnDKUxycW/Blade---Banking-Dark?type=design&node-id=16868-832623&t=rK6ydo54uVejIH9p-0',
+      }}
+    >
+      <Title>Usage</Title>
+      <Sandbox editorHeight={500}>
+        {`
+        import { Collapsible, CollapsibleButton, CollapsibleBody, Text } from '@razorpay/blade/components';
+
+        function App() {
+          return (
+            <Collapsible>
+              <CollapsibleButton>Answer to life, universe and everything</CollapsibleButton>
+              <CollapsibleBody>
+                <Text>42</Text>
+              </CollapsibleBody>
+            </Collapsible>
+          )
+        }
+
+        export default App;
+        `}
+      </Sandbox>
+    </StoryPageWrapper>
+  );
+};
+
+// TODO: Change this story from internal when releasing
+const meta: Meta<AccordionProps> = {
+  title: 'Components/Accordion (Internal)',
+  component: AccordionComponent,
+  args: {},
+  argTypes: {
+    ...getStyledPropsArgTypes(),
+  },
+  parameters: {
+    docs: {
+      page: Page,
+    },
+  },
+};
+
+const AccordionTemplate: ComponentStory<typeof AccordionComponent> = ({ ...args }) => {
+  return (
+    <AccordionComponent {...args}>
+      <AccordionItem title="Title" description="description" />
+    </AccordionComponent>
+  );
+};
+
+export const WithCollapsibleButton = AccordionTemplate.bind({});
+
+export default meta;

--- a/packages/blade/src/components/Accordion/Accordion.stories.internal.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.stories.internal.tsx
@@ -8,6 +8,7 @@ import { AccordionItem } from './AccordionItem';
 import { Sandbox } from '~src/_helpers/storybook/Sandbox';
 import StoryPageWrapper from '~src/_helpers/storybook/StoryPageWrapper';
 import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
+import { MusicIcon, PauseCircleIcon, PlayIcon } from '~components/Icons';
 
 // TODO: udpate
 const Page = (): ReactElement => {
@@ -63,11 +64,46 @@ const meta: Meta<AccordionProps> = {
 const AccordionTemplate: ComponentStory<typeof AccordionComponent> = ({ ...args }) => {
   return (
     <AccordionComponent {...args}>
-      <AccordionItem title="Title" description="description" />
+      <AccordionItem
+        title="Appetite for Destruction Appetite for Destruction Appetite for Destruction Appetite for Destruction"
+        description={`Appetite for Destruction is the debut studio album by American hard rock band Guns N' Roses, released by Geffen Records on July 21, 1987. It initially received little mainstream attention, and it was not until the following year that Appetite for Destruction became a commercial success, after the band had toured and received significant airplay with the singles "Welcome to the Jungle", "Paradise City", and "Sweet Child o' Mine".`}
+      />
+      <AccordionItem
+        title="Appetite for Destruction Appetite for Destruction Appetite for Destruction Appetite for Destruction"
+        description={`Appetite for Destruction is the debut studio album by American hard rock band Guns N' Roses, released by Geffen Records on July 21, 1987. It initially received little mainstream attention, and it was not until the following year that Appetite for Destruction became a commercial success, after the band had toured and received significant airplay with the singles "Welcome to the Jungle", "Paradise City", and "Sweet Child o' Mine".`}
+      />
+      <AccordionItem
+        title="Appetite for Destruction Appetite for Destruction Appetite for Destruction Appetite for Destruction"
+        description={`Appetite for Destruction is the debut studio album by American hard rock band Guns N' Roses, released by Geffen Records on July 21, 1987. It initially received little mainstream attention, and it was not until the following year that Appetite for Destruction became a commercial success, after the band had toured and received significant airplay with the singles "Welcome to the Jungle", "Paradise City", and "Sweet Child o' Mine".`}
+      />
     </AccordionComponent>
   );
 };
 
-export const WithCollapsibleButton = AccordionTemplate.bind({});
+const AccordionWithIconsTemplate: ComponentStory<typeof AccordionComponent> = ({ ...args }) => {
+  return (
+    <AccordionComponent {...args}>
+      <AccordionItem
+        title="Appetite for Destruction Appetite for Destruction Appetite for Destruction Appetite for Destruction"
+        description={`Appetite for Destruction is the debut studio album by American hard rock band Guns N' Roses, released by Geffen Records on July 21, 1987. It initially received little mainstream attention, and it was not until the following year that Appetite for Destruction became a commercial success, after the band had toured and received significant airplay with the singles "Welcome to the Jungle", "Paradise City", and "Sweet Child o' Mine".`}
+        icon={MusicIcon}
+      />
+      <AccordionItem
+        title="Appetite for Destruction Appetite for Destruction Appetite for Destruction Appetite for Destruction"
+        description={`Appetite for Destruction is the debut studio album by American hard rock band Guns N' Roses, released by Geffen Records on July 21, 1987. It initially received little mainstream attention, and it was not until the following year that Appetite for Destruction became a commercial success, after the band had toured and received significant airplay with the singles "Welcome to the Jungle", "Paradise City", and "Sweet Child o' Mine".`}
+        icon={PlayIcon}
+      />
+      <AccordionItem
+        title="Appetite for Destruction Appetite for Destruction Appetite for Destruction Appetite for Destruction"
+        description={`Appetite for Destruction is the debut studio album by American hard rock band Guns N' Roses, released by Geffen Records on July 21, 1987. It initially received little mainstream attention, and it was not until the following year that Appetite for Destruction became a commercial success, after the band had toured and received significant airplay with the singles "Welcome to the Jungle", "Paradise City", and "Sweet Child o' Mine".`}
+        icon={PauseCircleIcon}
+      />
+    </AccordionComponent>
+  );
+};
+
+export const Default = AccordionTemplate.bind({});
+
+export const WithIcons = AccordionWithIconsTemplate.bind({});
 
 export default meta;

--- a/packages/blade/src/components/Accordion/Accordion.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.tsx
@@ -1,4 +1,5 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
+import { cloneElement, Children } from 'react';
 import { BaseBox } from '~components/Box/BaseBox';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import type { TestID } from '~src/_helpers/types';
@@ -29,7 +30,7 @@ type AccordionProps = {
   /**
    * Accepts `AccordionItem` child nodes
    */
-  children: ReactNode;
+  children: ReactElement | ReactElement[];
 } & TestID &
   StyledPropsBlade;
 
@@ -37,10 +38,16 @@ const Accordion = ({
   defaultExpandedIndex,
   expandedIndex,
   onChange,
-  showNumberPrefix,
+  showNumberPrefix = false,
   children,
 }: AccordionProps): ReactElement => {
-  return <BaseBox>{children}</BaseBox>;
+  return showNumberPrefix ? (
+    <BaseBox>
+      {Children.map(children, (child, index) => cloneElement(child, { _index: index, key: index }))}
+    </BaseBox>
+  ) : (
+    <BaseBox>{children}</BaseBox>
+  );
 };
 
 export { AccordionProps, Accordion };

--- a/packages/blade/src/components/Accordion/Accordion.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement, ReactNode } from 'react';
+import { BaseBox } from '~components/Box/BaseBox';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import type { TestID } from '~src/_helpers/types';
+
+type AccordionProps = {
+  /**
+   * Makes the passed item index expanded by default (uncontrolled)
+   */
+  defaultExpandedIndex?: number;
+
+  /**
+   * Expands the passed index (controlled)
+   */
+  expandedIndex?: number;
+
+  /**
+   * Callback for change in any item's expanded state
+   */
+  onChange?: ({ expandedIndex }: { expandedIndex: number | undefined }) => void;
+
+  /**
+   * Adds numeric index at the beginning of items
+   *
+   * @default false
+   */
+  showNumberPrefix?: boolean;
+
+  /**
+   * Accepts `AccordionItem` child nodes
+   */
+  children: ReactNode;
+} & TestID &
+  StyledPropsBlade;
+
+const Accordion = ({
+  defaultExpandedIndex,
+  expandedIndex,
+  onChange,
+  showNumberPrefix,
+  children,
+}: AccordionProps): ReactElement => {
+  return <BaseBox>{children}</BaseBox>;
+};
+
+export { AccordionProps, Accordion };

--- a/packages/blade/src/components/Accordion/AccordionButton.native.tsx
+++ b/packages/blade/src/components/Accordion/AccordionButton.native.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+import { StyledAccordionButton } from './StyledAccordionButton';
+import { Heading } from '~components/Typography';
+
+type AccordionButtonProps = {
+  children: string;
+};
+
+// TODO: implement with reanimated, pressable
+const AccordionButton = ({ children }: AccordionButtonProps): ReactElement => {
+  return (
+    <StyledAccordionButton
+      // TODO: add logic
+      isExpanded={false}
+    >
+      <Heading size="small">{children}</Heading>
+    </StyledAccordionButton>
+  );
+};
+
+export { AccordionButton, AccordionButtonProps };

--- a/packages/blade/src/components/Accordion/AccordionButton.web.tsx
+++ b/packages/blade/src/components/Accordion/AccordionButton.web.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from 'react';
+import { StyledAccordionButton } from './StyledAccordionButton';
+import { BaseBox } from '~components/Box/BaseBox';
+import { makeAccessible } from '~utils';
+import { Heading } from '~components/Typography';
+import { ChevronDownIcon } from '~components/Icons';
+
+type AccordionButtonProps = {
+  children: string;
+};
+
+const AccordionButton = ({ children }: AccordionButtonProps): ReactElement => {
+  return (
+    <BaseBox
+      // a11y guidelines suggest having a heading surround a button but heading level is hardcoded here
+      {...makeAccessible({ role: 'heading', level: 3 })}
+    >
+      <StyledAccordionButton
+        /**
+         * This is a button role rather than an actual button because markup requires following nesting:
+         * - heading (AccordionItem wrapper) -> button (trigger) -> heading (blade) for title
+         *
+         * However, a heading inside a button is invalid markup on web so we need something like a span for
+         * inner blade heading https://github.com/razorpay/blade/issues/812
+         */
+        {...makeAccessible({ role: 'button' })}
+        tabIndex={0}
+        // TODO: add logic
+        isExpanded={false}
+      >
+        <Heading size="small">{children}</Heading>
+        <ChevronDownIcon color="currentColor" size="large" />
+      </StyledAccordionButton>
+    </BaseBox>
+  );
+};
+
+export { AccordionButton, AccordionButtonProps };

--- a/packages/blade/src/components/Accordion/AccordionButton.web.tsx
+++ b/packages/blade/src/components/Accordion/AccordionButton.web.tsx
@@ -3,16 +3,39 @@ import { StyledAccordionButton } from './StyledAccordionButton';
 import { BaseBox } from '~components/Box/BaseBox';
 import { makeAccessible } from '~utils';
 import { Heading } from '~components/Typography';
+import type { IconComponent } from '~components/Icons';
 import { ChevronDownIcon } from '~components/Icons';
+import { useCollapsible } from '~components/Collapsible/CollapsibleContext';
 
 type AccordionButtonProps = {
+  index?: number;
+  icon?: IconComponent;
   children: string;
 };
 
-const AccordionButton = ({ children }: AccordionButtonProps): ReactElement => {
+const AccordionButton = ({ index, icon: Icon, children }: AccordionButtonProps): ReactElement => {
+  const { setIsExpanded } = useCollapsible();
+
+  const onClick = (): void => setIsExpanded((prev) => !prev);
+
+  const _index =
+    typeof index === 'number' ? (
+      <Heading size="small" marginRight="spacing.2">
+        {index + 1}.
+      </Heading>
+    ) : null;
+
+  const _icon = Icon && (
+    <Icon size="medium" color="currentColor" marginRight="spacing.3" marginY="spacing.2" />
+  );
+
+  if (_index && _icon) {
+    console.warn(`[Blade: Accordion]: showNumberPrefix and icon shouldn't be used together`);
+  }
+
   return (
     <BaseBox
-      // a11y guidelines suggest having a heading surround a button but heading level is hardcoded here
+      // a11y guidelines suggest having an apt heading surround a button but heading level is hardcoded here
       {...makeAccessible({ role: 'heading', level: 3 })}
     >
       <StyledAccordionButton
@@ -27,9 +50,14 @@ const AccordionButton = ({ children }: AccordionButtonProps): ReactElement => {
         tabIndex={0}
         // TODO: add logic
         isExpanded={false}
+        onClick={onClick}
       >
-        <Heading size="small">{children}</Heading>
-        <ChevronDownIcon color="currentColor" size="large" />
+        <BaseBox display="flex" flexDirection="row" alignItems="flex-start">
+          {_index}
+          {_icon}
+          <Heading size="small">{children}</Heading>
+        </BaseBox>
+        <ChevronDownIcon color="currentColor" size="large" marginLeft="spacing.4" />
       </StyledAccordionButton>
     </BaseBox>
   );

--- a/packages/blade/src/components/Accordion/AccordionContext.tsx
+++ b/packages/blade/src/components/Accordion/AccordionContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+type AccordionContextState = {
+  expandedIndex?: number;
+};
+
+const AccordionContext = createContext<AccordionContextState>({
+  expandedIndex: undefined,
+});
+
+const useAccordionContext = (): AccordionContextState => useContext(AccordionContext);
+
+export { AccordionContext, useAccordionContext, AccordionContextState };

--- a/packages/blade/src/components/Accordion/AccordionItem.tsx
+++ b/packages/blade/src/components/Accordion/AccordionItem.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement, ReactNode } from 'react';
+import { AccordionButton } from './AccordionButton';
+import { BaseBox } from '~components/Box/BaseBox';
+import type { IconComponent } from '~components/Icons';
+import type { TestID } from '~src/_helpers/types';
+
+type AccordionItemProps = {
+  /**
+   * Title text content
+   */
+  title: string;
+
+  /**
+   * Body text content
+   */
+  description?: string;
+
+  /**
+   * Renders a Blade icon as title prefix (requires `showNumberPrefix={false}`)
+   */
+  icon?: IconComponent;
+
+  /**
+   * Slot, renders any custom content
+   */
+  children?: ReactNode;
+} & TestID;
+
+const AccordionItem = ({
+  title,
+  description,
+  icon,
+  children,
+}: AccordionItemProps): ReactElement => {
+  return (
+    <BaseBox>
+      <AccordionButton>{title}</AccordionButton>
+      {description}
+    </BaseBox>
+  );
+};
+
+export { AccordionItemProps, AccordionItem };

--- a/packages/blade/src/components/Accordion/AccordionItem.tsx
+++ b/packages/blade/src/components/Accordion/AccordionItem.tsx
@@ -3,6 +3,9 @@ import { AccordionButton } from './AccordionButton';
 import { BaseBox } from '~components/Box/BaseBox';
 import type { IconComponent } from '~components/Icons';
 import type { TestID } from '~src/_helpers/types';
+import { Divider } from '~components/BaseHeaderFooter/Divider';
+import { Text } from '~components/Typography';
+import { Collapsible, CollapsibleBody } from '~components/Collapsible';
 
 type AccordionItemProps = {
   /**
@@ -24,6 +27,12 @@ type AccordionItemProps = {
    * Slot, renders any custom content
    */
   children?: ReactNode;
+
+  /**
+   * **Internal:** used for determining numbering, you don't need to pass this,
+   * instead pass `showNumberPrefix` to root `Accordion`
+   */
+  _index?: number;
 } & TestID;
 
 const AccordionItem = ({
@@ -31,12 +40,25 @@ const AccordionItem = ({
   description,
   icon,
   children,
+  _index,
 }: AccordionItemProps): ReactElement => {
+  const _description = description && <Text type="subtle">{description}</Text>;
+
   return (
-    <BaseBox>
-      <AccordionButton>{title}</AccordionButton>
-      {description}
-    </BaseBox>
+    <>
+      <Collapsible>
+        <AccordionButton index={_index} icon={icon}>
+          {title}
+        </AccordionButton>
+        <CollapsibleBody>
+          <BaseBox gap="spacing.5" marginBottom="spacing.5" marginX="spacing.5">
+            {_description}
+            {children}
+          </BaseBox>
+        </CollapsibleBody>
+      </Collapsible>
+      <Divider />
+    </>
   );
 };
 

--- a/packages/blade/src/components/Accordion/StyledAccordionButton.native.tsx
+++ b/packages/blade/src/components/Accordion/StyledAccordionButton.native.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components/native';
+
+const StyledAccordionButton = styled.Pressable((props) => {});
+
+export { StyledAccordionButton };

--- a/packages/blade/src/components/Accordion/StyledAccordionButton.web.tsx
+++ b/packages/blade/src/components/Accordion/StyledAccordionButton.web.tsx
@@ -3,6 +3,7 @@ import type { StyledAccordionButtonProps } from './types';
 import { castWebType, makeMotionTime } from '~utils';
 
 // TODO: refactor common tokens after native implementation
+// TODO: svg icon colors based on state
 const StyledAccordionButton = styled.div<StyledAccordionButtonProps>((props) => {
   const { theme, isExpanded } = props;
   return {
@@ -12,6 +13,10 @@ const StyledAccordionButton = styled.div<StyledAccordionButtonProps>((props) => 
     transitionDuration: castWebType(makeMotionTime(theme.motion.duration['2xquick'])),
     transitionTimingFunction: castWebType(theme.motion.easing.standard.effective),
     cursor: 'pointer',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
 
     '&:hover, &:focus': {
       backgroundColor: isExpanded

--- a/packages/blade/src/components/Accordion/StyledAccordionButton.web.tsx
+++ b/packages/blade/src/components/Accordion/StyledAccordionButton.web.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import type { StyledAccordionButtonProps } from './types';
+import { castWebType, makeMotionTime } from '~utils';
+
+// TODO: refactor common tokens after native implementation
+const StyledAccordionButton = styled.div<StyledAccordionButtonProps>((props) => {
+  const { theme, isExpanded } = props;
+  return {
+    backgroundColor: isExpanded ? theme.colors.brand.gray.a50.lowContrast : undefined,
+    padding: theme.spacing[5],
+    transitionProperty: 'background-color, box-shadow, border-radius',
+    transitionDuration: castWebType(makeMotionTime(theme.motion.duration['2xquick'])),
+    transitionTimingFunction: castWebType(theme.motion.easing.standard.effective),
+    cursor: 'pointer',
+
+    '&:hover, &:focus': {
+      backgroundColor: isExpanded
+        ? theme.colors.brand.gray.a100.lowContrast
+        : theme.colors.brand.gray.a50.lowContrast,
+    },
+
+    '&:focus': {
+      outline: 'none',
+      boxShadow: `0px 0px 0px 4px ${theme.colors.brand.primary[400]}`,
+      // only need border radius on the focus ring
+      borderRadius: theme.border.radius.small,
+    },
+  };
+});
+
+export { StyledAccordionButton };

--- a/packages/blade/src/components/Accordion/types.ts
+++ b/packages/blade/src/components/Accordion/types.ts
@@ -1,0 +1,5 @@
+type StyledAccordionButtonProps = {
+  isExpanded: boolean;
+};
+
+export { StyledAccordionButtonProps };

--- a/packages/blade/src/components/Collapsible/Collapsible.tsx
+++ b/packages/blade/src/components/Collapsible/Collapsible.tsx
@@ -18,28 +18,28 @@ type CollapsibleProps = {
    *
    * @default bottom
    */
-  direction: 'bottom' | 'top';
+  direction?: 'bottom' | 'top';
 
   /**
    * Expands the collapsible content by default (uncontrolled)
    *
    * @default false
    */
-  defaultIsExpanded: boolean;
+  defaultIsExpanded?: boolean;
 
   /**
    * Expands the collapsible content (controlled)
    *
    * @default undefined
    */
-  isExpanded: boolean;
+  isExpanded?: boolean;
 
   /**
    * Callback for change in collapsible's expanded state
    *
    * @default undefined
    */
-  onChange: ({ isExpanded }: { isExpanded: boolean }) => void;
+  onChange?: ({ isExpanded }: { isExpanded: boolean }) => void;
 } & TestID &
   StyledPropsBlade;
 

--- a/packages/blade/src/components/Collapsible/CollapsibleButton.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleButton.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { useCallback } from 'react';
-import { useCollapsibleContext } from './CollapsibleContext';
+import { useCollapsible } from './CollapsibleContext';
 import type { ButtonProps } from '~components/Button';
 import { Button } from '~components/Button';
 import type { IconComponent } from '~components/Icons';
@@ -27,7 +27,7 @@ const CollapsibleButton = ({
   testID,
   accessibilityLabel,
 }: CollapsibleButtonProps): ReactElement => {
-  const { setIsExpanded } = useCollapsibleContext();
+  const { setIsExpanded } = useCollapsible();
 
   const toggleIsExpanded = useCallback(() => setIsExpanded((prevIsExpanded) => !prevIsExpanded), [
     setIsExpanded,

--- a/packages/blade/src/components/Collapsible/CollapsibleContext.ts
+++ b/packages/blade/src/components/Collapsible/CollapsibleContext.ts
@@ -19,6 +19,6 @@ const CollapsibleContext = createContext<CollapsibleContextState>({
   direction: 'bottom',
 });
 
-const useCollapsibleContext = (): CollapsibleContextState => useContext(CollapsibleContext);
+const useCollapsible = (): CollapsibleContextState => useContext(CollapsibleContext);
 
-export { CollapsibleContext, useCollapsibleContext, CollapsibleContextState };
+export { CollapsibleContext, useCollapsible, CollapsibleContextState };

--- a/packages/blade/src/components/Collapsible/CollapsibleLink.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleLink.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { useCallback } from 'react';
 import styled from 'styled-components';
-import { useCollapsibleContext } from './CollapsibleContext';
+import { useCollapsible } from './CollapsibleContext';
 import type { CollapsibleProps } from './Collapsible';
 import type { IconComponent } from '~components/Icons';
 import { ChevronDownIcon } from '~components/Icons';
@@ -45,7 +45,7 @@ const StyledCollapsibleLinkIcon = styled(BaseBox)<StyledCollapsibleLinkIconProps
 
 // Not really an IconComponent, a wrapper is needed for animating the icon inside
 const CollapsibleLinkIcon: IconComponent = (props) => {
-  const { isExpanded, direction } = useCollapsibleContext();
+  const { isExpanded, direction } = useCollapsible();
   return (
     <StyledCollapsibleLinkIcon
       isExpanded={isExpanded}
@@ -65,7 +65,7 @@ const CollapsibleLink = ({
   testID,
   accessibilityLabel,
 }: CollapsibleLinkProps): ReactElement => {
-  const { setIsExpanded } = useCollapsibleContext();
+  const { setIsExpanded } = useCollapsible();
 
   const toggleIsExpanded = useCallback(() => setIsExpanded((prevIsExpanded) => !prevIsExpanded), [
     setIsExpanded,

--- a/packages/blade/src/components/Collapsible/CollapsibleLink.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleLink.tsx
@@ -8,7 +8,7 @@ import { ChevronDownIcon } from '~components/Icons';
 import type { LinkProps } from '~components/Link';
 import { Link } from '~components/Link';
 import { BaseBox } from '~components/Box/BaseBox';
-import { castWebType, makeMotionTime } from '~utils';
+import { castWebType, makeAccessible, makeMotionTime } from '~utils';
 
 type CollapsibleLinkProps = Pick<
   LinkProps,
@@ -47,7 +47,11 @@ const StyledCollapsibleLinkIcon = styled(BaseBox)<StyledCollapsibleLinkIconProps
 const CollapsibleLinkIcon: IconComponent = (props) => {
   const { isExpanded, direction } = useCollapsibleContext();
   return (
-    <StyledCollapsibleLinkIcon isExpanded={isExpanded} direction={direction}>
+    <StyledCollapsibleLinkIcon
+      isExpanded={isExpanded}
+      direction={direction}
+      {...makeAccessible({ hidden: true })}
+    >
       <ChevronDownIcon {...props} />
     </StyledCollapsibleLinkIcon>
   );

--- a/packages/blade/src/components/Collapsible/CollapsiblePanel.web.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsiblePanel.web.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode, TransitionEventHandler } from 'react';
 import { useRef } from 'react';
 import styled from 'styled-components';
-import { useCollapsibleContext } from './CollapsibleContext';
+import { useCollapsible } from './CollapsibleContext';
 import { castWebType, makeMotionTime, makeSize } from '~utils';
 import { useDidUpdate } from '~src/hooks/useDidUpdate';
 import { Box } from '~components/Box';
@@ -44,7 +44,7 @@ const StyledCollapsiblePanel = styled.div<StyledCollapsiblePanelProps>((props) =
 });
 
 const CollapsiblePanel = ({ children }: CollapsiblePanelProps): ReactElement => {
-  const { isExpanded, defaultIsExpanded, direction } = useCollapsibleContext();
+  const { isExpanded, defaultIsExpanded, direction } = useCollapsible();
   const collapsiblePanelRef = useRef<HTMLDivElement>(null);
 
   /**


### PR DESCRIPTION
- Builds up on `Collapsible` to have a basic toggle functionality for `Accordion`
- Some features missing right now like only having one toggle-able accordion item (in further PRs)

https://github.com/razorpay/blade/assets/6682655/709a5cf9-74a8-401b-b2a8-2efcd690bfed

