### PR TITLE
fix(blade): BottomSheet unable to find ActionList component

### DIFF
--- a/.changeset/lazy-bottles-learn.md
+++ b/.changeset/lazy-bottles-learn.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): BottomSheet unable to find ActionList component

--- a/packages/blade/src/components/ActionList/ActionList.tsx
+++ b/packages/blade/src/components/ActionList/ActionList.tsx
@@ -156,6 +156,7 @@ const _ActionList = ({ children, surfaceLevel = 2, testID }: ActionListProps): J
 
 const ActionList = assignWithoutSideEffects(React.memo(_ActionList), {
   displayName: componentIds.ActionList,
+  componentId: componentIds.ActionList,
 });
 
 export { ActionList, useActionListContext, ActionListProps };

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -237,18 +237,24 @@ const _BottomSheet = ({
       <DropdownContext.Provider value={dropdownProps}>
         <BottomSheetContext.Provider value={contextValue}>
           <GorhomBottomSheet
-            style={{
-              // this is reverse top elevation of highRaised elevation token
-              shadowColor: 'hsla(217,56%,17%,0.64)',
-              shadowOffset: {
-                width: 0,
-                height: -18,
-              },
-              shadowOpacity: 0.2,
-              shadowRadius: 12,
-              // this fails on andorid because its not handled on GorhomBottomSheet internally, hence tradeoff but its fine because visually this barely makes any difference its that nice design detail
-              // elevation: 40,
-            }}
+            style={
+              // only render shadow when the sheet is open,
+              // otherwise there is visible shadow leak from the bottom edge of the screen
+              isOpen
+                ? {
+                    // this is reverse top elevation of highRaised elevation token
+                    shadowColor: 'hsla(217,56%,17%,0.64)',
+                    shadowOffset: {
+                      width: 0,
+                      height: -18,
+                    },
+                    shadowOpacity: 0.2,
+                    shadowRadius: 12,
+                    // this fails on andorid because its not handled on GorhomBottomSheet internally, hence tradeoff but its fine because visually this barely makes any difference its that nice design detail
+                    // elevation: 40,
+                  }
+                : {}
+            }
             enablePanDownToClose
             enableOverDrag
             enableContentPanningGesture


### PR DESCRIPTION
Fixed react-native error "VirtualizedLists should never be nested inside plain ScrollViews"

ActionList's componentId accidentally got removed in this [commit](https://github.com/razorpay/blade/commit/fc8fef39b3eeac5d5f8ccec374a251d097475723#diff-56bfde9740ed80178b00a3439c5943a881552847e2caba74f7bc2d643962f899R159-R161), resulting in BottomSheet to not find the ActionList and satisfy this [condition](https://github.com/razorpay/blade/blob/36d8b2f563ae0ea33860d8bea214d207a3179d09/packages/blade/src/components/BottomSheet/BottomSheetBody.native.tsx#L21). 

> :( really need e2e tests to catch these issues