### PR TITLE
fix(DropdownOverlay): DropdownOverlay width

### DIFF
--- a/.changeset/fast-rings-count.md
+++ b/.changeset/fast-rings-count.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(DropdownOverlay): DropdownOverlay width in SelectInput trigger

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
@@ -129,7 +129,8 @@ const _DropdownOverlay = ({ children, testID }: DropdownOverlayProps): JSX.Eleme
     <BaseBox position="relative">
       <StyledDropdownOverlay
         width={isMenu ? undefined : width}
-        minWidth="240px"
+        // In SelectInput, Overlay should always take width of Input
+        minWidth={isMenu ? undefined : '240px'}
         // in SelectInput, we don't want to set maxWidth because it takes width according to the trigger
         maxWidth={isMenu ? '400px' : undefined}
         left={isMenu ? 'spacing.0' : undefined}

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.web.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.web.test.tsx.snap
@@ -1017,7 +1017,6 @@ exports[`<Dropdown /> with <DropdownButton /> should render menu and make items 
 .c6 {
   display: block;
   position: absolute;
-  min-width: 240px;
   max-width: 400px;
   left: 0px;
 }


### PR DESCRIPTION
In `SelectInput` trigger, DropdownOverlay should not have minWidth and it should always take width of the input

Slack Issue: https://razorpay.slack.com/archives/CMQ3RBHEU/p1686718789586659

Resolves #1299 