### PR TITLE
fix: show decimal upto 2 places when `isAfixSubtle:false`

### DIFF
--- a/.changeset/few-llamas-doubt.md
+++ b/.changeset/few-llamas-doubt.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: show decimal upto 2 places when `isAfixSubtle:false`

--- a/packages/blade/src/components/Amount/Amount.stories.tsx
+++ b/packages/blade/src/components/Amount/Amount.stories.tsx
@@ -52,7 +52,7 @@ const AmountDefaultTemplate: ComponentStory<typeof AmountComponent> = (args) => 
 
 export const Amount = AmountDefaultTemplate.bind({});
 Amount.args = {
-  value: 122345.678,
+  value: 12500.45,
 };
 Amount.storyName = 'Default';
 
@@ -69,7 +69,7 @@ const AmountTemplateWithText: ComponentStory<typeof AmountComponent> = (args) =>
 export const AmountWithText = AmountTemplateWithText.bind({});
 
 AmountWithText.args = {
-  value: 122345.678,
+  value: 12500.45,
   size: 'body-medium',
 };
 AmountWithText.storyName = 'With Text';

--- a/packages/blade/src/components/Amount/Amount.tsx
+++ b/packages/blade/src/components/Amount/Amount.tsx
@@ -160,9 +160,9 @@ export const getFlooredFixed = (value: number, decimalPlaces: number): number =>
   return Number(roundedValue.toFixed(decimalPlaces));
 };
 
-export const addCommas = (amountValue: number, currency: Currency): string => {
+export const addCommas = (amountValue: number, currency: Currency, decimalPlaces = 0): string => {
   const locale = currencyLocaleMapping[currency];
-  return amountValue.toLocaleString(locale);
+  return amountValue.toLocaleString(locale, { minimumFractionDigits: decimalPlaces });
 };
 /**
  * This function returns the humanized amount
@@ -196,7 +196,7 @@ export const formatAmountWithSuffix = ({
   switch (suffix) {
     case 'decimals': {
       const decimalNumber = getFlooredFixed(value, 2);
-      return addCommas(decimalNumber, currency);
+      return addCommas(decimalNumber, currency, 2);
     }
     case 'humanize': {
       return getHumanizedAmount(value, currency);

--- a/packages/blade/src/components/Amount/__tests__/Amount.native.test.tsx
+++ b/packages/blade/src/components/Amount/__tests__/Amount.native.test.tsx
@@ -95,7 +95,7 @@ describe('<Amount />', () => {
       '1k',
     );
     expect(formatAmountWithSuffix({ value: 1000000, currency: 'INR', suffix: 'decimals' })).toBe(
-      '10,00,000',
+      '10,00,000.00',
     );
     expect(formatAmountWithSuffix({ value: 10000000, currency: 'INR', suffix: 'none' })).toBe(
       '1,00,00,000',
@@ -104,7 +104,7 @@ describe('<Amount />', () => {
       '1K',
     );
     expect(formatAmountWithSuffix({ value: 1000000, currency: 'MYR', suffix: 'decimals' })).toBe(
-      '1,000,000',
+      '1,000,000.00',
     );
     expect(formatAmountWithSuffix({ value: 10000000, currency: 'MYR', suffix: 'none' })).toBe(
       '10,000,000',

--- a/packages/blade/src/components/Amount/__tests__/Amount.web.test.tsx
+++ b/packages/blade/src/components/Amount/__tests__/Amount.web.test.tsx
@@ -92,10 +92,11 @@ describe('<Amount />', () => {
 
   it('should check if getFlooredFixed is returning the floored value ', () => {
     expect(getFlooredFixed(1000.22, 2)).toBe(1000.22);
+    expect(getFlooredFixed(1000.0, 2)).toBe(1000.0);
   });
 
   it('should check if addCommas is returning the value with commas', () => {
-    expect(addCommas(1000.22, 'INR')).toBe('1,000.22');
+    expect(addCommas(1000.22, 'INR', 2)).toBe('1,000.22');
   });
 
   it('should check if getHumanizedAmount is returning the humanized value', () => {
@@ -111,8 +112,8 @@ describe('<Amount />', () => {
     expect(formatAmountWithSuffix({ value: 1000.22, currency: 'INR', suffix: 'humanize' })).toBe(
       '1k',
     );
-    expect(formatAmountWithSuffix({ value: 1000000, currency: 'INR', suffix: 'decimals' })).toBe(
-      '10,00,000',
+    expect(formatAmountWithSuffix({ value: 1000000.0, currency: 'INR', suffix: 'decimals' })).toBe(
+      '10,00,000.00',
     );
     expect(formatAmountWithSuffix({ value: 10000000, currency: 'INR', suffix: 'none' })).toBe(
       '1,00,00,000',
@@ -121,7 +122,7 @@ describe('<Amount />', () => {
       '1K',
     );
     expect(formatAmountWithSuffix({ value: 1000000, currency: 'MYR', suffix: 'decimals' })).toBe(
-      '1,000,000',
+      '1,000,000.00',
     );
     expect(formatAmountWithSuffix({ value: 10000000, currency: 'MYR', suffix: 'none' })).toBe(
       '10,000,000',

--- a/packages/blade/src/components/Amount/__tests__/__snapshots__/Amount.native.test.tsx.snap
+++ b/packages/blade/src/components/Amount/__tests__/__snapshots__/Amount.native.test.tsx.snap
@@ -1772,7 +1772,7 @@ exports[`<Amount /> should render information intent Amount  1`] = `
         ]
       }
     >
-      1,000
+      1,000.00
     </Text>
   </View>
 </View>

--- a/packages/blade/src/components/Amount/__tests__/__snapshots__/Amount.web.test.tsx.snap
+++ b/packages/blade/src/components/Amount/__tests__/__snapshots__/Amount.web.test.tsx.snap
@@ -1100,7 +1100,7 @@ exports[`<Amount /> should render negative intent Amount  1`] = `
       font-size="100"
       font-weight="regular"
     >
-      1,000
+      1,000.00
     </div>
   </div>
 </div>


### PR DESCRIPTION
fixes #1307 