### PR TITLE
fix(patch-package): move to dependencies

### DIFF
--- a/.changeset/thick-bags-cry.md
+++ b/.changeset/thick-bags-cry.md
@@ -1,0 +1,6 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(patch-package): move to dependencies
+- this should fix an issue with `patch-package` when trying to install latest version of blade

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -113,7 +113,8 @@
     "body-scroll-lock": "4.0.0-beta.0",
     "use-presence": "1.1.0",
     "@floating-ui/react": "0.24.2",
-    "@floating-ui/react-native": "0.10.0"
+    "@floating-ui/react-native": "0.10.0",
+    "patch-package": "7.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.16.5",
@@ -209,7 +210,6 @@
     "styled-components": "5.3.5",
     "tsconfig-paths-webpack-plugin": "3.5.2",
     "jsdom-testing-mocks": "1.9.0",
-    "patch-package": "7.0.0",
     "postinstall-postinstall": "2.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
postinstall will be run even on consumers end when they install blade, so this will be needed as a direct dependency. Followup for #1309 