### PR TITLE
fix: PR title check workflow for forked repos

### DIFF
--- a/.github/workflows/blade-pr-title-check.yml
+++ b/.github/workflows/blade-pr-title-check.yml
@@ -1,7 +1,7 @@
 name: Blade PR Title Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [open, edited, synchronize]
 
 concurrency: # cancel previously running workflows when a new workflow is re-run
@@ -10,7 +10,7 @@ concurrency: # cancel previously running workflows when a new workflow is re-run
 
 jobs:
   pr-title-check:
-    name: Check
+    name: PR Title Check
     runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
     env:
       GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
PR title check is failing on #1354 which comes from a forked repo. Trying to fix that as suggested at https://github.com/marocchino/sticky-pull-request-comment/issues/930#issuecomment-1515431005