### PR TITLE
docs(divider): updated component status

### DIFF
--- a/packages/blade/src/utils/storybook/ComponentStatusTable.tsx
+++ b/packages/blade/src/utils/storybook/ComponentStatusTable.tsx
@@ -329,6 +329,13 @@ const componentData: ComponentStatusData = [
     storybookLink: 'Components/Modal/SimpleModal',
   },
   {
+    name: 'Divider',
+    status: 'released',
+    description: 'Dividers are used to visually separate content in a list or group.',
+    releasedIn: '8.14.0',
+    storybookLink: 'Components/Divider',
+  },
+  {
     name: 'Pill',
     status: 'planned-Q2-dev',
     description: '',
@@ -372,11 +379,6 @@ const componentData: ComponentStatusData = [
     status: 'planned-Q2-dev',
     description:
       'Tabs is a component which will allow you to show multiple clickable tabs in your UI',
-  },
-  {
-    name: 'Divider',
-    status: 'planned-Q2-dev',
-    description: 'Dividers are used to visually separate content in a list or group.',
   },
   {
     name: 'Data Table',


### PR DESCRIPTION
Have updated the component status page for divider component.

<img width="1031" alt="image" src="https://github.com/razorpay/blade/assets/24494390/b40f0b27-782d-4aae-8bf8-0fd4412b59ef">
