### PR TITLE
feat(Box, Typography): expose brand colors

### DIFF
--- a/.changeset/lovely-seals-rush.md
+++ b/.changeset/lovely-seals-rush.md
@@ -1,0 +1,8 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(Box, Typography): expose brand colors
+
+- On Box, we're exposing all `brand.*` tokens on the background.
+- On Typography, we're exposing all `brand.primary.*` tokens as color prop

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -117,6 +117,8 @@ const validBoxAsValues = [
 
 type BoxAsType = typeof validBoxAsValues[number];
 
+type BrandColorString = `brand.${DotNotationColorStringToken<Theme['colors']['brand']>}`;
+
 // Visual props that are common for both Box and BaseBox
 type CommonBoxVisualProps = MakeObjectResponsive<
   {
@@ -152,6 +154,7 @@ type BaseBoxVisualProps = MakeObjectResponsive<
       | BackgroundColorString<'feedback'>
       | BackgroundColorString<'surface'>
       | BackgroundColorString<'action'>
+      | BrandColorString
       | (string & Record<never, never>);
     lineHeight: SpacingValueType;
     touchAction: CSSObject['touchAction'];
@@ -169,7 +172,7 @@ type BaseBoxVisualProps = MakeObjectResponsive<
 
 // Visual props that are specific to Box
 type BoxVisualProps = MakeObjectResponsive<{
-  backgroundColor: BackgroundColorString<'surface'>;
+  backgroundColor: BackgroundColorString<'surface'> | BrandColorString;
 }> & {
   // Intentionally keeping this outside of MakeObjectResponsive since we only want as to be string and not responsive object
   // styled-components do not support passing `as` prop as an object

--- a/packages/blade/src/components/Box/Box.stories.tsx
+++ b/packages/blade/src/components/Box/Box.stories.tsx
@@ -62,10 +62,10 @@ export const Responsive = (args: BoxProps): JSX.Element => {
     <>
       <Text>Change screen size to see flexDirection switch between row and column</Text>
       <Box {...args}>
-        <Box flex="1" backgroundColor="surface.background.level2.highContrast" padding="spacing.5">
+        <Box flex="1" backgroundColor="brand.primary.500" padding="spacing.5">
           <Text contrast="high">Box1</Text>
         </Box>
-        <Box flex="1" backgroundColor="surface.background.level3.highContrast" padding="spacing.5">
+        <Box flex="1" backgroundColor="surface.background.level2.highContrast" padding="spacing.5">
           <Text contrast="high">Box2</Text>
         </Box>
       </Box>

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -8,9 +8,12 @@ import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 
 const validateBackgroundString = (stringBackgroundColorValue: string): void => {
-  if (!stringBackgroundColorValue.startsWith('surface.background')) {
+  if (
+    !stringBackgroundColorValue.startsWith('surface.background') &&
+    !stringBackgroundColorValue.startsWith('brand.')
+  ) {
     throw new Error(
-      `[Blade - Box]: Oops! Currently you can only use \`surface.background.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
+      `[Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
     );
   }
 };

--- a/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
@@ -61,7 +61,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\`  tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
@@ -61,7 +61,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\`  tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.ssr.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.ssr.test.tsx
@@ -63,7 +63,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
@@ -71,7 +71,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -18,6 +18,8 @@ type BadgeTextColors = `badge.text.${DotNotationColorStringToken<
   Theme['colors']['badge']['text']
 >}`;
 
+type BrandPrimaryColors = `brand.primary.${keyof Theme['colors']['brand']['primary']}`;
+
 type As =
   | 'code'
   | 'h1'
@@ -35,7 +37,13 @@ type As =
   | 'div';
 export type BaseTextProps = {
   id?: string;
-  color?: ActionColors | FeedbackColors | SurfaceColors | FeedbackActionColors | BadgeTextColors;
+  color?:
+    | BrandPrimaryColors
+    | ActionColors
+    | FeedbackColors
+    | SurfaceColors
+    | FeedbackActionColors
+    | BadgeTextColors;
   fontFamily?: keyof Theme['typography']['fonts']['family'];
   fontSize?: keyof Theme['typography']['fonts']['size'];
   fontWeight?: keyof Theme['typography']['fonts']['weight'];

--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -88,19 +88,13 @@ const WithMixedColorsTemplate: ComponentStory<typeof HeadingComponent> = () => {
     <Box>
       <HeadingComponent>
         Supercharge your business with the all‑powerful{' '}
-        <HeadingComponent
-          as="span"
-          color="feedback.information.action.text.primary.default.lowContrast"
-        >
+        <HeadingComponent as="span" color="brand.primary.600">
           Payment Gateway
         </HeadingComponent>
       </HeadingComponent>
       <HeadingComponent marginTop="spacing.5">
         Start accepting{' '}
-        <HeadingComponent
-          as="span"
-          color="feedback.information.action.text.primary.default.lowContrast"
-        >
+        <HeadingComponent as="span" color="feedback.text.information.lowContrast">
           payments
         </HeadingComponent>{' '}
         at just 2% <Sup>*</Sup>

--- a/packages/blade/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.stories.tsx
@@ -74,7 +74,7 @@ const AsPropTemplate: ComponentStory<typeof TextComponent> = (args) => {
   return (
     <TextComponent {...args} as="p">
       Power your{' '}
-      <TextComponent {...args} color="feedback.text.positive.lowContrast" as="span" weight="bold">
+      <TextComponent {...args} color="brand.primary.500" as="span" weight="bold">
         finance
       </TextComponent>
       , grow your{' '}

--- a/packages/blade/src/components/Typography/Title/Title.stories.tsx
+++ b/packages/blade/src/components/Typography/Title/Title.stories.tsx
@@ -68,7 +68,7 @@ export default TitleStoryMeta;
 export const Title = TitleTemplate.bind({});
 export const WithColor = TitleTemplate.bind({});
 WithColor.args = {
-  color: 'feedback.positive.action.text.primary.default.lowContrast',
+  color: 'brand.primary.500',
 };
 
 const Sup = isReactNative() ? TitleComponent : 'sup';
@@ -77,19 +77,13 @@ const WithMixedColorsTemplate: ComponentStory<typeof TitleComponent> = () => {
     <Box>
       <TitleComponent>
         Supercharge your business with the all‑powerful{' '}
-        <TitleComponent
-          as="span"
-          color="feedback.information.action.text.primary.default.lowContrast"
-        >
+        <TitleComponent as="span" color="brand.primary.500">
           Payment Gateway
         </TitleComponent>
       </TitleComponent>
       <TitleComponent marginTop="spacing.5">
         Start accepting{' '}
-        <TitleComponent
-          as="span"
-          color="feedback.information.action.text.primary.default.lowContrast"
-        >
+        <TitleComponent as="span" color="feedback.text.information.lowContrast">
           payments
         </TitleComponent>{' '}
         at just 2% <Sup>*</Sup>


### PR DESCRIPTION
On Box, we're exposing all `brand.*` tokens on the background.

On Typography, we're exposing all `brand.primary.*` tokens as color prop