### PR TITLE
fix(List): re-export ListItemText

### DIFF
--- a/.changeset/brown-frogs-call.md
+++ b/.changeset/brown-frogs-call.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(List): re-export ListItemText

--- a/packages/blade/src/components/List/ListItemText.tsx
+++ b/packages/blade/src/components/List/ListItemText.tsx
@@ -17,4 +17,4 @@ const ListItemText = assignWithoutSideEffects(_ListItemText, {
   componentId: MetaConstants.ListItemText,
 });
 
-export { ListItemText };
+export { ListItemText, ListItemTextProps };

--- a/packages/blade/src/components/List/index.ts
+++ b/packages/blade/src/components/List/index.ts
@@ -6,3 +6,5 @@ export { ListItemLink } from './ListItemLink';
 export type { ListItemLinkProps } from './ListItemLink';
 export { ListItemCode } from './ListItemCode';
 export type { ListItemCodeProps } from './ListItemCode';
+export { ListItemText } from './ListItemText';
+export type { ListItemTextProps } from './ListItemText';


### PR DESCRIPTION
ListItemText is not exported right now for consumers https://razorpay.slack.com/archives/CMQ3RBHEU/p1689756239995169?thread_ts=1689159775.991879&cid=CMQ3RBHEU