### PR TITLE
feat: strip off logs & errors in production builds

### DIFF
--- a/.changeset/eight-wasps-smell.md
+++ b/.changeset/eight-wasps-smell.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+feat: strip off logs & errors in production builds

--- a/packages/blade/.storybook/react/main.js
+++ b/packages/blade/.storybook/react/main.js
@@ -1,4 +1,5 @@
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const { DefinePlugin } = require('webpack');
 const path = require('path');
 
 module.exports = {
@@ -53,6 +54,13 @@ module.exports = {
       ...(config.resolve.plugins || []),
       new TsconfigPathsPlugin({
         extensions: config.resolve.extensions,
+      }),
+    ];
+
+    config.plugins = [
+      ...(config.plugins || []),
+      new DefinePlugin({
+        __DEV__: true,
       }),
     ];
 

--- a/packages/blade/jest.web.config.js
+++ b/packages/blade/jest.web.config.js
@@ -24,6 +24,9 @@ const baseConfig = {
     '^\\~utils/(.*)': '<rootDir>/src/utils/$1',
     '^\\~tokens/(.*)': '<rootDir>/src/tokens/$1',
   },
+  globals: {
+    __DEV__: true,
+  },
 };
 
 module.exports = {

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -86,9 +86,9 @@
     "types:copy-declarations:native": "copyfiles -u 1 \"src/**/*.d.ts\" build/types/native",
     "build:generate-root-imports": "rollup -c && node ./scripts/generateRootImports.js",
     "build:clean-declarations": "rm -rf build/types",
-    "build:react-dev": "FRAMEWORK=REACT NODE_ENV=development rollup -c && node ./scripts/generateRootImports.js",
-    "build:react-prod": "FRAMEWORK=REACT NODE_ENV=production rollup -c && node ./scripts/generateRootImports.js",
-    "build:react-native": "FRAMEWORK=REACT_NATIVE rollup -c && node ./scripts/generateRootImports.js",
+    "build:react-dev": "FRAMEWORK=REACT NODE_ENV=development rollup -c",
+    "build:react-prod": "FRAMEWORK=REACT NODE_ENV=production rollup -c",
+    "build:react-native": "FRAMEWORK=REACT_NATIVE rollup -c",
     "build:generate-css-variables": "GENERATE_CSS_VARIABLES=true FRAMEWORK=REACT rollup -c && node ./scripts/generateCssThemeVariables.js",
     "build:clean-theme-bundle": "rm -rf build/js-bundle-for-css",
     "react-native:get-stories": "sb-rn-get-stories --config-path=./.storybook/react-native && yarn prettier --write ./.storybook/react-native/storybook.requires.js",
@@ -254,11 +254,7 @@
   "bundlemon": {
     "files": [
       {
-        "friendlyName": "Development Web Components",
-        "path": "./build/components/index.development.web.js"
-      },
-      {
-        "friendlyName": "Production Web Components",
+        "friendlyName": "Web Components",
         "path": "./build/components/index.production.web.js"
       },
       {
@@ -278,11 +274,7 @@
         "path": "./build/css/*.css"
       },
       {
-        "friendlyName": "Development Web Utils",
-        "path": "./build/utils/index.development.web.js"
-      },
-      {
-        "friendlyName": "Production Web Utils",
+        "friendlyName": "Web Utils",
         "path": "./build/utils/index.production.web.js"
       },
       {

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -39,7 +39,9 @@
       },
       "default": {
         "types": "./build/components/index.d.ts",
-        "default": "./build/components/index.web.js"
+        "development": "./build/components/index.development.web.js",
+        "production": "./build/components/index.production.web.js",
+        "default": "./build/components/index.development.web.js"
       }
     },
     "./tokens": {
@@ -49,7 +51,9 @@
       },
       "default": {
         "types": "./build/tokens/index.d.ts",
-        "default": "./build/tokens/index.web.js"
+        "development": "./build/tokens/index.development.web.js",
+        "production": "./build/tokens/index.production.web.js",
+        "default": "./build/tokens/index.development.web.js"
       }
     },
     "./utils": {
@@ -59,7 +63,9 @@
       },
       "default": {
         "types": "./build/utils/index.d.ts",
-        "default": "./build/utils/index.web.js"
+        "development": "./build/utils/index.development.web.js",
+        "production": "./build/utils/index.production.web.js",
+        "default": "./build/utils/index.development.web.js"
       }
     }
   },
@@ -80,7 +86,8 @@
     "types:copy-declarations:native": "copyfiles -u 1 \"src/**/*.d.ts\" build/types/native",
     "build:generate-root-imports": "rollup -c && node ./scripts/generateRootImports.js",
     "build:clean-declarations": "rm -rf build/types",
-    "build:react": "FRAMEWORK=REACT rollup -c && node ./scripts/generateRootImports.js",
+    "build:react-dev": "FRAMEWORK=REACT NODE_ENV=development rollup -c && node ./scripts/generateRootImports.js",
+    "build:react-prod": "FRAMEWORK=REACT NODE_ENV=production rollup -c && node ./scripts/generateRootImports.js",
     "build:react-native": "FRAMEWORK=REACT_NATIVE rollup -c && node ./scripts/generateRootImports.js",
     "build:generate-css-variables": "GENERATE_CSS_VARIABLES=true FRAMEWORK=REACT rollup -c && node ./scripts/generateCssThemeVariables.js",
     "build:clean-theme-bundle": "rm -rf build/js-bundle-for-css",
@@ -133,6 +140,7 @@
     "@rollup/plugin-babel": "5.3.1",
     "@rollup/plugin-commonjs": "21.1.0",
     "@rollup/plugin-node-resolve": "13.1.1",
+    "@rollup/plugin-replace": "5.0.2",
     "@size-limit/preset-big-lib": "8.2.4",
     "@storybook/addon-a11y": "6.3.0",
     "@storybook/addon-actions": "6.3.0",
@@ -246,8 +254,12 @@
   "bundlemon": {
     "files": [
       {
-        "friendlyName": "Web Components",
-        "path": "./build/components/index.web.js"
+        "friendlyName": "Development Web Components",
+        "path": "./build/components/index.development.web.js"
+      },
+      {
+        "friendlyName": "Production Web Components",
+        "path": "./build/components/index.production.web.js"
       },
       {
         "friendlyName": "React Native Components",
@@ -255,7 +267,7 @@
       },
       {
         "friendlyName": "Web Tokens",
-        "path": "./build/tokens/index.web.js"
+        "path": "./build/tokens/index.development.web.js"
       },
       {
         "friendlyName": "React Native Tokens",
@@ -266,8 +278,12 @@
         "path": "./build/css/*.css"
       },
       {
-        "friendlyName": "Web Utils",
-        "path": "./build/utils/index.web.js"
+        "friendlyName": "Development Web Utils",
+        "path": "./build/utils/index.development.web.js"
+      },
+      {
+        "friendlyName": "Production Web Utils",
+        "path": "./build/utils/index.production.web.js"
       },
       {
         "friendlyName": "React Native Utils",
@@ -281,14 +297,14 @@
   "size-limit": [
     {
       "name": "Import Button only",
-      "path": "./build/components/index.web.js",
+      "path": "./build/components/index.production.web.js",
       "import": "{ Button }",
       "limit": "20 kb",
       "running": false
     },
     {
       "name": "Import Text only",
-      "path": "./build/components/index.web.js",
+      "path": "./build/components/index.production.web.js",
       "import": "{ Text }",
       "limit": "15 kb",
       "running": false

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -263,7 +263,7 @@
       },
       {
         "friendlyName": "Web Tokens",
-        "path": "./build/tokens/index.development.web.js"
+        "path": "./build/tokens/index.production.web.js"
       },
       {
         "friendlyName": "React Native Tokens",

--- a/packages/blade/rollup.config.js
+++ b/packages/blade/rollup.config.js
@@ -62,7 +62,7 @@ const getWebConfig = ({ exportCategory }) => ({
   input: `${inputRootDirectory}/${exportCategory}/index.ts`,
   output: [
     {
-      file: `${outputRootDirectory}/${exportCategory}/index.${process.env.NODE_ENV}.web.js`,
+      file: `${outputRootDirectory}/${exportCategory}/index.${process.env.NODE_ENV || 'development'}.web.js`,
       format: 'esm',
       sourcemap: true,
     },

--- a/packages/blade/rollup.config.js
+++ b/packages/blade/rollup.config.js
@@ -62,7 +62,9 @@ const getWebConfig = ({ exportCategory }) => ({
   input: `${inputRootDirectory}/${exportCategory}/index.ts`,
   output: [
     {
-      file: `${outputRootDirectory}/${exportCategory}/index.${process.env.NODE_ENV || 'development'}.web.js`,
+      file: `${outputRootDirectory}/${exportCategory}/index.${
+        process.env.NODE_ENV || 'development'
+      }.web.js`,
       format: 'esm',
       sourcemap: true,
     },

--- a/packages/blade/rollup.config.js
+++ b/packages/blade/rollup.config.js
@@ -6,6 +6,7 @@ import pluginResolve from '@rollup/plugin-node-resolve';
 import pluginCommonjs from '@rollup/plugin-commonjs';
 import pluginDeclarations from 'rollup-plugin-dts';
 import pluginAlias from '@rollup/plugin-alias';
+import pluginReplace from '@rollup/plugin-replace';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import ts from 'typescript';
 
@@ -61,13 +62,17 @@ const getWebConfig = ({ exportCategory }) => ({
   input: `${inputRootDirectory}/${exportCategory}/index.ts`,
   output: [
     {
-      file: `${outputRootDirectory}/${exportCategory}/index.web.js`,
+      file: `${outputRootDirectory}/${exportCategory}/index.${process.env.NODE_ENV}.web.js`,
       format: 'esm',
       sourcemap: true,
     },
   ],
   external: (id) => id.includes('@babel/runtime'),
   plugins: [
+    pluginReplace({
+      __DEV__: process.env.NODE_ENV !== 'production',
+      preventAssignment: true,
+    }),
     pluginPeerDepsExternal(),
     pluginResolve({ extensions: webExtensions }),
     pluginCommonjs(),

--- a/packages/blade/src/components/Accordion/AccordionButton.native.tsx
+++ b/packages/blade/src/components/Accordion/AccordionButton.native.tsx
@@ -79,8 +79,10 @@ const _AccordionButton = ({ index, icon: Icon, children }: AccordionButtonProps)
       <Icon size="medium" color={iconColor} marginRight="spacing.3" marginY="spacing.2" />
     );
 
-    if (_index && _icon) {
-      throw new Error(`[Blade: Accordion]: showNumberPrefix and icon shouldn't be used together`);
+    if (__DEV__) {
+      if (_index && _icon) {
+        throw new Error(`[Blade: Accordion]: showNumberPrefix and icon shouldn't be used together`);
+      }
     }
 
     return (

--- a/packages/blade/src/components/Accordion/AccordionButton.web.tsx
+++ b/packages/blade/src/components/Accordion/AccordionButton.web.tsx
@@ -28,8 +28,10 @@ const _AccordionButton = ({ index, icon: Icon, children }: AccordionButtonProps)
     <Icon size="medium" color="currentColor" marginRight="spacing.3" marginY="spacing.2" />
   );
 
-  if (_index && _icon) {
-    throw new Error(`[Blade: Accordion]: showNumberPrefix and icon shouldn't be used together`);
+  if (__DEV__) {
+    if (_index && _icon) {
+      throw new Error(`[Blade: Accordion]: showNumberPrefix and icon shouldn't be used together`);
+    }
   }
 
   const isItemExpanded = expandedIndex === index;

--- a/packages/blade/src/components/Accordion/AccordionContext.tsx
+++ b/packages/blade/src/components/Accordion/AccordionContext.tsx
@@ -11,12 +11,14 @@ const AccordionContext = createContext<AccordionContextState | null>(null);
 
 const useAccordion = (): AccordionContextState => {
   const accordionContext = useContext(AccordionContext);
-  if (!accordionContext) {
-    throw new Error(
-      `[Blade: AccordionContext]: useAccordion should be only used within AccordionContext`,
-    );
+  if (__DEV__) {
+    if (!accordionContext) {
+      throw new Error(
+        `[Blade: AccordionContext]: useAccordion should be only used within AccordionContext`,
+      );
+    }
   }
-  return accordionContext;
+  return accordionContext!;
 };
 
 export { AccordionContext, useAccordion, AccordionContextState };

--- a/packages/blade/src/components/ActionList/ActionList.tsx
+++ b/packages/blade/src/components/ActionList/ActionList.tsx
@@ -18,10 +18,12 @@ const ActionListContext = React.createContext<ActionListContextProp>({ surfaceLe
 const useActionListContext = (): ActionListContextProp => {
   const context = React.useContext(ActionListContext);
 
-  if (!context) {
-    throw new Error(
-      '[Blade ActionList]: useActionListContext has to be called inside ActionListContext.Provider',
-    );
+  if (__DEV__) {
+    if (!context) {
+      throw new Error(
+        '[Blade ActionList]: useActionListContext has to be called inside ActionListContext.Provider',
+      );
+    }
   }
   return context;
 };

--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -348,10 +348,12 @@ const _ActionListItem = (props: ActionListItemProps): JSX.Element => {
   }, [props.leading, props.trailing]);
 
   React.useEffect(() => {
-    if (dropdownTriggerer === 'SelectInput' && props.intent === 'negative') {
-      throw new Error(
-        '[ActionListItem]: negative intent ActionListItem cannot be used inside Dropdown with SelectInput trigger',
-      );
+    if (__DEV__) {
+      if (dropdownTriggerer === 'SelectInput' && props.intent === 'negative') {
+        throw new Error(
+          '[ActionListItem]: negative intent ActionListItem cannot be used inside Dropdown with SelectInput trigger',
+        );
+      }
     }
   }, [props.intent, dropdownTriggerer]);
 

--- a/packages/blade/src/components/ActionList/actionListUtils.ts
+++ b/packages/blade/src/components/ActionList/actionListUtils.ts
@@ -158,9 +158,11 @@ const getActionListProperties = (
         return getActionListItemWithId(child, true);
       }
 
-      throw new Error(
-        `[ActionList]: Only ${actionListAllowedChildren.join(', ')} supported inside ActionList`,
-      );
+      if (__DEV__) {
+        throw new Error(
+          `[ActionList]: Only ${actionListAllowedChildren.join(', ')} supported inside ActionList`,
+        );
+      }
     }
     return child;
   });
@@ -180,25 +182,29 @@ const validateActionListItemProps = ({
   trailing: ActionListItemProps['trailing'];
 }): void => {
   React.Children.map(trailing, (child) => {
-    if (
-      !isValidAllowedChildren(child, componentIds.ActionListItemIcon) &&
-      !isValidAllowedChildren(child, componentIds.ActionListItemText)
-    ) {
-      throw new Error(
-        `[ActionListItem]: Only ${componentIds.ActionListItemIcon} and ${componentIds.ActionListItemText} are allowed in trailing prop`,
-      );
+    if (__DEV__) {
+      if (
+        !isValidAllowedChildren(child, componentIds.ActionListItemIcon) &&
+        !isValidAllowedChildren(child, componentIds.ActionListItemText)
+      ) {
+        throw new Error(
+          `[ActionListItem]: Only ${componentIds.ActionListItemIcon} and ${componentIds.ActionListItemText} are allowed in trailing prop`,
+        );
+      }
     }
   });
 
   React.Children.map(leading, (child) => {
-    if (
-      !isValidAllowedChildren(child, componentIds.ActionListItemIcon) &&
-      !isValidAllowedChildren(child, componentIds.ActionListItemText) &&
-      !isValidAllowedChildren(child, componentIds.ActionListItemAsset)
-    ) {
-      throw new Error(
-        `[ActionListItem]: Only ${componentIds.ActionListItemIcon}, ${componentIds.ActionListItemAsset}, and ${componentIds.ActionListItemText} are allowed in leading prop`,
-      );
+    if (__DEV__) {
+      if (
+        !isValidAllowedChildren(child, componentIds.ActionListItemIcon) &&
+        !isValidAllowedChildren(child, componentIds.ActionListItemText) &&
+        !isValidAllowedChildren(child, componentIds.ActionListItemAsset)
+      ) {
+        throw new Error(
+          `[ActionListItem]: Only ${componentIds.ActionListItemIcon}, ${componentIds.ActionListItemAsset}, and ${componentIds.ActionListItemText} are allowed in leading prop`,
+        );
+      }
     }
   });
 };

--- a/packages/blade/src/components/ActionList/actionListUtils.ts
+++ b/packages/blade/src/components/ActionList/actionListUtils.ts
@@ -181,8 +181,8 @@ const validateActionListItemProps = ({
   leading: ActionListItemProps['leading'];
   trailing: ActionListItemProps['trailing'];
 }): void => {
-  React.Children.map(trailing, (child) => {
-    if (__DEV__) {
+  if (__DEV__) {
+    React.Children.map(trailing, (child) => {
       if (
         !isValidAllowedChildren(child, componentIds.ActionListItemIcon) &&
         !isValidAllowedChildren(child, componentIds.ActionListItemText)
@@ -191,11 +191,9 @@ const validateActionListItemProps = ({
           `[ActionListItem]: Only ${componentIds.ActionListItemIcon} and ${componentIds.ActionListItemText} are allowed in trailing prop`,
         );
       }
-    }
-  });
+    });
 
-  React.Children.map(leading, (child) => {
-    if (__DEV__) {
+    React.Children.map(leading, (child) => {
       if (
         !isValidAllowedChildren(child, componentIds.ActionListItemIcon) &&
         !isValidAllowedChildren(child, componentIds.ActionListItemText) &&
@@ -205,8 +203,8 @@ const validateActionListItemProps = ({
           `[ActionListItem]: Only ${componentIds.ActionListItemIcon}, ${componentIds.ActionListItemAsset}, and ${componentIds.ActionListItemText} are allowed in leading prop`,
         );
       }
-    }
-  });
+    });
+  }
 };
 
 const getNormalTextColor = (

--- a/packages/blade/src/components/Alert/Alert.tsx
+++ b/packages/blade/src/components/Alert/Alert.tsx
@@ -135,10 +135,12 @@ const Alert = ({
   testID,
   ...styledProps
 }: AlertProps): ReactElement | null => {
-  if (!actions?.primary && actions?.secondary) {
-    throw new Error(
-      '[Blade: Alert]: SecondaryAction is allowed only when PrimaryAction is defined.',
-    );
+  if (__DEV__) {
+    if (!actions?.primary && actions?.secondary) {
+      throw new Error(
+        '[Blade: Alert]: SecondaryAction is allowed only when PrimaryAction is defined.',
+      );
+    }
   }
   const { theme } = useTheme();
   const { matchedDeviceType } = useBreakpoint({ breakpoints: theme.breakpoints });

--- a/packages/blade/src/components/Amount/Amount.tsx
+++ b/packages/blade/src/components/Amount/Amount.tsx
@@ -230,12 +230,14 @@ const _Amount = ({
   currency = 'INR',
   ...styledProps
 }: AmountProps): ReactElement => {
-  if (typeof value !== 'number') {
-    throw new Error('[Blade: Amount]: `value` prop must be of type `number` for Amount.');
-  }
-  // @ts-expect-error neutral intent should throw error
-  if (intent === 'neutral') {
-    throw new Error('[Blade Amount]: `neutral` intent is not supported.');
+  if (__DEV__) {
+    if (typeof value !== 'number') {
+      throw new Error('[Blade: Amount]: `value` prop must be of type `number` for Amount.');
+    }
+    // @ts-expect-error neutral intent should throw error
+    if (intent === 'neutral') {
+      throw new Error('[Blade Amount]: `neutral` intent is not supported.');
+    }
   }
 
   const currencyPrefix = currencyPrefixMapping[currency][prefix];

--- a/packages/blade/src/components/Badge/Badge.tsx
+++ b/packages/blade/src/components/Badge/Badge.tsx
@@ -100,8 +100,10 @@ const _Badge = ({
   ...styledProps
 }: BadgeProps): ReactElement => {
   const childrenString = getStringFromReactText(children);
-  if (!childrenString?.trim()) {
-    throw new Error('[Blade: Badge]: Text as children is required for Badge.');
+  if (__DEV__) {
+    if (!childrenString?.trim()) {
+      throw new Error('[Blade: Badge]: Text as children is required for Badge.');
+    }
   }
   const { backgroundColor, iconColor, textColor } = getColorProps({
     variant,

--- a/packages/blade/src/components/BaseHeaderFooter/BaseHeader.tsx
+++ b/packages/blade/src/components/BaseHeaderFooter/BaseHeader.tsx
@@ -104,12 +104,14 @@ const useTrailingRestriction = (trailing: React.ReactNode): React.ReactNode => {
       const trailingComponentType = getComponentId(trailing) as TrailingComponents;
       const restrictedProps = propRestrictionMap[trailingComponentType];
       const allowedComponents = Object.keys(propRestrictionMap);
-      if (!restrictedProps) {
-        throw new Error(
-          `[Blade Header]: Only one of \`${allowedComponents.join(
-            ', ',
-          )}\` component is accepted as trailing`,
-        );
+      if (__DEV__) {
+        if (!restrictedProps) {
+          throw new Error(
+            `[Blade Header]: Only one of \`${allowedComponents.join(
+              ', ',
+            )}\` component is accepted as trailing`,
+          );
+        }
       }
 
       const restrictedPropKeys = Object.keys(propRestrictionMap[trailingComponentType]);

--- a/packages/blade/src/components/BladeProvider/useBladeProvider.ts
+++ b/packages/blade/src/components/BladeProvider/useBladeProvider.ts
@@ -27,16 +27,18 @@ const useBladeProvider = ({
   themeTokens: ThemeTokens;
   initialColorScheme?: ColorSchemeNamesInput;
 }): { theme: Theme; themeContextValue: ThemeContextValue } => {
-  if (!themeTokens) {
-    throw new Error(
-      `[BladeProvider]: Expected valid themeTokens of type ThemeTokens to be passed but found ${typeof themeTokens}`,
-    );
-  }
+  if (__DEV__) {
+    if (!themeTokens) {
+      throw new Error(
+        `[BladeProvider]: Expected valid themeTokens of type ThemeTokens to be passed but found ${typeof themeTokens}`,
+      );
+    }
 
-  if (initialColorScheme && !colorSchemeNamesInput.includes(initialColorScheme)) {
-    throw new Error(
-      `[BladeProvider]: Expected color scheme to be one of [${colorSchemeNamesInput.toString()}] but received ${initialColorScheme}`,
-    );
+    if (initialColorScheme && !colorSchemeNamesInput.includes(initialColorScheme)) {
+      throw new Error(
+        `[BladeProvider]: Expected color scheme to be one of [${colorSchemeNamesInput.toString()}] but received ${initialColorScheme}`,
+      );
+    }
   }
 
   const { colorScheme, setColorScheme } = useColorScheme(initialColorScheme);

--- a/packages/blade/src/components/BladeProvider/useTheme.ts
+++ b/packages/blade/src/components/BladeProvider/useTheme.ts
@@ -18,11 +18,15 @@ export const ThemeContext = createContext<ThemeContext>({
 
 const useTheme = (): ThemeContext => {
   const themeContext = useContext<ThemeContext>(ThemeContext);
-  if (!themeContext.theme) {
-    throw new Error(`[@razorpay/blade:BladeProvider]: BladeProvider is missing theme`);
-  }
-  if (themeContext === undefined) {
-    throw new Error(`[@razorpay/blade:BladeProvider]: useTheme must be used within BladeProvider`);
+  if (__DEV__) {
+    if (!themeContext.theme) {
+      throw new Error(`[@razorpay/blade:BladeProvider]: BladeProvider is missing theme`);
+    }
+    if (themeContext === undefined) {
+      throw new Error(
+        `[@razorpay/blade:BladeProvider]: useTheme must be used within BladeProvider`,
+      );
+    }
   }
   return themeContext;
 };

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -8,28 +8,32 @@ import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 
 const validateBackgroundString = (stringBackgroundColorValue: string): void => {
-  if (
-    !stringBackgroundColorValue.startsWith('surface.background') &&
-    !stringBackgroundColorValue.startsWith('brand.')
-  ) {
-    throw new Error(
-      `[Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
-    );
+  if (__DEV__) {
+    if (
+      !stringBackgroundColorValue.startsWith('surface.background') &&
+      !stringBackgroundColorValue.startsWith('brand.')
+    ) {
+      throw new Error(
+        `[Blade - Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
+      );
+    }
   }
 };
 
 const validateBackgroundProp = (
   responsiveBackgroundColor: MakeValueResponsive<string | undefined>,
 ): void => {
-  if (responsiveBackgroundColor) {
-    if (typeof responsiveBackgroundColor === 'string') {
-      validateBackgroundString(responsiveBackgroundColor);
-      return;
-    }
+  if (__DEV__) {
+    if (responsiveBackgroundColor) {
+      if (typeof responsiveBackgroundColor === 'string') {
+        validateBackgroundString(responsiveBackgroundColor);
+        return;
+      }
 
-    Object.values(responsiveBackgroundColor).forEach((backgroundColor) => {
-      validateBackgroundString(backgroundColor);
-    });
+      Object.values(responsiveBackgroundColor).forEach((backgroundColor) => {
+        validateBackgroundString(backgroundColor);
+      });
+    }
   }
 };
 
@@ -186,21 +190,25 @@ const makeBoxProps = (props: BoxProps): KeysRequired<Omit<BoxProps, 'testID' | '
  */
 const _Box: React.ForwardRefRenderFunction<BoxRefType, BoxProps> = (props, ref) => {
   React.useEffect(() => {
-    validateBackgroundProp(props.backgroundColor);
+    if (__DEV__) {
+      validateBackgroundProp(props.backgroundColor);
+    }
   }, [props.backgroundColor]);
 
   React.useEffect(() => {
-    if (props.as) {
-      if (isReactNative()) {
-        throw new Error('[Blade - Box]: `as` prop is not supported on React Native');
-      }
+    if (__DEV__) {
+      if (props.as) {
+        if (isReactNative()) {
+          throw new Error('[Blade - Box]: `as` prop is not supported on React Native');
+        }
 
-      if (!validBoxAsValues.includes(props.as)) {
-        throw new Error(
-          `[Blade - Box]: Invalid \`as\` prop value - ${props.as}. Only ${validBoxAsValues.join(
-            ', ',
-          )} are valid values`,
-        );
+        if (!validBoxAsValues.includes(props.as)) {
+          throw new Error(
+            `[Blade - Box]: Invalid \`as\` prop value - ${props.as}. Only ${validBoxAsValues.join(
+              ', ',
+            )} are valid values`,
+          );
+        }
       }
     }
   }, [props.as]);

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -333,10 +333,13 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
   // Button cannot be disabled when its rendered as Link
   const disabled = isLoading || (isDisabled && !isLink);
   const { theme } = useTheme();
-  if (!Icon && !childrenString?.trim()) {
-    throw new Error(
-      `[Blade: BaseButton]: At least one of icon or text is required to render a button.`,
-    );
+
+  if (__DEV__) {
+    if (!Icon && !childrenString?.trim()) {
+      throw new Error(
+        `[Blade: BaseButton]: At least one of icon or text is required to render a button.`,
+      );
+    }
   }
 
   const prevLoading = usePrevious(isLoading);

--- a/packages/blade/src/components/Card/CardContext.tsx
+++ b/packages/blade/src/components/Card/CardContext.tsx
@@ -6,8 +6,10 @@ const CardContext = React.createContext<CardContextType>(null);
 
 const useVerifyInsideCard = (componentName: string): CardContextType => {
   const context = React.useContext(CardContext);
-  if (!context) {
-    throw new Error(`[Blade Card]: ${componentName} cannot be used outside of Card component`);
+  if (__DEV__) {
+    if (!context) {
+      throw new Error(`[Blade Card]: ${componentName} cannot be used outside of Card component`);
+    }
   }
   return true;
 };
@@ -22,12 +24,14 @@ const useVerifyAllowedComponents = (
 ): void => {
   React.Children.forEach(children, (child) => {
     const isValidChild = child && allowedComponents.includes(getComponentId(child)!);
-    if (!isValidChild) {
-      throw new Error(
-        `[Blade Card]: Only one of \`${allowedComponents.join(
-          ', ',
-        )}\` component is accepted as ${componentName} children`,
-      );
+    if (__DEV__) {
+      if (!isValidChild) {
+        throw new Error(
+          `[Blade Card]: Only one of \`${allowedComponents.join(
+            ', ',
+          )}\` component is accepted as ${componentName} children`,
+        );
+      }
     }
   });
 };

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import React, { ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import React from 'react';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
 import { useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import React from 'react';
+import React, { ReactElement } from 'react';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
 import { useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
@@ -41,8 +41,10 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
   ]);
 
   const footerChildrensArray = React.Children.toArray(children);
-  if (!React.isValidElement(footerChildrensArray[0])) {
-    throw new Error(`Invalid React Element ${footerChildrensArray}`);
+  if (__DEV__) {
+    if (!React.isValidElement(footerChildrensArray[0])) {
+      throw new Error(`Invalid React Element ${footerChildrensArray}`);
+    }
   }
 
   // the reason why we are checking for actions here is, because we want the footerTrailing
@@ -50,7 +52,7 @@ const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement 
   // if we don't check for action here, and if we do not have footerTrailing and only footerLeading
   // then the content of footerLeading will be justified to the end.
   const baseBoxJustifyContent =
-    footerChildrensArray.length === 2 || !footerChildrensArray[0]?.props?.actions
+    footerChildrensArray.length === 2 || !(footerChildrensArray[0] as ReactElement)?.props?.actions
       ? 'space-between'
       : 'flex-end';
 

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -141,16 +141,18 @@ const _CardHeaderLeading = ({
 }: CardHeaderLeadingProps): React.ReactElement => {
   useVerifyInsideCard('CardHeaderLeading');
 
-  if (prefix && !isValidAllowedChildren(prefix, ComponentIds.CardHeaderIcon)) {
-    throw new Error(
-      `[Blade CardHeaderLeading]: Only \`${ComponentIds.CardHeaderIcon}\` component is accepted in prefix`,
-    );
-  }
+  if (__DEV__) {
+    if (prefix && !isValidAllowedChildren(prefix, ComponentIds.CardHeaderIcon)) {
+      throw new Error(
+        `[Blade CardHeaderLeading]: Only \`${ComponentIds.CardHeaderIcon}\` component is accepted in prefix`,
+      );
+    }
 
-  if (suffix && !isValidAllowedChildren(suffix, ComponentIds.CardHeaderCounter)) {
-    throw new Error(
-      `[Blade CardHeaderLeading]: Only \`${ComponentIds.CardHeaderCounter}\` component is accepted in prefix`,
-    );
+    if (suffix && !isValidAllowedChildren(suffix, ComponentIds.CardHeaderCounter)) {
+      throw new Error(
+        `[Blade CardHeaderLeading]: Only \`${ComponentIds.CardHeaderCounter}\` component is accepted in prefix`,
+      );
+    }
   }
 
   return (
@@ -197,12 +199,14 @@ const headerTrailingAllowedComponents = [
 const _CardHeaderTrailing = ({ visual }: CardHeaderTrailingProps): React.ReactElement => {
   useVerifyInsideCard('CardHeaderTrailing');
 
-  if (visual && !headerTrailingAllowedComponents.includes(getComponentId(visual)!)) {
-    throw new Error(
-      `[Blade CardHeaderTrailing]: Only one of \`${headerTrailingAllowedComponents.join(
-        ', ',
-      )}\` component is accepted in visual`,
-    );
+  if (__DEV__) {
+    if (visual && !headerTrailingAllowedComponents.includes(getComponentId(visual)!)) {
+      throw new Error(
+        `[Blade CardHeaderTrailing]: Only one of \`${headerTrailingAllowedComponents.join(
+          ', ',
+        )}\` component is accepted in visual`,
+      );
+    }
   }
 
   return <BaseBox alignSelf="center">{visual}</BaseBox>;

--- a/packages/blade/src/components/Checkbox/Checkbox.tsx
+++ b/packages/blade/src/components/Checkbox/Checkbox.tsx
@@ -139,35 +139,38 @@ const _Checkbox: React.ForwardRefRenderFunction<BladeElementRef, CheckboxProps> 
   const hasDefaultChecked = !isUndefined(defaultChecked);
   const hasIsChecked = !isUndefined(isChecked);
   const hasOnChange = !isUndefined(onChange);
-  if (
-    (hasValidationState || hasName || hasDefaultChecked || hasIsChecked || hasOnChange) &&
-    !isEmpty(groupProps)
-  ) {
-    const props = [
-      hasValidationState ? 'validationState' : undefined,
-      hasName ? 'name' : undefined,
-      hasDefaultChecked ? 'defaultChecked' : undefined,
-      hasIsChecked ? 'isChecked' : undefined,
-      hasOnChange ? 'onChange' : undefined,
-    ]
-      .filter(Boolean)
-      .join(',');
 
-    throw new Error(
-      `[Blade Checkbox]: Cannot set \`${props}\` on <Checkbox /> when it's inside <CheckboxGroup />, Please set it on the <CheckboxGroup /> itself`,
-    );
-  }
+  if (__DEV__) {
+    if (
+      (hasValidationState || hasName || hasDefaultChecked || hasIsChecked || hasOnChange) &&
+      !isEmpty(groupProps)
+    ) {
+      const props = [
+        hasValidationState ? 'validationState' : undefined,
+        hasName ? 'name' : undefined,
+        hasDefaultChecked ? 'defaultChecked' : undefined,
+        hasIsChecked ? 'isChecked' : undefined,
+        hasOnChange ? 'onChange' : undefined,
+      ]
+        .filter(Boolean)
+        .join(',');
 
-  // mandate value prop when using inside group
-  if (!value && !isEmpty(groupProps)) {
-    throw new Error(
-      `[Blade Checkbox]: <CheckboxGroup /> requires that you pass unique "value" prop to each <Checkbox />
+      throw new Error(
+        `[Blade Checkbox]: Cannot set \`${props}\` on <Checkbox /> when it's inside <CheckboxGroup />, Please set it on the <CheckboxGroup /> itself`,
+      );
+    }
+
+    // mandate value prop when using inside group
+    if (!value && !isEmpty(groupProps)) {
+      throw new Error(
+        `[Blade Checkbox]: <CheckboxGroup /> requires that you pass unique "value" prop to each <Checkbox />
       <CheckboxGroup>
         <Checkbox value="apple">Apple</Checkbox>
         <Checkbox value="mango">Mango</Checkbox>
       </CheckboxGroup>
       `,
-    );
+      );
+    }
   }
 
   const _validationState = validationState ?? groupProps?.validationState;

--- a/packages/blade/src/components/Checkbox/useCheckbox.ts
+++ b/packages/blade/src/components/Checkbox/useCheckbox.ts
@@ -52,10 +52,12 @@ const useCheckbox = ({
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const isReactNative = getPlatformType() === 'react-native';
-  if (isChecked && defaultChecked) {
-    throw new Error(
-      `[Blade useCheckbox] Do not provide both 'isChecked' and 'defaultChecked' to useCheckbox. Consider if you want this component to be controlled or uncontrolled.`,
-    );
+  if (__DEV__) {
+    if (isChecked && defaultChecked) {
+      throw new Error(
+        `[Blade useCheckbox] Do not provide both 'isChecked' and 'defaultChecked' to useCheckbox. Consider if you want this component to be controlled or uncontrolled.`,
+      );
+    }
   }
 
   const [checkboxState, setCheckboxStateChange] = useControllableState({

--- a/packages/blade/src/components/Collapsible/Collapsible.tsx
+++ b/packages/blade/src/components/Collapsible/Collapsible.tsx
@@ -103,20 +103,22 @@ const Collapsible = ({
     [isBodyExpanded, direction, handleExpandChange, isExpanded, collapsibleBodyId],
   );
 
-  Children.forEach(children, (child) => {
-    if (
-      !(
-        isValidAllowedChildren(child, MetaConstants.CollapsibleBody) ||
-        isValidAllowedChildren(child, MetaConstants.CollapsibleButton) ||
-        isValidAllowedChildren(child, MetaConstants.CollapsibleLink) ||
-        isValidAllowedChildren(child, MetaConstants.AccordionButton)
-      )
-    ) {
-      throw new Error(
-        `[Blade: Collapsible]: only the following are supported as valid children: CollapsibleBody, CollapsibleButton, CollapsibleLink`,
-      );
-    }
-  });
+  if (__DEV__) {
+    Children.forEach(children, (child) => {
+      if (
+        !(
+          isValidAllowedChildren(child, MetaConstants.CollapsibleBody) ||
+          isValidAllowedChildren(child, MetaConstants.CollapsibleButton) ||
+          isValidAllowedChildren(child, MetaConstants.CollapsibleLink) ||
+          isValidAllowedChildren(child, MetaConstants.AccordionButton)
+        )
+      ) {
+        throw new Error(
+          `[Blade: Collapsible]: only the following are supported as valid children: CollapsibleBody, CollapsibleButton, CollapsibleLink`,
+        );
+      }
+    });
+  }
 
   return (
     <CollapsibleContext.Provider value={contextValue}>

--- a/packages/blade/src/components/Collapsible/CollapsibleContext.ts
+++ b/packages/blade/src/components/Collapsible/CollapsibleContext.ts
@@ -13,12 +13,14 @@ const CollapsibleContext = createContext<CollapsibleContextState | null>(null);
 
 const useCollapsible = (): CollapsibleContextState => {
   const collapsibleContext = useContext(CollapsibleContext);
-  if (!collapsibleContext) {
-    throw new Error(
-      `[Blade: CollapsibleContext]: You're trying to use Collapsible sub-components without Collapsible. useCollapsible should only be used within CollapsibleContext`,
-    );
+  if (__DEV__) {
+    if (!collapsibleContext) {
+      throw new Error(
+        `[Blade: CollapsibleContext]: You're trying to use Collapsible sub-components without Collapsible. useCollapsible should only be used within CollapsibleContext`,
+      );
+    }
   }
-  return collapsibleContext;
+  return collapsibleContext!;
 };
 
 export { CollapsibleContext, useCollapsible, CollapsibleContextState };

--- a/packages/blade/src/components/Dropdown/Dropdown.tsx
+++ b/packages/blade/src/components/Dropdown/Dropdown.tsx
@@ -99,12 +99,14 @@ const _Dropdown = ({
 
   React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
-      if (!validDropdownChildren.includes(getComponentId(child) ?? '')) {
-        throw new Error(
-          `[Dropdown]: Dropdown can only have one of following elements as children - \n\n ${validDropdownChildren.join(
-            ', ',
-          )} \n\n Check out: https://blade.razorpay.com/?path=/story/components-dropdown`,
-        );
+      if (__DEV__) {
+        if (!validDropdownChildren.includes(getComponentId(child) ?? '')) {
+          throw new Error(
+            `[Dropdown]: Dropdown can only have one of following elements as children - \n\n ${validDropdownChildren.join(
+              ', ',
+            )} \n\n Check out: https://blade.razorpay.com/?path=/story/components-dropdown`,
+          );
+        }
       }
 
       if (isValidAllowedChildren(child, componentIds.triggers.SelectInput)) {

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -320,10 +320,12 @@ const useInput = ({
   handleOnKeyDown: FormInputHandleOnKeyDownEvent;
   inputValue?: string;
 } => {
-  if (value && defaultValue) {
-    throw new Error(
-      `[Blade: Input]: Either 'value' or 'defaultValue' shall be passed. This decides if the input field is controlled or uncontrolled`,
-    );
+  if (__DEV__) {
+    if (value && defaultValue) {
+      throw new Error(
+        `[Blade: Input]: Either 'value' or 'defaultValue' shall be passed. This decides if the input field is controlled or uncontrolled`,
+      );
+    }
   }
 
   const [inputValue, setInputValue] = React.useState(defaultValue ?? value);
@@ -628,15 +630,17 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
 
     const willRenderHintText = Boolean(helpText) || Boolean(successText) || Boolean(errorText);
 
-    if (
-      autoCompleteSuggestionType &&
-      !autoCompleteSuggestionTypeValues.includes(autoCompleteSuggestionType)
-    ) {
-      throw new Error(
-        `[Blade: Input]: Expected autoCompleteSuggestionType to be one of ${autoCompleteSuggestionTypeValues.join(
-          ', ',
-        )} but received ${autoCompleteSuggestionType}`,
-      );
+    if (__DEV__) {
+      if (
+        autoCompleteSuggestionType &&
+        !autoCompleteSuggestionTypeValues.includes(autoCompleteSuggestionType)
+      ) {
+        throw new Error(
+          `[Blade: Input]: Expected autoCompleteSuggestionType to be one of ${autoCompleteSuggestionTypeValues.join(
+            ', ',
+          )} but received ${autoCompleteSuggestionType}`,
+        );
+      }
     }
 
     const isTextArea = as === 'textarea';

--- a/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
+++ b/packages/blade/src/components/Link/BaseLink/BaseLink.tsx
@@ -294,10 +294,12 @@ const _BaseLink: React.ForwardRefRenderFunction<BladeElementRef, BaseLinkProps> 
   const childrenString = getStringFromReactText(children);
   const { currentInteraction, setCurrentInteraction, ...syntheticEvents } = useInteraction();
   const { theme } = useTheme();
-  if (!Icon && !childrenString?.trim()) {
-    throw new Error(
-      `[Blade: BaseLink]: At least one of icon or text is required to render a link.`,
-    );
+  if (__DEV__) {
+    if (!Icon && !childrenString?.trim()) {
+      throw new Error(
+        `[Blade: BaseLink]: At least one of icon or text is required to render a link.`,
+      );
+    }
   }
   const {
     as,

--- a/packages/blade/src/components/List/List.tsx
+++ b/packages/blade/src/components/List/List.tsx
@@ -103,9 +103,11 @@ const _List = ({
   const childListItems = childrenArray.filter((child) => {
     if (isValidAllowedChildren(child, MetaConstants.ListItem)) {
       return child;
-    } else {
+    }
+    if (__DEV__) {
       throw new Error('[Blade List]: You can only pass a ListItem as a child to List.');
     }
+    return null;
   });
 
   return (

--- a/packages/blade/src/components/List/ListItem.tsx
+++ b/packages/blade/src/components/List/ListItem.tsx
@@ -98,8 +98,10 @@ const _ListItem = ({
   const { theme, platform } = useTheme();
   const ItemIcon = Icon ?? ListContextIcon;
 
-  if (level && level > 3) {
-    throw new Error('[Blade List]: List Nesting is allowed only upto 3 levels.');
+  if (__DEV__) {
+    if (level && level > 3) {
+      throw new Error('[Blade List]: List Nesting is allowed only upto 3 levels.');
+    }
   }
 
   const childrenArray = React.Children.toArray(children);
@@ -115,11 +117,12 @@ const _ListItem = ({
       isValidAllowedChildren(child, MetaConstants.ListItemCode)
     ) {
       return child;
-    } else {
+    } else if (__DEV__) {
       throw new Error(
         '[Blade List]: You can only pass a List, ListItemLink, ListItemCode, ListItemText or a string as a child to ListItem.',
       );
     }
+    return null;
   });
   // Get child that is a List component
   const childList = childrenArray.filter((child) =>

--- a/packages/blade/src/components/Modal/Modal.web.tsx
+++ b/packages/blade/src/components/Modal/Modal.web.tsx
@@ -147,11 +147,12 @@ const Modal = ({
       isValidAllowedChildren(child, MetaConstants.ModalFooter)
     ) {
       return child;
-    } else {
+    } else if (__DEV__) {
       throw new Error(
         '[Blade Modal] Modal only accepts ModalHeader, ModalBody and ModalFooter as children',
       );
     }
+    return null;
   });
 
   return (

--- a/packages/blade/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/blade/src/components/ProgressBar/ProgressBar.tsx
@@ -120,10 +120,12 @@ const ProgressBar = ({
   const { theme } = useTheme();
   const id = useId(variant);
 
-  if (variant === 'meter' && isIndeterminate) {
-    throw new Error(
-      `[Blade: ProgressBar]: Cannot set 'isIndeterminate' when 'variant' is 'meter'.`,
-    );
+  if (__DEV__) {
+    if (variant === 'meter' && isIndeterminate) {
+      throw new Error(
+        `[Blade: ProgressBar]: Cannot set 'isIndeterminate' when 'variant' is 'meter'.`,
+      );
+    }
   }
 
   const unfilledBackgroundColor = theme.colors.brand.gray.a100[`${contrast}Contrast`];

--- a/packages/blade/src/components/Radio/Radio.tsx
+++ b/packages/blade/src/components/Radio/Radio.tsx
@@ -55,8 +55,10 @@ const _Radio: React.ForwardRefRenderFunction<BladeElementRef, RadioProps> = (
   const groupProps = useRadioGroupContext();
   const isInsideGroup = !isEmpty(groupProps);
 
-  if (!isInsideGroup) {
-    throw new Error('[Blade Radio]: Cannot use <Radio /> outside of <RadioGroup />');
+  if (__DEV__) {
+    if (!isInsideGroup) {
+      throw new Error('[Blade Radio]: Cannot use <Radio /> outside of <RadioGroup />');
+    }
   }
 
   const isChecked = groupProps?.state?.isChecked(value);

--- a/packages/blade/src/components/Radio/useRadio.ts
+++ b/packages/blade/src/components/Radio/useRadio.ts
@@ -74,10 +74,12 @@ const useRadio = ({
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const isReactNative = getPlatformType() === 'react-native';
-  if (isChecked && defaultChecked) {
-    throw new Error(
-      `[Blade: Radio]: Do not provide both 'isChecked' and 'defaultChecked' to useRadio. Consider if you want this component to be controlled or uncontrolled.`,
-    );
+  if (__DEV__) {
+    if (isChecked && defaultChecked) {
+      throw new Error(
+        `[Blade: Radio]: Do not provide both 'isChecked' and 'defaultChecked' to useRadio. Consider if you want this component to be controlled or uncontrolled.`,
+      );
+    }
   }
 
   const [radioState, setRadioState] = useControllableState({

--- a/packages/blade/src/components/SkipNav/SkipNav.native.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.native.tsx
@@ -5,16 +5,12 @@ type SkipNavLinkProps = {
   children?: StringChildrenType;
 };
 
-const SkipNavLink = (_props: SkipNavLinkProps): void | never => {
-  if (__DEV__) {
-    throw new Error('[Blade: SkipNav]: SkipNavLink is not available on React Native');
-  }
+const SkipNavLink = (_props: SkipNavLinkProps): never => {
+  throw new Error('[Blade: SkipNav]: SkipNavLink is not available on React Native');
 };
 
-const SkipNavContent = (_props: SkipNavLinkProps): void | never => {
-  if (__DEV__) {
-    throw new Error('[Blade: SkipNav]: SkipNavContent is not available on React Native');
-  }
+const SkipNavContent = (_props: SkipNavLinkProps): never => {
+  throw new Error('[Blade: SkipNav]: SkipNavContent is not available on React Native');
 };
 
 export { SkipNavLink, SkipNavContent };

--- a/packages/blade/src/components/SkipNav/SkipNav.native.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.native.tsx
@@ -5,12 +5,16 @@ type SkipNavLinkProps = {
   children?: StringChildrenType;
 };
 
-const SkipNavLink = (_props: SkipNavLinkProps): never => {
-  throw new Error('[Blade: SkipNav]: SkipNavLink is not available on React Native');
+const SkipNavLink = (_props: SkipNavLinkProps): void | never => {
+  if (__DEV__) {
+    throw new Error('[Blade: SkipNav]: SkipNavLink is not available on React Native');
+  }
 };
 
-const SkipNavContent = (_props: SkipNavLinkProps): never => {
-  throw new Error('[Blade: SkipNav]: SkipNavContent is not available on React Native');
+const SkipNavContent = (_props: SkipNavLinkProps): void | never => {
+  if (__DEV__) {
+    throw new Error('[Blade: SkipNav]: SkipNavContent is not available on React Native');
+  }
 };
 
 export { SkipNavLink, SkipNavContent };

--- a/packages/blade/src/components/Tooltip/TooltipContext.ts
+++ b/packages/blade/src/components/Tooltip/TooltipContext.ts
@@ -5,8 +5,11 @@ const TooltipContext = React.createContext<TooltipContext>(null);
 
 const useTooltipContext = (): TooltipContext => {
   const context = React.useContext(TooltipContext);
-  if (!context) {
-    throw new Error('[Blade Tooltip]: TooltipInteractiveWrapper must be used within Tooltip');
+
+  if (__DEV__) {
+    if (!context) {
+      throw new Error('[Blade Tooltip]: TooltipInteractiveWrapper must be used within Tooltip');
+    }
   }
 
   return context;

--- a/packages/blade/src/components/Typography/Code/Code.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.tsx
@@ -67,14 +67,17 @@ const isPlatformWeb = platformType === 'browser' || platformType === 'node';
 
 const getCodeFontSizeAndLineHeight = (
   size: CodeProps['size'],
-): { fontSize: keyof FontSize; lineHeight: keyof Typography['lineHeights'] } => {
+): { fontSize: keyof FontSize; lineHeight: keyof Typography['lineHeights'] } | undefined => {
   switch (size) {
     case 'medium':
       return { fontSize: 75, lineHeight: 75 };
     case 'small':
       return { fontSize: 25, lineHeight: 25 };
     default:
-      throw new Error(`[Blade Code]: Unexpected size: ${size}`);
+      if (__DEV__) {
+        throw new Error(`[Blade Code]: Unexpected size: ${size}`);
+      }
+      return undefined;
   }
 };
 
@@ -98,8 +101,12 @@ const getCodeColor = ({
   color,
 }: Pick<CodeProps, 'isHighlighted' | 'color'>): CodeProps['color'] => {
   if (isHighlighted) {
-    if (color) {
-      throw new Error('[Blade: Code]: `color` prop cannot be used without `isHighlighted={false}`');
+    if (__DEV__) {
+      if (color) {
+        throw new Error(
+          '[Blade: Code]: `color` prop cannot be used without `isHighlighted={false}`',
+        );
+      }
     }
 
     return 'surface.text.subtle.lowContrast';
@@ -146,7 +153,7 @@ const Code = ({
   testID,
   ...styledProps
 }: CodeProps): JSX.Element => {
-  const { fontSize, lineHeight } = getCodeFontSizeAndLineHeight(size);
+  const { fontSize, lineHeight } = getCodeFontSizeAndLineHeight(size)!;
   const codeTextColor = React.useMemo<CodeProps['color']>(
     () => getCodeColor({ isHighlighted, color }),
     [isHighlighted, color],

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -104,13 +104,17 @@ const getProps = <T extends { variant: HeadingVariant }>({
       props.as = 'h4';
     }
   } else if (variant === 'subheading') {
-    if (weight === 'regular') {
-      throw new Error(`[Blade: Heading]: weight cannot be 'regular' when variant is 'subheading'`);
-    }
-    if (size) {
-      throw new Error(
-        `[Blade: Heading]: size prop cannot be added when variant is 'subheading'. Use variant 'regular' or remove size prop`,
-      );
+    if (__DEV__) {
+      if (weight === 'regular') {
+        throw new Error(
+          `[Blade: Heading]: weight cannot be 'regular' when variant is 'subheading'`,
+        );
+      }
+      if (size) {
+        throw new Error(
+          `[Blade: Heading]: size prop cannot be added when variant is 'subheading'. Use variant 'regular' or remove size prop`,
+        );
+      }
     }
     props.fontSize = 75;
     props.lineHeight = 50;

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -116,7 +116,7 @@ const getTextProps = <T extends { variant: TextVariant }>({
     if (size === 'medium') {
       props.fontSize = 50;
       props.lineHeight = 50;
-    } else {
+    } else if (__DEV__) {
       throw new Error(`[Blade: Text]: size cannot be '${size}' when variant is 'caption'`);
     }
     props.fontStyle = 'italic';

--- a/packages/blade/src/components/Typography/utils.ts
+++ b/packages/blade/src/components/Typography/utils.ts
@@ -10,12 +10,14 @@ const useValidateAsProp = ({
   validAsValues: readonly string[];
 }): void => {
   React.useEffect(() => {
-    if (as && !validAsValues.includes(as)) {
-      throw new Error(
-        `[Blade ${componentName}]: Invalid \`as\` prop value - ${as}. Only ${validAsValues.join(
-          ', ',
-        )} are accepted`,
-      );
+    if (__DEV__) {
+      if (as && !validAsValues.includes(as)) {
+        throw new Error(
+          `[Blade ${componentName}]: Invalid \`as\` prop value - ${as}. Only ${validAsValues.join(
+            ', ',
+          )} are accepted`,
+        );
+      }
     }
   }, [as, componentName, validAsValues]);
 };

--- a/packages/blade/src/tokens/theme/overrideTheme.ts
+++ b/packages/blade/src/tokens/theme/overrideTheme.ts
@@ -45,20 +45,21 @@ type OverrideTheme = {
  * ```
  */
 const overrideTheme = ({ baseThemeTokens, overrides }: OverrideTheme): ThemeTokens => {
-  // TODO: wrap this check inside a __DEV__ flag so it gets trimmed off in production
-  if (!isEqual(baseThemeTokens, paymentTheme) && !isEqual(baseThemeTokens, bankingTheme)) {
-    throw new Error(
-      '[@razorpay/blade:overrideTheme]: The base theme provided is not a valid Blade theme',
-    );
-  }
+  if (__DEV__) {
+    if (!isEqual(baseThemeTokens, paymentTheme) && !isEqual(baseThemeTokens, bankingTheme)) {
+      throw new Error(
+        '[@razorpay/blade:overrideTheme]: The base theme provided is not a valid Blade theme',
+      );
+    }
 
-  if (
-    !isPartialMatchObjectKeys<ThemeTokens>({
-      objectToMatch: overrides,
-      objectToInspect: baseThemeTokens,
-    })
-  ) {
-    throw new Error('[@razorpay/blade:overrideTheme]: The overrides object is not valid');
+    if (
+      !isPartialMatchObjectKeys<ThemeTokens>({
+        objectToMatch: overrides,
+        objectToInspect: baseThemeTokens,
+      })
+    ) {
+      throw new Error('[@razorpay/blade:overrideTheme]: The overrides object is not valid');
+    }
   }
 
   // Need to clone before merging since merge changes/mutates the actual object

--- a/packages/blade/src/utils/isPartialMatchObjectKeys/isPartialMatchObjectKeys.ts
+++ b/packages/blade/src/utils/isPartialMatchObjectKeys/isPartialMatchObjectKeys.ts
@@ -33,12 +33,14 @@ export const isPartialMatchObjectKeys = <ActualObject>({
           // the condition checks if the "valueToMatch" is not of type object then "valueToMatch" type should be same as type of "valueToInspect"
           (!(valueToMatch instanceof Object) && typeof valueToMatch !== typeof valueToInspect)
         ) {
-          // this is an invalid case, so we log error
-          console.error(
-            `[isPartialMatchObjectKeys]: Unexpected value: ${JSON.stringify(
-              valueToMatch,
-            )} of type ${typeof valueToMatch} for key: ${key}`,
-          );
+          if (__DEV__) {
+            // this is an invalid case, so we log error
+            console.error(
+              `[isPartialMatchObjectKeys]: Unexpected value: ${JSON.stringify(
+                valueToMatch,
+              )} of type ${typeof valueToMatch} for key: ${key}`,
+            );
+          }
           matchResponses.push(false);
         }
 
@@ -55,14 +57,16 @@ export const isPartialMatchObjectKeys = <ActualObject>({
           });
         }
       } else {
-        // the key doesn't exist in the innerObjectToMatch, so we log error
-        console.error(
-          `[isPartialMatchObjectKeys]: ${key} doesn't exist in ${JSON.stringify(
-            innerObjectToInspect,
-            null,
-            2,
-          )}`,
-        );
+        if (__DEV__) {
+          // the key doesn't exist in the innerObjectToMatch, so we log error
+          console.error(
+            `[isPartialMatchObjectKeys]: ${key} doesn't exist in ${JSON.stringify(
+              innerObjectToInspect,
+              null,
+              2,
+            )}`,
+          );
+        }
         matchResponses.push(false);
       }
     }

--- a/packages/blade/src/utils/useColorScheme/useColorScheme.ts
+++ b/packages/blade/src/utils/useColorScheme/useColorScheme.ts
@@ -17,10 +17,12 @@ export const useColorScheme = (
   );
 
   const setColorScheme = useCallback(function setThemeMode(colorScheme: ColorSchemeNamesInput) {
-    if (!colorSchemeNamesInput.includes(colorScheme)) {
-      throw new Error(
-        `[useColorScheme]: Expected color scheme to be one of [${colorSchemeNamesInput.toString()}] but received ${colorScheme}`,
-      );
+    if (__DEV__) {
+      if (!colorSchemeNamesInput.includes(colorScheme)) {
+        throw new Error(
+          `[useColorScheme]: Expected color scheme to be one of [${colorSchemeNamesInput.toString()}] but received ${colorScheme}`,
+        );
+      }
     }
     setColorSchemeState(getColorScheme(colorScheme));
   }, []);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,6 +2978,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.4.13":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
@@ -4291,6 +4296,14 @@
     is-module "^1.0.0"
     resolve "^1.14.2"
 
+"@rollup/plugin-replace@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz#45f53501b16311feded2485e98419acb8448c61d"
+  integrity sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.27.0"
+
 "@rollup/plugin-replace@^2.3.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz#a2d539314fbc77c244858faa523012825068510a"
@@ -4307,6 +4320,15 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
+  integrity sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
 
 "@sideway/address@^4.1.3":
   version "4.1.3"
@@ -12145,7 +12167,7 @@ estree-walker@^1.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
-estree-walker@^2.0.1:
+estree-walker@^2.0.1, estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
@@ -17045,6 +17067,13 @@ magic-string@^0.25.0, magic-string@^0.25.7:
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   dependencies:
     sourcemap-codec "^1.4.4"
+
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
- Fixes https://github.com/razorpay/blade/issues/272
- Wrapped all errors inside a `__DEV__` flag.
- Create two different bundles `index.development.web.js` and `index.production.web.js`.
- Updated `package.json` exports to [include `development` & `production` exports](https://nodejs.org/api/packages.html#resolving-user-conditions).
- [Webpack automatically resolves to the correct bundle based on the `mode` option in config](https://webpack.js.org/guides/package-exports/#providing-devtools-or-production-optimizations). Users don't have to do anything.
- In react native, `__DEV__` is `true` in debug mode & `false` in release mode. We don't strip but suppress the error in case of react native.
