### PR TITLE
docs: remove default size from story controls of heading

### DIFF
--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -56,7 +56,6 @@ const HeadingStoryMeta: Meta<HeadingProps<{ variant: 'regular' | 'subheading' }>
   component: HeadingComponent,
   args: {
     variant: 'regular',
-    size: 'large',
     type: 'normal',
     children: 'Get Started With Payment Gateway',
     weight: 'bold',


### PR DESCRIPTION
Fix: #1463 