### PR TITLE
feat(Input): make `label` prop optional & add `accessibilityLabel` prop

### DIFF
--- a/.changeset/nervous-chicken-explain.md
+++ b/.changeset/nervous-chicken-explain.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(TextInput): make `label` prop optional & add `accessibilityLabel` prop

--- a/.changeset/nervous-chicken-explain.md
+++ b/.changeset/nervous-chicken-explain.md
@@ -3,3 +3,11 @@
 ---
 
 feat(TextInput): make `label` prop optional & add `accessibilityLabel` prop
+
+#### Key Updates
+
+- **Optional `label` Prop**: We understand that not all use cases require a label for the TextInput. Therefore, we have made the label prop optional, providing you with the freedom to choose whether to display a label or not, depending on your specific application requirements.
+
+- **Introducing `accessibilityLabel`:** Recognizing the significance of accessibility in modern applications, we have added the `accessibilityLabel` prop to the TextInput. This prop enables developers to assign a descriptive label for the input field, making it more user-friendly for individuals using assistive technologies or screen readers.
+
+- **Enhanced User Guidance:** To maintain usability, we have implemented a requirement that either the `label` or `accessibilityLabel` prop must be provided. This ensures that users will always have clear guidance when interacting with TextInput, promoting a seamless user experience.

--- a/.changeset/nervous-chicken-explain.md
+++ b/.changeset/nervous-chicken-explain.md
@@ -2,12 +2,12 @@
 "@razorpay/blade": minor
 ---
 
-feat(TextInput): make `label` prop optional & add `accessibilityLabel` prop
+feat(Input): make `label` prop optional & add `accessibilityLabel` prop to `TextInput`, `TextArea`, `PasswordInput`, `SelectInput`, and `OTPInput` components
 
 #### Key Updates
 
-- **Optional `label` Prop**: We understand that not all use cases require a label for the TextInput. Therefore, we have made the label prop optional, providing you with the freedom to choose whether to display a label or not, depending on your specific application requirements.
+- **Optional `label` Prop**: We understand that not all use cases require a label for the Input components. Therefore, we have made the label prop optional, providing you with the freedom to choose whether to display a label or not, depending on your specific application requirements.
 
-- **Introducing `accessibilityLabel`:** Recognizing the significance of accessibility in modern applications, we have added the `accessibilityLabel` prop to the TextInput. This prop enables developers to assign a descriptive label for the input field, making it more user-friendly for individuals using assistive technologies or screen readers.
+- **Introducing `accessibilityLabel`:** Recognizing the significance of accessibility in modern applications, we have added the `accessibilityLabel` prop to the Input components. This prop enables developers to assign a descriptive label for the input field, making it more user-friendly for individuals using assistive technologies or screen readers.
 
-- **Enhanced User Guidance:** To maintain usability, we have implemented a requirement that either the `label` or `accessibilityLabel` prop must be provided. This ensures that users will always have clear guidance when interacting with TextInput, promoting a seamless user experience.
+- **Enhanced User Guidance:** To maintain usability, we have implemented a requirement that either the `label` or `accessibilityLabel` prop must be provided. This ensures that users will always have clear guidance when interacting with Inputs, promoting a seamless user experience.

--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -37,7 +37,7 @@ export type FormInputLabelProps = {
   /**
    * Label to be shown for the input field
    */
-  label: string;
+  label?: string;
   /**
    * Desktop only prop. Default value on mobile will be `top`
    */

--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -16,7 +16,7 @@ type CommonProps = {
   position?: 'top' | 'left';
   necessityIndicator?: 'required' | 'optional' | 'none';
   accessibilityText?: string;
-  children: string;
+  children: string | undefined;
   id?: string;
   contrast?: ColorContrastTypes;
 };

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -273,7 +273,7 @@ type BaseInputCommonProps = FormInputLabelProps &
 /*
   Mandatory accessibilityLabel prop when label is not provided
 */
-type BaseInputPropsWithLabel = {
+type BaseInputPropsWithA11yLabel = {
   /**
    * Label to be shown for the input field
    */
@@ -287,7 +287,7 @@ type BaseInputPropsWithLabel = {
 /*
   Optional accessibilityLabel prop when label is provided
 */
-type BaseInputPropsWithA11yLabel = {
+type BaseInputPropsWithLabel = {
   /**
    * Label to be shown for the input field
    */

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -731,7 +731,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
         </BaseBox>
         {/* the magic number 136 is basically max-width of label i.e 120 and then right margin i.e 16 which is the spacing between label and input field */}
         {!hideFormHint && (
-          <BaseBox marginLeft={makeSize(isLabelLeftPositioned ? 136 : 0)}>
+          <BaseBox marginLeft={makeSize(isLabelLeftPositioned && !hideLabelText ? 136 : 0)}>
             <BaseBox
               display="flex"
               flexDirection="row"

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -698,7 +698,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
                 id={labelId}
                 htmlFor={inputId}
               >
-                {label as string}
+                {label}
               </FormLabel>
               {trailingHeaderSlot?.(inputValue)}
             </BaseBox>

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -50,7 +50,7 @@ type CommonAutoCompleteSuggestionTypes =
 
 type WebAutoCompleteSuggestionType = CommonAutoCompleteSuggestionTypes | 'on';
 
-export type BaseInputProps = FormInputLabelProps &
+type BaseInputCommonProps = FormInputLabelProps &
   FormInputValidationProps & {
     /**
      * Determines if it needs to be rendered as input, textarea or button
@@ -269,6 +269,37 @@ export type BaseInputProps = FormInputLabelProps &
     };
   }> &
   StyledPropsBlade;
+
+/*
+  Mandatory accessibilityLabel prop when label is not provided
+*/
+type BaseInputPropsWithLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: undefined;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel: string;
+};
+
+/*
+  Optional accessibilityLabel prop when label is provided
+*/
+type BaseInputPropsWithA11yLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel?: string;
+};
+
+export type BaseInputProps = (BaseInputPropsWithA11yLabel | BaseInputPropsWithLabel) &
+  BaseInputCommonProps;
 
 const autoCompleteSuggestionTypeValues = [
   'none',
@@ -667,7 +698,7 @@ export const BaseInput = React.forwardRef<HTMLInputElement, BaseInputProps>(
                 id={labelId}
                 htmlFor={inputId}
               >
-                {label}
+                {label as string}
               </FormLabel>
               {trailingHeaderSlot?.(inputValue)}
             </BaseBox>

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
@@ -89,6 +89,11 @@ export default {
         category: propsCategory.LABEL_PROPS,
       },
     },
+    accessibilityLabel: {
+      table: {
+        category: propsCategory.LABEL_PROPS,
+      },
+    },
     labelPosition: {
       table: {
         category: propsCategory.LABEL_PROPS,
@@ -190,6 +195,14 @@ OTPInput4Fields.args = {
 export const OTPInputHelpText = OTPInputTemplate.bind({});
 OTPInputHelpText.storyName = 'OTPInput with Help Text';
 OTPInputHelpText.args = {
+  helpText: 'Add a message here',
+};
+
+export const OTPInputWithoutLabel = OTPInputTemplate.bind({});
+OTPInputWithoutLabel.storyName = 'OTPInput without Label';
+OTPInputWithoutLabel.args = {
+  label: undefined,
+  accessibilityLabel: 'Enter OTP',
   helpText: 'Add a message here',
 };
 

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -377,7 +377,7 @@ const OTPInput = ({
       >
         {Boolean(label) && (
           <FormLabel as="label" position={labelPosition} htmlFor={inputId}>
-            {label as string}
+            {label}
           </FormLabel>
         )}
         <BaseBox display="flex" flexDirection="row">

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -27,6 +27,7 @@ type FormInputOnEventWithIndex = ({
 export type OTPInputProps = Pick<
   BaseInputProps,
   | 'label'
+  | 'accessibilityLabel'
   | 'labelPosition'
   | 'validationState'
   | 'helpText'
@@ -111,6 +112,7 @@ const OTPInput = ({
   keyboardReturnKeyType,
   keyboardType = 'decimal',
   label,
+  accessibilityLabel,
   labelPosition,
   name,
   onChange,
@@ -295,7 +297,9 @@ const OTPInput = ({
           <BaseInput
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={autoFocus && index === 0}
-            accessibilityLabel={`${index === 0 ? label : ''} character ${index + 1}`}
+            accessibilityLabel={`${index === 0 ? label || accessibilityLabel : ''} character ${
+              index + 1
+            }`}
             label={label}
             hideLabelText={true}
             id={`${inputId}-${index}`}
@@ -341,9 +345,11 @@ const OTPInput = ({
         alignItems={isLabelLeftPositioned ? 'center' : undefined}
         position="relative"
       >
-        <FormLabel as="label" position={labelPosition} htmlFor={inputId}>
-          {label}
-        </FormLabel>
+        {Boolean(label) && (
+          <FormLabel as="label" position={labelPosition} htmlFor={inputId}>
+            {label as string}
+          </FormLabel>
+        )}
         <BaseBox display="flex" flexDirection="row">
           {getHiddenInput()}
           {getOTPInputFields()}

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -24,7 +24,7 @@ type FormInputOnEventWithIndex = ({
   inputIndex: number;
 }) => void;
 
-export type OTPInputProps = Pick<
+export type OTPInputCommonProps = Pick<
   BaseInputProps,
   | 'label'
   | 'accessibilityLabel'
@@ -82,6 +82,36 @@ export type OTPInputProps = Pick<
    */
   onBlur?: FormInputOnEventWithIndex;
 } & StyledPropsBlade;
+
+/*
+  Mandatory accessibilityLabel prop when label is not provided
+*/
+type OTPInputPropsWithLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: undefined;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel: string;
+};
+
+/*
+  Optional accessibilityLabel prop when label is provided
+*/
+type OTPInputPropsWithA11yLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel?: string;
+};
+
+type OTPInputProps = (OTPInputPropsWithA11yLabel | OTPInputPropsWithLabel) & OTPInputCommonProps;
 
 const isReactNative = getPlatformType() === 'react-native';
 

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -86,7 +86,7 @@ export type OTPInputCommonProps = Pick<
 /*
   Mandatory accessibilityLabel prop when label is not provided
 */
-type OTPInputPropsWithLabel = {
+type OTPInputPropsWithA11yLabel = {
   /**
    * Label to be shown for the input field
    */
@@ -100,7 +100,7 @@ type OTPInputPropsWithLabel = {
 /*
   Optional accessibilityLabel prop when label is provided
 */
-type OTPInputPropsWithA11yLabel = {
+type OTPInputPropsWithLabel = {
   /**
    * Label to be shown for the input field
    */

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
@@ -163,6 +163,12 @@ LabelAtLeft.parameters = {
   },
 };
 
+export const PasswordInputWithoutLabel = PasswordInputTemplate.bind({});
+PasswordInputWithoutLabel.args = {
+  label: undefined,
+  accessibilityLabel: 'Password',
+};
+
 export const Disabled = PasswordInputTemplate.bind({});
 Disabled.args = {
   isDisabled: true,

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
@@ -78,7 +78,7 @@ type PasswordInputCommonProps = Pick<
 /*
   Mandatory accessibilityLabel prop when label is not provided
 */
-type PasswordInputPropsWithLabel = {
+type PasswordInputPropsWithA11yLabel = {
   /**
    * Label to be shown for the input field
    */
@@ -92,7 +92,7 @@ type PasswordInputPropsWithLabel = {
 /*
   Optional accessibilityLabel prop when label is provided
 */
-type PasswordInputPropsWithA11yLabel = {
+type PasswordInputPropsWithLabel = {
   /**
    * Label to be shown for the input field
    */

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
@@ -50,6 +50,7 @@ type PasswordInputExtraProps = {
 type PasswordInputProps = Pick<
   BaseInputProps,
   | 'label'
+  | 'accessibilityLabel'
   | 'labelPosition'
   | 'maxCharacters'
   | 'validationState'
@@ -77,6 +78,7 @@ type PasswordInputProps = Pick<
 const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordInputProps> = (
   {
     label,
+    accessibilityLabel,
     labelPosition = 'top',
     showRevealButton = true,
     maxCharacters,
@@ -111,7 +113,7 @@ const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordIn
   const isRevealedAndEnabled = isRevealed && isEnabled;
 
   const toggleIsRevealed = (): void => setIsRevealed((revealed) => !revealed);
-  const accessibilityLabel = isRevealedAndEnabled ? 'Hide password' : 'Show password';
+  const iconAccessibilityLabel = isRevealedAndEnabled ? 'Hide password' : 'Show password';
   const type = isRevealedAndEnabled ? 'text' : 'password';
 
   const revealButtonIcon = isRevealedAndEnabled ? EyeOffIcon : EyeIcon;
@@ -121,7 +123,7 @@ const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordIn
         size="medium"
         icon={revealButtonIcon}
         onClick={toggleIsRevealed}
-        accessibilityLabel={accessibilityLabel}
+        accessibilityLabel={iconAccessibilityLabel}
       />
     ) : null;
 
@@ -138,6 +140,8 @@ const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordIn
       componentName={MetaConstants.PasswordInput}
       id="password-field"
       label={label}
+      accessibilityLabel={accessibilityLabel}
+      hideLabelText={!Boolean(label)}
       labelPosition={labelPosition}
       type={type}
       interactionElement={revealButton}

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
@@ -47,7 +47,7 @@ type PasswordInputExtraProps = {
   >;
 };
 
-type PasswordInputProps = Pick<
+type PasswordInputCommonProps = Pick<
   BaseInputProps,
   | 'label'
   | 'accessibilityLabel'
@@ -74,6 +74,37 @@ type PasswordInputProps = Pick<
 > &
   PasswordInputExtraProps &
   StyledPropsBlade;
+
+/*
+  Mandatory accessibilityLabel prop when label is not provided
+*/
+type PasswordInputPropsWithLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: undefined;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel: string;
+};
+
+/*
+  Optional accessibilityLabel prop when label is provided
+*/
+type PasswordInputPropsWithA11yLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel?: string;
+};
+
+type PasswordInputProps = (PasswordInputPropsWithA11yLabel | PasswordInputPropsWithLabel) &
+  PasswordInputCommonProps;
 
 const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordInputProps> = (
   {

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.tsx
@@ -139,7 +139,7 @@ const _PasswordInput: React.ForwardRefRenderFunction<BladeElementRef, PasswordIn
       ref={inputRef as React.Ref<HTMLInputElement>}
       componentName={MetaConstants.PasswordInput}
       id="password-field"
-      label={label}
+      label={label as string}
       accessibilityLabel={accessibilityLabel}
       hideLabelText={!Boolean(label)}
       labelPosition={labelPosition}

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.stories.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.stories.tsx
@@ -112,6 +112,11 @@ export default {
         category: propsCategory.LABEL_PROPS,
       },
     },
+    accessibilityLabel: {
+      table: {
+        category: propsCategory.LABEL_PROPS,
+      },
+    },
     labelPosition: {
       table: {
         category: propsCategory.LABEL_PROPS,
@@ -233,3 +238,10 @@ const SelectInputTemplate: ComponentStory<typeof SelectInput> = ({ icon, ...args
 export const Default = SelectInputTemplate.bind({});
 // Need to do this because of storybook's weird naming convention, More details here: https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy#single-story-hoisting
 Default.storyName = 'SelectInput';
+
+export const SelectInputWithoutLabel = SelectInputTemplate.bind({});
+SelectInputWithoutLabel.args = {
+  label: undefined,
+  accessibilityLabel: 'City',
+};
+SelectInputWithoutLabel.storyName = 'SelectInput without Label';

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -16,7 +16,7 @@ import { useBladeInnerRef } from '~utils/useBladeInnerRef';
 import { MetaConstants } from '~utils/metaAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 
-type SelectInputProps = Pick<
+type SelectInputCommonProps = Pick<
   BaseInputProps,
   | 'label'
   | 'accessibilityLabel'
@@ -51,6 +51,37 @@ type SelectInputProps = Pick<
   defaultValue?: string | string[];
   onChange?: ({ name, values }: { name?: string; values: string[] }) => void;
 };
+
+/*
+  Mandatory accessibilityLabel prop when label is not provided
+*/
+type SelectInputPropsWithLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: undefined;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel: string;
+};
+
+/*
+  Optional accessibilityLabel prop when label is provided
+*/
+type SelectInputPropsWithA11yLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel?: string;
+};
+
+type SelectInputProps = (SelectInputPropsWithA11yLabel | SelectInputPropsWithLabel) &
+  SelectInputCommonProps;
 
 const _SelectInput = (
   props: SelectInputProps,

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -197,6 +197,7 @@ const _SelectInput = (
       <BaseInput
         {...baseInputProps}
         as="button"
+        label={props.label as string}
         hideLabelText={props.label?.length === 0}
         componentName={MetaConstants.SelectInput}
         ref={!isReactNative() ? (triggererRef as React.MutableRefObject<HTMLInputElement>) : null}

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -19,6 +19,7 @@ import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 type SelectInputProps = Pick<
   BaseInputProps,
   | 'label'
+  | 'accessibilityLabel'
   | 'labelPosition'
   | 'necessityIndicator'
   | 'validationState'

--- a/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
+++ b/packages/blade/src/components/Input/SelectInput/SelectInput.tsx
@@ -55,7 +55,7 @@ type SelectInputCommonProps = Pick<
 /*
   Mandatory accessibilityLabel prop when label is not provided
 */
-type SelectInputPropsWithLabel = {
+type SelectInputPropsWithA11yLabel = {
   /**
    * Label to be shown for the input field
    */
@@ -69,7 +69,7 @@ type SelectInputPropsWithLabel = {
 /*
   Optional accessibilityLabel prop when label is provided
 */
-type SelectInputPropsWithA11yLabel = {
+type SelectInputPropsWithLabel = {
   /**
    * Label to be shown for the input field
    */

--- a/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
@@ -111,6 +111,11 @@ export default {
         category: propsCategory.LABEL_PROPS,
       },
     },
+    accessibilityLabel: {
+      table: {
+        category: propsCategory.LABEL_PROPS,
+      },
+    },
     labelPosition: {
       table: {
         category: propsCategory.LABEL_PROPS,
@@ -223,6 +228,14 @@ TextAreaSuccess.args = {
   defaultValue: 'TextArea content',
   validationState: 'success',
   successText: 'Validated',
+};
+
+export const TextAreaWithoutLabel = TextAreaTemplate.bind({});
+TextAreaWithoutLabel.storyName = 'TextArea without Label';
+TextAreaWithoutLabel.args = {
+  label: undefined,
+  accessibilityLabel: 'Description',
+  helpText: 'Add a message here',
 };
 
 export const TextAreaNumberOfLines = TextAreaTemplate.bind({});
@@ -345,6 +358,17 @@ const TextAreaKitchenSinkTemplate: ComponentStory<typeof TextAreaComponent> = ()
         <TextArea
           necessityIndicator="required"
           label="Description"
+          placeholder="Enter Description"
+          name="description"
+          labelPosition="left"
+          numberOfLines={3}
+          maxCharacters={100}
+          validationState="none"
+          helpText="Write your message"
+        />
+        <TextArea
+          necessityIndicator="required"
+          accessibilityLabel="Description"
           placeholder="Enter Description"
           name="description"
           labelPosition="left"

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -18,6 +18,7 @@ import { getPlatformType } from '~utils';
 type TextAreaProps = Pick<
   BaseInputProps,
   | 'label'
+  | 'accessibilityLabel'
   | 'labelPosition'
   | 'necessityIndicator'
   | 'validationState'
@@ -58,6 +59,7 @@ const isReactNative = (_textInputRef: any): _textInputRef is TextInputReactNativ
 const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> = (
   {
     label,
+    accessibilityLabel,
     labelPosition,
     necessityIndicator,
     errorText,
@@ -130,6 +132,8 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
       autoFocus={autoFocus}
       ref={inputRef as React.Ref<HTMLInputElement>}
       label={label}
+      accessibilityLabel={accessibilityLabel}
+      hideLabelText={!Boolean(label)}
       labelPosition={labelPosition}
       necessityIndicator={necessityIndicator}
       errorText={errorText}

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -15,7 +15,7 @@ import { useBladeInnerRef } from '~utils/useBladeInnerRef';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { getPlatformType } from '~utils';
 
-type TextAreaProps = Pick<
+type TextAreaCommonProps = Pick<
   BaseInputProps,
   | 'label'
   | 'accessibilityLabel'
@@ -49,6 +49,36 @@ type TextAreaProps = Pick<
    */
   onClearButtonClick?: () => void;
 } & StyledPropsBlade;
+
+/*
+  Mandatory accessibilityLabel prop when label is not provided
+*/
+type TextAreaPropsWithLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: undefined;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel: string;
+};
+
+/*
+  Optional accessibilityLabel prop when label is provided
+*/
+type TextAreaPropsWithA11yLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel?: string;
+};
+
+type TextAreaProps = (TextAreaPropsWithA11yLabel | TextAreaPropsWithLabel) & TextAreaCommonProps;
 
 // need to do this to tell TS to infer type as TextInput of React Native and make it believe that `ref.current.clear()` exists
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -53,7 +53,7 @@ type TextAreaCommonProps = Pick<
 /*
   Mandatory accessibilityLabel prop when label is not provided
 */
-type TextAreaPropsWithLabel = {
+type TextAreaPropsWithA11yLabel = {
   /**
    * Label to be shown for the input field
    */
@@ -67,7 +67,7 @@ type TextAreaPropsWithLabel = {
 /*
   Optional accessibilityLabel prop when label is provided
 */
-type TextAreaPropsWithA11yLabel = {
+type TextAreaPropsWithLabel = {
   /**
    * Label to be shown for the input field
    */

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -131,7 +131,7 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
       componentName={MetaConstants.TextArea}
       autoFocus={autoFocus}
       ref={inputRef as React.Ref<HTMLInputElement>}
-      label={label}
+      label={label as string}
       accessibilityLabel={accessibilityLabel}
       hideLabelText={!Boolean(label)}
       labelPosition={labelPosition}

--- a/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
@@ -126,6 +126,11 @@ export default {
         category: propsCategory.LABEL_PROPS,
       },
     },
+    accessibilityLabel: {
+      table: {
+        category: propsCategory.LABEL_PROPS,
+      },
+    },
     labelPosition: {
       table: {
         category: propsCategory.LABEL_PROPS,

--- a/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
@@ -294,6 +294,14 @@ TextInputSuccess.args = {
   successText: 'Name validated',
 };
 
+export const TextInputWithoutLabel = TextInputTemplate.bind({});
+TextInputWithoutLabel.storyName = 'TextInput without label';
+TextInputWithoutLabel.args = {
+  defaultValue: 'John Ives',
+  label: undefined,
+  accessibilityLabel: 'Enter your name',
+};
+
 const TextInputMaxCharactersTemplate: ComponentStory<typeof TextInputComponent> = () => {
   return (
     <TextInput
@@ -414,6 +422,17 @@ const TextInputKitchenSinkTemplate: ComponentStory<typeof TextInputComponent> = 
         <TextInput
           necessityIndicator="required"
           label="Enter Your Residential Address"
+          placeholder="Enter your address"
+          name="fullName"
+          labelPosition="left"
+          maxCharacters={100}
+          validationState="none"
+          helpText="Write your message"
+        />
+
+        <TextInput
+          accessibilityLabel="Enter Your Residential Address"
+          necessityIndicator="required"
           placeholder="Enter your address"
           name="fullName"
           labelPosition="left"

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -20,7 +20,7 @@ import { getPlatformType } from '~utils';
 // Users should use PasswordInput for input type password
 type Type = Exclude<BaseInputProps['type'], 'password'>;
 
-type TextInputProps = Pick<
+type TextInputCommonProps = Pick<
   BaseInputProps,
   | 'label'
   | 'accessibilityLabel'
@@ -91,6 +91,37 @@ type TextInputKeyboardAndAutoComplete = Pick<
 > & {
   type: Type;
 };
+
+/*
+  Mandatory accessibilityLabel prop when label is not provided
+*/
+type TextInputPropsWithLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: undefined;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel: string;
+};
+
+/*
+  Optional accessibilityLabel prop when label is provided
+*/
+type TextInputPropsWithA11yLabel = {
+  /**
+   * Label to be shown for the input field
+   */
+  label: string;
+  /**
+   * Accessibility label for the input
+   */
+  accessibilityLabel?: string;
+};
+
+type TextInputProps = (TextInputPropsWithA11yLabel | TextInputPropsWithLabel) &
+  TextInputCommonProps;
 
 const getKeyboardAndAutocompleteProps = ({
   type = 'text',

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -22,7 +22,7 @@ type Type = Exclude<BaseInputProps['type'], 'password'>;
 
 type TextInputProps = Pick<
   BaseInputProps,
-  | 'label'
+  | 'accessibilityLabel'
   | 'labelPosition'
   | 'necessityIndicator'
   | 'validationState'
@@ -48,6 +48,10 @@ type TextInputProps = Pick<
   | 'autoCapitalize'
   | 'testID'
 > & {
+  /**
+   * Label to be shown for the input field
+   */
+  label?: string;
   /**
    * Decides whether to render a clear icon button
    */
@@ -182,6 +186,7 @@ const isReactNative = (_textInputRef: any): _textInputRef is TextInputReactNativ
 const _TextInput: React.ForwardRefRenderFunction<BladeElementRef, TextInputProps> = (
   {
     label,
+    accessibilityLabel,
     labelPosition = 'top',
     placeholder,
     type = 'text',
@@ -217,6 +222,13 @@ const _TextInput: React.ForwardRefRenderFunction<BladeElementRef, TextInputProps
 ): ReactElement => {
   const textInputRef = useBladeInnerRef(ref);
   const [shouldShowClearButton, setShouldShowClearButton] = useState(false);
+  const isLabelDefined = typeof label === 'string' && label.length > 0;
+  const isAccessibilityLabelDefined =
+    typeof accessibilityLabel === 'string' && accessibilityLabel.length > 0;
+
+  if (!(isLabelDefined || isAccessibilityLabelDefined)) {
+    throw new Error('[Blade TextInput]: Either label or accessibilityLabel is required');
+  }
 
   React.useEffect(() => {
     setShouldShowClearButton(Boolean(showClearButton && (defaultValue ?? value)));
@@ -261,7 +273,9 @@ const _TextInput: React.ForwardRefRenderFunction<BladeElementRef, TextInputProps
       id="textinput"
       componentName={MetaConstants.TextInput}
       ref={textInputRef as React.Ref<HTMLInputElement>}
-      label={label}
+      label={label as string}
+      accessibilityLabel={accessibilityLabel}
+      hideLabelText={!isLabelDefined}
       labelPosition={labelPosition}
       placeholder={placeholder}
       defaultValue={defaultValue}

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -22,6 +22,7 @@ type Type = Exclude<BaseInputProps['type'], 'password'>;
 
 type TextInputProps = Pick<
   BaseInputProps,
+  | 'label'
   | 'accessibilityLabel'
   | 'labelPosition'
   | 'necessityIndicator'
@@ -48,10 +49,6 @@ type TextInputProps = Pick<
   | 'autoCapitalize'
   | 'testID'
 > & {
-  /**
-   * Label to be shown for the input field
-   */
-  label?: string;
   /**
    * Decides whether to render a clear icon button
    */
@@ -222,13 +219,6 @@ const _TextInput: React.ForwardRefRenderFunction<BladeElementRef, TextInputProps
 ): ReactElement => {
   const textInputRef = useBladeInnerRef(ref);
   const [shouldShowClearButton, setShouldShowClearButton] = useState(false);
-  const isLabelDefined = typeof label === 'string' && label.length > 0;
-  const isAccessibilityLabelDefined =
-    typeof accessibilityLabel === 'string' && accessibilityLabel.length > 0;
-
-  if (!(isLabelDefined || isAccessibilityLabelDefined)) {
-    throw new Error('[Blade TextInput]: Either label or accessibilityLabel is required');
-  }
 
   React.useEffect(() => {
     setShouldShowClearButton(Boolean(showClearButton && (defaultValue ?? value)));
@@ -275,7 +265,7 @@ const _TextInput: React.ForwardRefRenderFunction<BladeElementRef, TextInputProps
       ref={textInputRef as React.Ref<HTMLInputElement>}
       label={label as string}
       accessibilityLabel={accessibilityLabel}
-      hideLabelText={!isLabelDefined}
+      hideLabelText={!Boolean(label)}
       labelPosition={labelPosition}
       placeholder={placeholder}
       defaultValue={defaultValue}

--- a/packages/blade/src/components/Input/TextInput/TextInput.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.tsx
@@ -95,7 +95,7 @@ type TextInputKeyboardAndAutoComplete = Pick<
 /*
   Mandatory accessibilityLabel prop when label is not provided
 */
-type TextInputPropsWithLabel = {
+type TextInputPropsWithA11yLabel = {
   /**
    * Label to be shown for the input field
    */
@@ -109,7 +109,7 @@ type TextInputPropsWithLabel = {
 /*
   Optional accessibilityLabel prop when label is provided
 */
-type TextInputPropsWithA11yLabel = {
+type TextInputPropsWithLabel = {
   /**
    * Label to be shown for the input field
    */


### PR DESCRIPTION
Fixes https://github.com/razorpay/blade/issues/1237

I'm thrilled to introduce an important update to our TextInput component, aimed at improving accessibility and flexibility. With this latest release, we have made the `label` prop optional while introducing the all-new `accessibilityLabel` prop, ensuring an inclusive user experience for everyone.

### Key Updates:

**Optional `label` Prop**: We understand that not all use cases require a label for the TextInput. Therefore, we have made the label prop optional, providing you with the freedom to choose whether to display a label or not, depending on your specific application requirements.

**Introducing `accessibilityLabel`:** Recognizing the significance of accessibility in modern applications, we have added the `accessibilityLabel` prop to the TextInput. This prop enables developers to assign a descriptive label for the input field, making it more user-friendly for individuals using assistive technologies or screen readers.

**Enhanced User Guidance:** To maintain usability, we have implemented a requirement that either the `label` or `accessibilityLabel` prop must be provided. This ensures that users will always have clear guidance when interacting with TextInput, promoting a seamless user experience.

**Updated Stories:** As part of this PR, I have also added new stories for the TextInput without a label, demonstrating its versatility and how it can be used effectively without a visible label.

<!--
We believe these enhancements will benefit developers by providing more options and contribute to creating a more inclusive and accessible environment for all users. We're excited to see how you leverage these new features in your applications and welcome your feedback on this update.

You can upgrade your TextInput component now and take advantage of these empowering improvements. Happy coding!

-->





