### PR TITLE
docs: update useTheme usage

### DIFF
--- a/packages/blade/docs/utils/useTheme.stories.mdx
+++ b/packages/blade/docs/utils/useTheme.stories.mdx
@@ -31,7 +31,7 @@ To use the `useTheme` hook, you must first wrap your application with a `Blad
 
 ```tsx
 import React from 'react';
-import { useTheme, Heading, Text, Button } from '@razorpay/blade/utils';
+import { useTheme, Heading, Text, Button } from '@razorpay/blade/components';
 
 const MyComponent = () => {
   const { theme, colorScheme, platform, setColorScheme } = useTheme();


### PR DESCRIPTION
- Heading, Text, Button are not available to import from utils.
- `useTheme` export from utils is not working as expected (#1497 )