### PR TITLE
feat(Box): add support for `transparent` background color

### DIFF
--- a/.changeset/thick-countries-search.md
+++ b/.changeset/thick-countries-search.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(Box): add support for the `transparent` background color

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -167,6 +167,7 @@ type BaseBoxVisualProps = MakeObjectResponsive<
       | BackgroundColorString<'surface'>
       | BackgroundColorString<'action'>
       | BrandColorString
+      | 'transparent'
       | (string & Record<never, never>);
     lineHeight: SpacingValueType;
     touchAction: CSSObject['touchAction'];
@@ -184,7 +185,7 @@ type BaseBoxVisualProps = MakeObjectResponsive<
 
 // Visual props that are specific to Box
 type BoxVisualProps = MakeObjectResponsive<{
-  backgroundColor: BackgroundColorString<'surface'> | BrandColorString;
+  backgroundColor: BackgroundColorString<'surface'> | BrandColorString | 'transparent';
 }> & {
   // Intentionally keeping this outside of MakeObjectResponsive since we only want as to be string and not responsive object
   // styled-components do not support passing `as` prop as an object

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -12,7 +12,8 @@ const validateBackgroundString = (stringBackgroundColorValue: string): void => {
   if (__DEV__) {
     if (
       !stringBackgroundColorValue.startsWith('surface.background') &&
-      !stringBackgroundColorValue.startsWith('brand.')
+      !stringBackgroundColorValue.startsWith('brand.') &&
+      stringBackgroundColorValue !== 'transparent'
     ) {
       throwBladeError({
         message: `Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -16,7 +16,7 @@ const validateBackgroundString = (stringBackgroundColorValue: string): void => {
       stringBackgroundColorValue !== 'transparent'
     ) {
       throwBladeError({
-        message: `Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
+        message: `Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
         moduleName: 'Box',
       });
     }

--- a/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
@@ -61,7 +61,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade: Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.ssr.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.ssr.test.tsx
@@ -63,7 +63,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade: Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
@@ -71,7 +71,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade: Box]: Oops! Currently you can only use \`surface.background.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
@@ -119,6 +119,32 @@ describe('<Box />', () => {
     `);
   });
 
+  it('should accept "transparent" value for backgroundColor', () => {
+    const { container } = renderWithTheme(
+      <Box backgroundColor={{ base: 'brand.primary.300', l: 'transparent' }}>I am Visible</Box>,
+    );
+    expect(container).toMatchInlineSnapshot(`
+      .c0 {
+        background-color: hsla(218,89%,51%,0.09);
+      }
+
+      @media screen and (min-width:1024px) {
+        .c0 {
+          background-color: transparent;
+        }
+      }
+
+      <div>
+        <div
+          class="c0"
+          data-blade-component="box"
+        >
+          I am Visible
+        </div>
+      </div>
+    `);
+  });
+
   it('should support ref on Box', async () => {
     const user = userEvent.setup();
     const boxClickHandler = jest.fn();


### PR DESCRIPTION

https://github.com/razorpay/blade/assets/46647141/51595886-6c29-46f5-8d6e-38e215468ff3

