### PR TITLE
ci: don't build blade for running tests

### DIFF
--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -51,10 +51,7 @@ jobs:
           node-version: 18.12.1
       - name: Setup Cache & Install Dependencies
         uses: ./.github/actions/install-dependencies
-      - name: Build Blade
-        run: yarn build
-        working-directory: packages/blade
-      - name: Run React Tests
+      - name: Run React & React Native Tests
         run: yarn test
         working-directory: packages/blade
         env:


### PR DESCRIPTION
- Build blade step is not required to run tests and only adds up to the workflow time. We already have this step in the `Validate Source Code` job.