### PR TITLE
chore: ignore KitchenSink stories for React Native

### DIFF
--- a/packages/blade/.storybook/react-native/main.js
+++ b/packages/blade/.storybook/react-native/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: [
-    '../../src/**/*.stories.?(ts|tsx|js|jsx)',
+    '../../src/**/!(_KitchenSink)*.stories.?(ts|tsx|js|jsx)',
     '../../src/**/*.stories.internal.?(ts|tsx|js|jsx)',
   ],
   addons: [

--- a/packages/blade/.storybook/react-native/storybook.requires.js
+++ b/packages/blade/.storybook/react-native/storybook.requires.js
@@ -12,9 +12,9 @@ global.STORIES = [
   {
     titlePrefix: '',
     directory: './src',
-    files: '**/*.stories.?(ts|tsx|js|jsx)',
+    files: '**/!(_KitchenSink)*.stories.?(ts|tsx|js|jsx)',
     importPathMatcher:
-      '^\\.[\\\\/](?:src(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$',
+      '^\\.[\\\\/](?:src(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?:(?!(?:_KitchenSink))[^/]*?)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$',
   },
   {
     titlePrefix: '',


### PR DESCRIPTION
`KitchenSink` seems to crash the react-native storybook setup, this PR ignores these stories for RN. We only need these for chromatic snapshots.

### Screenshots

| Emulator | Terminal |
| --------- | -------- |
| <img width="338" alt="Screenshot 2023-08-21 at 8 36 39 AM" src="https://github.com/razorpay/blade/assets/46647141/624557a9-d87c-4869-b10b-427f8ceb9af2"> | <img width="1011" alt="Screenshot 2023-08-21 at 8 36 28 AM" src="https://github.com/razorpay/blade/assets/46647141/8e05e284-a14f-4cdb-aded-fd82694ef7b9"> |



