### PR TITLE
chore(blade): remove broken figma link in `Card`

### DIFF
--- a/.changeset/flat-books-raise.md
+++ b/.changeset/flat-books-raise.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+chore(blade): remove broken figma link from Card

--- a/packages/blade/src/components/Card/Card.tsx
+++ b/packages/blade/src/components/Card/Card.tsx
@@ -52,7 +52,6 @@ export type CardProps = {
    *
    * **Links:**
    * - Docs: https://blade.razorpay.com/?path=/docs/tokens-colors--page#-theme-tokens
-   * - Figma: https://shorturl.at/fsvwK
    */
   surfaceLevel?: Exclude<SurfaceLevels, 1>;
   /**


### PR DESCRIPTION
Fixes #1565 
Removed broken figma link