### PR TITLE
fix(Tooltip): prevent overriding the `aria-label` attribute

### DIFF
--- a/packages/blade/src/components/Tooltip/Tooltip.web.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.web.tsx
@@ -98,7 +98,7 @@ const Tooltip = ({
       {React.cloneElement(children, {
         ref: refs.setReference,
         ...mergeProps(children.props, getReferenceProps()),
-        ...makeAccessible({ label: content }),
+        ...makeAccessible({ describedBy: content }),
       })}
       {isMounted && (
         <FloatingPortal>

--- a/packages/blade/src/components/Tooltip/Tooltip.web.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.web.tsx
@@ -97,8 +97,8 @@ const Tooltip = ({
       {/* Cloning the trigger children to enhance it with ref and event handler */}
       {React.cloneElement(children, {
         ref: refs.setReference,
+        ...makeAccessible({ label: content }),
         ...mergeProps(children.props, getReferenceProps()),
-        ...makeAccessible({ describedBy: content }),
       })}
       {isMounted && (
         <FloatingPortal>

--- a/packages/blade/src/components/Tooltip/__tests__/Tooltip.web.test.tsx
+++ b/packages/blade/src/components/Tooltip/__tests__/Tooltip.web.test.tsx
@@ -34,6 +34,7 @@ describe('<Tooltip />', () => {
     expect(queryByRole('tooltip')).toBeInTheDocument();
     expect(queryByRole('tooltip')).toHaveStyle({ 'z-index': 1100 });
     expect(baseElement).toMatchSnapshot();
+<<<<<<< HEAD
   });
 
   it('should render with title', () => {
@@ -49,11 +50,13 @@ describe('<Tooltip />', () => {
     expect(queryByRole('tooltip')).toBeInTheDocument();
     expect(queryByRole('tooltip')).toHaveStyle({ 'z-index': 1100 });
     expect(baseElement).toMatchSnapshot();
+=======
+>>>>>>> 693f8820 (fix(Tooltip): prevent overriding the `aria-label` attribute)
   });
 
   it('should render tooltip with custom zIndex', () => {
     const buttonText = 'Hover me';
-    const { container, getByRole, queryByRole } = renderWithTheme(
+    const { baseElement, getByRole, queryByRole } = renderWithTheme(
       <Tooltip content="Hello world" zIndex={9999}>
         <Button>{buttonText}</Button>
       </Tooltip>,
@@ -63,7 +66,7 @@ describe('<Tooltip />', () => {
     fireEvent.focus(getByRole('button', { name: buttonText }));
     expect(queryByRole('tooltip')).toBeInTheDocument();
     expect(queryByRole('tooltip')).toHaveStyle({ 'z-index': 9999 });
-    expect(container).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
   });
 
   it('should open on hovering over', async () => {
@@ -285,7 +288,10 @@ describe('<Tooltip />', () => {
     );
     fireEvent.focus(getByRole('button', { name: buttonText }));
     expect(queryByRole('tooltip')).toBeInTheDocument();
-    expect(getByRole('button', { name: buttonText })).toHaveAccessibleDescription(tooltipContent);
+    expect(getByRole('button', { name: buttonText })).toHaveAttribute(
+      'aria-describedby',
+      tooltipContent,
+    );
     await assertAccessible(getByRole('tooltip'));
   });
 
@@ -310,5 +316,18 @@ describe('<Tooltip />', () => {
       jest.advanceTimersByTime(300);
     });
     expect(queryByRole('tooltip')).toHaveAttribute('data-blade-component', MetaConstants.Tooltip);
+  });
+
+  // https://github.com/razorpay/blade/issues/1386
+  it("should not override trigger's aria-label attribute", () => {
+    const tooltipContent = 'Hello world';
+    const { container, getByLabelText } = renderWithTheme(
+      <Tooltip content={tooltipContent}>
+        <input aria-label="Email Address" type="email" placeholder="Enter email" />
+      </Tooltip>,
+    );
+
+    expect(getByLabelText('Email Address')).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/packages/blade/src/components/Tooltip/__tests__/Tooltip.web.test.tsx
+++ b/packages/blade/src/components/Tooltip/__tests__/Tooltip.web.test.tsx
@@ -285,10 +285,7 @@ describe('<Tooltip />', () => {
     );
     fireEvent.focus(getByRole('button', { name: buttonText }));
     expect(queryByRole('tooltip')).toBeInTheDocument();
-    expect(getByRole('button', { name: buttonText })).toHaveAttribute(
-      'aria-describedby',
-      tooltipContent,
-    );
+    expect(getByRole('button', { name: buttonText })).toHaveAccessibleDescription(tooltipContent);
     await assertAccessible(getByRole('tooltip'));
   });
 

--- a/packages/blade/src/components/Tooltip/__tests__/Tooltip.web.test.tsx
+++ b/packages/blade/src/components/Tooltip/__tests__/Tooltip.web.test.tsx
@@ -34,7 +34,6 @@ describe('<Tooltip />', () => {
     expect(queryByRole('tooltip')).toBeInTheDocument();
     expect(queryByRole('tooltip')).toHaveStyle({ 'z-index': 1100 });
     expect(baseElement).toMatchSnapshot();
-<<<<<<< HEAD
   });
 
   it('should render with title', () => {
@@ -50,8 +49,6 @@ describe('<Tooltip />', () => {
     expect(queryByRole('tooltip')).toBeInTheDocument();
     expect(queryByRole('tooltip')).toHaveStyle({ 'z-index': 1100 });
     expect(baseElement).toMatchSnapshot();
-=======
->>>>>>> 693f8820 (fix(Tooltip): prevent overriding the `aria-label` attribute)
   });
 
   it('should render tooltip with custom zIndex', () => {

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`<Tooltip /> should not override trigger's aria-label attribute 1`] = `
 <div>
   <input
-    aria-describedby="Hello world"
     aria-label="Email Address"
     placeholder="Enter email"
     type="email"
@@ -186,7 +185,7 @@ exports[`<Tooltip /> should render 1`] = `
 <body>
   <div>
     <button
-      aria-describedby="Hello world"
+      aria-describedby=":r0:"
       class="c0"
       data-blade-component="button"
       role="button"
@@ -439,7 +438,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
 <body>
   <div>
     <button
-      aria-describedby="Hello world"
+      aria-describedby=":r8:"
       class="c0"
       data-blade-component="button"
       role="button"
@@ -705,7 +704,7 @@ exports[`<Tooltip /> should render with title 1`] = `
 <body>
   <div>
     <button
-      aria-describedby="Hello world"
+      aria-describedby=":r4:"
       class="c0"
       data-blade-component="button"
       role="button"

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
@@ -186,11 +186,7 @@ exports[`<Tooltip /> should render 1`] = `
 <body>
   <div>
     <button
-<<<<<<< HEAD
       aria-describedby=":r0:"
-=======
-      aria-describedby="Hello world"
->>>>>>> 693f8820 (fix(Tooltip): prevent overriding the `aria-label` attribute)
       class="c0"
       data-blade-component="button"
       role="button"
@@ -440,7 +436,6 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
   }
 }
 
-<<<<<<< HEAD
 <div>
   <button
     aria-describedby=":r8:"
@@ -452,16 +447,6 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
     <div
       class="c1 c2"
       data-blade-component="base-box"
-=======
-<body>
-  <div>
-    <button
-      aria-describedby="Hello world"
-      class="c0"
-      data-blade-component="button"
-      role="button"
-      type="button"
->>>>>>> 693f8820 (fix(Tooltip): prevent overriding the `aria-label` attribute)
     >
       <div
         class="c1 c2"

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Tooltip /> should not override trigger's aria-label attribute 1`] = `
+<div>
+  <input
+    aria-describedby="Hello world"
+    aria-label="Email Address"
+    placeholder="Enter email"
+    type="email"
+  />
+</div>
+`;
+
 exports[`<Tooltip /> should render 1`] = `
 .c1 {
   display: -webkit-box;
@@ -175,7 +186,11 @@ exports[`<Tooltip /> should render 1`] = `
 <body>
   <div>
     <button
+<<<<<<< HEAD
       aria-describedby=":r0:"
+=======
+      aria-describedby="Hello world"
+>>>>>>> 693f8820 (fix(Tooltip): prevent overriding the `aria-label` attribute)
       class="c0"
       data-blade-component="button"
       role="button"
@@ -275,6 +290,33 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
   justify-content: center;
 }
 
+.c4 {
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.c5 {
+  position: relative;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-right: 12px;
+  padding-left: 12px;
+  max-width: 200px;
+}
+
+.c6 {
+  background-color: hsla(216,33%,29%,1);
+  border-width: 1px;
+  border-radius: 4px;
+  border-color: hsla(216,27%,36%,1);
+  border-style: solid;
+  box-shadow: 0 4px 8px -2px hsla(217,56%,17%,0.1),0 2px 4px -2px hsla(217,56%,17%,0.06);
+  opacity: 0;
+  -webkit-transform: translateY(4px);
+  -ms-transform: translateY(4px);
+  transform: translateY(4px);
+}
+
 .c3 {
   color: hsla(0,0%,100%,1);
   font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
@@ -285,6 +327,19 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
   text-decoration-line: none;
   line-height: 1.25rem;
   text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+.c7 {
+  color: hsla(0,0%,100%,1);
+  font-family: Lato,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1rem;
   margin: 0;
   padding: 0;
 }
@@ -356,25 +411,36 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
 }
 
 @media screen and (min-width:320px) {
-
+  .c4 {
+    pointer-events: none;
+  }
 }
 
 @media screen and (min-width:480px) {
-
+  .c4 {
+    pointer-events: none;
+  }
 }
 
 @media screen and (min-width:768px) {
-
+  .c4 {
+    pointer-events: none;
+  }
 }
 
 @media screen and (min-width:1024px) {
-
+  .c4 {
+    pointer-events: none;
+  }
 }
 
 @media screen and (min-width:1200px) {
-
+  .c4 {
+    pointer-events: none;
+  }
 }
 
+<<<<<<< HEAD
 <div>
   <button
     aria-describedby=":r8:"
@@ -386,16 +452,87 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
     <div
       class="c1 c2"
       data-blade-component="base-box"
+=======
+<body>
+  <div>
+    <button
+      aria-describedby="Hello world"
+      class="c0"
+      data-blade-component="button"
+      role="button"
+      type="button"
+>>>>>>> 693f8820 (fix(Tooltip): prevent overriding the `aria-label` attribute)
     >
       <div
-        class="c3"
-        data-blade-component="base-text"
+        class="c1 c2"
+        data-blade-component="base-box"
       >
-        Hover me
+        <div
+          class="c3"
+          data-blade-component="base-text"
+        >
+          Hover me
+        </div>
+      </div>
+    </button>
+  </div>
+  <div
+    data-floating-ui-portal=""
+    id=":r6:"
+  >
+    <div
+      class="c4"
+      data-blade-component="tooltip"
+      id=":r4:"
+      pointer-events="none"
+      role="tooltip"
+      style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 0px);"
+      tabindex="-1"
+    >
+      <div
+        class="c5 c6"
+        data-blade-component="base-box"
+      >
+        <p
+          class="c7"
+          data-blade-component="text"
+        >
+          Hello world
+        </p>
+        <svg
+          aria-hidden="true"
+          fill="hsla(216, 33%, 29%, 1)"
+          height="14"
+          style="position: absolute; pointer-events: none; top: 100%;"
+          viewBox="0 0 14 14"
+          width="16"
+        >
+          <path
+            clip-path="url(#:r7:)"
+            d="M0,0 H14 L7,7 Q7,7 7,7 Z"
+            fill="none"
+            stroke="hsla(216, 27%, 36%, 1)"
+            stroke-width="3"
+          />
+          <path
+            d="M0,0 H14 L7,7 Q7,7 7,7 Z"
+            stroke="hsla(216, 33%, 29%, 1)"
+          />
+          <clippath
+            id=":r7:"
+          >
+            <rect
+              height="14"
+              width="16"
+              x="-1"
+              y="1"
+            />
+          </clippath>
+        </svg>
       </div>
     </div>
-  </button>
-</div>
+  </div>
+</body>
 `;
 
 exports[`<Tooltip /> should render with title 1`] = `

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`<Tooltip /> should render 1`] = `
 <body>
   <div>
     <button
-      aria-describedby=":r0:"
+      aria-describedby="Hello world"
       class="c0"
       data-blade-component="button"
       role="button"
@@ -436,17 +436,14 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
   }
 }
 
-<div>
-  <button
-    aria-describedby=":r8:"
-    class="c0"
-    data-blade-component="button"
-    role="button"
-    type="button"
-  >
-    <div
-      class="c1 c2"
-      data-blade-component="base-box"
+<body>
+  <div>
+    <button
+      aria-describedby="Hello world"
+      class="c0"
+      data-blade-component="button"
+      role="button"
+      type="button"
     >
       <div
         class="c1 c2"
@@ -463,12 +460,12 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
   </div>
   <div
     data-floating-ui-portal=""
-    id=":r6:"
+    id=":ra:"
   >
     <div
       class="c4"
       data-blade-component="tooltip"
-      id=":r4:"
+      id=":r8:"
       pointer-events="none"
       role="tooltip"
       style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 0px);"
@@ -493,7 +490,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
           width="16"
         >
           <path
-            clip-path="url(#:r7:)"
+            clip-path="url(#:rb:)"
             d="M0,0 H14 L7,7 Q7,7 7,7 Z"
             fill="none"
             stroke="hsla(216, 27%, 36%, 1)"
@@ -504,7 +501,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
             stroke="hsla(216, 33%, 29%, 1)"
           />
           <clippath
-            id=":r7:"
+            id=":rb:"
           >
             <rect
               height="14"
@@ -708,7 +705,7 @@ exports[`<Tooltip /> should render with title 1`] = `
 <body>
   <div>
     <button
-      aria-describedby=":r4:"
+      aria-describedby="Hello world"
       class="c0"
       data-blade-component="button"
       role="button"


### PR DESCRIPTION
Fixes https://github.com/razorpay/blade/issues/1386

The issue exists on the web only because we don't set the `accessibilityLabel` prop to trigger on react-native.

https://github.com/razorpay/blade/blob/7c116d54164124651fe420a93f182fb4caf49cf9/packages/blade/src/components/Tooltip/Tooltip.native.tsx#L72-L80