### PR TITLE
fix(AutoComplete): controlled single selection

### DIFF
--- a/.changeset/dry-llamas-explain.md
+++ b/.changeset/dry-llamas-explain.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(AutoComplete): Handle inputValue in Controlled Single Selection

--- a/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.stories.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.stories.tsx
@@ -286,6 +286,43 @@ export const InternalAutoCompleteUncontrolled = (): React.ReactElement => {
   );
 };
 
+export const InternalAutoCompleteControlledSelection = (): React.ReactElement => {
+  const [currentSelection, setCurrentSelection] = React.useState<undefined | string>();
+
+  return (
+    <>
+      <Button marginBottom="spacing.4" onClick={() => setCurrentSelection('bangalore')}>
+        Select Bangalore
+      </Button>
+      <Button
+        marginBottom="spacing.4"
+        marginLeft="spacing.4"
+        onClick={() => setCurrentSelection('')}
+      >
+        Clear Selection
+      </Button>
+      <Dropdown selectionType="single">
+        <AutoComplete
+          label="Select A City"
+          value={currentSelection}
+          onChange={(args) => {
+            if (args) {
+              setCurrentSelection(args.values[0]);
+              console.log('onChange triggered');
+            }
+          }}
+        />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Mumbai" value="mumbai" />
+            <ActionListItem title="Bangalore" value="bangalore" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>
+    </>
+  );
+};
+
 const cities = [
   {
     title: 'Mumbai',

--- a/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.tsx
@@ -196,6 +196,14 @@ const _AutoComplete = (
         onChange={onSelectionChange}
         isSelectInput={false}
         inputValue={inputValue}
+        syncInputValueWithSelection={(value) => {
+          if (!value) {
+            setInputValue('');
+            return;
+          }
+          const selectedOption = options.find((option) => option.value === value);
+          setInputValue(selectedOption?.title ?? '');
+        }}
         onTriggerKeydown={onTriggerKeydown}
         onInputValueChange={onInputValueChange}
         onTriggerClick={(triggerEvent) => {

--- a/packages/blade/src/components/Input/DropdownInputTriggers/BaseDropdownInputTrigger.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/BaseDropdownInputTrigger.tsx
@@ -20,6 +20,7 @@ const useControlledDropdownInput = (
     | 'defaultValue'
     | 'onInputValueChange'
     | 'syncInputValueWithSelection'
+    | 'isSelectInput'
   >,
 ): void => {
   const isFirstRender = useFirstRender();
@@ -90,8 +91,8 @@ const useControlledDropdownInput = (
 
       selectValues(props.value);
 
-      // we only
-      if (selectionType === 'single' && !Array.isArray(props.value)) {
+      // in single select AutoComplete, we have to set inputValue of autocomplete according to the new selection.
+      if (selectionType === 'single' && !Array.isArray(props.value) && !props.isSelectInput) {
         props.syncInputValueWithSelection?.(props.value);
       }
     }
@@ -164,6 +165,7 @@ const _BaseDropdownInputTrigger = (
     value: props.value,
     defaultValue: props.defaultValue,
     syncInputValueWithSelection: props.syncInputValueWithSelection,
+    isSelectInput: props.isSelectInput,
   });
 
   const getValue = (): string | undefined => {

--- a/packages/blade/src/components/Input/DropdownInputTriggers/BaseDropdownInputTrigger.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/BaseDropdownInputTrigger.tsx
@@ -12,7 +12,15 @@ import type { BladeElementRef } from '~utils/types';
 import { useFirstRender } from '~utils/useFirstRender';
 
 const useControlledDropdownInput = (
-  props: Pick<BaseDropdownInputTriggerProps, 'onChange' | 'name' | 'value' | 'defaultValue'>,
+  props: Pick<
+    BaseDropdownInputTriggerProps,
+    | 'onChange'
+    | 'name'
+    | 'value'
+    | 'defaultValue'
+    | 'onInputValueChange'
+    | 'syncInputValueWithSelection'
+  >,
 ): void => {
   const isFirstRender = useFirstRender();
   const {
@@ -81,6 +89,11 @@ const useControlledDropdownInput = (
       }
 
       selectValues(props.value);
+
+      // we only
+      if (selectionType === 'single' && !Array.isArray(props.value)) {
+        props.syncInputValueWithSelection?.(props.value);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.value, options]);
@@ -150,6 +163,7 @@ const _BaseDropdownInputTrigger = (
     name: props.name,
     value: props.value,
     defaultValue: props.defaultValue,
+    syncInputValueWithSelection: props.syncInputValueWithSelection,
   });
 
   const getValue = (): string | undefined => {

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/AutoComplete.native.test.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/AutoComplete.native.test.tsx
@@ -184,4 +184,58 @@ describe('<Dropdown /> with <AutoComplete />', () => {
     fireEvent.press(getByRole('menuitem', { name: 'Bengaluru' }));
     expect(getByLabelText('Close Bengaluru tag')).toBeOnTheScreen();
   });
+
+  it('should handle controlled single selection', async () => {
+    const ControlledDropdown = (): React.ReactElement => {
+      const [currentSelection, setCurrentSelection] = React.useState<string>('');
+
+      return (
+        <>
+          <Button
+            onClick={() => {
+              setCurrentSelection('bangalore');
+            }}
+          >
+            Select Bangalore
+          </Button>
+          <Button
+            onClick={() => {
+              setCurrentSelection('');
+            }}
+          >
+            Clear Selection
+          </Button>
+          <Dropdown selectionType="single">
+            <AutoComplete
+              label="Select City"
+              value={currentSelection}
+              onChange={(args) => {
+                setCurrentSelection(args?.values[0]);
+              }}
+            />
+            <DropdownOverlay>
+              <ActionList>
+                <ActionListItem title="Bangalore" value="bangalore" />
+                <ActionListItem title="Pune" value="pune" />
+                <ActionListItem title="Chennai" value="chennai" />
+              </ActionList>
+            </DropdownOverlay>
+          </Dropdown>
+        </>
+      );
+    };
+
+    const { getByRole, getByDisplayValue, queryByDisplayValue } = renderWithTheme(
+      <ControlledDropdown />,
+    );
+
+    expect(getByDisplayValue('')).toBeTruthy();
+
+    expect(queryByDisplayValue('Bangalore')).toBeFalsy();
+    fireEvent.press(getByRole('button', { name: 'Select Bangalore' }));
+    expect(getByDisplayValue('Bangalore')).toBeTruthy();
+
+    fireEvent.press(getByRole('button', { name: 'Clear Selection' }));
+    expect(queryByDisplayValue('Bangalore')).toBeFalsy();
+  });
 });

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/AutoComplete.native.test.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/AutoComplete.native.test.tsx
@@ -185,7 +185,7 @@ describe('<Dropdown /> with <AutoComplete />', () => {
     expect(getByLabelText('Close Bengaluru tag')).toBeOnTheScreen();
   });
 
-  it('should handle controlled single selection', async () => {
+  it('should handle controlled single selection', () => {
     const ControlledDropdown = (): React.ReactElement => {
       const [currentSelection, setCurrentSelection] = React.useState<string>('');
 

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/AutoComplete.web.test.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/AutoComplete.web.test.tsx
@@ -211,6 +211,62 @@ describe('<Dropdown /> with <AutoComplete />', () => {
     Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 0 });
   });
 
+  it('should handle controlled single selection', async () => {
+    const ControlledDropdown = (): React.ReactElement => {
+      const [currentSelection, setCurrentSelection] = React.useState<string>('');
+
+      return (
+        <>
+          <Button
+            onClick={() => {
+              setCurrentSelection('bangalore');
+            }}
+          >
+            Select Bangalore
+          </Button>
+          <Button
+            onClick={() => {
+              setCurrentSelection('');
+            }}
+          >
+            Clear Selection
+          </Button>
+          <Dropdown selectionType="single">
+            <AutoComplete
+              label="Select City"
+              value={currentSelection}
+              onChange={(args) => {
+                setCurrentSelection(args?.values[0]);
+              }}
+            />
+            <DropdownOverlay>
+              <ActionList>
+                <ActionListItem title="Bangalore" value="bangalore" />
+                <ActionListItem title="Pune" value="pune" />
+                <ActionListItem title="Chennai" value="chennai" />
+              </ActionList>
+            </DropdownOverlay>
+          </Dropdown>
+        </>
+      );
+    };
+
+    const user = userEvent.setup();
+    const { getByRole } = renderWithTheme(<ControlledDropdown />);
+
+    const selectInput = getByRole('combobox', { name: 'Select City' });
+    expect(selectInput).toHaveValue('');
+    await user.click(getByRole('button', { name: 'Select Bangalore' }));
+    expect(selectInput).toHaveValue('Bangalore');
+
+    await user.click(selectInput);
+    await user.click(getByRole('option', { name: 'Pune' }));
+    expect(selectInput).toHaveValue('Pune');
+
+    await user.click(getByRole('button', { name: 'Clear Selection' }));
+    expect(selectInput).toHaveValue('');
+  });
+
   it('should handle controlled filtering', async () => {
     const cities = [
       {

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
@@ -1148,8 +1148,8 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
             >
               <label
                 data-blade-component="form-label"
-                for="dropdown-842-trigger-843-input-844"
-                id="dropdown-842-label"
+                for="dropdown-1003-trigger-1004-input-1005"
+                id="dropdown-1003-label"
                 style="width: auto; flex-shrink: 0; margin-right: 16px;"
               >
                 <div
@@ -1192,8 +1192,8 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                   data-blade-component="base-box"
                 >
                   <button
-                    aria-activedescendant="dropdown-842-0"
-                    aria-controls="dropdown-842-actionlist"
+                    aria-activedescendant="dropdown-1003-0"
+                    aria-controls="dropdown-1003-actionlist"
                     aria-describedby=""
                     aria-disabled="false"
                     aria-expanded="true"
@@ -1203,7 +1203,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                     autocomplete="off"
                     class="c13"
                     data-blade-component="styled-base-input"
-                    id="dropdown-842-trigger-843-input-844"
+                    id="dropdown-1003-trigger-1004-input-1005"
                     placeholder="Select Option"
                     role="combobox"
                     type="button"
@@ -1394,8 +1394,8 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                       >
                         <label
                           data-blade-component="form-label"
-                          for="dropdown-842-trigger-850-input-851"
-                          id="dropdown-842-label"
+                          for="dropdown-1003-trigger-1011-input-1012"
+                          id="dropdown-1003-label"
                           style="width: auto; flex-shrink: 0; margin-right: 16px;"
                         >
                           <div
@@ -1438,8 +1438,8 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                             data-blade-component="base-box"
                           >
                             <input
-                              aria-activedescendant="dropdown-842-0"
-                              aria-controls="dropdown-842-actionlist"
+                              aria-activedescendant="dropdown-1003-0"
+                              aria-controls="dropdown-1003-actionlist"
                               aria-describedby=""
                               aria-disabled="false"
                               aria-expanded="true"
@@ -1450,7 +1450,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                               autofocus=""
                               class="c38"
                               data-blade-component="styled-base-input"
-                              id="dropdown-842-trigger-850-input-851"
+                              id="dropdown-1003-trigger-1011-input-1012"
                               placeholder="Select Option"
                               role="combobox"
                               type="text"
@@ -1503,7 +1503,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                   data-blade-component="action-list-item"
                   data-index="0"
                   data-value="apple"
-                  id="dropdown-842-0"
+                  id="dropdown-1003-0"
                   role="option"
                   tabindex="-1"
                   type="button"
@@ -1543,7 +1543,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                   data-blade-component="action-list-item"
                   data-index="1"
                   data-value="mango"
-                  id="dropdown-842-1"
+                  id="dropdown-1003-1"
                   role="option"
                   tabindex="-1"
                   type="button"

--- a/packages/blade/src/components/Input/DropdownInputTriggers/types.ts
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/types.ts
@@ -40,11 +40,9 @@ type DropdownInputTriggersCommonProps = Pick<
   defaultValue?: string | string[];
   onChange?: ({ name, values }: { name?: string; values: string[] }) => void;
   /**
-   * Handles the controlled selection change.
+   * Syncs the selected value to inputValue in AutoComplete
    *
-   * Most controlled changing is handled internally in base component so this is only required when you want to perform additional changes.
-   *
-   * E.g. in AutoComplete, we want to sync the inputValue of autocomplete with its selection
+   * Only needed in single select AutoComplete because inputValue is expected to be same as selected value there
    */
   syncInputValueWithSelection?: (value: string) => void;
   /**

--- a/packages/blade/src/components/Input/DropdownInputTriggers/types.ts
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/types.ts
@@ -40,6 +40,14 @@ type DropdownInputTriggersCommonProps = Pick<
   defaultValue?: string | string[];
   onChange?: ({ name, values }: { name?: string; values: string[] }) => void;
   /**
+   * Handles the controlled selection change.
+   *
+   * Most controlled changing is handled internally in base component so this is only required when you want to perform additional changes.
+   *
+   * E.g. in AutoComplete, we want to sync the inputValue of autocomplete with its selection
+   */
+  syncInputValueWithSelection?: (value: string) => void;
+  /**
    * constraints the height of input to given number rows
    *
    * When set to expandable, input takes 1 row in the begining and expands to take 3 when active


### PR DESCRIPTION
AutoComplete when used in single selection controlled version, was not changing its input value on selection change.

In AutoComplete single select, the value displayed inside AutoComplete is inputValue. When we select item in controlled version, we also have to set its inputValue to the selection