### PR TITLE
fix(AutoComplete): handle focus ring on option change

### DIFF
--- a/.changeset/yellow-melons-deliver.md
+++ b/.changeset/yellow-melons-deliver.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(AutoComplete): handle focus ring on option change

--- a/packages/blade/src/components/Dropdown/dropdownUtils.ts
+++ b/packages/blade/src/components/Dropdown/dropdownUtils.ts
@@ -319,7 +319,7 @@ export const makeInputDisplayValue = (selectedIndices: number[], options: Option
 
   // When one item is selected, we display that item's title in input
   if (selectedIndices.length === 1) {
-    return options[selectedIndices[0]].title;
+    return options[selectedIndices[0]]?.title;
   }
 
   // When more than one item is selected, we display the count of items

--- a/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.tsx
@@ -54,7 +54,7 @@ const useAutoComplete = ({
       setActiveIndex(firstItemOptionIndex);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [globalFilteredValues.length]);
+  }, [globalFilteredValues.length, options.length]);
 
   // When input is empty or its single select, we want all items to be shown in filter on open of dropdown
   React.useEffect(() => {


### PR DESCRIPTION
In certain cases where data needs to be fetched and rendered in item, we have to re-calculate the first item and set focus ring on it on change of options. This PR does that.