### PR TITLE
feat(ListItemText): making span as default tag for ListItemText

### DIFF
--- a/.changeset/bright-pumpkins-push.md
+++ b/.changeset/bright-pumpkins-push.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(ListItemText): make span as default tag for ListItemText

--- a/packages/blade/src/components/List/ListItemText.tsx
+++ b/packages/blade/src/components/List/ListItemText.tsx
@@ -10,7 +10,7 @@ type ListItemTextProps = Omit<TextProps<{ variant: TextVariant }>, 'variant' | '
 const _ListItemText = ({ children, testID, ...props }: ListItemTextProps): ReactElement => {
   const { size } = useListContext();
 
-  return <Text {...props} size={size} children={children} testID={testID} />;
+  return <Text as="span" {...props} size={size} children={children} testID={testID} />;
 };
 
 const ListItemText = assignWithoutSideEffects(_ListItemText, {

--- a/packages/blade/src/components/List/__tests__/__snapshots__/List.web.test.tsx.snap
+++ b/packages/blade/src/components/List/__tests__/__snapshots__/List.web.test.tsx.snap
@@ -501,12 +501,12 @@ exports[`<List /> should render List with inline ListItemText 1`] = `
             class="c5"
             data-blade-component="text"
           >
-            <p
+            <span
               class="c6"
               data-blade-component="text"
             >
               Level 1
-            </p>
+            </span>
           </p>
         </div>
       </li>


### PR DESCRIPTION
Issue: https://github.com/razorpay/blade/issues/1696

Context: `Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>`
`<ListItemText />` uses `<p>` tag by default and `<ListItem />` renders a `<p>` tag as well which is causing the aforementioned issue.

Solution: ListItemText uses Text component which renders `<p>` tag by default. However, for almost all the use-cases ListItemText will get rendered inside ListItem and we can make `<span>` as default

https://razorpay.slack.com/archives/CMQ3RBHEU/p1696501813630969