### PR TITLE
docs: Fixed links that were broken in Installation.stories.mdx

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -9,7 +9,7 @@ import { Meta } from '@storybook/addon-docs';
 
 ## ✍🏻 Pre-requisite
 
-Before you install the package, make sure that you have performed following steps:
+Before you install the package, make sure that you have performed the following steps:
 
 - You must be running Node version >=14.19.0
 
@@ -41,7 +41,7 @@ Before you install the package, make sure that you have performed following step
 ## ⬇ Add blade to your application
 
 1. Install blade as a dependency. 
-Blade has a peer dependency on few libraries, you can skip adding it if you already have it installed in your project.
+Blade has a peer dependency on a few libraries, you can skip adding it if you already have it installed in your project.
 
   - `styled-components`
   - `@floating-ui/react`
@@ -67,7 +67,7 @@ Blade has a peer dependency on few libraries, you can skip adding it if you alre
     - @floating-ui/react-native
       - Add this as peer dependency, no need to do additional setup.
 
-## 🔜 Add blade libraries to your figma project
+## 🔜 Add blade libraries to your Figma project
 
 Coming Soon
 
@@ -77,11 +77,11 @@ We are using `Lato` font family which is not a system font so we need to perform
 
 ### Web Projects
 
-For web projects we can either use google fonts or self hosted fonts. Self hosted fonts have certain benefits that you can find [here](https://fontsource.org/docs/introduction)
+For web projects, we can either use Google fonts or self-hosted fonts. Self-hosted fonts have certain benefits that you can find [here](https://fontsource.org/docs/getting-started/introduction)
 
-#### Self Hosted (Recommended)
+#### Self-Hosted (Recommended)
 
-We recommend to use self hosted fonts. We'll use [Fontsource](https://fontsource.org/) which provides fonts as npm packages.
+We recommend using self-hosted fonts. We'll use [Fontsource](https://fontsource.org/) which provides fonts as npm packages.
 
 - Install `Lato` font
 
@@ -99,13 +99,13 @@ We recommend to use self hosted fonts. We'll use [Fontsource](https://fontsource
 
 #### Google Fonts
 
-There are downsides to using google fonts which can be found [here](https://fontsource.org/docs/introduction) but still for some reason if you have some use case where google fonts makes more sense then you can [click this link](https://fonts.google.com/share?selection.family=Lato:ital,wght@0,400;0,700;1,400;1,700) and follow the instructions there to configure `Lato` for your applications.
+There are downsides to using Google fonts which can be found [here](https://fontsource.org/docs/getting-started/introduction) but still for some reason if you have some use case where Google fonts makes more sense then you can [click this link](https://fonts.google.com/share?selection.family=Lato:ital,wght@0,400;0,700;1,400;1,700) and follow the instructions there to configure `Lato` for your applications.
 
 ### React Native Projects
 
 - Download `Lato` font from [here](https://fonts.google.com/share?selection.family=Lato:ital,wght@0,400;0,700;1,400;1,700)
-- Copy the font files and paste it under the directory `<project_root>/public/fonts`(**create the directory if it doesn't exist**)
-- Create React Native config file at the root of your project - `<project_root>/react-native.config.js` and add following content to it
+- Copy the font files and paste them under the directory `<project_root>/public/fonts`(**create the directory if it doesn't exist**)
+- Create a React Native config file at the root of your project - `<project_root>/react-native.config.js` and add the following content to it
 
   ```js
   module.exports = {
@@ -116,7 +116,7 @@ There are downsides to using google fonts which can be found [here](https://font
 
 #### android
 
-Follow the next steps mentioned below for configuring fonts to work on android:
+Follow the next steps mentioned below for configuring fonts to work on Android:
 
 - Create a directory `font` under `/android/app/src/main/res/font`
 - Copy the font files `Lato-Regular` and `Lato-Bold` you had downloaded earlier and paste them under `/android/app/src/main/res/font`
@@ -135,10 +135,10 @@ Follow the next steps mentioned below for configuring fonts to work on android:
     <font app:fontStyle="italic" app:fontWeight="700" app:font="@font/lato_bold_italic" />
   </font-family>
   ```
-- Navigate to `/android/app/src/main/java/com/<your_package_name>/MainApplication.java` and add following contents to it
+- Navigate to `/android/app/src/main/java/com/<your_package_name>/MainApplication.java` and add the following contents to it
 
   ```js
-  // add the below import statement after all the import statements
+  //Add the below import statement after all the import statements
   import com.facebook.react.views.text.ReactFontManager;
   ```
 
@@ -146,7 +146,7 @@ Follow the next steps mentioned below for configuring fonts to work on android:
 
   ```js
   public void onCreate() {
-    // add below line as the first line
+    //Add the below line as the first line
     ReactFontManager.getInstance().addCustomFont(this, "Lato", R.font.lato);
     // rest of the content of the method
   }
@@ -156,7 +156,7 @@ Follow the next steps mentioned below for configuring fonts to work on android:
 
 Follow the next steps mentioned below for configuring fonts to work on iOS:
 
-- Once you've copied the font files under `<project_root>/public/fonts` you need to link it using following command
+- Once you've copied the font files under `<project_root>/public/fonts` you need to link it using the following command
 
   ```shell
   npx react-native link --platforms ios

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -138,7 +138,7 @@ Follow the next steps mentioned below for configuring fonts to work on Android:
 - Navigate to `/android/app/src/main/java/com/<your_package_name>/MainApplication.java` and add the following contents to it
 
   ```js
-  //Add the below import statement after all the import statements
+  // add the below import statement after all the import statements
   import com.facebook.react.views.text.ReactFontManager;
   ```
 
@@ -146,7 +146,7 @@ Follow the next steps mentioned below for configuring fonts to work on Android:
 
   ```js
   public void onCreate() {
-    //Add the below line as the first line
+    // add the below line as the first line
     ReactFontManager.getInstance().addCustomFont(this, "Lato", R.font.lato);
     // rest of the content of the method
   }


### PR DESCRIPTION
![2023-10-13 20_04_01-Guides _ Installation - Page ⋅ Storybook and 3 more pages - Personal - Microsoft](https://github.com/razorpay/blade/assets/133931559/eb7ba7b6-2922-4178-96fc-a400b0f6f01e)
![2023-10-13 20_04_07-Guides _ Installation - Page ⋅ Storybook and 3 more pages - Personal - Microsoft](https://github.com/razorpay/blade/assets/133931559/d7a5e336-88b0-47a3-a466-991f809c707f)

Two of these links were broken and showed a **404 error**. I have updated them to redirect to the intended page. 

Also, I have made a few **grammatical corrections** in the guide. Thanks :)

