### PR TITLE
fix(ActionListItem): checkbox spacing

### DIFF
--- a/.changeset/tricky-mice-tie.md
+++ b/.changeset/tricky-mice-tie.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(ActionListItem): checkbox spacing

--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -238,10 +238,6 @@ const ActionListItemText = assignWithoutSideEffects(_ActionListItemText, {
   componentId: componentIds.ActionListItemText,
 });
 
-const ActionListCheckboxWrapper = styled(BaseBox)<{ hasDescription: boolean }>((_props) => ({
-  pointerEvents: 'none',
-}));
-
 type ClickHandlerType = (e: React.MouseEvent<HTMLButtonElement>) => void;
 
 const makeActionListItemClickable = (
@@ -287,8 +283,9 @@ const _ActionListItemBody = ({
         <BaseBox display="flex" justifyContent="center" alignItems="center">
           {selectionType === 'multiple' ? (
             // Adding aria-hidden because the listbox item in multiselect in itself explains the behaviour so announcing checkbox is unneccesary and just a nice UI tweak for us
-            <ActionListCheckboxWrapper
-              hasDescription={Boolean(description)}
+            <BaseBox
+              pointerEvents="none"
+              paddingRight="spacing.2"
               {...makeAccessible({
                 hidden: true,
               })}
@@ -300,7 +297,7 @@ const _ActionListItemBody = ({
                     */}
                 {null}
               </Checkbox>
-            </ActionListCheckboxWrapper>
+            </BaseBox>
           ) : (
             leading
           )}

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
@@ -931,12 +931,12 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                           <View
                             accessibilityElementsHidden={true}
                             data-blade-component="base-box"
-                            hasDescription={false}
                             importantForAccessibility="no-hide-descendants"
+                            pointerEvents="none"
                             style={
                               [
-                                {},
                                 {
+                                  "paddingRight": 4,
                                   "pointerEvents": "none",
                                 },
                               ]
@@ -1219,12 +1219,12 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                           <View
                             accessibilityElementsHidden={true}
                             data-blade-component="base-box"
-                            hasDescription={false}
                             importantForAccessibility="no-hide-descendants"
+                            pointerEvents="none"
                             style={
                               [
-                                {},
                                 {
+                                  "paddingRight": 4,
                                   "pointerEvents": "none",
                                 },
                               ]
@@ -1507,12 +1507,12 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                           <View
                             accessibilityElementsHidden={true}
                             data-blade-component="base-box"
-                            hasDescription={false}
                             importantForAccessibility="no-hide-descendants"
+                            pointerEvents="none"
                             style={
                               [
-                                {},
                                 {
+                                  "paddingRight": 4,
                                   "pointerEvents": "none",
                                 },
                               ]


### PR DESCRIPTION
Fixes #1733 

There was some additional spacing around Checkbox earlier which we removed in #1661 but that changed spacing for Checkbox in ActionListItem as well.

This PR adds some new spacing around checkbox of ActionListItem to fix it.

Before this PR
<img width="267" alt="image" src="https://github.com/razorpay/blade/assets/30949385/ec65d7bd-71df-4a24-8531-92fe9093e112">


After this PR
<img width="283" alt="image" src="https://github.com/razorpay/blade/assets/30949385/cbc538dd-217c-45a0-a138-98ec94c7002a">
