### PR TITLE
fix(ActionListItem): Width based Truncation 

### DIFF
--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -313,6 +313,7 @@ const _ActionListItemBody = ({
           flexDirection="row"
         >
           <Text
+            shouldTruncate={true}
             truncateAfterLines={1}
             color={
               intent === 'negative'

--- a/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
@@ -19,6 +19,7 @@ const StyledBaseText = styled.div.withConfig({
     fontWeight,
     fontStyle,
     textDecorationLine,
+    shouldTruncate,
     numberOfLines,
     lineHeight,
     textAlign,
@@ -34,6 +35,7 @@ const StyledBaseText = styled.div.withConfig({
         fontStyle,
         textDecorationLine,
         numberOfLines,
+        shouldTruncate,
         lineHeight,
         textAlign,
         theme: props.theme,
@@ -56,6 +58,7 @@ export const BaseText = ({
   textAlign,
   children,
   truncateAfterLines,
+  shouldTruncate,
   className,
   style,
   accessibilityProps = {},
@@ -76,6 +79,7 @@ export const BaseText = ({
       as={as}
       textAlign={textAlign}
       numberOfLines={truncateAfterLines}
+      shouldTruncate={shouldTruncate}
       className={className}
       style={style}
       id={id}

--- a/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
+++ b/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
@@ -12,6 +12,7 @@ const getBaseTextStyles = ({
   fontStyle = 'normal',
   textDecorationLine = 'none',
   numberOfLines,
+  shouldTruncate,
   lineHeight = 100,
   textAlign,
   theme,
@@ -22,6 +23,7 @@ const getBaseTextStyles = ({
   const themeFontWeight = theme.typography.fonts.weight[fontWeight];
   const themeLineHeight = makeTypographySize(theme.typography.lineHeights[lineHeight]);
   let truncateStyles: CSSObject = {};
+  let truncateWidthStyles: CSSObject = {};
   if (numberOfLines !== undefined) {
     if (isReactNative()) {
       truncateStyles = {};
@@ -32,6 +34,18 @@ const getBaseTextStyles = ({
         'line-clamp': `${numberOfLines}`,
         '-webkit-line-clamp': `${numberOfLines}`,
         '-webkit-box-orient': 'vertical',
+      };
+    }
+  }
+  if(shouldTruncate !== undefined) {
+    if (isReactNative()) {
+      truncateWidthStyles = {};
+    } else {
+      truncateWidthStyles = {
+        overflow: 'hidden',
+        maxWidth: '100%',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
       };
     }
   }
@@ -51,6 +65,7 @@ const getBaseTextStyles = ({
     margin: 0,
     padding: 0,
     ...truncateStyles,
+    ...truncateWidthStyles,
   };
 };
 

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -60,6 +60,7 @@ export type BaseTextProps = {
   as?: As;
   textAlign?: 'center' | 'justify' | 'left' | 'right';
   truncateAfterLines?: number;
+  shouldTruncate?: boolean;
   className?: string;
   style?: React.CSSProperties;
   children: React.ReactNode;
@@ -85,6 +86,7 @@ export type StyledBaseTextProps = Pick<
   | 'textAlign'
   | 'numberOfLines'
   | 'truncateAfterLines'
+  | 'shouldTruncate'
 > & { theme: Theme };
 
 export type BaseTextSizes = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -19,6 +19,7 @@ type TextCommonProps = {
   contrast?: ColorContrastTypes;
   truncateAfterLines?: number;
   children: React.ReactNode;
+  shouldTruncate ?: boolean;
   weight?: keyof Theme['typography']['fonts']['weight'];
   /**
    * Overrides the color of the Text component.
@@ -137,6 +138,7 @@ const _Text = <T extends { variant: TextVariant }>({
   type = 'normal',
   contrast = 'low',
   truncateAfterLines,
+  shouldTruncate,
   children,
   color,
   testID,
@@ -147,6 +149,7 @@ const _Text = <T extends { variant: TextVariant }>({
   const props: Omit<BaseTextProps, 'children'> = {
     as,
     truncateAfterLines,
+    shouldTruncate,
     ...getTextProps({
       variant,
       type,


### PR DESCRIPTION
## Description

This pull request adds a new prop to the `Text` component called `shouldTruncate` which takes in a boolean value. When `shouldTruncate` is set to `true`, the `Text` component will apply CSS to truncate the text if it exceeds the container's width.

The `shouldTruncate` prop is then set to `true` for the `ActionListItem` component to enable text truncation for the dropdown overlay.

## Changes Made

- Added a new prop called `shouldTruncate` to the `Text` component.
- Added CSS to the `Text` component to truncate text if it exceeds the container's width and the shouldTruncate prop is flagged true.
- Set `shouldTruncate` to `true` for the `ActionListItem` component.

## Screenshots

<img width="1078" alt="image" src="https://github.com/razorpay/blade/assets/88273114/8eedf628-c8a0-45d1-8115-9a6e5e893813">




## Related Issue

Closes #1699
