### PR TITLE
fix(blade): remove preventDefault in selector label

### DIFF
--- a/.changeset/plenty-ligers-study.md
+++ b/.changeset/plenty-ligers-study.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): remove preventDefault in selector label

--- a/packages/blade/src/components/Form/Selector/SelectorLabel.web.tsx
+++ b/packages/blade/src/components/Form/Selector/SelectorLabel.web.tsx
@@ -30,10 +30,7 @@ const SelectorLabel = ({
     <StyledSelectorLabel
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
-      onMouseDown={(e) => {
-        e.preventDefault();
-        onMouseDown?.(e);
-      }}
+      onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       onMouseOut={onMouseOut}
       onKeyDown={onKeyDown}


### PR DESCRIPTION
Fixes: #1746

Removed preventDefault from SelectorLabel onMouseDown event which was causing Radio to behave oddly while any text is selected. 

The preventDefault was previously added because when using a mouse and toggling a component like checkbox there was a focus flicker which was happening and we wanted to prevent that: 

**with preventDefault:** 


https://github.com/razorpay/blade/assets/35374649/01770544-b81b-496b-be55-e4fdfbc1e4d3

**without preventDefault:**


https://github.com/razorpay/blade/assets/35374649/d00d6532-62df-4ee8-96b5-91efe1f6d002

But after the `focus-visible` change in #1670 that we made this is no longer needed since focus won't be visible when clicking with mouse, so removed it. 