### PR TITLE
docs: Move Google Docs info to API Decisions

### DIFF
--- a/packages/blade/src/components/Dropdown/_decisions/decisions.md
+++ b/packages/blade/src/components/Dropdown/_decisions/decisions.md
@@ -24,6 +24,7 @@ Dropdown Menu displays a list of choices on temporary surfaces. They allow users
 
 - [Dropdown](#dropdown)
   - [SelectInput](#selectinput)
+  - [DropdownButton & DropdownLink](#dropdownbutton-&-dropdownlink)
   - [DropdownOverlay](#dropdownoverlay)
 - [ActionList](#actionlist)
   - [ActionList Parent Component](#actionlist-parent-component)
@@ -92,6 +93,69 @@ type SelectInputProps = {
 Would be ideal if we can render it as `button` with `aria-expanded` prop to handle state of dropdown open and close.
 
 Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded#buttons
+
+### `DropdownButton` & `DropdownLink`
+
+```diff
+<Dropdown>
++	<DropdownButton /> // or <DropdownLink />
+	<DropdownOverlay>
+		<ActionList />
+	</DropdownOverlay>
+</Dropdown>
+```
+
+#### Pros
+
+- Encourages consumers to use Blade component for trigger
+- Easy to add common triggers like Button and Link for consumer without creating extra wrappers
+
+#### Cons
+
+- Requires new components to be created for different triggers on our end
+- Open / Close states are handled internally and consumer doesn’t have a control there
+
+#### Alternate API
+
+<details>
+<summary>Alternative API is to expose useDropdown hook and allow consumers to create triggers on their end</summary>
+
+##### `useDropdownTrigger` hook
+
+As suggested by Anurag Hazra, `useDropdownTrigger` hook
+
+```jsx
+// MyCustomTrigger.ts
+const MyCustomTrigger = (props) => {
+  const triggerProps = useDropdownTrigger();
+  return <MyCustomStyledComponent {...triggerProps} {...props} />;
+};
+
+// Usage
+<Dropdown>
+  <MyCustomTrigger />
+  <DropdownOverlay>
+    <ActionList />
+  </DropdownOverlay>
+</Dropdown>;
+```
+
+##### Pros
+
+- Can support all custom triggers on the user's end (E.g. if they want to trigger dropdown with button that is not from blade or link that is not from blade)
+
+##### Cons
+
+- The props that we spread on Trigger are accessible inside Dropdown context so consumers will have to create a separate trigger component in their repo to use the hook and then add it inside Dropdown. Check the example above.
+- Still won’t support some components from blade that do not expose all trigger-required props like `onKeyDown`, `onBlur`, forward refs with focus exposed, etc. So if the consumer is expecting to turn the `Box` component into a trigger, it won’t work.
+
+</details>
+
+#### Conclusion on DropdownButton and DropdownLink
+
+We decided to go with DropdownButton and DropdownLink due to mentioned pros above.
+
+Exposing hook like `useDropdownTrigger` can be explored in future if more custom trigger usecases show up.
 
 ### `DropdownOverlay`
 

--- a/packages/blade/src/components/Dropdown/_decisions/decisions.md
+++ b/packages/blade/src/components/Dropdown/_decisions/decisions.md
@@ -24,7 +24,7 @@ Dropdown Menu displays a list of choices on temporary surfaces. They allow users
 
 - [Dropdown](#dropdown)
   - [SelectInput](#selectinput)
-  - [DropdownButton & DropdownLink](#dropdownbutton-&-dropdownlink)
+  - [DropdownButton & DropdownLink](#dropdownbutton--dropdownlink)
   - [DropdownOverlay](#dropdownoverlay)
 - [ActionList](#actionlist)
   - [ActionList Parent Component](#actionlist-parent-component)
@@ -98,10 +98,10 @@ Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attri
 
 ```diff
 <Dropdown>
-+	<DropdownButton /> // or <DropdownLink />
-	<DropdownOverlay>
-		<ActionList />
-	</DropdownOverlay>
++ <DropdownButton /> // or <DropdownLink />
+  <DropdownOverlay>
+    <ActionList />
+  </DropdownOverlay>
 </Dropdown>
 ```
 

--- a/rfcs/2023-01-06-layout.md
+++ b/rfcs/2023-01-06-layout.md
@@ -458,3 +458,84 @@ Few design systems support a grid system _(12 column, 24 column, etc.)_, althoug
 - [MUI](https://mui.com/material-ui/react-grid/)
 - [Antd](https://ant.design/components/grid)
 - [Bootstrap, the real OG](https://getbootstrap.com/docs/5.3/layout/grid/#how-it-works)
+
+### Discussions
+
+#### Platform Specific Defaults vs Consistent Defaults
+
+- Consistent Defaults: One code, works everywhere
+- ✅ Platform Specific Defaults: React Native | web maintain their own defaults.
+
+**Conclusion:**
+
+Going ahead with Platform Specific Defaults because-
+
+- This will ensure we don’t hamper DX for React Native Developers by enforcing web defaults on them.
+- If someone wants to have same defaults, they can set default values on their end with-
+
+```jsx
+const CrossPlatformBox = (props: BoxProps) => {
+  return <Box display="flex" flexDirection="column" {...props} />;
+};
+```
+
+#### Padding & Margin Shorthands
+
+```jsx
+<Box padding={['spacing.2', 'spacing.1']} />
+```
+
+This syntax is padding shorthand for us. But in other libraries, this takes breakpoint values (considers first value for mobile and second for desktop)
+
+**Alternative:**
+
+```jsx
+<Box padding="spacing.2 spacing.1" />
+```
+
+**Conclusion:**
+
+We're going with first array syntax because-
+
+- Since typescript would break on string syntax.
+- There will be little learning curve but consumers will get used to it.
+
+#### Additional Prop Supports In First Release
+
+- **`background-color`**
+
+  We decided to support it with `surface.background.*` tokens because there were clear usecases of setting surface background colors.
+
+- **Support for `border-size: box` prop in Alert and Card**
+
+  Added.
+
+- **`as` prop**
+
+  Added with limited values like div, span, section, main, etc.
+
+- **`id` prop**
+
+  Not added. We decided to wait for usecases.
+
+#### Styled Props vs Style Props
+
+Consumers can confuse “Styled Props” with styled-component or styled-system.
+
+Options:
+
+- [ ] Style-props
+- [x] Styled-props
+- [ ] Styling-props
+
+**Conclusion:**
+
+We figured that calling it style-props won’t solve the problem either so we decided to go with “styled-props” since “styled” is a common term used in most libraries.
+
+We decided to add more specific heading in documentation like- "Styled Props for Components"
+
+#### Whether styled-props get more priority over defined props in blade or the other way
+
+**Conclusion:** We decided to give more priority to styled-props and let consumers override.
+
+The only concern we had was that this comes with the possibility of consumer passing some prop that breaks the UI of component. Ideally this shouldn’t happen in most cases as the styled-props are very limited and rarely change UI. For some cases where this does happen, consumers would know they broke something and can find a workaround.


### PR DESCRIPTION
Resolves #1172 

Moved information from our [Layout Discussion Doc](https://docs.google.com/document/d/1Ifcgh1hXvEykO8YbfcyiWoFktAHSe57xXiPz53Puew8/edit#heading=h.wcduvwj40y7e) and [Dropdown Triggers API Doc](https://docs.google.com/document/d/1vxwF_CuF6dDYJuIcxck16jusfufWhMJflWbeQG9SD3o/edit#heading=h.ajyy8ugby849) to their respective API decisions