### PR TITLE
chore: use gpt3 for heavy reviews as well

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -27,3 +27,4 @@ jobs:
           debug: true
           review_simple_changes: false
           review_comment_lgtm: false
+          openai_heavy_model: 'gpt-3.5-turbo'


### PR DESCRIPTION
By default it tries to use gpt4 which we do not have access to 😢 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new configuration option `openai_heavy_model` with the value `'gpt-3.5-turbo'` to the AI PR Review workflow. This allows users to specify the heavy model version for their AI reviews, providing more advanced capabilities.

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->