### PR TITLE
chore: only allow CarouselItem in Carousel children

### DIFF
--- a/.changeset/proud-pianos-switch.md
+++ b/.changeset/proud-pianos-switch.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+chore(blade): only allow CarouselItem in Carousel children

--- a/packages/blade/src/components/Card/Card.tsx
+++ b/packages/blade/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CardSurface } from './CardSurface';
-import { CardProvider, useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
+import { CardProvider, useVerifyInsideCard } from './CardContext';
 import { LinkOverlay } from './LinkOverlay';
 import { CardRoot } from './CardRoot';
 import type { LinkOverlayProps } from './types';
@@ -16,6 +16,7 @@ import type { Elevation } from '~tokens/global';
 import type { SurfaceLevels } from '~tokens/theme/theme';
 import type { BoxProps } from '~components/Box';
 import { makeAccessible } from '~utils/makeAccessible';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
 import { isReactNative } from '~utils';
 
 export const ComponentIds = {
@@ -157,11 +158,12 @@ const Card = ({
   ...styledProps
 }: CardProps): React.ReactElement => {
   const [isFocused, setIsFocused] = React.useState(false);
-  useVerifyAllowedComponents(children, 'Card', [
-    ComponentIds.CardHeader,
-    ComponentIds.CardBody,
-    ComponentIds.CardFooter,
-  ]);
+
+  useVerifyAllowedChildren({
+    children,
+    componentName: 'Card',
+    allowedComponents: [ComponentIds.CardHeader, ComponentIds.CardBody, ComponentIds.CardFooter],
+  });
 
   const linkOverlayProps: LinkOverlayProps = {
     ...metaAttribute({ name: CARD_LINK_OVERLAY_ID }),

--- a/packages/blade/src/components/Card/Card.tsx
+++ b/packages/blade/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ import type { Elevation } from '~tokens/global';
 import type { SurfaceLevels } from '~tokens/theme/theme';
 import type { BoxProps } from '~components/Box';
 import { makeAccessible } from '~utils/makeAccessible';
-import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren/useVerifyAllowedChildren';
 import { isReactNative } from '~utils';
 
 export const ComponentIds = {

--- a/packages/blade/src/components/Card/CardContext.tsx
+++ b/packages/blade/src/components/Card/CardContext.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { getComponentId } from '~utils/isValidAllowedChildren';
 import { throwBladeError } from '~utils/logger';
 
 type CardContextType = true | null;
@@ -18,32 +17,9 @@ const useVerifyInsideCard = (componentName: string): CardContextType => {
   return true;
 };
 
-/**
- * Verify if the passed childrens are only of allowedComponents list
- */
-const useVerifyAllowedComponents = (
-  children: React.ReactNode,
-  componentName: string,
-  allowedComponents: string[],
-): void => {
-  React.Children.forEach(children, (child) => {
-    const isValidChild = child && allowedComponents.includes(getComponentId(child)!);
-    if (__DEV__) {
-      if (!isValidChild) {
-        throwBladeError({
-          message: `Only one of \`${allowedComponents.join(
-            ', ',
-          )}\` component is accepted as ${componentName} children`,
-          moduleName: 'Card',
-        });
-      }
-    }
-  });
-};
-
 type CardProviderProps = { children: React.ReactNode };
 const CardProvider = ({ children }: CardProviderProps): React.ReactElement => {
   return <CardContext.Provider value={true}>{children}</CardContext.Provider>;
 };
 
-export { useVerifyInsideCard, useVerifyAllowedComponents, CardProvider };
+export { useVerifyInsideCard, CardProvider };

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import type { ReactElement } from 'react';
 import React from 'react';
-import { useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
+import { useVerifyInsideCard } from './CardContext';
 import { ComponentIds } from './Card';
 import type { ButtonProps } from '~components/Button';
 import { Button } from '~components/Button';
@@ -13,6 +13,7 @@ import type { TestID } from '~utils/types';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { useIsMobile } from '~utils/useIsMobile';
 import { throwBladeError } from '~utils/logger';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
 
 export type CardFooterAction = Pick<
   ButtonProps,
@@ -28,10 +29,11 @@ type CardFooterProps = {
 const _CardFooter = ({ children, testID }: CardFooterProps): React.ReactElement => {
   const isMobile = useIsMobile();
   useVerifyInsideCard('CardFooter');
-  useVerifyAllowedComponents(children, 'CardFooter', [
-    ComponentIds.CardFooterLeading,
-    ComponentIds.CardFooterTrailing,
-  ]);
+  useVerifyAllowedChildren({
+    children,
+    componentName: 'CardFooter',
+    allowedComponents: [ComponentIds.CardFooterLeading, ComponentIds.CardFooterTrailing],
+  });
 
   const footerChildrensArray = React.Children.toArray(children);
   if (__DEV__) {

--- a/packages/blade/src/components/Card/CardFooter.tsx
+++ b/packages/blade/src/components/Card/CardFooter.tsx
@@ -13,7 +13,7 @@ import type { TestID } from '~utils/types';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { useIsMobile } from '~utils/useIsMobile';
 import { throwBladeError } from '~utils/logger';
-import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren/useVerifyAllowedChildren';
 
 export type CardFooterAction = Pick<
   ButtonProps,

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -22,7 +22,7 @@ import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { makeSpace } from '~utils/makeSpace';
 import { getComponentId, isValidAllowedChildren } from '~utils/isValidAllowedChildren';
 import { throwBladeError } from '~utils/logger';
-import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren/useVerifyAllowedChildren';
 
 const _CardHeaderIcon = ({ icon: Icon }: { icon: IconComponent }): React.ReactElement => {
   useVerifyInsideCard('CardHeaderIcon');

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { useVerifyInsideCard, useVerifyAllowedComponents } from './CardContext';
+import { useVerifyInsideCard } from './CardContext';
 import { ComponentIds } from './Card';
 import type { BadgeProps } from '~components/Badge';
 import { Badge } from '~components/Badge';
@@ -22,6 +22,7 @@ import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { makeSpace } from '~utils/makeSpace';
 import { getComponentId, isValidAllowedChildren } from '~utils/isValidAllowedChildren';
 import { throwBladeError } from '~utils/logger';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
 
 const _CardHeaderIcon = ({ icon: Icon }: { icon: IconComponent }): React.ReactElement => {
   useVerifyInsideCard('CardHeaderIcon');
@@ -94,10 +95,11 @@ type CardHeaderProps = {
 
 const _CardHeader = ({ children, testID }: CardHeaderProps): React.ReactElement => {
   useVerifyInsideCard('CardHeader');
-  useVerifyAllowedComponents(children, 'CardHeader', [
-    ComponentIds.CardHeaderLeading,
-    ComponentIds.CardHeaderTrailing,
-  ]);
+  useVerifyAllowedChildren({
+    children,
+    componentName: 'CardHeader',
+    allowedComponents: [ComponentIds.CardHeaderLeading, ComponentIds.CardHeaderTrailing],
+  });
 
   return (
     <BaseBox

--- a/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.native.test.tsx
@@ -206,7 +206,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade: Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted as Card children',
+      '[Blade: Card]: Only `CardHeader, CardBody, CardFooter` components are accepted in `Card` children',
     );
     mockConsoleError.mockRestore();
   });
@@ -226,7 +226,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade: Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted as CardHeader children',
+      '[Blade: CardHeader]: Only `CardHeaderLeading, CardHeaderTrailing` components are accepted in `CardHeader` children',
     );
     mockConsoleError.mockRestore();
   });
@@ -246,7 +246,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade: Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted as CardFooter children',
+      '[Blade: CardFooter]: Only `CardFooterLeading, CardFooterTrailing` components are accepted in `CardFooter` children',
     );
     mockConsoleError.mockRestore();
   });

--- a/packages/blade/src/components/Card/__tests__/Card.web.test.tsx
+++ b/packages/blade/src/components/Card/__tests__/Card.web.test.tsx
@@ -203,7 +203,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade: Card]: Only one of `CardHeader, CardBody, CardFooter` component is accepted as Card children',
+      '[Blade: Card]: Only `CardHeader, CardBody, CardFooter` components are accepted in `Card` children',
     );
     mockConsoleError.mockRestore();
   });
@@ -223,7 +223,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade: Card]: Only one of `CardHeaderLeading, CardHeaderTrailing` component is accepted as CardHeader children',
+      '[Blade: CardHeader]: Only `CardHeaderLeading, CardHeaderTrailing` components are accepted in `CardHeader` children',
     );
     mockConsoleError.mockRestore();
   });
@@ -243,7 +243,7 @@ describe('<Card />', () => {
         </Card>,
       ),
     ).toThrow(
-      '[Blade: Card]: Only one of `CardFooterLeading, CardFooterTrailing` component is accepted as CardFooter children',
+      '[Blade: CardFooter]: Only `CardFooterLeading, CardFooterTrailing` components are accepted in `CardFooter` children',
     );
     mockConsoleError.mockRestore();
   });

--- a/packages/blade/src/components/Carousel/Carousel.web.tsx
+++ b/packages/blade/src/components/Carousel/Carousel.web.tsx
@@ -23,7 +23,7 @@ import { useId } from '~utils/useId';
 import { makeAccessible } from '~utils/makeAccessible';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { useDidUpdate } from '~utils/useDidUpdate';
-import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren/useVerifyAllowedChildren';
 
 type ControlsProp = Required<
   Pick<

--- a/packages/blade/src/components/Carousel/Carousel.web.tsx
+++ b/packages/blade/src/components/Carousel/Carousel.web.tsx
@@ -15,7 +15,7 @@ import type { CarouselProps } from './types';
 import type { CarouselContextProps } from './CarouselContext';
 import { CarouselContext } from './CarouselContext';
 import { getCarouselItemId } from './utils';
-import { CAROUSEL_AUTOPLAY_INTERVAL } from './constants';
+import { CAROUSEL_AUTOPLAY_INTERVAL, componentIds } from './constants';
 import { Box } from '~components/Box';
 import BaseBox from '~components/Box/BaseBox';
 import { castWebType, makeMotionTime, useInterval, useTheme } from '~utils';
@@ -23,6 +23,7 @@ import { useId } from '~utils/useId';
 import { makeAccessible } from '~utils/makeAccessible';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { useDidUpdate } from '~utils/useDidUpdate';
+import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren';
 
 type ControlsProp = Required<
   Pick<
@@ -244,6 +245,12 @@ const Carousel = ({
   const containerRef = React.useRef<HTMLDivElement>(null);
   const isMobile = platform === 'onMobile';
   const id = useId('carousel');
+
+  useVerifyAllowedChildren({
+    componentName: 'Carousel',
+    allowedComponents: [componentIds.CarouselItem],
+    children,
+  });
 
   const [isScrollAtStart, setScrollStart] = React.useState(
     // on mobile we do not want to render the overlay

--- a/packages/blade/src/components/Carousel/CarouselItem.web.tsx
+++ b/packages/blade/src/components/Carousel/CarouselItem.web.tsx
@@ -5,9 +5,11 @@ import styled from 'styled-components';
 import React from 'react';
 import type { CarouselProps } from './types';
 import { useCarouselContext } from './CarouselContext';
+import { componentIds } from './constants';
 import BaseBox from '~components/Box/BaseBox';
 import { useBreakpoint, useTheme } from '~utils';
 import { makeAccessible } from '~utils/makeAccessible';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 
 type StyledCarouselItemProps = Pick<CarouselProps, 'visibleItems' | 'shouldAddStartEndSpacing'> &
   Pick<CarouselItemProps, 'shouldHaveEndSpacing' | 'shouldHaveStartSpacing'> & {
@@ -48,7 +50,7 @@ type CarouselItemProps = {
   shouldHaveEndSpacing?: boolean;
 };
 
-const CarouselItem = ({
+const _CarouselItem = ({
   children,
   shouldHaveStartSpacing,
   shouldHaveEndSpacing,
@@ -88,5 +90,9 @@ const CarouselItem = ({
     </StyledCarouselItem>
   );
 };
+
+const CarouselItem = assignWithoutSideEffects(_CarouselItem, {
+  componentId: componentIds.CarouselItem,
+});
 
 export { CarouselItem };

--- a/packages/blade/src/components/Carousel/constants.ts
+++ b/packages/blade/src/components/Carousel/constants.ts
@@ -1,3 +1,7 @@
 const CAROUSEL_AUTOPLAY_INTERVAL = 6000;
 
-export { CAROUSEL_AUTOPLAY_INTERVAL };
+const componentIds = {
+  CarouselItem: 'CarouselItem',
+};
+
+export { CAROUSEL_AUTOPLAY_INTERVAL, componentIds };

--- a/packages/blade/src/utils/useVerifyAllowedChildren.ts
+++ b/packages/blade/src/utils/useVerifyAllowedChildren.ts
@@ -1,0 +1,29 @@
+import React from 'react';
+import { getComponentId } from './isValidAllowedChildren';
+import { throwBladeError } from './logger';
+
+/**
+ * Verify if the passed childrens are only of allowedComponents list
+ */
+const useVerifyAllowedChildren = (props: {
+  children: React.ReactNode;
+  componentName: string;
+  allowedComponents: string[];
+}): void => {
+  const { children, componentName, allowedComponents } = props;
+  if (__DEV__) {
+    React.Children.forEach(children, (child) => {
+      const isValidChild = child && allowedComponents.includes(getComponentId(child)!);
+      if (!isValidChild) {
+        throwBladeError({
+          message: `Only \`${allowedComponents.join(
+            ', ',
+          )}\` components are accepted in \`${componentName}\` children`,
+          moduleName: componentName,
+        });
+      }
+    });
+  }
+};
+
+export { useVerifyAllowedChildren };

--- a/packages/blade/src/utils/useVerifyAllowedChildren/index.ts
+++ b/packages/blade/src/utils/useVerifyAllowedChildren/index.ts
@@ -1,0 +1,1 @@
+export * from './useVerifyAllowedChildren';

--- a/packages/blade/src/utils/useVerifyAllowedChildren/useVerifyAllowedChildren.native.test.tsx
+++ b/packages/blade/src/utils/useVerifyAllowedChildren/useVerifyAllowedChildren.native.test.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { render } from '@testing-library/react-native';
+import { assignWithoutSideEffects } from '../assignWithoutSideEffects';
+import { useVerifyAllowedChildren } from './useVerifyAllowedChildren';
+
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
+afterAll(() => jest.restoreAllMocks());
+
+const componentIds = {
+  AllowedChildOne: 'AllowedChildOne',
+  AllowedChildTwo: 'AllowedChildTwo',
+  disallowedChild: 'disallowedChild',
+};
+const _AllowedChildOne = () => <></>;
+const AllowedChildOne = assignWithoutSideEffects(_AllowedChildOne, {
+  componentId: componentIds.AllowedChildOne,
+});
+const _AllowedChildTwo = () => <></>;
+const AllowedChildTwo = assignWithoutSideEffects(_AllowedChildTwo, {
+  componentId: componentIds.AllowedChildTwo,
+});
+
+const Example = ({ children }: { children: React.ReactNode }) => {
+  useVerifyAllowedChildren({
+    children,
+    componentName: 'Example',
+    allowedComponents: [componentIds.AllowedChildOne, componentIds.AllowedChildTwo],
+  });
+
+  return <></>;
+};
+
+describe('useVerifyAllowedChildren', () => {
+  it('should throw error if disallowed component is passed to children', () => {
+    expect(() =>
+      render(
+        <Example>
+          <p>hello world</p>
+        </Example>,
+      ),
+    ).toThrow(
+      '[Blade: Example]: Only `AllowedChildOne, AllowedChildTwo` components are accepted in `Example` children',
+    );
+  });
+
+  it('should not throw error if allowed component is passed', () => {
+    expect(() =>
+      render(
+        <Example>
+          <AllowedChildOne />
+          <AllowedChildTwo />
+        </Example>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/blade/src/utils/useVerifyAllowedChildren/useVerifyAllowedChildren.ts
+++ b/packages/blade/src/utils/useVerifyAllowedChildren/useVerifyAllowedChildren.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import { getComponentId } from './isValidAllowedChildren';
-import { throwBladeError } from './logger';
+import { getComponentId } from '../isValidAllowedChildren';
+import { throwBladeError } from '../logger';
 
 /**
  * Verify if the passed childrens are only of allowedComponents list

--- a/packages/blade/src/utils/useVerifyAllowedChildren/useVerifyAllowedChildren.web.test.tsx
+++ b/packages/blade/src/utils/useVerifyAllowedChildren/useVerifyAllowedChildren.web.test.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { render } from '@testing-library/react';
+import { assignWithoutSideEffects } from '../assignWithoutSideEffects';
+import { useVerifyAllowedChildren } from './useVerifyAllowedChildren';
+
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
+afterAll(() => jest.restoreAllMocks());
+
+const componentIds = {
+  AllowedChildOne: 'AllowedChildOne',
+  AllowedChildTwo: 'AllowedChildTwo',
+  disallowedChild: 'disallowedChild',
+};
+const _AllowedChildOne = () => <></>;
+const AllowedChildOne = assignWithoutSideEffects(_AllowedChildOne, {
+  componentId: componentIds.AllowedChildOne,
+});
+const _AllowedChildTwo = () => <></>;
+const AllowedChildTwo = assignWithoutSideEffects(_AllowedChildTwo, {
+  componentId: componentIds.AllowedChildTwo,
+});
+
+const Example = ({ children }: { children: React.ReactNode }) => {
+  useVerifyAllowedChildren({
+    children,
+    componentName: 'Example',
+    allowedComponents: [componentIds.AllowedChildOne, componentIds.AllowedChildTwo],
+  });
+
+  return <></>;
+};
+
+describe('useVerifyAllowedChildren', () => {
+  it('should throw error if disallowed component is passed to children', () => {
+    expect(() =>
+      render(
+        <Example>
+          <p>hello world</p>
+        </Example>,
+      ),
+    ).toThrow(
+      '[Blade: Example]: Only `AllowedChildOne, AllowedChildTwo` components are accepted in `Example` children',
+    );
+  });
+
+  it('should not throw error if allowed component is passed', () => {
+    expect(() =>
+      render(
+        <Example>
+          <AllowedChildOne />
+          <AllowedChildTwo />
+        </Example>,
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes: #1771 

- Added validation in Carousel component JSX to only allow CarouselItem.
- Refactored out a common `useVerifyAllowedChildren` hook to help us add validations.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: The `CardHeader` component now uses the `useVerifyAllowedChildren` hook to validate its children and ensure that only specific components are allowed.
- Bug Fix: Error messages in the `Card` component have been improved to provide more specific information about the allowed children components, enhancing clarity for developers using the `Card` component.
- Refactor: The `Carousel` component now enforces validation to only allow `CarouselItem` as children. Additionally, a common hook called `useVerifyAllowedChildren` has been refactored to simplify the process of adding validations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->