### PR TITLE
fix(blade): fixed react-native bottomsheet state bugs

### DIFF
--- a/.changeset/smooth-jobs-notice.md
+++ b/.changeset/smooth-jobs-notice.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): fixed react-native bottomsheet state bugs

--- a/packages/blade/.storybook/react-native/storybook.requires.js
+++ b/packages/blade/.storybook/react-native/storybook.requires.js
@@ -57,6 +57,7 @@ try {
 const getStories = () => {
   return {
     './src/components/Accordion/Accordion.stories.tsx': require('../../src/components/Accordion/Accordion.stories.tsx'),
+    './src/components/ActionList/ActionList.stories.tsx': require('../../src/components/ActionList/ActionList.stories.tsx'),
     './src/components/Alert/Alert.stories.tsx': require('../../src/components/Alert/Alert.stories.tsx'),
     './src/components/Amount/Amount.stories.tsx': require('../../src/components/Amount/Amount.stories.tsx'),
     './src/components/Badge/Badge.stories.tsx': require('../../src/components/Badge/Badge.stories.tsx'),

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -55,9 +55,9 @@ const _BottomSheet = ({
   const bottomSheetAndDropdownGlue = useBottomSheetAndDropdownGlue();
   const defaultInitialFocusRef = React.useRef<any>(null);
   const sheetRef = React.useRef<GorhomBottomSheet>(null);
-  const header = React.useRef<React.ReactNode>();
-  const footer = React.useRef<React.ReactNode>();
-  const body = React.useRef<React.ReactNode>();
+  const [header, setHeader] = React.useState<React.ReactNode>();
+  const [footer, setFooter] = React.useState<React.ReactNode>();
+  const [body, setBody] = React.useState<React.ReactNode>();
   const _isOpen = isOpen ?? bottomSheetAndDropdownGlue?.isOpen;
   const [headerHeight, setHeaderHeight] = React.useState(0);
   const [footerHeight, setFooterHeight] = React.useState(0);
@@ -135,35 +135,38 @@ const _BottomSheet = ({
     bottomSheetAndDropdownGlue.setDropdownHasBottomSheet(true);
   }, [bottomSheetAndDropdownGlue]);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     React.Children.forEach(children, (child) => {
       if (getComponentId(child) === ComponentIds.BottomSheetHeader) {
-        header.current = child;
+        setHeader(child);
       }
       if (getComponentId(child) === ComponentIds.BottomSheetFooter) {
-        footer.current = child;
+        setFooter(child);
       }
       if (getComponentId(child) === ComponentIds.BottomSheetBody) {
-        body.current = child;
+        setBody(child);
       }
     });
   }, [children]);
 
-  const renderFooter = React.useCallback((props): React.ReactElement => {
-    return (
-      <GorhomBottomSheetFooter {...props}>
-        <View
-          onLayout={(event) => {
-            // save footer height so that later we can offset the marginBottom from body content
-            // otherwise few elements gets hidden under the footer
-            setFooterHeight(event.nativeEvent.layout.height);
-          }}
-        >
-          {footer.current}
-        </View>
-      </GorhomBottomSheetFooter>
-    );
-  }, []);
+  const renderFooter = React.useCallback(
+    (props): React.ReactElement => {
+      return (
+        <GorhomBottomSheetFooter {...props}>
+          <View
+            onLayout={(event) => {
+              // save footer height so that later we can offset the marginBottom from body content
+              // otherwise few elements gets hidden under the footer
+              setFooterHeight(event.nativeEvent.layout.height);
+            }}
+          >
+            {footer}
+          </View>
+        </GorhomBottomSheetFooter>
+      );
+    },
+    [footer],
+  );
 
   const renderBackdrop = React.useCallback(
     (props): React.ReactElement => {
@@ -186,10 +189,10 @@ const _BottomSheet = ({
         <BaseBox zIndex={zIndex}>
           <BottomSheetGrabHandle />
         </BaseBox>
-        {header.current}
+        {header}
       </BaseBox>
     );
-  }, [isHeaderEmpty, zIndex]);
+  }, [isHeaderEmpty, zIndex, header]);
 
   const isHeaderFloating = !hasBodyPadding && isHeaderEmpty;
   const contextValue = React.useMemo<BottomSheetContextProps>(
@@ -274,9 +277,11 @@ const _BottomSheet = ({
             enableOverDrag
             enableContentPanningGesture
             ref={sheetRef}
-            index={-1}
+            // on initial render if _isOpen is true we want to render the sheet at initialSnapPoint
+            // otherwise we want to render it at -1 so that it is not visible
+            index={_isOpen ? initialSnapPoint.current : -1}
             containerStyle={{ zIndex }}
-            animateOnMount={false}
+            animateOnMount={true}
             handleComponent={renderHandle}
             backgroundComponent={BottomSheetSurface}
             footerComponent={renderFooter}
@@ -284,7 +289,7 @@ const _BottomSheet = ({
             onClose={close}
             snapPoints={_snapPoints}
           >
-            {body.current}
+            {body}
           </GorhomBottomSheet>
         </BottomSheetContext.Provider>
       </DropdownContext.Provider>


### PR DESCRIPTION
fixes #1775
fixes #1776
fixes #1777

Changes: 

1. **1775 - unable to open bottomsheet on mount**

Bug was introduced because we did not update the GorhomBottomSheet's [index prop](https://gorhom.github.io/react-native-bottom-sheet/props/#index) to react with the `isOpen` prop, and instead always set that to `-1` which meant BottomSheet will always be closed on initial mount. 

**Fix:** 
This was fixed by adding a check for isOpen prop and updating the index prop: 

```jsx
index={_isOpen ? initialSnapPoint.current : -1}
```

2. **1776 & 1777 - bottomsheet doesn't re-render it's children**

This bug was happening because we saved the children of the BottomSheetBody, BottomSheetFooter & BottomSheetHeader in a ref and then rendered those refs which meant that any updates to the children components inside BottomSheetBody will only reflect if the parent component rerenders. 

**Fix:** 
Instead of using refs, we switched this to using useState so it retains the children and also updates the children if any content changes. 

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new file `ActionList.stories.tsx` to the React Native Storybook, allowing users to view and interact with stories related to the ActionList component.
- Bug Fix: Fixed issues with the React Native BottomSheet component where the header, footer, and body were not updating correctly. Refactored the code to use useState hooks instead of useRef for better state management.
- Bug Fix: Resolved a bug in the BottomSheetComponent where it was not opening on mount. Updated the index prop based on the isOpen prop to fix this issue. Also fixed a bug where the children components were not re-rendering when their content changed.
- Documentation: Added an example use case for the ProductUseCase1 component in the BottomSheet stories.
- Chore: Fixed three bugs related to the React Native BottomSheet state in the smooth-jobs-notice.md file. Replaced the use of refs with useState for proper child component updates.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->