### PR TITLE
fix: react native text input alignment with prefix

### DIFF
--- a/.changeset/wet-cycles-greet.md
+++ b/.changeset/wet-cycles-greet.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: react native text input alignment with prefix

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -129,7 +129,7 @@ const getRNInputStyles = (
       isDropdownTrigger: props.isDropdownTrigger,
     }),
     lineHeight: RNPlatform.select({
-      android: makeSize(props.theme.typography.lineHeights[75]),
+      android: makeSize(props.theme.typography.lineHeights[100]),
       ios: undefined,
     }),
     textAlignVertical: 'top',

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -8,6 +8,7 @@ import type {
   TouchableHighlightProps,
   GestureResponderEvent,
 } from 'react-native';
+import { Platform as RNPlatform } from 'react-native';
 import type { BaseInputProps } from './BaseInput';
 import type { StyledBaseInputProps } from './types';
 import { getBaseInputStyles } from './baseInputStyles';
@@ -127,7 +128,10 @@ const getRNInputStyles = (
       hasTags: props.hasTags,
       isDropdownTrigger: props.isDropdownTrigger,
     }),
-    lineHeight: undefined,
+    lineHeight: RNPlatform.select({
+      android: makeSize(props.theme.typography.lineHeights[75]),
+      ios: undefined,
+    }),
     textAlignVertical: 'top',
     height: getInputHeight({
       isTextArea: props.isTextArea,


### PR DESCRIPTION
Fixes: https://github.com/razorpay/blade/issues/1774

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the `@razorpay/blade` package to the latest patch version.
- Style: Modified the `getRNInputStyles` function in a React Native component to set the `lineHeight` property based on the platform. For Android, it uses a specific value from the theme's typography, while for iOS, it leaves it as undefined.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->