### PR TITLE
fix: refined text input label truncation for single-word overflow

### DIFF
--- a/.changeset/pretty-clocks-end.md
+++ b/.changeset/pretty-clocks-end.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: refined text input label truncation for single-word overflow

--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -112,6 +112,7 @@ const FormLabel = ({
         size={isLabelLeftPositioned ? 'medium' : 'small'}
         truncateAfterLines={2}
         weight="bold"
+        wordBreak={isLabelLeftPositioned ? 'break-word' : undefined}
       >
         {children}
       </Text>

--- a/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
@@ -22,6 +22,7 @@ const StyledBaseText = styled.div.withConfig({
     numberOfLines,
     lineHeight,
     textAlign,
+    wordBreak,
     ...props
   }) => {
     const styledPropsCSSObject = useStyledProps(props);
@@ -36,6 +37,7 @@ const StyledBaseText = styled.div.withConfig({
         numberOfLines,
         lineHeight,
         textAlign,
+        wordBreak,
         theme: props.theme,
       }),
       ...styledPropsCSSObject,
@@ -56,6 +58,7 @@ export const BaseText = ({
   textAlign,
   children,
   truncateAfterLines,
+  wordBreak,
   className,
   style,
   accessibilityProps = {},
@@ -76,6 +79,7 @@ export const BaseText = ({
       as={as}
       textAlign={textAlign}
       numberOfLines={truncateAfterLines}
+      wordBreak={wordBreak}
       className={className}
       style={style}
       id={id}

--- a/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
+++ b/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
@@ -12,6 +12,7 @@ const getBaseTextStyles = ({
   fontStyle = 'normal',
   textDecorationLine = 'none',
   numberOfLines,
+  wordBreak,
   lineHeight = 100,
   textAlign,
   theme,
@@ -22,6 +23,7 @@ const getBaseTextStyles = ({
   const themeFontWeight = theme.typography.fonts.weight[fontWeight];
   const themeLineHeight = makeTypographySize(theme.typography.lineHeights[lineHeight]);
   let truncateStyles: CSSObject = {};
+  let wordBreakStyles: CSSObject = {};
   if (numberOfLines !== undefined) {
     if (isReactNative()) {
       truncateStyles = {};
@@ -32,6 +34,15 @@ const getBaseTextStyles = ({
         'line-clamp': `${numberOfLines}`,
         '-webkit-line-clamp': `${numberOfLines}`,
         '-webkit-box-orient': 'vertical',
+      };
+    }
+  }
+  if (wordBreak !== undefined) {
+    if (isReactNative()) {
+      wordBreakStyles = {};
+    } else {
+      wordBreakStyles = {
+        wordBreak,
       };
     }
   }
@@ -51,6 +62,7 @@ const getBaseTextStyles = ({
     margin: 0,
     padding: 0,
     ...truncateStyles,
+    ...wordBreakStyles,
   };
 };
 

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -56,7 +56,7 @@ export type BaseTextProps = {
   fontStyle?: 'italic' | 'normal';
   textDecorationLine?: 'line-through' | 'none' | 'underline';
   lineHeight?: keyof Theme['typography']['lineHeights'];
-  wordBreak?: 'normal' | 'break-all' | 'keep-all' | 'break-word' | undefined;
+  wordBreak?: 'normal' | 'break-all' | 'keep-all' | 'break-word';
   /**
    * Web only
    */

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -56,6 +56,7 @@ export type BaseTextProps = {
   fontStyle?: 'italic' | 'normal';
   textDecorationLine?: 'line-through' | 'none' | 'underline';
   lineHeight?: keyof Theme['typography']['lineHeights'];
+  wordBreak?: 'normal' | 'break-all' | 'keep-all' | 'break-word' | undefined;
   /**
    * Web only
    */
@@ -87,6 +88,7 @@ export type StyledBaseTextProps = Pick<
   | 'textAlign'
   | 'numberOfLines'
   | 'truncateAfterLines'
+  | 'wordBreak'
 > & { theme: Theme };
 
 export type BaseTextSizes = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -28,6 +28,7 @@ type TextCommonProps = {
   color?: BaseTextProps['color'];
   textAlign?: BaseTextProps['textAlign'];
   textDecorationLine?: BaseTextProps['textDecorationLine'];
+  wordBreak?: BaseTextProps['wordBreak'];
 } & TestID &
   StyledPropsBlade;
 
@@ -142,11 +143,13 @@ const _Text = <T extends { variant: TextVariant }>({
   testID,
   textAlign,
   textDecorationLine,
+  wordBreak,
   ...styledProps
 }: TextProps<T>): ReactElement => {
   const props: Omit<BaseTextProps, 'children'> = {
     as,
     truncateAfterLines,
+    wordBreak,
     ...getTextProps({
       variant,
       type,


### PR DESCRIPTION
<img width="737" alt="image" src="https://github.com/razorpay/blade/assets/33349461/ed1f9f20-067a-4092-ad66-52a5ec833fbc">
image Previously, single words exceeding a specified width of 120px were truncated, potentially impacting readability and aesthetics. Added new prop for wordBreak in BaseText and also expose it in the Text component.