### PR TITLE
fix(blade): remove extra margin left on carousel

### DIFF
--- a/.changeset/heavy-rockets-design.md
+++ b/.changeset/heavy-rockets-design.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): remove extra margin left on carousel

--- a/packages/blade/src/components/Carousel/CarouselItem.web.tsx
+++ b/packages/blade/src/components/Carousel/CarouselItem.web.tsx
@@ -34,7 +34,7 @@ const StyledCarouselItem = styled(BaseBox)<StyledCarouselItemProps>(
       ...(isResponsive && {
         width: '100%',
         scrollSnapAlign: isMobile || !shouldAddStartEndSpacing ? 'start' : 'center',
-        marginLeft: shouldHaveStartSpacing ? '100%' : 0,
+        marginLeft: shouldHaveStartSpacing ? '40%' : 0,
       }),
     };
   },


### PR DESCRIPTION
Fixes: https://github.com/razorpay/blade/issues/1788

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Style: Modified the `marginLeft` property of the `StyledCarouselItem` component in `CarouselItem.web.tsx` to have a value of `40%` instead of `0` when the `shouldHaveStartSpacing` prop is true. This change improves the spacing of carousel items and enhances the visual presentation for the end-user.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->