### PR TITLE
chore(installation): add note for styled-components supported version

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -44,10 +44,13 @@ Before you install the package, make sure that you have performed the following 
 Blade has a peer dependency on a few libraries, you can skip adding it if you already have it installed in your project.
 
   - `styled-components`
+  > **Note**
+  >
+  > Currently, blade only supports styled-components v5 only
   - `@floating-ui/react`
 
    ```shell
-   yarn add @razorpay/blade styled-components @floating-ui/react
+   yarn add @razorpay/blade styled-components@5.3.11 @floating-ui/react
    ```
 
 2. Follow [this guide](#-install-fonts) to install the fonts.


### PR DESCRIPTION
Notifies blade users about the `styled-components` version (v5) supported by blade