### PR TITLE
feat(Dropdown): support `width` prop on DropdownOverlay

### DIFF
--- a/.changeset/pretty-wolves-deny.md
+++ b/.changeset/pretty-wolves-deny.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(Dropdown): Support `width` prop on DropdownOverlay

--- a/packages/blade/.storybook/react-native/storybook.requires.js
+++ b/packages/blade/.storybook/react-native/storybook.requires.js
@@ -100,6 +100,7 @@ const getStories = () => {
     './src/components/SkipNav/SkipNav.stories.tsx': require('../../src/components/SkipNav/SkipNav.stories.tsx'),
     './src/components/Spinner/BaseSpinner/BaseSpinner.stories.tsx': require('../../src/components/Spinner/BaseSpinner/BaseSpinner.stories.tsx'),
     './src/components/Spinner/Spinner/Spinner.stories.tsx': require('../../src/components/Spinner/Spinner/Spinner.stories.tsx'),
+    './src/components/SpotlightPopoverTour/Tour.stories.tsx': require('../../src/components/SpotlightPopoverTour/Tour.stories.tsx'),
     './src/components/Switch/Switch.stories.tsx': require('../../src/components/Switch/Switch.stories.tsx'),
     './src/components/Tabs/Tabs.stories.tsx': require('../../src/components/Tabs/Tabs.stories.tsx'),
     './src/components/Tag/Tag.stories.tsx': require('../../src/components/Tag/Tag.stories.tsx'),

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   autoUpdate,
   offset,
@@ -33,9 +33,11 @@ const _DropdownOverlay = ({
   children,
   testID,
   zIndex = OVERLAY_ZINDEX,
+  width,
 }: DropdownOverlayProps): React.ReactElement | null => {
   const { isOpen, triggererRef, triggererWrapperRef, dropdownTriggerer, setIsOpen } = useDropdown();
   const { theme } = useTheme();
+  const [widthValue, setwidthValue] = useState<string | undefined>(width);
   const bottomSheetAndDropdownGlue = useBottomSheetAndDropdownGlue();
 
   const isMenu =
@@ -91,6 +93,11 @@ const _DropdownOverlay = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
+  React.useEffect(() => {
+    if (width) {
+      setwidthValue(width);
+    }
+  }, [width]);
   return (
     <BaseBox
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -103,7 +110,7 @@ const _DropdownOverlay = ({
         isInBottomSheet={bottomSheetAndDropdownGlue?.dropdownHasBottomSheet}
         elevation={bottomSheetAndDropdownGlue?.dropdownHasBottomSheet ? undefined : 'midRaised'}
         style={{ ...styles }}
-        width="100%"
+        width={widthValue ? widthValue : '100%'}
         {...metaAttribute({ name: MetaConstants.DropdownOverlay, testID })}
       >
         {children}

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   autoUpdate,
   offset,
@@ -37,7 +37,6 @@ const _DropdownOverlay = ({
 }: DropdownOverlayProps): React.ReactElement | null => {
   const { isOpen, triggererRef, triggererWrapperRef, dropdownTriggerer, setIsOpen } = useDropdown();
   const { theme } = useTheme();
-  const [widthValue, setwidthValue] = useState<string | undefined>(width);
   const bottomSheetAndDropdownGlue = useBottomSheetAndDropdownGlue();
 
   const isMenu =
@@ -93,11 +92,6 @@ const _DropdownOverlay = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
-  React.useEffect(() => {
-    if (width) {
-      setwidthValue(width);
-    }
-  }, [width]);
   return (
     <BaseBox
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -110,7 +104,7 @@ const _DropdownOverlay = ({
         isInBottomSheet={bottomSheetAndDropdownGlue?.dropdownHasBottomSheet}
         elevation={bottomSheetAndDropdownGlue?.dropdownHasBottomSheet ? undefined : 'midRaised'}
         style={{ ...styles }}
-        width={widthValue ? widthValue : '100%'}
+        width={width ? width : '100%'}
         {...metaAttribute({ name: MetaConstants.DropdownOverlay, testID })}
       >
         {children}

--- a/packages/blade/src/components/Dropdown/StyledDropdownOverlay.tsx
+++ b/packages/blade/src/components/Dropdown/StyledDropdownOverlay.tsx
@@ -4,8 +4,9 @@ import { makeSize } from '~utils';
 
 const StyledDropdownOverlay = styled(BaseBox)<{
   isInBottomSheet?: boolean;
+  width?: string;
 }>((props) => {
-  const { theme, isInBottomSheet } = props;
+  const { theme, isInBottomSheet, width } = props;
 
   return {
     backgroundColor: theme.colors.surface.popup.background,
@@ -13,6 +14,7 @@ const StyledDropdownOverlay = styled(BaseBox)<{
     borderColor: theme.colors.surface.border.normal.lowContrast,
     borderStyle: isInBottomSheet ? undefined : 'solid',
     borderRadius: makeSize(theme.border.radius.medium),
+    width: width ? width : '100%',
   };
 });
 

--- a/packages/blade/src/components/Dropdown/StyledDropdownOverlay.tsx
+++ b/packages/blade/src/components/Dropdown/StyledDropdownOverlay.tsx
@@ -4,9 +4,8 @@ import { makeSize } from '~utils';
 
 const StyledDropdownOverlay = styled(BaseBox)<{
   isInBottomSheet?: boolean;
-  width?: string;
 }>((props) => {
-  const { theme, isInBottomSheet, width } = props;
+  const { theme, isInBottomSheet } = props;
 
   return {
     backgroundColor: theme.colors.surface.popup.background,
@@ -14,7 +13,6 @@ const StyledDropdownOverlay = styled(BaseBox)<{
     borderColor: theme.colors.surface.border.normal.lowContrast,
     borderStyle: isInBottomSheet ? undefined : 'solid',
     borderRadius: makeSize(theme.border.radius.medium),
-    width: width ? width : '100%',
   };
 });
 

--- a/packages/blade/src/components/Dropdown/docs/DropdownWithButton.stories.tsx
+++ b/packages/blade/src/components/Dropdown/docs/DropdownWithButton.stories.tsx
@@ -167,7 +167,7 @@ export const InternalAutoPositioning = (): React.ReactElement => {
       <Box display="inline-flex" position="fixed" left="spacing.5" top="spacing.5">
         <Dropdown>
           <DropdownButton>Top Left Menu</DropdownButton>
-          <DropdownOverlay>
+          <DropdownOverlay width="70%">
             <ActionList surfaceLevel={3}>
               <ActionListItem title="Apples" value="Apples" />
               <ActionListItem title="Appricots" value="Appricots" />

--- a/packages/blade/src/components/Dropdown/types.ts
+++ b/packages/blade/src/components/Dropdown/types.ts
@@ -1,7 +1,7 @@
 import type React from 'react';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import type { TestID } from '~utils/types';
-
+import type { BoxProps } from '~components/Box';
 type DropdownProps = {
   /**
    * Control open / close state of the Dropdown component
@@ -47,7 +47,7 @@ type DropdownOverlayProps = {
    * @default 1001
    */
   zIndex?: number;
-  width?: string;
+  width?: BoxProps['width'];
 } & TestID;
 
 export type { DropdownProps, DropdownOverlayProps };

--- a/packages/blade/src/components/Dropdown/types.ts
+++ b/packages/blade/src/components/Dropdown/types.ts
@@ -47,6 +47,7 @@ type DropdownOverlayProps = {
    * @default 1001
    */
   zIndex?: number;
+  width?: string;
 } & TestID;
 
 export type { DropdownProps, DropdownOverlayProps };


### PR DESCRIPTION
This PR is in reference to adding width support to DropdownOverlay. Now users can choose to have the width of the dropdown or it will be set to "100%"

Fixes #1660 