### PR TITLE
fix(blade): page gets scrolled to top on iOS on bottomsheet open

### DIFF
--- a/.changeset/fluffy-chicken-hunt.md
+++ b/.changeset/fluffy-chicken-hunt.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): page gets scrolled to top on iOS when bottomsheet open

--- a/packages/blade/.storybook/react/global.css
+++ b/packages/blade/.storybook/react/global.css
@@ -6,4 +6,5 @@
 body {
   width: 100%;
   height: 100%;
+  padding: 0 !important;
 }

--- a/packages/blade/.storybook/react/preview.js
+++ b/packages/blade/.storybook/react/preview.js
@@ -118,15 +118,9 @@ export const parameters = {
 const StoryCanvas = styled.div(
   ({ theme, context }) =>
     `
-      position: ${context.viewMode === 'story' ? 'absolute' : 'relative'};
-      top: 0;
-      left: 0;
-      bottom: 0;
-      right: 0;
-      border-right: 'none';
       border: ${theme.border.width.thin}px solid ${theme.colors.surface.border.subtle.lowContrast};
       width: 100%;
-      height: 100%;
+      height: ${context.viewMode === 'story' ? '100vh' : '100%'};
       overflow: auto;
       padding: ${
         context.kind.includes('/Dropdown/With Select') ||

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -121,7 +121,7 @@
     "@table-library/react-table-library": "4.1.7",
     "@types/body-scroll-lock": "3.1.0",
     "@use-gesture/react": "10.2.24",
-    "body-scroll-lock": "4.0.0-beta.0",
+    "body-scroll-lock-upgrade": "1.1.0",
     "patch-package": "7.0.0",
     "react-native-pager-view": "6.2.1",
     "react-native-tab-view": "3.5.2",

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { rubberbandIfOutOfBounds, useDrag } from '@use-gesture/react';
 import usePresence from 'use-presence';
-import { clearAllBodyScrollLocks } from 'body-scroll-lock';
+import { clearAllBodyScrollLocks } from 'body-scroll-lock-upgrade';
 import { BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetFooter } from './BottomSheetFooter';
 import { BottomSheetBody } from './BottomSheetBody';

--- a/packages/blade/src/utils/useScrollLock.ts
+++ b/packages/blade/src/utils/useScrollLock.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock-upgrade';
 import React from 'react';
 
 type UseScrollLockProps = {
@@ -53,7 +53,7 @@ export function useScrollLock({
       return;
     }
 
-    const target = targetRef ? targetRef.current : document.body;
+    const target = (targetRef ? targetRef.current : document.body) as HTMLElement;
     active.current = false;
 
     ref.current = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9724,10 +9724,10 @@ body-parser@1.20.1:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-scroll-lock@4.0.0-beta.0:
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz#4f78789d10e6388115c0460cd6d7d4dd2bbc4f7e"
-  integrity sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==
+body-scroll-lock-upgrade@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock-upgrade/-/body-scroll-lock-upgrade-1.1.0.tgz#3df63fca3d1db2f896bd9a050bd14c33cd0085d2"
+  integrity sha512-nnfVAS+tB7CS9RaksuHVTpgHWHF7fE/ptIBJnwZrMqImIvWJF1OGcLnMpBhC6qhkx9oelvyxmWXwmIJXCV98Sw==
 
 bonjour@^3.5.0:
   version "3.5.0"


### PR DESCRIPTION
Fixes #1860 

There's a bug in the body-scroll-lock packages which causes iOS mobile to scroll to the top when bottomsheet opens. 

https://github.com/willmcpo/body-scroll-lock/issues/237

I've updated the lib with the community fixed version. 


And also updated the storybook canvas to NOT use absolute positioning while rendering the stories which causes issues because this is not how most consumers use our components. 
