### PR TITLE
fix: Indicator intent prop, Code component color

### DIFF
--- a/packages/blade/.storybook/react/main.js
+++ b/packages/blade/.storybook/react/main.js
@@ -25,6 +25,7 @@ module.exports = {
     '../../src/components/List/**/*.stories.@(ts|tsx|js|jsx)',
     '../../src/components/Link/**/*.stories.@(ts|tsx|js|jsx)',
     '../../src/components/Tooltip/**/*.stories.@(ts|tsx|js|jsx)',
+    '../../src/components/Typography/**/**/*.stories.@(ts|tsx|js|jsx)',
     // '../../docs/**/*.stories.mdx',
     // '../../docs/**/*.stories.@(ts|tsx|js|jsx)',
     // '../../src/**/*.stories.mdx',

--- a/packages/blade/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/blade/src/components/Indicator/Indicator.stories.tsx
@@ -26,7 +26,7 @@ const Page = (): ReactElement => {
         function App() {
           return (
             <Box>
-              <Indicator accessibilityLabel="Success" intent="positive" />
+              <Indicator accessibilityLabel="Success" color="positive" />
             </Box>
           )
         }
@@ -98,7 +98,7 @@ export const Composition: ComponentStory<typeof IndicatorComponent> = ({ ...args
 };
 Composition.args = {
   children: undefined,
-  intent: 'notice',
+  color: 'notice',
   accessibilityLabel: 'New offers',
   size: 'large',
 };

--- a/packages/blade/src/components/Indicator/Indicator.tsx
+++ b/packages/blade/src/components/Indicator/Indicator.tsx
@@ -21,7 +21,7 @@ type IndicatorCommonProps = {
    *
    * @default neutral
    */
-  intent?: FeedbackColors;
+  color?: FeedbackColors;
 
   /**
    * Size of the indicator
@@ -67,14 +67,14 @@ const Indicator = ({
   accessibilityLabel,
   children,
   size = 'medium',
-  intent = 'neutral',
+  color = 'neutral',
   testID,
   ...styledProps
 }: IndicatorProps): ReactElement => {
   const { theme } = useTheme();
   const childrenString = getStringFromReactText(children);
 
-  const fillColor = theme.colors.feedback.background[intent].intense;
+  const fillColor = theme.colors.feedback.background[color].intense;
   const getDimension = useCallback((): Dimensions => {
     switch (size) {
       case 'small':

--- a/packages/blade/src/components/Typography/Code/Code.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.tsx
@@ -90,7 +90,7 @@ const CodeContainer = styled(BaseBox)<CodeContainerProps>((props) => {
   return {
     padding,
     backgroundColor: props.isHighlighted
-      ? props.theme.colors.surface.background.gray.subtle
+      ? props.theme.colors.feedback.background.neutral.subtle
       : undefined,
     borderRadius: props.theme.border.radius.medium,
     display: isPlatformWeb ? 'inline-block' : 'flex',


### PR DESCRIPTION
- Rename `intent` to `color`
- Fix Code component color and add typography to migrated documentation