### PR TITLE
fix: React Native iOS fonts

### DIFF
--- a/packages/blade/.storybook/react/main.js
+++ b/packages/blade/.storybook/react/main.js
@@ -13,6 +13,7 @@ module.exports = {
     '@storybook/design-system': { disable: true },
   },
   stories: [
+    '../../docs/guides/*.stories.mdx',
     '../../src/components/Box/**/*.stories.@(ts|tsx|js|jsx)',
     '../../src/components/Badge/**/*.stories.@(ts|tsx|js|jsx)',
     '../../src/components/Icons/**/*.stories.@(ts|tsx|js|jsx)',

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -40,48 +40,47 @@ Before you install the package, make sure that you have performed the following 
 
 ## ⬇ Add blade to your application
 
-1. Install blade as a dependency.
-   Blade has a peer dependency on a few libraries, you can skip adding it if you already have it installed in your project.
+1. Install blade as a dependency. 
+Blade has a peer dependency on a few libraries, you can skip adding it if you already have it installed in your project.
 
-- `styled-components`
+  - `styled-components`
   > **Note**
   >
   > Currently, blade only supports styled-components v5 only
 
-```shell
-yarn add @razorpay/blade styled-components@5.3.11
-```
-
+   ```shell
+   yarn add @razorpay/blade styled-components@5.3.11
+   ```
 2. Follow [this guide](#-install-fonts) to install the fonts.
 
-3. For **React Native** projects you need to do additional setup for the peer dependencies:
+3. For **React Native** projects you need to do additional setup for the peer dependencies: 
 
-```shell
-yarn add @floating-ui/react-native@0.10.0 react-native-reanimated@3.4.1 react-native-tab-view@3.5.2 react-native-pager-view@6.2.1 react-native-svg@12.3.0 react-native-gesture-handler@2.9.0 @gorhom/bottom-sheet@4.4.6 @gorhom/portal@1.0.1
-```
+  ```shell
+  yarn add @floating-ui/react-native@0.10.0 react-native-reanimated@3.4.1 react-native-tab-view@3.5.2 react-native-pager-view@6.2.1 react-native-svg@12.3.0 react-native-gesture-handler@2.9.0 @gorhom/bottom-sheet@4.4.6 @gorhom/portal@1.0.1
+  ```
 
-- `react-native-reanimated`
-  - Follow [this guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) to install it on Android & iOS which is required by Blade.
-- `react-native-svg`
-  - Follow [this guide](https://github.com/react-native-svg/react-native-svg#with-react-native-cli) to install it on Android & iOS which is required by Blade.
-- `react-native-gesture-handler`
-  - Follow [this guide](https://docs.swmansion.com/react-native-gesture-handler/docs/installation) to install it, note that you don't need to add `<GestureHandlerRootView style={{ flex: 1 }}>` again on the root because BladeProvider already adds that out of the box.
-- `@gorhom/bottom-sheet`
-  - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
-- `@gorhom/portal`
-  - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
-- `@floating-ui/react-native`
-  - Add this as peer dependency, no need to do additional setup.
-- `react-native-tab-view`
-  - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
-- `react-native-pager-view`
-  - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
+  - `react-native-reanimated`
+    - Follow [this guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) to install it on Android & iOS which is required by Blade.
+  - `react-native-svg`
+    - Follow [this guide](https://github.com/react-native-svg/react-native-svg#with-react-native-cli) to install it on Android & iOS which is required by Blade.
+  - `react-native-gesture-handler`
+    - Follow [this guide](https://docs.swmansion.com/react-native-gesture-handler/docs/installation) to install it, note that you don't need to add `<GestureHandlerRootView style={{ flex: 1 }}>` again on the root because BladeProvider already adds that out of the box.
+  - `@gorhom/bottom-sheet`
+    - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
+  - `@gorhom/portal`
+    - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
+  - `@floating-ui/react-native`
+    - Add this as peer dependency, no need to do additional setup.
+  - `react-native-tab-view`
+    - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
+  - `react-native-pager-view`
+    - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
 
-And finally run `pod install` command so that blade's RN dependencies are linked to your project:
+  And finally run `pod install` command so that blade's RN dependencies are linked to your project: 
 
-```shell
- cd ios && pod install
-```
+   ```shell
+    cd ios && pod install
+   ```
 
 ## 🔜 Add blade libraries to your Figma project
 

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -40,139 +40,127 @@ Before you install the package, make sure that you have performed the following 
 
 ## ⬇ Add blade to your application
 
-1. Install blade as a dependency. 
-Blade has a peer dependency on a few libraries, you can skip adding it if you already have it installed in your project.
+1. Install blade as a dependency.
+   Blade has a peer dependency on a few libraries, you can skip adding it if you already have it installed in your project.
 
-  - `styled-components`
+- `styled-components`
   > **Note**
   >
   > Currently, blade only supports styled-components v5 only
 
-   ```shell
-   yarn add @razorpay/blade styled-components@5.3.11
-   ```
+```shell
+yarn add @razorpay/blade styled-components@5.3.11
+```
+
 2. Follow [this guide](#-install-fonts) to install the fonts.
 
-3. For **React Native** projects you need to do additional setup for the peer dependencies: 
+3. For **React Native** projects you need to do additional setup for the peer dependencies:
 
-  ```shell
-  yarn add @floating-ui/react-native@0.10.0 react-native-reanimated@3.4.1 react-native-tab-view@3.5.2 react-native-pager-view@6.2.1 react-native-svg@12.3.0 react-native-gesture-handler@2.9.0 @gorhom/bottom-sheet@4.4.6 @gorhom/portal@1.0.1
-  ```
+```shell
+yarn add @floating-ui/react-native@0.10.0 react-native-reanimated@3.4.1 react-native-tab-view@3.5.2 react-native-pager-view@6.2.1 react-native-svg@12.3.0 react-native-gesture-handler@2.9.0 @gorhom/bottom-sheet@4.4.6 @gorhom/portal@1.0.1
+```
 
-  - `react-native-reanimated`
-    - Follow [this guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) to install it on Android & iOS which is required by Blade.
-  - `react-native-svg`
-    - Follow [this guide](https://github.com/react-native-svg/react-native-svg#with-react-native-cli) to install it on Android & iOS which is required by Blade.
-  - `react-native-gesture-handler`
-    - Follow [this guide](https://docs.swmansion.com/react-native-gesture-handler/docs/installation) to install it, note that you don't need to add `<GestureHandlerRootView style={{ flex: 1 }}>` again on the root because BladeProvider already adds that out of the box.
-  - `@gorhom/bottom-sheet`
-    - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
-  - `@gorhom/portal`
-    - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
-  - `@floating-ui/react-native`
-    - Add this as peer dependency, no need to do additional setup.
-  - `react-native-tab-view`
-    - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
-  - `react-native-pager-view`
-    - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
+- `react-native-reanimated`
+  - Follow [this guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) to install it on Android & iOS which is required by Blade.
+- `react-native-svg`
+  - Follow [this guide](https://github.com/react-native-svg/react-native-svg#with-react-native-cli) to install it on Android & iOS which is required by Blade.
+- `react-native-gesture-handler`
+  - Follow [this guide](https://docs.swmansion.com/react-native-gesture-handler/docs/installation) to install it, note that you don't need to add `<GestureHandlerRootView style={{ flex: 1 }}>` again on the root because BladeProvider already adds that out of the box.
+- `@gorhom/bottom-sheet`
+  - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
+- `@gorhom/portal`
+  - Add this as peer dependency, no need to do additional setup since BladeProvider already sets everything up.
+- `@floating-ui/react-native`
+  - Add this as peer dependency, no need to do additional setup.
+- `react-native-tab-view`
+  - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
+- `react-native-pager-view`
+  - Add this as peer dependency, no need to do additional setup. This is needed for react-native Tabs component as per [this guide](https://reactnavigation.org/docs/tab-view/#installation).
 
-  And finally run `pod install` command so that blade's RN dependencies are linked to your project: 
+And finally run `pod install` command so that blade's RN dependencies are linked to your project:
 
-   ```shell
-    cd ios && pod install
-   ```
+```shell
+ cd ios && pod install
+```
 
 ## 🔜 Add blade libraries to your Figma project
 
 Coming Soon
 
-## 🔡 Install Fonts
+## 🔡 Installing Fonts
 
-We are using `Lato` font family which is not a system font so we need to perform some additional steps to download, install and configure it.
+We use 2 fonts. [TASA Orbiter](https://tasatype.localremote.co/) (for our headings), and [Inter](https://rsms.me/inter/) (for other text elements).
 
 ### Web Projects
 
-For web projects, we can either use Google fonts or self-hosted fonts. Self-hosted fonts have certain benefits that you can find [here](https://fontsource.org/docs/getting-started/introduction)
+- To add these fonts to your project, you can import them from blade package in your root entry file.
 
-#### Self-Hosted (Recommended)
-
-We recommend using self-hosted fonts. We'll use [Fontsource](https://fontsource.org/) which provides fonts as npm packages.
-
-- Install `Lato` font
-
-  ```shell
-  yarn add @fontsource/lato
+  ```ts
+  // Somewhere in root index.ts or entryBrowser.tsx file
+  import '@razorpay/blade/fonts.css';
   ```
 
-- Import within your app entry file(eg: `App.tsx`, `entryBrowser.tsx` etc.).
-  ```js
-  import '@fontsource/lato/400.css';
-  import '@fontsource/lato/400-italic.css';
-  import '@fontsource/lato/700.css';
-  import '@fontsource/lato/700-italic.css';
+- While Blade handles setting font-family for its own components, you can set font-family globally as well in your global styles for any custom components or exceptions
+
+  ```ts
+  import { createGlobalStyle } from 'styled-components';
+
+  const GlobalStyles = createGlobalStyle`
+  * { 
+    box-sizing: border-box;
+  }
+  
+  body {
+    margin: 0;
+    padding: 0;
+    font-family: ${(props) => props.theme.typography.fonts.family.text}
+  }
+  
+  h1, h2, h3, h4, h5, h6 {
+    font-family: ${(props) => props.theme.typography.fonts.family.heading};
+  }
+  `;
   ```
-
-#### Google Fonts
-
-There are downsides to using Google fonts which can be found [here](https://fontsource.org/docs/getting-started/introduction) but still for some reason if you have some use case where Google fonts makes more sense then you can [click this link](https://fonts.google.com/share?selection.family=Lato:ital,wght@0,400;0,700;1,400;1,700) and follow the instructions there to configure `Lato` for your applications.
 
 ### React Native Projects
 
-- Download `Lato` font from [here](https://fonts.google.com/share?selection.family=Lato:ital,wght@0,400;0,700;1,400;1,700)
-- Copy the font files and paste them under the directory `<project_root>/public/fonts`(**create the directory if it doesn't exist**)
-- Create a React Native config file at the root of your project - `<project_root>/react-native.config.js` and add the following content to it
+- Download fonts from <a href="https://github.com/razorpay/blade/tree/master/packages/blade/fonts/blade-fonts-react-native.zip">blade-fonts-react-native.zip</a> and unzip.
 
-  ```js
-  module.exports = {
-    // ... rest of the config
-    assets: ['./public/fonts/'],
-  };
-  ```
+- #### For iOS
 
-#### android
+  - Copy all font files from the `ios-fonts` directory to `<project_root>/public/fonts` (**create the directory if it doesn't exist**)
+  - Create a React Native config file at the root of your project - `<project_root>/react-native.config.js` and add the following content to it
 
-Follow the next steps mentioned below for configuring fonts to work on Android:
+    ```js
+    module.exports = {
+      // ... rest of the config
+      assets: ['./public/fonts/'],
+    };
+    ```
 
-- Create a directory `font` under `/android/app/src/main/res/font`
-- Copy the font files `Lato-Regular` and `Lato-Bold` you had downloaded earlier and paste them under `/android/app/src/main/res/font`
-- Rename the font files (**mind the casing and underscores**):
-  - ~~`Lato-Regular.ttf`~~ ➡️ `lato_regular.ttf`
-  - ~~`Lato-RegularItalic.ttf`~~ ➡️ `lato_regular_italic.ttf`
-  - ~~`Lato-Bold.ttf`~~ ➡️`lato_bold.ttf` 
-  - ~~`Lato-BoldItalic.ttf`~~ ➡️ `lato_bold_italic.ttf`
-- Create a file `lato.xml` under `/android/app/src/main/res/font/lato.xml` and copy the following contents to it
-  ```xml
-  <?xml version="1.0" encoding="utf-8"?>
-    <font-family xmlns:app="http://schemas.android.com/apk/res-auto">
-    <font app:fontStyle="normal" app:fontWeight="400" app:font="@font/lato_regular"/>
-    <font app:fontStyle="normal" app:fontWeight="700" app:font="@font/lato_bold" />
-    <font app:fontStyle="italic" app:fontWeight="400" app:font="@font/lato_regular_italic" />
-    <font app:fontStyle="italic" app:fontWeight="700" app:font="@font/lato_bold_italic" />
-  </font-family>
-  ```
-- Navigate to `/android/app/src/main/java/com/<your_package_name>/MainApplication.java` and add the following contents to it
+  - Run the following command to link fonts in ios
 
-  ```js
-  // add the below import statement after all the import statements
-  import com.facebook.react.views.text.ReactFontManager;
-  ```
+    ```shell
+    npx react-native-asset -ios-a
+    ```
 
-  Now search for `onCreate` method and add the following line to it
+- #### For Android
 
-  ```js
-  public void onCreate() {
-    // add the below line as the first line
-    ReactFontManager.getInstance().addCustomFont(this, "Lato", R.font.lato);
-    // rest of the content of the method
-  }
-  ```
+  - Copy all files from `android-fonts` to `/android/app/src/main/res/font`
+  - Navigate to `/android/app/src/main/java/com/<your_package_name>/MainApplication.java` and add the following contents to it
 
-#### iOS
+    ```js
+    // add the below import statement after all the import statements
+    import com.facebook.react.views.text.ReactFontManager;
+    ```
 
-Follow the next steps mentioned below for configuring fonts to work on iOS:
+  - Now search for `onCreate` method and add the following line to it
 
-- Once you've copied the font files under `<project_root>/public/fonts` you need to link it using the following command
-
-  ```shell
-  npx react-native link --platforms ios
-  ```
+    ```js
+    public void onCreate() {
+      // add the below lines as the first lines
+      ReactFontManager.getInstance().addCustomFont(this, "Inter", R.font.inter);
+      ReactFontManager.getInstance().addCustomFont(this, "TASA Orbiter Display", R.font.tasa);
+      // rest of the content of the method
+    }
+    ```

--- a/packages/blade/ios/blade.xcodeproj/project.pbxproj
+++ b/packages/blade/ios/blade.xcodeproj/project.pbxproj
@@ -12,14 +12,14 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		15C1821D14554C109C0A2C42 /* TASAOrbiter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0E4CE3584AE645A18022AC6E /* TASAOrbiter-SemiBold.otf */; };
 		266F8222282194C84355FB43 /* libPods-blade.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A14C4DCE8FBCAD8DAD09818D /* libPods-blade.a */; };
 		3ACA67F067244DEB99783E06 /* Inter-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F7902B25200F4FEFA8929693 /* Inter-Regular.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		82C097F197BC4BE0AAF0D391 /* TASAOrbiter-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 64A70F2B3BB0413193E2E76D /* TASAOrbiter-Medium.otf */; };
 		B99D16E7788AF691EA9E6E1A /* libPods-blade-bladeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF7CC2C2C0866401CC832E2 /* libPods-blade-bladeTests.a */; };
 		BB8E5D4B741B4FE6809D0474 /* Inter-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A16BDE98C023436FB6B67991 /* Inter-SemiBold.ttf */; };
-		D8C6246C53D84CCBBA9E1105 /* TASAOrbiter-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 92B39F53BD7D4376835C95D9 /* TASAOrbiter-Regular.otf */; };
+		2DDA884D7B694E66B1FA25E8 /* TASAOrbiterDisplay-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = E8E92216E4A7480899561D98 /* TASAOrbiterDisplay-Medium.otf */; };
+		C165FFDEB65E4E1F81E5B86F /* TASAOrbiterDisplay-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = B3C7EB8E12344CD381BF5029 /* TASAOrbiterDisplay-Regular.otf */; };
+		3C6D9471A17E415FBA813B6A /* TASAOrbiterDisplay-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = C52015C732D640A597B8A769 /* TASAOrbiterDisplay-SemiBold.otf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,16 +36,13 @@
 		00E356EE1AD99517003FC87E /* bladeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bladeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* bladeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bladeTests.m; sourceTree = "<group>"; };
-		0E4CE3584AE645A18022AC6E /* TASAOrbiter-SemiBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "TASAOrbiter-SemiBold.otf"; path = "../public/fonts/TASAOrbiter-SemiBold.otf"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* blade.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = blade.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = blade/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.mm; path = blade/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = blade/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = blade/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = blade/main.m; sourceTree = "<group>"; };
-		64A70F2B3BB0413193E2E76D /* TASAOrbiter-Medium.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "TASAOrbiter-Medium.otf"; path = "../public/fonts/TASAOrbiter-Medium.otf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = blade/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		92B39F53BD7D4376835C95D9 /* TASAOrbiter-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "TASAOrbiter-Regular.otf"; path = "../public/fonts/TASAOrbiter-Regular.otf"; sourceTree = "<group>"; };
 		9B55C243E3A89932C0E9E7DB /* Pods-blade-bladeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-blade-bladeTests.release.xcconfig"; path = "Target Support Files/Pods-blade-bladeTests/Pods-blade-bladeTests.release.xcconfig"; sourceTree = "<group>"; };
 		9DFE3CEDD36C82CC4702A8EA /* Pods-blade.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-blade.debug.xcconfig"; path = "Target Support Files/Pods-blade/Pods-blade.debug.xcconfig"; sourceTree = "<group>"; };
 		A14C4DCE8FBCAD8DAD09818D /* libPods-blade.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-blade.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -56,6 +53,9 @@
 		C8AEEE4D40BD6854CCC4C971 /* Pods-blade-bladeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-blade-bladeTests.debug.xcconfig"; path = "Target Support Files/Pods-blade-bladeTests/Pods-blade-bladeTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F7902B25200F4FEFA8929693 /* Inter-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Regular.ttf"; path = "../public/fonts/Inter-Regular.ttf"; sourceTree = "<group>"; };
+		E8E92216E4A7480899561D98 /* TASAOrbiterDisplay-Medium.otf */ = {isa = PBXFileReference; name = "TASAOrbiterDisplay-Medium.otf"; path = "../public/fonts/TASAOrbiterDisplay-Medium.otf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		B3C7EB8E12344CD381BF5029 /* TASAOrbiterDisplay-Regular.otf */ = {isa = PBXFileReference; name = "TASAOrbiterDisplay-Regular.otf"; path = "../public/fonts/TASAOrbiterDisplay-Regular.otf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		C52015C732D640A597B8A769 /* TASAOrbiterDisplay-SemiBold.otf */ = {isa = PBXFileReference; name = "TASAOrbiterDisplay-SemiBold.otf"; path = "../public/fonts/TASAOrbiterDisplay-SemiBold.otf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,9 +124,9 @@
 				B567457C213041FE86C04D20 /* Inter-Medium.ttf */,
 				F7902B25200F4FEFA8929693 /* Inter-Regular.ttf */,
 				A16BDE98C023436FB6B67991 /* Inter-SemiBold.ttf */,
-				64A70F2B3BB0413193E2E76D /* TASAOrbiter-Medium.otf */,
-				92B39F53BD7D4376835C95D9 /* TASAOrbiter-Regular.otf */,
-				0E4CE3584AE645A18022AC6E /* TASAOrbiter-SemiBold.otf */,
+				E8E92216E4A7480899561D98 /* TASAOrbiterDisplay-Medium.otf */,
+				B3C7EB8E12344CD381BF5029 /* TASAOrbiterDisplay-Regular.otf */,
+				C52015C732D640A597B8A769 /* TASAOrbiterDisplay-SemiBold.otf */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -273,9 +273,9 @@
 				096B3CF46B7A474F807F3A37 /* Inter-Medium.ttf in Resources */,
 				3ACA67F067244DEB99783E06 /* Inter-Regular.ttf in Resources */,
 				BB8E5D4B741B4FE6809D0474 /* Inter-SemiBold.ttf in Resources */,
-				82C097F197BC4BE0AAF0D391 /* TASAOrbiter-Medium.otf in Resources */,
-				D8C6246C53D84CCBBA9E1105 /* TASAOrbiter-Regular.otf in Resources */,
-				15C1821D14554C109C0A2C42 /* TASAOrbiter-SemiBold.otf in Resources */,
+				2DDA884D7B694E66B1FA25E8 /* TASAOrbiterDisplay-Medium.otf in Resources */,
+				C165FFDEB65E4E1F81E5B86F /* TASAOrbiterDisplay-Regular.otf in Resources */,
+				3C6D9471A17E415FBA813B6A /* TASAOrbiterDisplay-SemiBold.otf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/blade/ios/blade/Info.plist
+++ b/packages/blade/ios/blade/Info.plist
@@ -42,9 +42,9 @@
 		<string>Inter-Medium.ttf</string>
 		<string>Inter-Regular.ttf</string>
 		<string>Inter-SemiBold.ttf</string>
-		<string>TASAOrbiter-Medium.otf</string>
-		<string>TASAOrbiter-Regular.otf</string>
-		<string>TASAOrbiter-SemiBold.otf</string>
+		<string>TASAOrbiterDisplay-Medium.otf</string>
+		<string>TASAOrbiterDisplay-Regular.otf</string>
+		<string>TASAOrbiterDisplay-SemiBold.otf</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/packages/blade/ios/link-assets-manifest.json
+++ b/packages/blade/ios/link-assets-manifest.json
@@ -14,15 +14,15 @@
       "sha1": "d48310d2f04c57af1bce0851e053be7b58b25dca"
     },
     {
-      "path": "public/fonts/TASAOrbiter-Medium.otf",
+      "path": "public/fonts/TASAOrbiterDisplay-Medium.otf",
       "sha1": "8654f4d9102bf662bba51400d0d7b0620f0fe02b"
     },
     {
-      "path": "public/fonts/TASAOrbiter-Regular.otf",
+      "path": "public/fonts/TASAOrbiterDisplay-Regular.otf",
       "sha1": "d0a82c67a1c5f2885eec09d1880ce67ec8e7c477"
     },
     {
-      "path": "public/fonts/TASAOrbiter-SemiBold.otf",
+      "path": "public/fonts/TASAOrbiterDisplay-SemiBold.otf",
       "sha1": "11e3f961d67d495814c3eab7c6ce6712f2ce4da6"
     }
   ]


### PR DESCRIPTION
I updated the font file names somewhere so it required running `npx react-native-asset -ios-a` once to update the instances where the older font file name was used. 

This PR fixes that.

It also adds back the documentation of new font installation which somewhere got reverted while pulling master on rebranding/master