### PR TITLE
refactor(rebranding): fix progressbar label text style

### DIFF
--- a/packages/blade/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/blade/src/components/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from 'react';
 import { ProgressBarFilled } from './ProgressBarFilled';
 import clamp from '~utils/lodashButBetter/clamp';
-import { FormLabel } from '~components/Form';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { Text } from '~components/Typography/Text';
 import { getStyledProps } from '~components/Box/styledProps';
@@ -170,9 +169,9 @@ const ProgressBar = ({
           justifyContent={hasLabel ? 'space-between' : 'flex-end'}
         >
           {hasLabel ? (
-            <FormLabel as="label" htmlFor={id}>
+            <Text as="label" variant="body" size="small" color="surface.text.gray.subtle">
               {label}
-            </FormLabel>
+            </Text>
           ) : null}
           {shouldShowPercentage ? (
             <BaseBox marginBottom="spacing.2">

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -26,7 +26,8 @@ type As =
   | 'q'
   | 'cite'
   | 'figcaption'
-  | 'div';
+  | 'div'
+  | 'label';
 
 export type BaseTextProps = {
   id?: string;

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -10,7 +10,7 @@ import type { TestID } from '~utils/types';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { throwBladeError } from '~utils/logger';
 
-const validAsValues = ['p', 'span', 'div', 'abbr', 'figcaption', 'cite', 'q'] as const;
+const validAsValues = ['p', 'span', 'div', 'abbr', 'figcaption', 'cite', 'q', 'label'] as const;
 type TextCommonProps = {
   as?: typeof validAsValues[number];
   truncateAfterLines?: number;


### PR DESCRIPTION
Removed FormLabel from ProgressBar since it's not using the base form label in design. 

https://razorpay.slack.com/archives/G01B3LQ9H0W/p1703663341935119