### PR TITLE
feat: add codemod for Text component migration

### DIFF
--- a/packages/blade/codemods/brand-refresh/transformers/__tests__/migrate-colors.test.ts
+++ b/packages/blade/codemods/brand-refresh/transformers/__tests__/migrate-colors.test.ts
@@ -61,7 +61,7 @@ it('should update token values contextually', async () => {
               <MapIcon color="interactive.icon.primary.normal" />
               <MapIcon color="surface.text.onSea.onSubtle" />
               <MapIcon color="interactive.icon.primary.normal" />
-              <MapIcon color="interactive.icon.gray.default" />
+              <MapIcon color="interactive.icon.gray.normal" />
             </>
           );"
   `);

--- a/packages/blade/codemods/brand-refresh/transformers/__tests__/migrate-typography.test.ts
+++ b/packages/blade/codemods/brand-refresh/transformers/__tests__/migrate-typography.test.ts
@@ -216,6 +216,36 @@ it('should update <Heading variant="subheading"> to <Text size="small">', async 
   `);
 });
 
+it('should update <Text variant="caption" size="medium"> to <Text variant="caption" size="small">', async () => {
+  const result = await applyTransform(
+    transformer,
+    `
+        const App = () => (
+          <>
+            // size="medium" should not be changed if variant is not "caption"
+            <Text size="medium">  Lorem ipsum </Text>
+            <Text variant="caption">  Lorem ipsum </Text>
+            <Text variant="caption" size="medium"> Lorem ipsum </Text>
+            <Text variant="caption" size="medium"> Lorem ipsum <Text variant="caption" size="medium" color="brand.primary.500"> Lorem ipsum </Text> </Text>
+          </>
+        );
+      `,
+    { parser: 'tsx' },
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+    "const App = () => (
+              <>
+                // size="medium" should not be changed if variant is not "caption"
+                <Text size="medium">  Lorem ipsum </Text>
+                <Text variant="caption">  Lorem ipsum </Text>
+                <Text variant="caption" size="small"> Lorem ipsum </Text>
+                <Text variant="caption" size="small"> Lorem ipsum <Text variant="caption" size="small" color="surface.text.primary.normal"> Lorem ipsum </Text> </Text>
+              </>
+            );"
+  `);
+});
+
 it('should update <Heading size="small"> to <Text size="large">', async () => {
   const result = await applyTransform(
     transformer,

--- a/packages/blade/codemods/brand-refresh/transformers/index.ts
+++ b/packages/blade/codemods/brand-refresh/transformers/index.ts
@@ -179,6 +179,30 @@ const transformer: Transform = (file, api, options) => {
       ['Text', 'Title', 'Code', 'Display', 'Heading'].includes(path.value.openingElement.name.name),
     );
 
+  // Update <Text variant="caption" size="medium" > to <Text variant="caption" size="small" >
+  try {
+    typographyJSXElements
+      .filter(
+        (path) =>
+          path.value.openingElement.name.name === 'Text' &&
+          path.value.openingElement.attributes.some(
+            (attribute) =>
+              attribute.name?.name === 'variant' && attribute.value?.value === 'caption',
+          ),
+      )
+      .find(j.JSXAttribute)
+      .filter((path) => path.node.name.name === 'size' && path.node.value.value === 'medium')
+      .replaceWith((path) => {
+        path.node.value.value = 'small';
+        return path.node;
+      });
+  } catch (error) {
+    console.error(
+      red(`⛔️ ${file.path}: Oops! Ran into an issue while updating the Text size prop.`),
+      `\n${red(error.stack)}\n`,
+    );
+  }
+
   // Update <Heading size="large|medium"> to <Heading size="medium|small">,
   // <Heading size="small">, <Heading variant="regular"> to <Text size="large">, and
   // <Heading variant="subheading"> to <Text size="small">

--- a/packages/blade/jest.web.config.js
+++ b/packages/blade/jest.web.config.js
@@ -17,6 +17,7 @@ const baseConfig = {
   testMatch: [
     ...rebrandedComponents.map((component) => `**/${component}.web.test.{ts,tsx}`),
     '**/Icons/*Icon/*.web.test.{ts,tsx}',
+    '**/codemods/**/*.test.{ts,tsx}',
   ],
   transform: {
     '\\.(js|ts|tsx)?$': './jest-preprocess.js',

--- a/packages/blade/upgrade-v11.md
+++ b/packages/blade/upgrade-v11.md
@@ -218,6 +218,13 @@ Only use this if you're unable to run the codemod described above.
   + <Text size="large"> Hello </Text>
   ```
 
+- **The `caption` variant of the `Text` component now accepts only `size="small"`.**
+
+  ```diff
+  - <Text variant="caption" size="medium"> Hello </Text>
+  + <Text variant="caption" size="small"> Hello </Text>
+  ```
+
 - **The `weight` prop now accepts `"semibold"` instead of `"bold"` in the ` Text`, `Heading` , & `Display` components. The `Code` component continues to accept `"bold"`.**
 
   ```diff


### PR DESCRIPTION
- **The `caption` variant of the `Text` component now accepts only `size="small"`.**

  ```diff
  - <Text variant="caption" size="medium"> Hello </Text>
  + <Text variant="caption" size="small"> Hello </Text>
  ```