### PR TITLE
chore: change text caption size to `small` instead of `medium`

### DIFF
--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -69,7 +69,7 @@ const FormLabel = ({
 
   if (necessityIndicator === 'optional') {
     necessityLabel = (
-      <Text variant="caption" size="medium" type="placeholder">
+      <Text variant="caption" size="small" type="placeholder">
         (optional)
       </Text>
     );

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -37,7 +37,7 @@ type TextBodyVariant = TextCommonProps & {
 
 type TextCaptionVariant = TextCommonProps & {
   variant?: Extract<TextVariant, 'caption'>;
-  size?: Extract<BaseTextSizes, 'medium'>;
+  size?: Extract<BaseTextSizes, 'small'>;
 };
 
 /**
@@ -101,7 +101,7 @@ const getTextProps = <T extends { variant: TextVariant }>({
     }
   }
   if (variant === 'caption') {
-    if (size === 'medium') {
+    if (size === 'small') {
       props.fontSize = 50;
       props.lineHeight = 50;
       props.fontWeight = 'regular';

--- a/packages/blade/src/components/Typography/Text/__tests__/Text.native.test.tsx
+++ b/packages/blade/src/components/Typography/Text/__tests__/Text.native.test.tsx
@@ -86,22 +86,22 @@ describe('<Text />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it('should throw error when variant is "caption" and size "small" is passed', () => {
+  it('should throw error when variant is "caption" and size "medium" is passed', () => {
     const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
     const displayText = 'Displaying some text';
     expect(() =>
       renderWithTheme(
-        // @ts-expect-error testing failure case when size='small' is passed with variant='caption'
+        // @ts-expect-error testing failure case when size='medium' is passed with variant='caption'
         <Text
           color="surface.text.gray.normal"
           variant="caption"
           truncateAfterLines={3}
-          size="small"
+          size="medium"
         >
           {displayText}
         </Text>,
       ),
-    ).toThrow(`[Blade: Text]: size cannot be 'small' when variant is 'caption'`);
+    ).toThrow(`[Blade: Text]: size cannot be 'medium' when variant is 'caption'`);
     mockConsoleError.mockRestore();
   });
 

--- a/packages/blade/src/components/Typography/Text/__tests__/Text.web.test.tsx
+++ b/packages/blade/src/components/Typography/Text/__tests__/Text.web.test.tsx
@@ -80,22 +80,22 @@ describe('<Text />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('should throw error when variant is "caption" and size "small" is passed', () => {
+  it('should throw error when variant is "caption" and size "medium" is passed', () => {
     const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
     const displayText = 'Displaying some text';
     expect(() =>
       renderWithTheme(
-        // @ts-expect-error testing failure case when size='small' is passed with variant='caption'
+        // @ts-expect-error testing failure case when size='medium' is passed with variant='caption'
         <Text
           color="surface.text.gray.normal"
           variant="caption"
           truncateAfterLines={3}
-          size="small"
+          size="medium"
         >
           {displayText}
         </Text>,
       ),
-    ).toThrow(`[Blade: Text]: size cannot be 'small' when variant is 'caption'`);
+    ).toThrow(`[Blade: Text]: size cannot be 'medium' when variant is 'caption'`);
     mockConsoleError.mockRestore();
   });
 


### PR DESCRIPTION
Rename caption size `medium` to `small`

PR for codemod: #1926 

```diff
- <Text variant="caption" size="medium">This is a help text</Text>
+ <Text variant="caption" size="small">This is a help text</Text>
```