### PR TITLE
fix(Table): handle case where currentPage is greater than total pages

### DIFF
--- a/.changeset/famous-cats-push.md
+++ b/.changeset/famous-cats-push.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Table): handle case where currentPage is greater than total pages

--- a/packages/blade/src/components/Table/TablePagination.web.tsx
+++ b/packages/blade/src/components/Table/TablePagination.web.tsx
@@ -23,6 +23,7 @@ import { Button } from '~components/Button';
 import { makeAccessible } from '~utils/makeAccessible';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { useTheme } from '~components/BladeProvider';
+import { throwBladeError } from '~utils/logger';
 
 const pageSizeOptions: NonNullable<TablePaginationProps['defaultPageSize']>[] = [10, 25, 50];
 
@@ -212,7 +213,14 @@ const _TablePagination = ({
   }, [controlledCurrentPage, currentPage, handlePageChange, onPageChange]);
 
   if (currentPage > totalPages - 1) {
-    handlePageChange(totalPages - 1);
+    if (!isUndefined(controlledCurrentPage)) {
+      if (__DEV__) {
+        throwBladeError({
+          moduleName: 'TablePagination',
+          message: `Value of 'currentPage' prop cannot be greater than the total pages`,
+        });
+      }
+    } else handlePageChange(totalPages - 1);
   }
 
   const handlePageSizeChange = (pageSize: number): void => {

--- a/packages/blade/src/components/Table/TablePagination.web.tsx
+++ b/packages/blade/src/components/Table/TablePagination.web.tsx
@@ -220,7 +220,9 @@ const _TablePagination = ({
           message: `Value of 'currentPage' prop cannot be greater than the total pages`,
         });
       }
-    } else handlePageChange(totalPages - 1);
+    } else {
+      handlePageChange(totalPages - 1);
+    }
   }
 
   const handlePageSizeChange = (pageSize: number): void => {

--- a/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
+++ b/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
@@ -806,4 +806,48 @@ describe('<Table />', () => {
     fireEvent.click(goBack5PagesButton);
     expect(onPageChange).toHaveBeenLastCalledWith({ page: 0 });
   }, 10000);
+
+  it('should throw error if currentPage is greater than total pages', () => {
+    const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+    expect(() =>
+      renderWithTheme(
+        <Table
+          data={{
+            nodes: [...nodes, ...nodes],
+          }}
+          pagination={<TablePagination defaultPageSize={10} currentPage={50} />}
+        >
+          {(tableData) => (
+            <>
+              <TableHeader>
+                <TableHeaderRow>
+                  <TableHeaderCell>Payment ID</TableHeaderCell>
+                  <TableHeaderCell>Amount</TableHeaderCell>
+                  <TableHeaderCell>Status</TableHeaderCell>
+                  <TableHeaderCell>Type</TableHeaderCell>
+                  <TableHeaderCell>Method</TableHeaderCell>
+                  <TableHeaderCell>Name</TableHeaderCell>
+                </TableHeaderRow>
+              </TableHeader>
+              <TableBody>
+                {tableData.map((tableItem, index) => (
+                  <TableRow item={tableItem} key={index}>
+                    <TableCell>{tableItem.paymentId}</TableCell>
+                    <TableCell>{tableItem.amount}</TableCell>
+                    <TableCell>{tableItem.status}</TableCell>
+                    <TableCell>{tableItem.type}</TableCell>
+                    <TableCell>{tableItem.method}</TableCell>
+                    <TableCell>{tableItem.name}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </>
+          )}
+        </Table>,
+      ),
+    ).toThrow(
+      `[Blade: TablePagination]: Value of 'currentPage' prop cannot be greater than the total pages`,
+    );
+    mockConsoleError.mockRestore();
+  });
 });


### PR DESCRIPTION
Fixes #1925 

- Fix an edge case where the controlled prop `currentPage` being greater that the total pages makes the table go in an infinite state update. 
- Throw appropriate error
- Add test
