### PR TITLE
feat(Card): add support for CardHeaderAmount

### DIFF
--- a/packages/blade/src/components/Card/Card.stories.tsx
+++ b/packages/blade/src/components/Card/Card.stories.tsx
@@ -17,6 +17,7 @@ import {
   CardHeaderBadge,
   CardHeaderIconButton,
   CardHeaderLink,
+  CardHeaderAmount,
   CardHeaderText,
 } from './';
 import { Sandbox } from '~utils/storybook/Sandbox';
@@ -151,6 +152,7 @@ const visual = {
   Text: <CardHeaderText>$100</CardHeaderText>,
   IconButton: <CardHeaderIconButton icon={TrashIcon} />,
   Badge: <CardHeaderBadge color="positive">NEW</CardHeaderBadge>,
+  Amount: <CardHeaderAmount value={1000} />,
 };
 
 export default {

--- a/packages/blade/src/components/Card/CardHeader.tsx
+++ b/packages/blade/src/components/Card/CardHeader.tsx
@@ -24,6 +24,8 @@ import { makeSpace } from '~utils/makeSpace';
 import { getComponentId, isValidAllowedChildren } from '~utils/isValidAllowedChildren';
 import { throwBladeError } from '~utils/logger';
 import { useVerifyAllowedChildren } from '~utils/useVerifyAllowedChildren/useVerifyAllowedChildren';
+import type { AmountProps } from '~components/Amount';
+import { Amount } from '~components/Amount';
 
 const _CardHeaderIcon = ({ icon: Icon }: { icon: IconComponent }): React.ReactElement => {
   useVerifyInsideCard('CardHeaderIcon');
@@ -52,15 +54,15 @@ const CardHeaderBadge = assignWithoutSideEffects(_CardHeaderBadge, {
   componentId: ComponentIds.CardHeaderBadge,
 });
 
-// @TODO: uncomment and export this when Amount component is migrated
-// const _CardHeaderAmount = (props: AmountProps): React.ReactElement => {
-//   useVerifyInsideCard('CardHeaderAmount');
+const _CardHeaderAmount = (props: AmountProps): React.ReactElement => {
+  useVerifyInsideCard('CardHeaderAmount');
 
-//   return <Amount {...props} />;
-// };
-// const CardHeaderAmount = assignWithoutSideEffects(_CardHeaderAmount, {
-//   componentId: ComponentIds.CardHeaderAmount,
-// });
+  return <Amount {...props} />;
+};
+
+const CardHeaderAmount = assignWithoutSideEffects(_CardHeaderAmount, {
+  componentId: ComponentIds.CardHeaderAmount,
+});
 
 const _CardHeaderText = (props: TextProps<{ variant: TextVariant }>): React.ReactElement => {
   useVerifyInsideCard('CardHeaderText');
@@ -228,6 +230,7 @@ const headerTrailingAllowedComponents = [
   ComponentIds.CardHeaderText,
   ComponentIds.CardHeaderIconButton,
   ComponentIds.CardHeaderBadge,
+  ComponentIds.CardHeaderAmount,
 ];
 
 const _CardHeaderTrailing = ({ visual }: CardHeaderTrailingProps): React.ReactElement => {
@@ -259,5 +262,6 @@ export {
   CardHeaderCounter,
   CardHeaderText,
   CardHeaderLink,
+  CardHeaderAmount,
   CardHeaderIconButton,
 };


### PR DESCRIPTION
I had kept CardHeaderAmount inside comment because Amount component had not been migrated back then.

Removing that comment and added it in validations and stories