### PR TITLE
chore: keep minimal codeowners to reduce noise

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/packages/blade/ @chaitanyadeorukhkar @kamleshchandnani @anuraghazra @nashcheez @saurabhdaware @snitin315
+/packages/blade/ @chaitanyadeorukhkar @kamleshchandnani


### PR DESCRIPTION
Reduce review noise on slack & keep minimal codeowners.