### PR TITLE
chore: remove razorsharp from workspace packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "workspaces": {
     "packages": [
       "packages/blade",
-      "packages/razorsharp",
       "packages/eslint-plugin-blade"
     ],
     "nohoist": [


### PR DESCRIPTION
It shouldn't be there.