### PR TITLE
chore: add `onHover` & `onClick` callback to `TableRow`

### DIFF
--- a/.changeset/quick-students-beam.md
+++ b/.changeset/quick-students-beam.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-chore: add `onHover` & `onClick` callback to `TableRow`
+feat: add `onHover` & `onClick` callback to `TableRow`

--- a/.changeset/quick-students-beam.md
+++ b/.changeset/quick-students-beam.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+chore: add `onHover` callback to `TableRow`

--- a/.changeset/quick-students-beam.md
+++ b/.changeset/quick-students-beam.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-chore: add `onHover` callback to `TableRow`
+chore: add `onHover` & `onClick` callback to `TableRow`

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -279,7 +279,7 @@ const _TableRow = <Item,>({
   children,
   item,
   isDisabled,
-  onMouseEnter,
+  onHover,
   onClick,
 }: TableRowProps<Item>): React.ReactElement => {
   const {
@@ -301,10 +301,10 @@ const _TableRow = <Item,>({
     <StyledRow
       disabled={isDisabled}
       $isSelectable={isDisabled ? false : isSelectable}
-      $isHoverable={isDisabled ? false : Boolean(onMouseEnter || onClick)}
+      $isHoverable={isDisabled ? false : Boolean(onHover || onClick)}
       item={item}
       className={isDisabled ? 'disabled-row' : ''}
-      onMouseEnter={() => onMouseEnter?.({ item })}
+      onMouseEnter={() => onHover?.({ item })}
       onClick={() => onClick?.({ item })}
       {...metaAttribute({ name: MetaConstants.TableRow })}
     >

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -280,6 +280,7 @@ const _TableRow = <Item,>({
   item,
   isDisabled,
   onMouseEnter,
+  onClick,
 }: TableRowProps<Item>): React.ReactElement => {
   const {
     selectionType,
@@ -300,10 +301,11 @@ const _TableRow = <Item,>({
     <StyledRow
       disabled={isDisabled}
       $isSelectable={isDisabled ? false : isSelectable}
-      $isHoverable={isDisabled ? false : Boolean(onMouseEnter)}
+      $isHoverable={isDisabled ? false : Boolean(onMouseEnter || onClick)}
       item={item}
       className={isDisabled ? 'disabled-row' : ''}
       onMouseEnter={() => onMouseEnter?.({ item })}
+      onClick={() => onClick?.({ item })}
       {...metaAttribute({ name: MetaConstants.TableRow })}
     >
       {isMultiSelect && (

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -301,7 +301,7 @@ const _TableRow = <Item,>({
     <StyledRow
       disabled={isDisabled}
       $isSelectable={isDisabled ? false : isSelectable}
-      $isHoverable={isDisabled ? false : Boolean(onHover || onClick)}
+      $isHoverable={isDisabled ? false : Boolean(onHover) || Boolean(onClick)}
       item={item}
       className={isDisabled ? 'disabled-row' : ''}
       onMouseEnter={() => onHover?.({ item })}

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -279,7 +279,7 @@ const _TableRow = <Item,>({
   children,
   item,
   isDisabled,
-  onHover,
+  onMouseEnter,
 }: TableRowProps<Item>): React.ReactElement => {
   const {
     selectionType,
@@ -300,10 +300,10 @@ const _TableRow = <Item,>({
     <StyledRow
       disabled={isDisabled}
       $isSelectable={isDisabled ? false : isSelectable}
-      $isHoverable={isDisabled ? false : Boolean(onHover)}
+      $isHoverable={isDisabled ? false : Boolean(onMouseEnter)}
       item={item}
       className={isDisabled ? 'disabled-row' : ''}
-      onMouseEnter={() => onHover?.({ item })}
+      onMouseEnter={() => onMouseEnter?.({ item })}
       {...metaAttribute({ name: MetaConstants.TableRow })}
     >
       {isMultiSelect && (

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -238,43 +238,48 @@ const TableCheckboxCell = ({
   );
 };
 
-const StyledRow = styled(Row)<{ $isSelectable: boolean }>(({ theme, $isSelectable }) => {
-  const rowBackgroundTransition = `background-color ${makeMotionTime(
-    getIn(theme.motion, tableRow.backgroundColorMotionDuration),
-  )} ${getIn(theme.motion, tableRow.backgroundColorMotionEasing)}`;
+const StyledRow = styled(Row)<{ $isSelectable: boolean; $isHoverable: boolean }>(
+  ({ theme, $isSelectable, $isHoverable }) => {
+    const rowBackgroundTransition = `background-color ${makeMotionTime(
+      getIn(theme.motion, tableRow.backgroundColorMotionDuration),
+    )} ${getIn(theme.motion, tableRow.backgroundColorMotionEasing)}`;
 
-  return {
-    '&&&': {
-      backgroundColor: 'transparent',
-      ...($isSelectable && {
-        '&:hover:not(.disabled-row) .cell-wrapper-base': {
-          transition: rowBackgroundTransition,
-          backgroundColor: getIn(theme.colors, tableRow.nonStripe.backgroundColorHover),
-          cursor: 'pointer',
+    return {
+      '&&&': {
+        backgroundColor: 'transparent',
+        ...(($isHoverable || $isSelectable) && {
+          '&:hover:not(.disabled-row) .cell-wrapper-base': {
+            transition: rowBackgroundTransition,
+            cursor: 'pointer',
+            backgroundColor: getIn(theme.colors, tableRow.nonStripe.backgroundColorHover),
+          },
+        }),
+        ...($isSelectable && {
+          '&:focus:not(.disabled-row) .cell-wrapper-base': {
+            transition: rowBackgroundTransition,
+            backgroundColor: getIn(theme.colors, tableRow.nonStripe.backgroundColorFocus),
+            cursor: 'pointer',
+          },
+          '&:active:not(.disabled-row) .cell-wrapper-base': {
+            transition: rowBackgroundTransition,
+            backgroundColor: getIn(theme.colors, tableRow.nonStripe.backgroundColorActive),
+            cursor: 'pointer',
+          },
+        }),
+        '&:focus': {
+          outline: 'none',
+          boxShadow: `0 0 0 2px ${getIn(theme.colors, 'brand.primary.300')}`,
         },
-        '&:focus:not(.disabled-row) .cell-wrapper-base': {
-          transition: rowBackgroundTransition,
-          backgroundColor: getIn(theme.colors, tableRow.nonStripe.backgroundColorFocus),
-          cursor: 'pointer',
-        },
-        '&:active:not(.disabled-row) .cell-wrapper-base': {
-          transition: rowBackgroundTransition,
-          backgroundColor: getIn(theme.colors, tableRow.nonStripe.backgroundColorActive),
-          cursor: 'pointer',
-        },
-      }),
-      '&:focus': {
-        outline: 'none',
-        boxShadow: `0 0 0 2px ${getIn(theme.colors, 'brand.primary.300')}`,
       },
-    },
-  };
-});
+    };
+  },
+);
 
 const _TableRow = <Item,>({
   children,
   item,
   isDisabled,
+  onHover,
 }: TableRowProps<Item>): React.ReactElement => {
   const {
     selectionType,
@@ -295,8 +300,10 @@ const _TableRow = <Item,>({
     <StyledRow
       disabled={isDisabled}
       $isSelectable={isDisabled ? false : isSelectable}
+      $isHoverable={isDisabled ? false : Boolean(onHover)}
       item={item}
       className={isDisabled ? 'disabled-row' : ''}
+      onMouseEnter={() => onHover?.({ item })}
       {...metaAttribute({ name: MetaConstants.TableRow })}
     >
       {isMultiSelect && (

--- a/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
+++ b/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
@@ -617,6 +617,45 @@ describe('<Table />', () => {
     expect(getAllByRole('row')[0]).toHaveTextContent('completed');
   });
 
+  it('should call onHover when row is hovered', async () => {
+    const onHover = jest.fn();
+    const user = userEvent.setup();
+    const { getByText } = renderWithTheme(
+      <Table data={{ nodes: nodes.slice(0, 5) }} selectionType="single">
+        {(tableData) => (
+          <>
+            <TableHeader>
+              <TableHeaderRow>
+                <TableHeaderCell>Payment ID</TableHeaderCell>
+                <TableHeaderCell>Amount</TableHeaderCell>
+                <TableHeaderCell>Status</TableHeaderCell>
+                <TableHeaderCell>Type</TableHeaderCell>
+                <TableHeaderCell>Method</TableHeaderCell>
+                <TableHeaderCell>Name</TableHeaderCell>
+              </TableHeaderRow>
+            </TableHeader>
+            <TableBody>
+              {tableData.map((tableItem, index) => (
+                <TableRow item={tableItem} key={index} onHover={onHover}>
+                  <TableCell>{tableItem.paymentId}</TableCell>
+                  <TableCell>{tableItem.amount}</TableCell>
+                  <TableCell>{tableItem.status}</TableCell>
+                  <TableCell>{tableItem.type}</TableCell>
+                  <TableCell>{tableItem.method}</TableCell>
+                  <TableCell>{tableItem.name}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </>
+        )}
+      </Table>,
+    );
+
+    const firstSelectableRow = getByText('rzp01').closest('td');
+    if (firstSelectableRow) await user.hover(firstSelectableRow);
+    expect(onHover).toHaveBeenCalledWith({ item: nodes[0] });
+  });
+
   it('should render table with single select', async () => {
     const onSelectionChange = jest.fn();
     const user = userEvent.setup();

--- a/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
+++ b/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
@@ -617,8 +617,8 @@ describe('<Table />', () => {
     expect(getAllByRole('row')[0]).toHaveTextContent('completed');
   });
 
-  it('should call onHover when row is hovered', async () => {
-    const onHover = jest.fn();
+  it('should call onMouseEnter when mouse enters the row', async () => {
+    const onMouseEnter = jest.fn();
     const user = userEvent.setup();
     const { getByText } = renderWithTheme(
       <Table data={{ nodes: nodes.slice(0, 5) }} selectionType="single">
@@ -636,7 +636,7 @@ describe('<Table />', () => {
             </TableHeader>
             <TableBody>
               {tableData.map((tableItem, index) => (
-                <TableRow item={tableItem} key={index} onHover={onHover}>
+                <TableRow item={tableItem} key={index} onMouseEnter={onMouseEnter}>
                   <TableCell>{tableItem.paymentId}</TableCell>
                   <TableCell>{tableItem.amount}</TableCell>
                   <TableCell>{tableItem.status}</TableCell>
@@ -653,7 +653,7 @@ describe('<Table />', () => {
 
     const firstSelectableRow = getByText('rzp01').closest('td');
     if (firstSelectableRow) await user.hover(firstSelectableRow);
-    expect(onHover).toHaveBeenCalledWith({ item: nodes[0] });
+    expect(onMouseEnter).toHaveBeenCalledWith({ item: nodes[0] });
   });
 
   it('should render table with single select', async () => {

--- a/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
+++ b/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
@@ -656,6 +656,45 @@ describe('<Table />', () => {
     expect(onMouseEnter).toHaveBeenCalledWith({ item: nodes[0] });
   });
 
+  it('should call onClick when the row is clicked', async () => {
+    const onClick = jest.fn();
+    const user = userEvent.setup();
+    const { getByText } = renderWithTheme(
+      <Table data={{ nodes: nodes.slice(0, 5) }} selectionType="single">
+        {(tableData) => (
+          <>
+            <TableHeader>
+              <TableHeaderRow>
+                <TableHeaderCell>Payment ID</TableHeaderCell>
+                <TableHeaderCell>Amount</TableHeaderCell>
+                <TableHeaderCell>Status</TableHeaderCell>
+                <TableHeaderCell>Type</TableHeaderCell>
+                <TableHeaderCell>Method</TableHeaderCell>
+                <TableHeaderCell>Name</TableHeaderCell>
+              </TableHeaderRow>
+            </TableHeader>
+            <TableBody>
+              {tableData.map((tableItem, index) => (
+                <TableRow item={tableItem} key={index} onClick={onClick}>
+                  <TableCell>{tableItem.paymentId}</TableCell>
+                  <TableCell>{tableItem.amount}</TableCell>
+                  <TableCell>{tableItem.status}</TableCell>
+                  <TableCell>{tableItem.type}</TableCell>
+                  <TableCell>{tableItem.method}</TableCell>
+                  <TableCell>{tableItem.name}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </>
+        )}
+      </Table>,
+    );
+
+    const firstSelectableRow = getByText('rzp01').closest('td');
+    if (firstSelectableRow) await user.click(firstSelectableRow);
+    expect(onClick).toHaveBeenCalledWith({ item: nodes[0] });
+  });
+
   it('should render table with single select', async () => {
     const onSelectionChange = jest.fn();
     const user = userEvent.setup();

--- a/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
+++ b/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
@@ -617,8 +617,8 @@ describe('<Table />', () => {
     expect(getAllByRole('row')[0]).toHaveTextContent('completed');
   });
 
-  it('should call onMouseEnter when mouse enters the row', async () => {
-    const onMouseEnter = jest.fn();
+  it('should call onHover when mouse enters the row', async () => {
+    const onHover = jest.fn();
     const user = userEvent.setup();
     const { getByText } = renderWithTheme(
       <Table data={{ nodes: nodes.slice(0, 5) }} selectionType="single">
@@ -636,7 +636,7 @@ describe('<Table />', () => {
             </TableHeader>
             <TableBody>
               {tableData.map((tableItem, index) => (
-                <TableRow item={tableItem} key={index} onMouseEnter={onMouseEnter}>
+                <TableRow item={tableItem} key={index} onHover={onHover}>
                   <TableCell>{tableItem.paymentId}</TableCell>
                   <TableCell>{tableItem.amount}</TableCell>
                   <TableCell>{tableItem.status}</TableCell>
@@ -653,7 +653,7 @@ describe('<Table />', () => {
 
     const firstSelectableRow = getByText('rzp01').closest('td');
     if (firstSelectableRow) await user.hover(firstSelectableRow);
-    expect(onMouseEnter).toHaveBeenCalledWith({ item: nodes[0] });
+    expect(onHover).toHaveBeenCalledWith({ item: nodes[0] });
   });
 
   it('should call onClick when the row is clicked', async () => {

--- a/packages/blade/src/components/Table/__tests__/__snapshots__/Table.web.test.tsx.snap
+++ b/packages/blade/src/components/Table/__tests__/__snapshots__/Table.web.test.tsx.snap
@@ -444,7 +444,7 @@ exports[`<Table /> should render table 1`] = `
         data-table-library_body=""
       >
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -608,7 +608,7 @@ exports[`<Table /> should render table 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -772,7 +772,7 @@ exports[`<Table /> should render table 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -936,7 +936,7 @@ exports[`<Table /> should render table 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -1100,7 +1100,7 @@ exports[`<Table /> should render table 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -1763,7 +1763,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
         data-table-library_body=""
       >
         <tr
-          class="tr tr-body c5 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c5 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -1927,7 +1927,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c5 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c5 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -2789,7 +2789,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
         data-table-library_body=""
       >
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -2953,7 +2953,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c9 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c9 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -3621,7 +3621,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
         data-table-library_body=""
       >
         <tr
-          class="tr tr-body c5 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c5 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -3785,7 +3785,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c5 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c5 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -4452,7 +4452,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
         data-table-library_body=""
       >
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -4616,7 +4616,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -4780,7 +4780,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -4944,7 +4944,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -5108,7 +5108,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -5272,7 +5272,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -5436,7 +5436,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -5600,7 +5600,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -5764,7 +5764,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -5928,7 +5928,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
           </td>
         </tr>
         <tr
-          class="tr tr-body c6 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c6 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -6591,7 +6591,7 @@ exports[`<Table /> should render table with surfaceLevel 1`] = `
         data-table-library_body=""
       >
         <tr
-          class="tr tr-body c5 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c5 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"
@@ -6755,7 +6755,7 @@ exports[`<Table /> should render table with surfaceLevel 1`] = `
           </td>
         </tr>
         <tr
-          class="tr tr-body c5 css-1rzx1gz-getRowContainerStyle-Row"
+          class="tr tr-body c5 clickable css-1rzx1gz-getRowContainerStyle-Row"
           data-blade-component="table-row"
           data-table-library_tr-body=""
           role="row"

--- a/packages/blade/src/components/Table/types.ts
+++ b/packages/blade/src/components/Table/types.ts
@@ -199,6 +199,10 @@ type TableRowProps<Item> = {
    * Callback triggered when the mouse pointer enters the row. It is called with the current row item prop.
    */
   onMouseEnter?: ({ item }: { item: TableNode<Item> }) => void;
+  /**
+   * Callback triggered when the row is clicked. It is called with the current row item prop.
+   */
+  onClick?: ({ item }: { item: TableNode<Item> }) => void;
 };
 
 type TableCellProps = {

--- a/packages/blade/src/components/Table/types.ts
+++ b/packages/blade/src/components/Table/types.ts
@@ -196,9 +196,9 @@ type TableRowProps<Item> = {
    **/
   isDisabled?: boolean;
   /**
-   * Callback triggered when the mouse pointer enters the row. It is called with the current row item prop.
+   * Callback triggered when the row is hovered. It is called with the current row item prop.
    */
-  onMouseEnter?: ({ item }: { item: TableNode<Item> }) => void;
+  onHover?: ({ item }: { item: TableNode<Item> }) => void;
   /**
    * Callback triggered when the row is clicked. It is called with the current row item prop.
    */

--- a/packages/blade/src/components/Table/types.ts
+++ b/packages/blade/src/components/Table/types.ts
@@ -195,6 +195,10 @@ type TableRowProps<Item> = {
    * </TableRow>
    **/
   isDisabled?: boolean;
+  /**
+   * Callback triggered when the row is hovered. It is called with the current row item prop.
+   */
+  onHover?: ({ item }: { item: TableNode<Item> }) => void;
 };
 
 type TableCellProps = {

--- a/packages/blade/src/components/Table/types.ts
+++ b/packages/blade/src/components/Table/types.ts
@@ -196,9 +196,9 @@ type TableRowProps<Item> = {
    **/
   isDisabled?: boolean;
   /**
-   * Callback triggered when the row is hovered. It is called with the current row item prop.
+   * Callback triggered when the mouse pointer enters the row. It is called with the current row item prop.
    */
-  onHover?: ({ item }: { item: TableNode<Item> }) => void;
+  onMouseEnter?: ({ item }: { item: TableNode<Item> }) => void;
 };
 
 type TableCellProps = {


### PR DESCRIPTION
Makes rows hoverable without them needing to be selectable. Consumers can decide what they want to do on hover.

Ref: [Issue raised on slack](https://razorpay.slack.com/archives/CMQ3RBHEU/p1704712316037749)
Resolves: #1966 