### PR TITLE
fix: i18nify-js local dependency added in sandboxes

### DIFF
--- a/.changeset/three-humans-divide.md
+++ b/.changeset/three-humans-divide.md
@@ -1,5 +1,0 @@
----
-"@razorpay/blade": patch
----
-
-fix: i18nify-js local dependency added in sandboxes

--- a/.changeset/three-humans-divide.md
+++ b/.changeset/three-humans-divide.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: i18nify-js local dependency added in sandboxes

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -59,6 +59,7 @@ export const getReactScriptsJSDependencies = (): Dependencies => {
       'styled-components': packageJson.peerDependencies['styled-components'],
       '@emotion/react': '11.11.1',
       '@table-library/react-table-library': '4.1.7',
+      '@razorpay/i18nify-js': '1.4.0',
     },
   };
 };
@@ -74,6 +75,7 @@ const getViteReactTSDependencies = (): Dependencies => {
       'styled-components': packageJson.peerDependencies['styled-components'],
       '@emotion/react': '11.11.1',
       '@table-library/react-table-library': '4.1.7',
+      '@razorpay/i18nify-js': '1.4.0',
     },
     devDependencies: {
       vite: '4.5.0',


### PR DESCRIPTION
## Description
As `@razorpay/i18nify-js` dependency was not added in sandbox environment, the sandbox was breaking with the error "Could not find @razorpay/i18nify-js dependency". 
Have added a fix for this issue in this PR.

Slack thread => 
https://razorpay.slack.com/archives/C01H13RTF8V/p1707796443539579 

Issue =>
![image](https://github.com/razorpay/blade/assets/21965506/b4f9fcbb-a615-45dc-b1eb-eb8bd918c640)

Fix => 
<img width="1016" alt="Screenshot 2024-02-13 at 7 34 42 PM" src="https://github.com/razorpay/blade/assets/21965506/f7f40d00-55f0-49aa-9ca8-e57656cfe5d8">

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
