### PR TITLE
fix(Dropdown): remove scrollbar on tag slot and clicks on icon

### DIFF
--- a/.changeset/tiny-cooks-relate.md
+++ b/.changeset/tiny-cooks-relate.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Dropdown): remove scrollbar on tag slot and allow clicks on DropdownLink and DropdownButton chevron icons

--- a/packages/blade/src/components/Dropdown/Dropdown.tsx
+++ b/packages/blade/src/components/Dropdown/Dropdown.tsx
@@ -227,7 +227,10 @@ const _Dropdown = ({
           return;
         }
 
-        const isOutsideClick = !dropdown.contains(target) && !isTagDismissedRef.current?.value;
+        const isOutsideClick =
+          !dropdown.contains(target) &&
+          !isTagDismissedRef.current?.value &&
+          document.body.contains(target);
 
         const isDropdownOpenState = isDropdownOpenRef.current;
         if (isOutsideClick && isDropdownOpenState) {

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = `"<div id="root"><div data-blade-component="dropdown" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx kUMlmJ"><div data-blade-component="base-box" class="BaseBox-bmPWx jjDQyK"><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 Fuolv"><input tabindex="-1" aria-hidden="true" value=""/></div><div data-blade-component="select-input" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx hqusWt"><div data-blade-component="base-box" class="BaseBox-bmPWx jaAmIu"><label for="dropdown-undefined-trigger-undefined-input-undefined" style="width:auto;flex-shrink:0;margin-right:16px" id="dropdown-undefined-label" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bmPWx fZlcZT"><div data-blade-component="base-box" class="BaseBox-bmPWx ikPXAQ"><p class="StyledBaseText-dVBfTO itNENY" data-blade-component="text">Fruits</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 Fuolv"><p class="StyledBaseText-dVBfTO lXtvZ" data-blade-component="text"></p></div></div></div></label></div><div data-blade-component="base-box" class="BaseBox-bmPWx AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1  djRbKc cgXnWX"><div class="BaseBox-bmPWx eRtEHm tags-slot" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bmPWx drbAuO"><button type="button" autoComplete="off" id="dropdown-undefined-trigger-undefined-input-undefined" value="" placeholder="Select Option" data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-haspopup="listbox" aria-expanded="false" aria-controls="dropdown-undefined-actionlist" role="combobox" class="StyledBaseInputweb__StyledBaseNativeButton-hsusrk-1 fpblXh"><p class="StyledBaseText-dVBfTO dNDwxU" data-blade-component="text">Select Option</p></button></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx hGaCmA"><div data-blade-component="base-box" class="BaseBox-bmPWx fTNRoG"><div data-blade-component="base-box" class="BaseBox-bmPWx dxquVw"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 lmEfDF"><path d="M5.29289 8.29289C5.68342 7.90237 6.31658 7.90237 6.70711 8.29289L12 13.5858L17.2929 8.29289C17.6834 7.90237 18.3166 7.90237 18.7071 8.29289C19.0976 8.68342 19.0976 9.31658 18.7071 9.70711L12.7071 15.7071C12.3166 16.0976 11.6834 16.0976 11.2929 15.7071L5.29289 9.70711C4.90237 9.31658 4.90237 8.68342 5.29289 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 fDSHXQ"><path d="M11.2929 8.29289C11.6834 7.90237 12.3166 7.90237 12.7071 8.29289L18.7071 14.2929C19.0976 14.6834 19.0976 15.3166 18.7071 15.7071C18.3166 16.0976 17.6834 16.0976 17.2929 15.7071L12 10.4142L6.70711 15.7071C6.31658 16.0976 5.68342 16.0976 5.29289 15.7071C4.90237 15.3166 4.90237 14.6834 5.29289 14.2929L11.2929 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx BaseInputAnimatedBorderweb__BaseInputStyledAnimatedBorder-sc-2cepod-0  HaFJL"></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx iARoiz"><div data-blade-component="base-box" class="BaseBox-bmPWx qIbA"></div></div></div></div><div style="position:fixed;left:0;top:0" data-blade-component="base-box" class="BaseBox-bmPWx yMflf"><div elevation="midRaised" style="transform:translateY(-8px);opacity:0" data-blade-component="dropdown-overlay" class="BaseBox-bmPWx StyledDropdownOverlay-sc-1dik5mo-0 qogZr hBPEVn"><div data-blade-component="base-box" class="BaseBox-bmPWx cZtflA"><div data-blade-component="dropdown-header" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx djABsd"><div data-blade-component="base-box" class="BaseBox-bmPWx hJkrmV"><div data-blade-component="base-box" class="BaseBox-bmPWx hXjMxV"><div data-blade-component="base-box" class="BaseBox-bmPWx jxfNRL"><div data-blade-component="base-box" class="BaseBox-bmPWx kDqSNs"><p class="StyledBaseText-dVBfTO eWWvyY" data-blade-component="text">Recent Searches</p></div></div></div></div></div><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div></div></div><div id="dropdown-undefined-actionlist" role="listbox" aria-multiselectable="false" aria-labelledby="dropdown-undefined-label" data-blade-component="action-list" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx StyledListBoxWrapperweb__StyledListBoxWrapper-sc-1eo4pr6-0  eqjJNO"><button id="dropdown-undefined-0" type="button" tabindex="-1" class="BaseBox-bmPWx StyledActionListItemweb__StyledActionListItem-sc-1okp9u4-0  kNhTCc" aria-selected="false" role="option" data-blade-component="action-list-item" data-value="apple" data-index="0"><div data-blade-component="base-box" class="BaseBox-bmPWx kCHCkj"><div data-blade-component="base-box" class="BaseBox-bmPWx ieaOju"></div><div data-blade-component="base-box" class="BaseBox-bmPWx bSRMqp"><p class="StyledBaseText-dVBfTO fMVqO" data-blade-component="text">Apple</p></div><div data-blade-component="base-box" class="BaseBox-bmPWx gAZVjQ"></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx"></div></button><button id="dropdown-undefined-1" type="button" tabindex="-1" class="BaseBox-bmPWx StyledActionListItemweb__StyledActionListItem-sc-1okp9u4-0  kNhTCc" aria-selected="false" role="option" data-blade-component="action-list-item" data-value="mango" data-index="1"><div data-blade-component="base-box" class="BaseBox-bmPWx kCHCkj"><div data-blade-component="base-box" class="BaseBox-bmPWx ieaOju"></div><div data-blade-component="base-box" class="BaseBox-bmPWx bSRMqp"><p class="StyledBaseText-dVBfTO fMVqO" data-blade-component="text">Mango</p></div><div data-blade-component="base-box" class="BaseBox-bmPWx gAZVjQ"></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx"></div></button></div></div><div role="group" data-blade-component="base-box" class="BaseBox-bmPWx"><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div><div data-blade-component="dropdown-footer" class="BaseBox-bmPWx dJEYFx"></div></div></div></div></div></div></div>"`;
+exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = `"<div id="root"><div data-blade-component="dropdown" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx kUMlmJ"><div data-blade-component="base-box" class="BaseBox-bmPWx jjDQyK"><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 Fuolv"><input tabindex="-1" aria-hidden="true" value=""/></div><div data-blade-component="select-input" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx hqusWt"><div data-blade-component="base-box" class="BaseBox-bmPWx jaAmIu"><label for="dropdown-undefined-trigger-undefined-input-undefined" style="width:auto;flex-shrink:0;margin-right:16px" id="dropdown-undefined-label" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bmPWx fZlcZT"><div data-blade-component="base-box" class="BaseBox-bmPWx ikPXAQ"><p class="StyledBaseText-dVBfTO itNENY" data-blade-component="text">Fruits</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 Fuolv"><p class="StyledBaseText-dVBfTO lXtvZ" data-blade-component="text"></p></div></div></div></label></div><div data-blade-component="base-box" class="BaseBox-bmPWx AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1  djRbKc cgXnWX"><div class="BaseBox-bmPWx BaseInputTagSlotweb__TagSlotContainer-sc-1bt1h3t-0 eRtEHm dUNBKx tags-slot" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bmPWx drbAuO"><button type="button" autoComplete="off" id="dropdown-undefined-trigger-undefined-input-undefined" value="" placeholder="Select Option" data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-haspopup="listbox" aria-expanded="false" aria-controls="dropdown-undefined-actionlist" role="combobox" class="StyledBaseInputweb__StyledBaseNativeButton-hsusrk-1 fpblXh"><p class="StyledBaseText-dVBfTO dNDwxU" data-blade-component="text">Select Option</p></button></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx hGaCmA"><div data-blade-component="base-box" class="BaseBox-bmPWx fTNRoG"><div data-blade-component="base-box" class="BaseBox-bmPWx dxquVw"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 lmEfDF"><path d="M5.29289 8.29289C5.68342 7.90237 6.31658 7.90237 6.70711 8.29289L12 13.5858L17.2929 8.29289C17.6834 7.90237 18.3166 7.90237 18.7071 8.29289C19.0976 8.68342 19.0976 9.31658 18.7071 9.70711L12.7071 15.7071C12.3166 16.0976 11.6834 16.0976 11.2929 15.7071L5.29289 9.70711C4.90237 9.31658 4.90237 8.68342 5.29289 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 fDSHXQ"><path d="M11.2929 8.29289C11.6834 7.90237 12.3166 7.90237 12.7071 8.29289L18.7071 14.2929C19.0976 14.6834 19.0976 15.3166 18.7071 15.7071C18.3166 16.0976 17.6834 16.0976 17.2929 15.7071L12 10.4142L6.70711 15.7071C6.31658 16.0976 5.68342 16.0976 5.29289 15.7071C4.90237 15.3166 4.90237 14.6834 5.29289 14.2929L11.2929 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx BaseInputAnimatedBorderweb__BaseInputStyledAnimatedBorder-sc-2cepod-0  HaFJL"></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx iARoiz"><div data-blade-component="base-box" class="BaseBox-bmPWx qIbA"></div></div></div></div><div style="position:fixed;left:0;top:0" data-blade-component="base-box" class="BaseBox-bmPWx yMflf"><div elevation="midRaised" style="transform:translateY(-8px);opacity:0" data-blade-component="dropdown-overlay" class="BaseBox-bmPWx StyledDropdownOverlay-sc-1dik5mo-0 qogZr hBPEVn"><div data-blade-component="base-box" class="BaseBox-bmPWx cZtflA"><div data-blade-component="dropdown-header" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx djABsd"><div data-blade-component="base-box" class="BaseBox-bmPWx hJkrmV"><div data-blade-component="base-box" class="BaseBox-bmPWx hXjMxV"><div data-blade-component="base-box" class="BaseBox-bmPWx jxfNRL"><div data-blade-component="base-box" class="BaseBox-bmPWx kDqSNs"><p class="StyledBaseText-dVBfTO eWWvyY" data-blade-component="text">Recent Searches</p></div></div></div></div></div><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div></div></div><div id="dropdown-undefined-actionlist" role="listbox" aria-multiselectable="false" aria-labelledby="dropdown-undefined-label" data-blade-component="action-list" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx StyledListBoxWrapperweb__StyledListBoxWrapper-sc-1eo4pr6-0  eqjJNO"><button id="dropdown-undefined-0" type="button" tabindex="-1" class="BaseBox-bmPWx StyledActionListItemweb__StyledActionListItem-sc-1okp9u4-0  kNhTCc" aria-selected="false" role="option" data-blade-component="action-list-item" data-value="apple" data-index="0"><div data-blade-component="base-box" class="BaseBox-bmPWx kCHCkj"><div data-blade-component="base-box" class="BaseBox-bmPWx ieaOju"></div><div data-blade-component="base-box" class="BaseBox-bmPWx bSRMqp"><p class="StyledBaseText-dVBfTO fMVqO" data-blade-component="text">Apple</p></div><div data-blade-component="base-box" class="BaseBox-bmPWx gAZVjQ"></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx"></div></button><button id="dropdown-undefined-1" type="button" tabindex="-1" class="BaseBox-bmPWx StyledActionListItemweb__StyledActionListItem-sc-1okp9u4-0  kNhTCc" aria-selected="false" role="option" data-blade-component="action-list-item" data-value="mango" data-index="1"><div data-blade-component="base-box" class="BaseBox-bmPWx kCHCkj"><div data-blade-component="base-box" class="BaseBox-bmPWx ieaOju"></div><div data-blade-component="base-box" class="BaseBox-bmPWx bSRMqp"><p class="StyledBaseText-dVBfTO fMVqO" data-blade-component="text">Mango</p></div><div data-blade-component="base-box" class="BaseBox-bmPWx gAZVjQ"></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx"></div></button></div></div><div role="group" data-blade-component="base-box" class="BaseBox-bmPWx"><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div><div data-blade-component="dropdown-footer" class="BaseBox-bmPWx dJEYFx"></div></div></div></div></div></div></div>"`;
 
 exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = `
 .c0.c0.c0.c0.c0 {
@@ -63,13 +63,13 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   gap: 0px;
 }
 
-.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13 {
   margin-top: -4px;
   width: 100%;
   min-width: 30px;
 }
 
-.c15.c15.c15.c15.c15 {
+.c16.c16.c16.c16.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -86,7 +86,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   align-self: center;
 }
 
-.c16.c16.c16.c16.c16 {
+.c17.c17.c17.c17.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -101,7 +101,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding-right: 12px;
 }
 
-.c17.c17.c17.c17.c17 {
+.c18.c18.c18.c18.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -117,11 +117,11 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   height: 100%;
 }
 
-.c21.c21.c21.c21.c21 {
+.c22.c22.c22.c22.c22 {
   margin-left: 0px;
 }
 
-.c22.c22.c22.c22.c22 {
+.c23.c23.c23.c23.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -135,18 +135,18 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   justify-content: flex-end;
 }
 
-.c24.c24.c24.c24.c24 {
+.c25.c25.c25.c25.c25 {
   width: 100%;
   box-shadow: 0px 8px 24px 0px hsla(217,56%,17%,0.12);
 }
 
-.c26.c26.c26.c26.c26 {
+.c27.c27.c27.c27.c27 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c27.c27.c27.c27.c27 {
+.c28.c28.c28.c28.c28 {
   padding-right: 16px;
   padding-left: 16px;
   margin-bottom: 16px;
@@ -154,7 +154,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   touch-action: none;
 }
 
-.c28.c28.c28.c28.c28 {
+.c29.c29.c29.c29.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,7 +168,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   user-select: none;
 }
 
-.c29.c29.c29.c29.c29 {
+.c30.c30.c30.c30.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -187,13 +187,13 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   margin-right: auto;
 }
 
-.c30.c30.c30.c30.c30 {
+.c31.c31.c31.c31.c31 {
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
 }
 
-.c31.c31.c31.c31.c31 {
+.c32.c32.c32.c32.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -206,12 +206,12 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   flex-shrink: 0;
 }
 
-.c33.c33.c33.c33.c33 {
+.c34.c34.c34.c34.c34 {
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-bottom-style: solid;
 }
 
-.c37.c37.c37.c37.c37 {
+.c38.c38.c38.c38.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -230,7 +230,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   max-height: 20px;
 }
 
-.c38.c38.c38.c38.c38 {
+.c39.c39.c39.c39.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -245,7 +245,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   justify-content: center;
 }
 
-.c39.c39.c39.c39.c39 {
+.c40.c40.c40.c40.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -261,15 +261,15 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding-left: 0px;
 }
 
-.c41.c41.c41.c41.c41 {
+.c42.c42.c42.c42.c42 {
   margin-left: auto;
 }
 
-.c42.c42.c42.c42.c42 {
+.c43.c43.c43.c43.c43 {
   padding: 16px;
 }
 
-.c23.c23.c23.c23.c23 {
+.c24.c24.c24.c24.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -277,7 +277,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   z-index: 1001;
 }
 
-.c44.c44.c44.c44.c44 {
+.c45.c45.c45.c45.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -318,7 +318,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   min-height: 36px;
 }
 
-.c25.c25.c25.c25.c25 {
+.c26.c26.c26.c26.c26 {
   background-color: hsla(0,0%,100%,1);
   border-width: 1px;
   border-color: hsla(211,20%,52%,0.18);
@@ -326,7 +326,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   border-radius: 4px;
 }
 
-.c43.c43.c43.c43.c43 {
+.c44.c44.c44.c44.c44 {
   min-height: 36px;
   width: 100%;
   cursor: pointer;
@@ -363,24 +363,24 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   position: relative;
 }
 
-.c43.c43.c43.c43.c43:hover {
+.c44.c44.c44.c44.c44:hover {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c43.c43.c43.c43.c43:active {
+.c44.c44.c44.c44.c44:active {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c43.c43.c43.c43.c43:focus-visible {
+.c44.c44.c44.c44.c44:focus-visible {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
   outline: 1px solid hsla(227,100%,59%,0.09);
   box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.18);
 }
 
-.c43.c43.c43.c43.c43 * {
+.c44.c44.c44.c44.c44 * {
   -webkit-transition-property: color,fill,opacity;
   transition-property: color,fill,opacity;
   -webkit-transition-duration: 150ms;
@@ -428,7 +428,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15 {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -451,7 +451,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   -webkit-box-orient: vertical;
 }
 
-.c32.c32.c32.c32.c32 {
+.c33.c33.c33.c33.c33 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 1rem;
@@ -468,7 +468,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c40.c40.c40.c40.c40 {
+.c41.c41.c41.c41.c41 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -490,7 +490,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   -webkit-box-orient: vertical;
 }
 
-.c46.c46.c46.c46.c46 {
+.c47.c47.c47.c47.c47 {
   color: hsla(0,0%,100%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -508,22 +508,22 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c19.c19.c19.c19.c19 {
+.c20.c20.c20.c20.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c18.c18.c18.c18.c18 {
+.c19.c19.c19.c19.c19 {
   display: none;
 }
 
-.c45.c45.c45.c45.c45 {
+.c46.c46.c46.c46.c46 {
   opacity: 1;
 }
 
-.c34.c34.c34.c34.c34 {
+.c35.c35.c35.c35.c35 {
   border-width: 0;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -533,7 +533,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   flex-grow: 1;
 }
 
-.c13.c13.c13.c13.c13 {
+.c14.c14.c14.c14.c14 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -566,7 +566,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   cursor: auto;
 }
 
-.c13.c13.c13.c13.c13::-webkit-input-placeholder {
+.c14.c14.c14.c14.c14::-webkit-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -584,7 +584,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::-moz-placeholder {
+.c14.c14.c14.c14.c14::-moz-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -602,7 +602,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:-ms-input-placeholder {
+.c14.c14.c14.c14.c14:-ms-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -620,7 +620,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::placeholder {
+.c14.c14.c14.c14.c14::placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -638,11 +638,11 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:focus {
+.c14.c14.c14.c14.c14:focus {
   outline: none;
 }
 
-.c20.c20.c20.c20.c20 {
+.c21.c21.c21.c21.c21 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -724,6 +724,18 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   max-height: 37px;
 }
 
+.c12.c12.c12.c12.c12 {
+  -ms-overflow-style: none;
+  -webkit-scrollbar-width: none;
+  -moz-scrollbar-width: none;
+  -ms-scrollbar-width: none;
+  scrollbar-width: none;
+}
+
+.c12.c12.c12.c12.c12::-webkit-scrollbar {
+  display: none;
+}
+
 .c2.c2.c2.c2.c2 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -741,17 +753,17 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   word-wrap: normal;
 }
 
-.c35.c35.c35.c35.c35 {
+.c36.c36.c36.c36.c36 {
   overflow-y: auto;
   max-height: 300px;
   padding: 8px;
 }
 
-.c35.c35.c35.c35.c35 [role=group]:last-child > [role=separator]:last-child {
+.c36.c36.c36.c36.c36 [role=group]:last-child > [role=separator]:last-child {
   display: none;
 }
 
-.c36.c36.c36.c36.c36 {
+.c37.c37.c37.c37.c37 {
   border-width: 4px;
   border-style: solid;
   border-color: transparent;
@@ -766,20 +778,20 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
   display: block;
 }
 
-.c36.c36.c36.c36.c36:hover:not([aria-disabled=true]) {
+.c37.c37.c37.c37.c37:hover:not([aria-disabled=true]) {
   background-color: hsla(211,20%,52%,0.09);
 }
 
-.c36.c36.c36.c36.c36[aria-selected=true] {
+.c37.c37.c37.c37.c37[aria-selected=true] {
   background-color: hsla(227,100%,59%,0.09);
 }
 
-.c36.c36.c36.c36.c36[aria-selected=true]:hover {
+.c37.c37.c37.c37.c37[aria-selected=true]:hover {
   background-color: hsla(227,100%,59%,0.18);
 }
 
 @media screen and (min-width:768px) {
-  .c27.c27.c27.c27.c27 {
+  .c28.c28.c28.c28.c28 {
     padding-right: 20px;
     padding-left: 20px;
     margin-bottom: 20px;
@@ -788,37 +800,37 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
 }
 
 @media screen and (min-width:320px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:480px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1200px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c42.c42.c42.c42.c42 {
+  .c43.c43.c43.c43.c43 {
     padding: 20px;
   }
 }
@@ -898,11 +910,11 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
               data-blade-component="base-box"
             >
               <div
-                class="c11 tags-slot"
+                class="c11 c12 tags-slot"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12"
+                  class="c13"
                   data-blade-component="base-box"
                 >
                   <button
@@ -914,7 +926,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                     aria-invalid="false"
                     aria-required="false"
                     autocomplete="off"
-                    class="c13"
+                    class="c14"
                     data-blade-component="styled-base-input"
                     id="dropdown-7-trigger-1-input-2"
                     placeholder="Select Option"
@@ -923,7 +935,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                     value=""
                   >
                     <p
-                      class="c14"
+                      class="c15"
                       data-blade-component="text"
                     >
                       Select Option
@@ -932,20 +944,20 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                 </div>
               </div>
               <div
-                class="c15"
+                class="c16"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c16"
+                  class="c17"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c17"
+                    class="c18"
                     data-blade-component="base-box"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c18"
+                      class="c19"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -962,7 +974,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                     </svg>
                     <svg
                       aria-hidden="true"
-                      class="c19"
+                      class="c20"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -981,35 +993,35 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                 </div>
               </div>
               <div
-                class=" c20"
+                class=" c21"
                 data-blade-component="base-box"
               />
             </div>
           </div>
           <div
-            class="c21"
+            class="c22"
             data-blade-component="base-box"
           >
             <div
-              class="c22"
+              class="c23"
               data-blade-component="base-box"
             />
           </div>
         </div>
       </div>
       <div
-        class="c23"
+        class="c24"
         data-blade-component="base-box"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 8px); width: 0px;"
       >
         <div
-          class="c24 c25"
+          class="c25 c26"
           data-blade-component="dropdown-overlay"
           elevation="midRaised"
           style="transition-property: transform,opacity; transition-duration: 200ms;"
         >
           <div
-            class="c26"
+            class="c27"
             data-blade-component="base-box"
           >
             <div
@@ -1017,27 +1029,27 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
               data-blade-component="dropdown-header"
             >
               <div
-                class="c27"
+                class="c28"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c28"
+                  class="c29"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c29"
+                    class="c30"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c30"
+                      class="c31"
                       data-blade-component="base-box"
                     >
                       <div
-                        class="c31"
+                        class="c32"
                         data-blade-component="base-box"
                       >
                         <p
-                          class="c32"
+                          class="c33"
                           data-blade-component="text"
                         >
                           Recent Searches
@@ -1048,7 +1060,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                 </div>
               </div>
               <div
-                class="c33 c34"
+                class="c34 c35"
                 data-blade-component="divider"
                 role="separator"
               />
@@ -1063,13 +1075,13 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
           >
             <div
               aria-multiselectable="false"
-              class=" c35"
+              class=" c36"
               data-blade-component="base-box"
               role="listbox"
             >
               <button
                 aria-selected="false"
-                class=" c36"
+                class=" c37"
                 data-blade-component="action-list-item"
                 data-index="0"
                 data-value="apple"
@@ -1079,26 +1091,26 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                 type="button"
               >
                 <div
-                  class="c37"
+                  class="c38"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c39"
+                    class="c40"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c40"
+                      class="c41"
                       data-blade-component="text"
                     >
                       Apple
                     </p>
                   </div>
                   <div
-                    class="c41"
+                    class="c42"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -1109,7 +1121,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
               </button>
               <button
                 aria-selected="false"
-                class=" c36"
+                class=" c37"
                 data-blade-component="action-list-item"
                 data-index="1"
                 data-value="mango"
@@ -1119,26 +1131,26 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
                 type="button"
               >
                 <div
-                  class="c37"
+                  class="c38"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c39"
+                    class="c40"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c40"
+                      class="c41"
                       data-blade-component="text"
                     >
                       Mango
                     </p>
                   </div>
                   <div
-                    class="c41"
+                    class="c42"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -1155,26 +1167,26 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 2`] = 
             role="group"
           >
             <div
-              class="c33 c34"
+              class="c34 c35"
               data-blade-component="divider"
               role="separator"
             />
             <div
-              class="c42"
+              class="c43"
               data-blade-component="dropdown-footer"
             >
               <button
-                class="c43"
+                class="c44"
                 data-blade-component="button"
                 role="button"
                 type="button"
               >
                 <div
-                  class="c44 c45"
+                  class="c45 c46"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c46"
+                    class="c47"
                     data-blade-component="base-text"
                   >
                     Apply

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.web.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.web.test.tsx.snap
@@ -61,13 +61,13 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   gap: 0px;
 }
 
-.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13 {
   margin-top: -4px;
   width: 100%;
   min-width: 30px;
 }
 
-.c15.c15.c15.c15.c15 {
+.c16.c16.c16.c16.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -84,7 +84,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   align-self: center;
 }
 
-.c16.c16.c16.c16.c16 {
+.c17.c17.c17.c17.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,7 +99,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding-right: 12px;
 }
 
-.c17.c17.c17.c17.c17 {
+.c18.c18.c18.c18.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -115,11 +115,11 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   height: 100%;
 }
 
-.c21.c21.c21.c21.c21 {
+.c22.c22.c22.c22.c22 {
   margin-left: 0px;
 }
 
-.c22.c22.c22.c22.c22 {
+.c23.c23.c23.c23.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -133,18 +133,18 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   justify-content: flex-end;
 }
 
-.c24.c24.c24.c24.c24 {
+.c25.c25.c25.c25.c25 {
   width: 100%;
   box-shadow: 0px 8px 24px 0px hsla(217,56%,17%,0.12);
 }
 
-.c26.c26.c26.c26.c26 {
+.c27.c27.c27.c27.c27 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c27.c27.c27.c27.c27 {
+.c28.c28.c28.c28.c28 {
   padding-right: 16px;
   padding-left: 16px;
   margin-bottom: 16px;
@@ -152,7 +152,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   touch-action: none;
 }
 
-.c28.c28.c28.c28.c28 {
+.c29.c29.c29.c29.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -166,7 +166,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   user-select: none;
 }
 
-.c29.c29.c29.c29.c29 {
+.c30.c30.c30.c30.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -185,13 +185,13 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   margin-right: auto;
 }
 
-.c30.c30.c30.c30.c30 {
+.c31.c31.c31.c31.c31 {
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
 }
 
-.c31.c31.c31.c31.c31 {
+.c32.c32.c32.c32.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -204,12 +204,12 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   flex-shrink: 0;
 }
 
-.c33.c33.c33.c33.c33 {
+.c34.c34.c34.c34.c34 {
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-bottom-style: solid;
 }
 
-.c37.c37.c37.c37.c37 {
+.c38.c38.c38.c38.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -228,7 +228,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   max-height: 20px;
 }
 
-.c38.c38.c38.c38.c38 {
+.c39.c39.c39.c39.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -243,7 +243,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   justify-content: center;
 }
 
-.c39.c39.c39.c39.c39 {
+.c40.c40.c40.c40.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -259,15 +259,15 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding-left: 0px;
 }
 
-.c41.c41.c41.c41.c41 {
+.c42.c42.c42.c42.c42 {
   margin-left: auto;
 }
 
-.c42.c42.c42.c42.c42 {
+.c43.c43.c43.c43.c43 {
   padding: 16px;
 }
 
-.c23.c23.c23.c23.c23 {
+.c24.c24.c24.c24.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -275,7 +275,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   z-index: 1002;
 }
 
-.c44.c44.c44.c44.c44 {
+.c45.c45.c45.c45.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -316,7 +316,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   min-height: 36px;
 }
 
-.c25.c25.c25.c25.c25 {
+.c26.c26.c26.c26.c26 {
   background-color: hsla(0,0%,100%,1);
   border-width: 1px;
   border-color: hsla(211,20%,52%,0.18);
@@ -324,7 +324,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   border-radius: 4px;
 }
 
-.c43.c43.c43.c43.c43 {
+.c44.c44.c44.c44.c44 {
   min-height: 36px;
   width: 100%;
   cursor: pointer;
@@ -361,24 +361,24 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   position: relative;
 }
 
-.c43.c43.c43.c43.c43:hover {
+.c44.c44.c44.c44.c44:hover {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c43.c43.c43.c43.c43:active {
+.c44.c44.c44.c44.c44:active {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c43.c43.c43.c43.c43:focus-visible {
+.c44.c44.c44.c44.c44:focus-visible {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
   outline: 1px solid hsla(227,100%,59%,0.09);
   box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.18);
 }
 
-.c43.c43.c43.c43.c43 * {
+.c44.c44.c44.c44.c44 * {
   -webkit-transition-property: color,fill,opacity;
   transition-property: color,fill,opacity;
   -webkit-transition-duration: 150ms;
@@ -426,7 +426,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15 {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -449,7 +449,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   -webkit-box-orient: vertical;
 }
 
-.c32.c32.c32.c32.c32 {
+.c33.c33.c33.c33.c33 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 1rem;
@@ -466,7 +466,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c40.c40.c40.c40.c40 {
+.c41.c41.c41.c41.c41 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -488,7 +488,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   -webkit-box-orient: vertical;
 }
 
-.c46.c46.c46.c46.c46 {
+.c47.c47.c47.c47.c47 {
   color: hsla(0,0%,100%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -506,22 +506,22 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c19.c19.c19.c19.c19 {
+.c20.c20.c20.c20.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c18.c18.c18.c18.c18 {
+.c19.c19.c19.c19.c19 {
   display: none;
 }
 
-.c45.c45.c45.c45.c45 {
+.c46.c46.c46.c46.c46 {
   opacity: 1;
 }
 
-.c34.c34.c34.c34.c34 {
+.c35.c35.c35.c35.c35 {
   border-width: 0;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -531,7 +531,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   flex-grow: 1;
 }
 
-.c13.c13.c13.c13.c13 {
+.c14.c14.c14.c14.c14 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -564,7 +564,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   cursor: auto;
 }
 
-.c13.c13.c13.c13.c13::-webkit-input-placeholder {
+.c14.c14.c14.c14.c14::-webkit-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -582,7 +582,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::-moz-placeholder {
+.c14.c14.c14.c14.c14::-moz-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -600,7 +600,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:-ms-input-placeholder {
+.c14.c14.c14.c14.c14:-ms-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -618,7 +618,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::placeholder {
+.c14.c14.c14.c14.c14::placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -636,11 +636,11 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:focus {
+.c14.c14.c14.c14.c14:focus {
   outline: none;
 }
 
-.c20.c20.c20.c20.c20 {
+.c21.c21.c21.c21.c21 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -722,6 +722,18 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   max-height: 37px;
 }
 
+.c12.c12.c12.c12.c12 {
+  -ms-overflow-style: none;
+  -webkit-scrollbar-width: none;
+  -moz-scrollbar-width: none;
+  -ms-scrollbar-width: none;
+  scrollbar-width: none;
+}
+
+.c12.c12.c12.c12.c12::-webkit-scrollbar {
+  display: none;
+}
+
 .c2.c2.c2.c2.c2 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -739,17 +751,17 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   word-wrap: normal;
 }
 
-.c35.c35.c35.c35.c35 {
+.c36.c36.c36.c36.c36 {
   overflow-y: auto;
   max-height: 300px;
   padding: 8px;
 }
 
-.c35.c35.c35.c35.c35 [role=group]:last-child > [role=separator]:last-child {
+.c36.c36.c36.c36.c36 [role=group]:last-child > [role=separator]:last-child {
   display: none;
 }
 
-.c36.c36.c36.c36.c36 {
+.c37.c37.c37.c37.c37 {
   border-width: 4px;
   border-style: solid;
   border-color: transparent;
@@ -764,20 +776,20 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
   display: block;
 }
 
-.c36.c36.c36.c36.c36:hover:not([aria-disabled=true]) {
+.c37.c37.c37.c37.c37:hover:not([aria-disabled=true]) {
   background-color: hsla(211,20%,52%,0.09);
 }
 
-.c36.c36.c36.c36.c36[aria-selected=true] {
+.c37.c37.c37.c37.c37[aria-selected=true] {
   background-color: hsla(227,100%,59%,0.09);
 }
 
-.c36.c36.c36.c36.c36[aria-selected=true]:hover {
+.c37.c37.c37.c37.c37[aria-selected=true]:hover {
   background-color: hsla(227,100%,59%,0.18);
 }
 
 @media screen and (min-width:768px) {
-  .c27.c27.c27.c27.c27 {
+  .c28.c28.c28.c28.c28 {
     padding-right: 20px;
     padding-left: 20px;
     margin-bottom: 20px;
@@ -786,37 +798,37 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
 }
 
 @media screen and (min-width:320px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:480px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1200px) {
-  .c33.c33.c33.c33.c33 {
+  .c34.c34.c34.c34.c34 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c42.c42.c42.c42.c42 {
+  .c43.c43.c43.c43.c43 {
     padding: 20px;
   }
 }
@@ -894,11 +906,11 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
               data-blade-component="base-box"
             >
               <div
-                class="c11 tags-slot"
+                class="c11 c12 tags-slot"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12"
+                  class="c13"
                   data-blade-component="base-box"
                 >
                   <button
@@ -910,7 +922,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                     aria-invalid="false"
                     aria-required="false"
                     autocomplete="off"
-                    class="c13"
+                    class="c14"
                     data-blade-component="styled-base-input"
                     id="dropdown-7-trigger-1-input-2"
                     placeholder="Select Option"
@@ -919,7 +931,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                     value=""
                   >
                     <p
-                      class="c14"
+                      class="c15"
                       data-blade-component="text"
                     >
                       Select Option
@@ -928,20 +940,20 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                 </div>
               </div>
               <div
-                class="c15"
+                class="c16"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c16"
+                  class="c17"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c17"
+                    class="c18"
                     data-blade-component="base-box"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c18"
+                      class="c19"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -958,7 +970,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                     </svg>
                     <svg
                       aria-hidden="true"
-                      class="c19"
+                      class="c20"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -977,35 +989,35 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                 </div>
               </div>
               <div
-                class=" c20"
+                class=" c21"
                 data-blade-component="base-box"
               />
             </div>
           </div>
           <div
-            class="c21"
+            class="c22"
             data-blade-component="base-box"
           >
             <div
-              class="c22"
+              class="c23"
               data-blade-component="base-box"
             />
           </div>
         </div>
       </div>
       <div
-        class="c23"
+        class="c24"
         data-blade-component="base-box"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 8px); width: 0px;"
       >
         <div
-          class="c24 c25"
+          class="c25 c26"
           data-blade-component="dropdown-overlay"
           elevation="midRaised"
           style="transition-property: transform,opacity; transition-duration: 200ms;"
         >
           <div
-            class="c26"
+            class="c27"
             data-blade-component="base-box"
           >
             <div
@@ -1013,27 +1025,27 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
               data-blade-component="dropdown-header"
             >
               <div
-                class="c27"
+                class="c28"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c28"
+                  class="c29"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c29"
+                    class="c30"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c30"
+                      class="c31"
                       data-blade-component="base-box"
                     >
                       <div
-                        class="c31"
+                        class="c32"
                         data-blade-component="base-box"
                       >
                         <p
-                          class="c32"
+                          class="c33"
                           data-blade-component="text"
                         >
                           Recent Searches
@@ -1044,7 +1056,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                 </div>
               </div>
               <div
-                class="c33 c34"
+                class="c34 c35"
                 data-blade-component="divider"
                 role="separator"
               />
@@ -1059,13 +1071,13 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
           >
             <div
               aria-multiselectable="false"
-              class=" c35"
+              class=" c36"
               data-blade-component="base-box"
               role="listbox"
             >
               <button
                 aria-selected="false"
-                class=" c36"
+                class=" c37"
                 data-blade-component="action-list-item"
                 data-index="0"
                 data-value="apple"
@@ -1075,26 +1087,26 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                 type="button"
               >
                 <div
-                  class="c37"
+                  class="c38"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c39"
+                    class="c40"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c40"
+                      class="c41"
                       data-blade-component="text"
                     >
                       Apple
                     </p>
                   </div>
                   <div
-                    class="c41"
+                    class="c42"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -1105,7 +1117,7 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
               </button>
               <button
                 aria-selected="false"
-                class=" c36"
+                class=" c37"
                 data-blade-component="action-list-item"
                 data-index="1"
                 data-value="mango"
@@ -1115,26 +1127,26 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                 type="button"
               >
                 <div
-                  class="c37"
+                  class="c38"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c39"
+                    class="c40"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c40"
+                      class="c41"
                       data-blade-component="text"
                     >
                       Mango
                     </p>
                   </div>
                   <div
-                    class="c41"
+                    class="c42"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -1151,12 +1163,12 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
             role="group"
           >
             <div
-              class="c33 c34"
+              class="c34 c35"
               data-blade-component="divider"
               role="separator"
             />
             <div
-              class="c42"
+              class="c43"
               data-blade-component="dropdown-footer"
             >
               <div
@@ -1164,17 +1176,17 @@ exports[`<Dropdown /> should render dropdown and make it visible on click 1`] = 
                 data-blade-component="box"
               >
                 <button
-                  class="c43"
+                  class="c44"
                   data-blade-component="button"
                   role="button"
                   type="button"
                 >
                   <div
-                    class="c44 c45"
+                    class="c45 c46"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c46"
+                      class="c47"
                       data-blade-component="base-text"
                     >
                       Apply

--- a/packages/blade/src/components/Dropdown/docs/DropdownWithButton.stories.tsx
+++ b/packages/blade/src/components/Dropdown/docs/DropdownWithButton.stories.tsx
@@ -99,10 +99,10 @@ export const InternalMenu = (): React.ReactElement => {
         <DropdownButton variant="tertiary">Status: {status ?? ''}</DropdownButton>
         <DropdownOverlay>
           <DropdownHeader
-            leading={<StarIcon color="surface.text.normal.lowContrast" size="large" />}
+            leading={<StarIcon color="surface.icon.gray.normal" size="large" />}
             title="Header Title Header Title Header Title Header Title Header Title"
             subtitle="Header Subtitle"
-            titleSuffix={<Badge variant="positive">New</Badge>}
+            titleSuffix={<Badge color="positive">New</Badge>}
             trailing={<Amount value={1000} />}
           />
           <ActionList>

--- a/packages/blade/src/components/Input/BaseInput/BaseInputTagSlot.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInputTagSlot.web.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import type { BaseInputTagSlotProps } from './types';
 import { BASEINPUT_DEFAULT_HEIGHT } from './baseInputConfig';
 import BaseBox from '~components/Box/BaseBox';
@@ -97,6 +98,17 @@ const getSelectedTextWithoutTags = ({
   return `${items} Selected`;
 };
 
+const TagSlotContainer = styled(BaseBox)(() => {
+  return {
+    // hides the scrollbar of tagslot
+    '::-webkit-scrollbar': {
+      display: 'none',
+    },
+    '-ms-overflow-style': 'none',
+    'scrollbar-width': 'none',
+  };
+});
+
 const BaseInputTagSlot = ({
   renderAs,
   children,
@@ -165,7 +177,7 @@ const BaseInputTagSlot = ({
   const paddingYWithTags = isMobile ? 'spacing.1' : 'spacing.2';
 
   return (
-    <BaseBox
+    <TagSlotContainer
       ref={slotRef}
       className="tags-slot"
       paddingY={paddingYWithTags}
@@ -214,7 +226,7 @@ const BaseInputTagSlot = ({
       >
         {children}
       </BaseBox>
-    </BaseBox>
+    </TagSlotContainer>
   );
 };
 

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it visible on click 1`] = `"<div id="root"><div data-blade-component="dropdown" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx kUMlmJ"><div data-blade-component="base-box" class="BaseBox-bmPWx jjDQyK"><div data-blade-component="autocomplete" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx hqusWt"><div data-blade-component="base-box" class="BaseBox-bmPWx jaAmIu"><label for="dropdown-undefined-trigger-undefined-input-undefined" style="width:auto;flex-shrink:0;margin-right:16px" id="dropdown-undefined-label" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bmPWx fZlcZT"><div data-blade-component="base-box" class="BaseBox-bmPWx ikPXAQ"><p class="StyledBaseText-dVBfTO itNENY" data-blade-component="text">Fruits</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 Fuolv"><p class="StyledBaseText-dVBfTO lXtvZ" data-blade-component="text"></p></div></div></div></label></div><div data-blade-component="base-box" class="BaseBox-bmPWx AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1  djRbKc cgXnWX"><div class="BaseBox-bmPWx eRtEHm tags-slot" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bmPWx drbAuO"><input type="text" autoComplete="off" id="dropdown-undefined-trigger-undefined-input-undefined" placeholder="Select Option" data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-haspopup="listbox" aria-expanded="false" aria-controls="dropdown-undefined-actionlist" role="combobox" class="StyledBaseInputweb__StyledBaseNativeInput-hsusrk-0 hsVmtU" value=""/></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx hGaCmA"><div data-blade-component="base-box" class="BaseBox-bmPWx fTNRoG"><div data-blade-component="base-box" class="BaseBox-bmPWx dxquVw"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 lmEfDF"><path d="M5.29289 8.29289C5.68342 7.90237 6.31658 7.90237 6.70711 8.29289L12 13.5858L17.2929 8.29289C17.6834 7.90237 18.3166 7.90237 18.7071 8.29289C19.0976 8.68342 19.0976 9.31658 18.7071 9.70711L12.7071 15.7071C12.3166 16.0976 11.6834 16.0976 11.2929 15.7071L5.29289 9.70711C4.90237 9.31658 4.90237 8.68342 5.29289 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 fDSHXQ"><path d="M11.2929 8.29289C11.6834 7.90237 12.3166 7.90237 12.7071 8.29289L18.7071 14.2929C19.0976 14.6834 19.0976 15.3166 18.7071 15.7071C18.3166 16.0976 17.6834 16.0976 17.2929 15.7071L12 10.4142L6.70711 15.7071C6.31658 16.0976 5.68342 16.0976 5.29289 15.7071C4.90237 15.3166 4.90237 14.6834 5.29289 14.2929L11.2929 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx BaseInputAnimatedBorderweb__BaseInputStyledAnimatedBorder-sc-2cepod-0  HaFJL"></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx iARoiz"><div data-blade-component="base-box" class="BaseBox-bmPWx qIbA"></div></div></div></div><div style="position:fixed;left:0;top:0" data-blade-component="base-box" class="BaseBox-bmPWx vaNBM"><div elevation="midRaised" style="transform:translateY(-8px);opacity:0" data-blade-component="dropdown-overlay" class="BaseBox-bmPWx StyledDropdownOverlay-sc-1dik5mo-0 qogZr hBPEVn"><div data-blade-component="base-box" class="BaseBox-bmPWx cZtflA"><div data-blade-component="dropdown-header" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx djABsd"><div data-blade-component="base-box" class="BaseBox-bmPWx hJkrmV"><div data-blade-component="base-box" class="BaseBox-bmPWx hXjMxV"><div data-blade-component="base-box" class="BaseBox-bmPWx jxfNRL"><div data-blade-component="base-box" class="BaseBox-bmPWx kDqSNs"><p class="StyledBaseText-dVBfTO eWWvyY" data-blade-component="text">Recent Searches</p></div></div></div></div></div><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div></div></div><div data-blade-component="box" class="BaseBox-bmPWx eVNphd"><svg aria-hidden="true" data-blade-component="icon" height="24px" viewBox="0 0 24 24" width="24px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M16.618 18.032a9 9 0 1 1 1.414-1.414l3.675 3.675a1 1 0 0 1-1.414 1.414l-3.675-3.675ZM4 11a7 7 0 1 1 12.041 4.857 1.009 1.009 0 0 0-.185.184A7 7 0 0 1 4 11Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><p class="StyledBaseText-dVBfTO gxxGIR" data-blade-component="text">No Search Result Found</p><p class="StyledBaseText-dVBfTO iuPBIs" data-blade-component="text">Try searching for a different value</p></div><div role="group" data-blade-component="base-box" class="BaseBox-bmPWx"><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div><div data-blade-component="dropdown-footer" class="BaseBox-bmPWx dJEYFx"></div></div></div></div></div></div></div>"`;
+exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it visible on click 1`] = `"<div id="root"><div data-blade-component="dropdown" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx kUMlmJ"><div data-blade-component="base-box" class="BaseBox-bmPWx jjDQyK"><div data-blade-component="autocomplete" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx hqusWt"><div data-blade-component="base-box" class="BaseBox-bmPWx jaAmIu"><label for="dropdown-undefined-trigger-undefined-input-undefined" style="width:auto;flex-shrink:0;margin-right:16px" id="dropdown-undefined-label" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bmPWx fZlcZT"><div data-blade-component="base-box" class="BaseBox-bmPWx ikPXAQ"><p class="StyledBaseText-dVBfTO itNENY" data-blade-component="text">Fruits</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 Fuolv"><p class="StyledBaseText-dVBfTO lXtvZ" data-blade-component="text"></p></div></div></div></label></div><div data-blade-component="base-box" class="BaseBox-bmPWx AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1  djRbKc cgXnWX"><div class="BaseBox-bmPWx BaseInputTagSlotweb__TagSlotContainer-sc-1bt1h3t-0 eRtEHm dUNBKx tags-slot" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bmPWx drbAuO"><input type="text" autoComplete="off" id="dropdown-undefined-trigger-undefined-input-undefined" placeholder="Select Option" data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-haspopup="listbox" aria-expanded="false" aria-controls="dropdown-undefined-actionlist" role="combobox" class="StyledBaseInputweb__StyledBaseNativeInput-hsusrk-0 hsVmtU" value=""/></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx hGaCmA"><div data-blade-component="base-box" class="BaseBox-bmPWx fTNRoG"><div data-blade-component="base-box" class="BaseBox-bmPWx dxquVw"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 lmEfDF"><path d="M5.29289 8.29289C5.68342 7.90237 6.31658 7.90237 6.70711 8.29289L12 13.5858L17.2929 8.29289C17.6834 7.90237 18.3166 7.90237 18.7071 8.29289C19.0976 8.68342 19.0976 9.31658 18.7071 9.70711L12.7071 15.7071C12.3166 16.0976 11.6834 16.0976 11.2929 15.7071L5.29289 9.70711C4.90237 9.31658 4.90237 8.68342 5.29289 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0 fDSHXQ"><path d="M11.2929 8.29289C11.6834 7.90237 12.3166 7.90237 12.7071 8.29289L18.7071 14.2929C19.0976 14.6834 19.0976 15.3166 18.7071 15.7071C18.3166 16.0976 17.6834 16.0976 17.2929 15.7071L12 10.4142L6.70711 15.7071C6.31658 16.0976 5.68342 16.0976 5.29289 15.7071C4.90237 15.3166 4.90237 14.6834 5.29289 14.2929L11.2929 8.29289Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx BaseInputAnimatedBorderweb__BaseInputStyledAnimatedBorder-sc-2cepod-0  HaFJL"></div></div></div><div data-blade-component="base-box" class="BaseBox-bmPWx iARoiz"><div data-blade-component="base-box" class="BaseBox-bmPWx qIbA"></div></div></div></div><div style="position:fixed;left:0;top:0" data-blade-component="base-box" class="BaseBox-bmPWx vaNBM"><div elevation="midRaised" style="transform:translateY(-8px);opacity:0" data-blade-component="dropdown-overlay" class="BaseBox-bmPWx StyledDropdownOverlay-sc-1dik5mo-0 qogZr hBPEVn"><div data-blade-component="base-box" class="BaseBox-bmPWx cZtflA"><div data-blade-component="dropdown-header" class="BaseBox-bmPWx"><div data-blade-component="base-box" class="BaseBox-bmPWx djABsd"><div data-blade-component="base-box" class="BaseBox-bmPWx hJkrmV"><div data-blade-component="base-box" class="BaseBox-bmPWx hXjMxV"><div data-blade-component="base-box" class="BaseBox-bmPWx jxfNRL"><div data-blade-component="base-box" class="BaseBox-bmPWx kDqSNs"><p class="StyledBaseText-dVBfTO eWWvyY" data-blade-component="text">Recent Searches</p></div></div></div></div></div><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div></div></div><div data-blade-component="box" class="BaseBox-bmPWx eVNphd"><svg aria-hidden="true" data-blade-component="icon" height="24px" viewBox="0 0 24 24" width="24px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M16.618 18.032a9 9 0 1 1 1.414-1.414l3.675 3.675a1 1 0 0 1-1.414 1.414l-3.675-3.675ZM4 11a7 7 0 1 1 12.041 4.857 1.009 1.009 0 0 0-.185.184A7 7 0 0 1 4 11Z" clip-rule="evenodd" fill="hsla(211, 22%, 56%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><p class="StyledBaseText-dVBfTO gxxGIR" data-blade-component="text">No Search Result Found</p><p class="StyledBaseText-dVBfTO iuPBIs" data-blade-component="text">Try searching for a different value</p></div><div role="group" data-blade-component="base-box" class="BaseBox-bmPWx"><div data-blade-component="divider" role="separator" class="BaseBox-bmPWx Divider__StyledDivider-sc-8k3avj-0 bWVnPN WrXok"></div><div data-blade-component="dropdown-footer" class="BaseBox-bmPWx dJEYFx"></div></div></div></div></div></div></div>"`;
 
 exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it visible on click 2`] = `
 .c0.c0.c0.c0.c0 {
@@ -63,13 +63,13 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   gap: 0px;
 }
 
-.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13 {
   margin-top: -4px;
   width: 100%;
   min-width: 30px;
 }
 
-.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -86,7 +86,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   align-self: center;
 }
 
-.c15.c15.c15.c15.c15 {
+.c16.c16.c16.c16.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -101,7 +101,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding-right: 12px;
 }
 
-.c16.c16.c16.c16.c16 {
+.c17.c17.c17.c17.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -117,11 +117,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   height: 100%;
 }
 
-.c20.c20.c20.c20.c20 {
+.c21.c21.c21.c21.c21 {
   margin-left: 0px;
 }
 
-.c21.c21.c21.c21.c21 {
+.c22.c22.c22.c22.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -135,18 +135,18 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   justify-content: flex-end;
 }
 
-.c23.c23.c23.c23.c23 {
+.c24.c24.c24.c24.c24 {
   width: 100%;
   box-shadow: 0px 8px 24px 0px hsla(217,56%,17%,0.12);
 }
 
-.c25.c25.c25.c25.c25 {
+.c26.c26.c26.c26.c26 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c26.c26.c26.c26.c26 {
+.c27.c27.c27.c27.c27 {
   padding-right: 16px;
   padding-left: 16px;
   margin-bottom: 16px;
@@ -154,7 +154,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   touch-action: none;
 }
 
-.c27.c27.c27.c27.c27 {
+.c28.c28.c28.c28.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,7 +168,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   user-select: none;
 }
 
-.c28.c28.c28.c28.c28 {
+.c29.c29.c29.c29.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -187,13 +187,13 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   margin-right: auto;
 }
 
-.c29.c29.c29.c29.c29 {
+.c30.c30.c30.c30.c30 {
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
 }
 
-.c30.c30.c30.c30.c30 {
+.c31.c31.c31.c31.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -206,16 +206,16 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   flex-shrink: 0;
 }
 
-.c32.c32.c32.c32.c32 {
+.c33.c33.c33.c33.c33 {
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-bottom-style: solid;
 }
 
-.c41.c41.c41.c41.c41 {
+.c42.c42.c42.c42.c42 {
   padding: 16px;
 }
 
-.c22.c22.c22.c22.c22 {
+.c23.c23.c23.c23.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -223,7 +223,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   z-index: 1002;
 }
 
-.c43.c43.c43.c43.c43 {
+.c44.c44.c44.c44.c44 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -264,7 +264,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   min-height: 36px;
 }
 
-.c36.c36.c36.c36.c36 {
+.c37.c37.c37.c37.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -283,7 +283,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   max-height: 20px;
 }
 
-.c37.c37.c37.c37.c37 {
+.c38.c38.c38.c38.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -298,7 +298,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   justify-content: center;
 }
 
-.c38.c38.c38.c38.c38 {
+.c39.c39.c39.c39.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -314,11 +314,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding-left: 0px;
 }
 
-.c40.c40.c40.c40.c40 {
+.c41.c41.c41.c41.c41 {
   margin-left: auto;
 }
 
-.c24.c24.c24.c24.c24 {
+.c25.c25.c25.c25.c25 {
   background-color: hsla(0,0%,100%,1);
   border-width: 1px;
   border-color: hsla(211,20%,52%,0.18);
@@ -326,7 +326,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   border-radius: 4px;
 }
 
-.c42.c42.c42.c42.c42 {
+.c43.c43.c43.c43.c43 {
   min-height: 36px;
   width: 100%;
   cursor: pointer;
@@ -363,24 +363,24 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   position: relative;
 }
 
-.c42.c42.c42.c42.c42:hover {
+.c43.c43.c43.c43.c43:hover {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c42.c42.c42.c42.c42:active {
+.c43.c43.c43.c43.c43:active {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c42.c42.c42.c42.c42:focus-visible {
+.c43.c43.c43.c43.c43:focus-visible {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
   outline: 1px solid hsla(227,100%,59%,0.09);
   box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.18);
 }
 
-.c42.c42.c42.c42.c42 * {
+.c43.c43.c43.c43.c43 * {
   -webkit-transition-property: color,fill,opacity;
   transition-property: color,fill,opacity;
   -webkit-transition-duration: 150ms;
@@ -428,7 +428,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c31.c31.c31.c31.c31 {
+.c32.c32.c32.c32.c32 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 1rem;
@@ -445,7 +445,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c45.c45.c45.c45.c45 {
+.c46.c46.c46.c46.c46 {
   color: hsla(0,0%,100%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -463,7 +463,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c39.c39.c39.c39.c39 {
+.c40.c40.c40.c40.c40 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -485,22 +485,22 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   -webkit-box-orient: vertical;
 }
 
-.c18.c18.c18.c18.c18 {
+.c19.c19.c19.c19.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c17.c17.c17.c17.c17 {
+.c18.c18.c18.c18.c18 {
   display: none;
 }
 
-.c44.c44.c44.c44.c44 {
+.c45.c45.c45.c45.c45 {
   opacity: 1;
 }
 
-.c33.c33.c33.c33.c33 {
+.c34.c34.c34.c34.c34 {
   border-width: 0;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -510,7 +510,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   flex-grow: 1;
 }
 
-.c13.c13.c13.c13.c13 {
+.c14.c14.c14.c14.c14 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -543,7 +543,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   cursor: auto;
 }
 
-.c13.c13.c13.c13.c13::-webkit-input-placeholder {
+.c14.c14.c14.c14.c14::-webkit-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -561,7 +561,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::-moz-placeholder {
+.c14.c14.c14.c14.c14::-moz-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -579,7 +579,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:-ms-input-placeholder {
+.c14.c14.c14.c14.c14:-ms-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -597,7 +597,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::placeholder {
+.c14.c14.c14.c14.c14::placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -615,11 +615,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:focus {
+.c14.c14.c14.c14.c14:focus {
   outline: none;
 }
 
-.c19.c19.c19.c19.c19 {
+.c20.c20.c20.c20.c20 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -699,6 +699,18 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   max-height: 37px;
 }
 
+.c12.c12.c12.c12.c12 {
+  -ms-overflow-style: none;
+  -webkit-scrollbar-width: none;
+  -moz-scrollbar-width: none;
+  -ms-scrollbar-width: none;
+  scrollbar-width: none;
+}
+
+.c12.c12.c12.c12.c12::-webkit-scrollbar {
+  display: none;
+}
+
 .c7.c7.c7.c7.c7 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -716,17 +728,17 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   word-wrap: normal;
 }
 
-.c34.c34.c34.c34.c34 {
+.c35.c35.c35.c35.c35 {
   overflow-y: auto;
   max-height: 300px;
   padding: 8px;
 }
 
-.c34.c34.c34.c34.c34 [role=group]:last-child > [role=separator]:last-child {
+.c35.c35.c35.c35.c35 [role=group]:last-child > [role=separator]:last-child {
   display: none;
 }
 
-.c35.c35.c35.c35.c35 {
+.c36.c36.c36.c36.c36 {
   border-width: 4px;
   border-style: solid;
   border-color: transparent;
@@ -741,20 +753,20 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   display: block;
 }
 
-.c35.c35.c35.c35.c35:hover:not([aria-disabled=true]) {
+.c36.c36.c36.c36.c36:hover:not([aria-disabled=true]) {
   background-color: hsla(211,20%,52%,0.09);
 }
 
-.c35.c35.c35.c35.c35[aria-selected=true] {
+.c36.c36.c36.c36.c36[aria-selected=true] {
   background-color: hsla(227,100%,59%,0.09);
 }
 
-.c35.c35.c35.c35.c35[aria-selected=true]:hover {
+.c36.c36.c36.c36.c36[aria-selected=true]:hover {
   background-color: hsla(227,100%,59%,0.18);
 }
 
 @media screen and (min-width:768px) {
-  .c26.c26.c26.c26.c26 {
+  .c27.c27.c27.c27.c27 {
     padding-right: 20px;
     padding-left: 20px;
     margin-bottom: 20px;
@@ -763,37 +775,37 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
 }
 
 @media screen and (min-width:320px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:480px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1200px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c41.c41.c41.c41.c41 {
+  .c42.c42.c42.c42.c42 {
     padding: 20px;
   }
 }
@@ -863,11 +875,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
               data-blade-component="base-box"
             >
               <div
-                class="c11 tags-slot"
+                class="c11 c12 tags-slot"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12"
+                  class="c13"
                   data-blade-component="base-box"
                 >
                   <input
@@ -880,7 +892,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                     aria-invalid="false"
                     aria-required="false"
                     autocomplete="off"
-                    class="c13"
+                    class="c14"
                     data-blade-component="styled-base-input"
                     id="dropdown-7-trigger-1-input-2"
                     placeholder="Select Option"
@@ -891,20 +903,20 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 </div>
               </div>
               <div
-                class="c14"
+                class="c15"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c16"
+                    class="c17"
                     data-blade-component="base-box"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c17"
+                      class="c18"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -921,7 +933,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                     </svg>
                     <svg
                       aria-hidden="true"
-                      class="c18"
+                      class="c19"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -940,35 +952,35 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 </div>
               </div>
               <div
-                class=" c19"
+                class=" c20"
                 data-blade-component="base-box"
               />
             </div>
           </div>
           <div
-            class="c20"
+            class="c21"
             data-blade-component="base-box"
           >
             <div
-              class="c21"
+              class="c22"
               data-blade-component="base-box"
             />
           </div>
         </div>
       </div>
       <div
-        class="c22"
+        class="c23"
         data-blade-component="base-box"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 8px); width: 0px;"
       >
         <div
-          class="c23 c24"
+          class="c24 c25"
           data-blade-component="dropdown-overlay"
           elevation="midRaised"
           style="transition-property: transform,opacity; transition-duration: 200ms;"
         >
           <div
-            class="c25"
+            class="c26"
             data-blade-component="base-box"
           >
             <div
@@ -976,27 +988,27 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
               data-blade-component="dropdown-header"
             >
               <div
-                class="c26"
+                class="c27"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c27"
+                  class="c28"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c28"
+                    class="c29"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c29"
+                      class="c30"
                       data-blade-component="base-box"
                     >
                       <div
-                        class="c30"
+                        class="c31"
                         data-blade-component="base-box"
                       >
                         <p
-                          class="c31"
+                          class="c32"
                           data-blade-component="text"
                         >
                           Recent Searches
@@ -1007,7 +1019,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 </div>
               </div>
               <div
-                class="c32 c33"
+                class="c33 c34"
                 data-blade-component="divider"
                 role="separator"
               />
@@ -1022,13 +1034,13 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
           >
             <div
               aria-multiselectable="false"
-              class=" c34"
+              class=" c35"
               data-blade-component="base-box"
               role="listbox"
             >
               <button
                 aria-selected="false"
-                class=" c35 active-focus"
+                class=" c36 active-focus"
                 data-blade-component="action-list-item"
                 data-index="0"
                 data-value="apple"
@@ -1038,26 +1050,26 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 type="button"
               >
                 <div
-                  class="c36"
+                  class="c37"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c37"
+                    class="c38"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c39"
+                      class="c40"
                       data-blade-component="text"
                     >
                       Apple
                     </p>
                   </div>
                   <div
-                    class="c40"
+                    class="c41"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -1068,7 +1080,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
               </button>
               <button
                 aria-selected="false"
-                class=" c35"
+                class=" c36"
                 data-blade-component="action-list-item"
                 data-index="1"
                 data-value="mango"
@@ -1078,26 +1090,26 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 type="button"
               >
                 <div
-                  class="c36"
+                  class="c37"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c37"
+                    class="c38"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c39"
+                      class="c40"
                       data-blade-component="text"
                     >
                       Mango
                     </p>
                   </div>
                   <div
-                    class="c40"
+                    class="c41"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -1114,12 +1126,12 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
             role="group"
           >
             <div
-              class="c32 c33"
+              class="c33 c34"
               data-blade-component="divider"
               role="separator"
             />
             <div
-              class="c41"
+              class="c42"
               data-blade-component="dropdown-footer"
             >
               <div
@@ -1127,17 +1139,17 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 data-blade-component="box"
               >
                 <button
-                  class="c42"
+                  class="c43"
                   data-blade-component="button"
                   role="button"
                   type="button"
                 >
                   <div
-                    class="c43 c44"
+                    class="c44 c45"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c45"
+                      class="c46"
                       data-blade-component="base-text"
                     >
                       Apply

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
@@ -80,13 +80,13 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   min-height: 36px;
 }
 
-.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13 {
   margin-top: -4px;
   width: 100%;
   min-width: 30px;
 }
 
-.c15.c15.c15.c15.c15 {
+.c16.c16.c16.c16.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -103,7 +103,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   align-self: center;
 }
 
-.c16.c16.c16.c16.c16 {
+.c17.c17.c17.c17.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +118,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding-right: 12px;
 }
 
-.c17.c17.c17.c17.c17 {
+.c18.c18.c18.c18.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -134,11 +134,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   height: 100%;
 }
 
-.c21.c21.c21.c21.c21 {
+.c22.c22.c22.c22.c22 {
   margin-left: 0px;
 }
 
-.c22.c22.c22.c22.c22 {
+.c23.c23.c23.c23.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -152,7 +152,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   justify-content: flex-end;
 }
 
-.c26.c26.c26.c26.c26 {
+.c27.c27.c27.c27.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -163,14 +163,14 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   height: 100%;
 }
 
-.c28.c28.c28.c28.c28 {
+.c29.c29.c29.c29.c29 {
   overflow: auto;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c29.c29.c29.c29.c29 {
+.c30.c30.c30.c30.c30 {
   padding-right: 16px;
   padding-left: 16px;
   margin-bottom: 16px;
@@ -178,7 +178,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   touch-action: none;
 }
 
-.c30.c30.c30.c30.c30 {
+.c31.c31.c31.c31.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,7 +192,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   user-select: none;
 }
 
-.c31.c31.c31.c31.c31 {
+.c32.c32.c32.c32.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -211,13 +211,13 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   margin-right: auto;
 }
 
-.c32.c32.c32.c32.c32 {
+.c33.c33.c33.c33.c33 {
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
 }
 
-.c33.c33.c33.c33.c33 {
+.c34.c34.c34.c34.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -230,7 +230,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   flex-shrink: 0;
 }
 
-.c34.c34.c34.c34.c34 {
+.c35.c35.c35.c35.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -246,12 +246,12 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   height: 28px;
 }
 
-.c40.c40.c40.c40.c40 {
+.c41.c41.c41.c41.c41 {
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-bottom-style: solid;
 }
 
-.c42.c42.c42.c42.c42 {
+.c43.c43.c43.c43.c43 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -261,7 +261,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   flex-shrink: 1;
 }
 
-.c46.c46.c46.c46.c46 {
+.c47.c47.c47.c47.c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -280,7 +280,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   max-height: 20px;
 }
 
-.c47.c47.c47.c47.c47 {
+.c48.c48.c48.c48.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -295,7 +295,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   justify-content: center;
 }
 
-.c48.c48.c48.c48.c48 {
+.c49.c49.c49.c49.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -311,11 +311,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding-left: 0px;
 }
 
-.c50.c50.c50.c50.c50 {
+.c51.c51.c51.c51.c51 {
   margin-left: auto;
 }
 
-.c51.c51.c51.c51.c51 {
+.c52.c52.c52.c52.c52 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -326,11 +326,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   touch-action: none;
 }
 
-.c52.c52.c52.c52.c52 {
+.c53.c53.c53.c53.c53 {
   padding: 16px;
 }
 
-.c54.c54.c54.c54.c54 {
+.c55.c55.c55.c55.c55 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -352,7 +352,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   z-index: 1;
 }
 
-.c43.c43.c43.c43.c43 {
+.c44.c44.c44.c44.c44 {
   overflow: auto;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -360,7 +360,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding-left: 8px;
 }
 
-.c37.c37.c37.c37.c37 {
+.c38.c38.c38.c38.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -379,7 +379,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   min-height: 36px;
 }
 
-.c23.c23.c23.c23.c23 {
+.c24.c24.c24.c24.c24 {
   position: fixed;
   z-index: 100;
   top: 0px;
@@ -390,7 +390,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   opacity: 1;
 }
 
-.c53.c53.c53.c53.c53 {
+.c54.c54.c54.c54.c54 {
   min-height: 36px;
   width: 100%;
   cursor: pointer;
@@ -427,24 +427,24 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   position: relative;
 }
 
-.c53.c53.c53.c53.c53:hover {
+.c54.c54.c54.c54.c54:hover {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c53.c53.c53.c53.c53:active {
+.c54.c54.c54.c54.c54:active {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c53.c53.c53.c53.c53:focus-visible {
+.c54.c54.c54.c54.c54:focus-visible {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
   outline: 1px solid hsla(227,100%,59%,0.09);
   box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.18);
 }
 
-.c53.c53.c53.c53.c53 * {
+.c54.c54.c54.c54.c54 * {
   -webkit-transition-property: color,fill,opacity;
   transition-property: color,fill,opacity;
   -webkit-transition-duration: 150ms;
@@ -492,7 +492,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15 {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -515,7 +515,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   -webkit-box-orient: vertical;
 }
 
-.c49.c49.c49.c49.c49 {
+.c50.c50.c50.c50.c50 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -537,7 +537,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   -webkit-box-orient: vertical;
 }
 
-.c56.c56.c56.c56.c56 {
+.c57.c57.c57.c57.c57 {
   color: hsla(0,0%,100%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -555,22 +555,22 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c19.c19.c19.c19.c19 {
+.c20.c20.c20.c20.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c18.c18.c18.c18.c18 {
+.c19.c19.c19.c19.c19 {
   display: none;
 }
 
-.c55.c55.c55.c55.c55 {
+.c56.c56.c56.c56.c56 {
   opacity: 1;
 }
 
-.c41.c41.c41.c41.c41 {
+.c42.c42.c42.c42.c42 {
   border-width: 0;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -580,7 +580,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   flex-grow: 1;
 }
 
-.c35.c35.c35.c35.c35 {
+.c36.c36.c36.c36.c36 {
   border: none;
   cursor: pointer;
   padding: 0;
@@ -607,11 +607,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c35.c35.c35.c35.c35:hover {
+.c36.c36.c36.c36.c36:hover {
   color: hsla(211,26%,34%,1);
 }
 
-.c35.c35.c35.c35.c35:focus-visible {
+.c36.c36.c36.c36.c36:focus-visible {
   outline: 4px solid hsla(227,100%,59%,0.18);
   outline-offset: 1px;
   -webkit-transition-property: outline-width;
@@ -623,11 +623,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   color: hsla(211,26%,34%,1);
 }
 
-.c35.c35.c35.c35.c35:active {
+.c36.c36.c36.c36.c36:active {
   color: hsla(211,26%,34%,1);
 }
 
-.c38.c38.c38.c38.c38 {
+.c39.c39.c39.c39.c39 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -660,7 +660,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   cursor: auto;
 }
 
-.c38.c38.c38.c38.c38::-webkit-input-placeholder {
+.c39.c39.c39.c39.c39::-webkit-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -678,7 +678,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c38.c38.c38.c38.c38::-moz-placeholder {
+.c39.c39.c39.c39.c39::-moz-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -696,7 +696,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c38.c38.c38.c38.c38:-ms-input-placeholder {
+.c39.c39.c39.c39.c39:-ms-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -714,7 +714,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c38.c38.c38.c38.c38::placeholder {
+.c39.c39.c39.c39.c39::placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -732,11 +732,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c38.c38.c38.c38.c38:focus {
+.c39.c39.c39.c39.c39:focus {
   outline: none;
 }
 
-.c13.c13.c13.c13.c13 {
+.c14.c14.c14.c14.c14 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -769,7 +769,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   cursor: auto;
 }
 
-.c13.c13.c13.c13.c13::-webkit-input-placeholder {
+.c14.c14.c14.c14.c14::-webkit-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -787,7 +787,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::-moz-placeholder {
+.c14.c14.c14.c14.c14::-moz-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -805,7 +805,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:-ms-input-placeholder {
+.c14.c14.c14.c14.c14:-ms-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -823,7 +823,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::placeholder {
+.c14.c14.c14.c14.c14::placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -841,11 +841,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:focus {
+.c14.c14.c14.c14.c14:focus {
   outline: none;
 }
 
-.c39.c39.c39.c39.c39 {
+.c40.c40.c40.c40.c40 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -858,7 +858,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   animation: cAlpMa-450290765 250ms cubic-bezier(0.3,0,0.2,1) forwards;
 }
 
-.c20.c20.c20.c20.c20 {
+.c21.c21.c21.c21.c21 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -934,7 +934,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   height: auto;
 }
 
-.c36.c36.c36.c36.c36 {
+.c37.c37.c37.c37.c37 {
   background-color: hsla(227,100%,59%,0.09);
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-top-left-radius: 2px;
@@ -953,7 +953,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   height: auto;
 }
 
-.c36.c36.c36.c36.c36:hover {
+.c37.c37.c37.c37.c37:hover {
   background-color: hsla(227,100%,59%,0.09);
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-top-left-radius: 2px;
@@ -978,7 +978,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c36.c36.c36.c36.c36:focus-within {
+.c37.c37.c37.c37.c37:focus-within {
   background-color: hsla(227,100%,59%,0.09);
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-top-left-radius: 2px;
@@ -1003,6 +1003,18 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   max-height: 37px;
 }
 
+.c12.c12.c12.c12.c12 {
+  -ms-overflow-style: none;
+  -webkit-scrollbar-width: none;
+  -moz-scrollbar-width: none;
+  -ms-scrollbar-width: none;
+  scrollbar-width: none;
+}
+
+.c12.c12.c12.c12.c12::-webkit-scrollbar {
+  display: none;
+}
+
 .c2.c2.c2.c2.c2 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -1020,15 +1032,15 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   word-wrap: normal;
 }
 
-.c44.c44.c44.c44.c44 {
+.c45.c45.c45.c45.c45 {
   overflow-y: auto;
 }
 
-.c44.c44.c44.c44.c44 [role=group]:last-child > [role=separator]:last-child {
+.c45.c45.c45.c45.c45 [role=group]:last-child > [role=separator]:last-child {
   display: none;
 }
 
-.c45.c45.c45.c45.c45 {
+.c46.c46.c46.c46.c46 {
   border-width: 4px;
   border-style: solid;
   border-color: transparent;
@@ -1043,19 +1055,19 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   display: block;
 }
 
-.c45.c45.c45.c45.c45:hover:not([aria-disabled=true]) {
+.c46.c46.c46.c46.c46:hover:not([aria-disabled=true]) {
   background-color: hsla(211,20%,52%,0.09);
 }
 
-.c45.c45.c45.c45.c45[aria-selected=true] {
+.c46.c46.c46.c46.c46[aria-selected=true] {
   background-color: hsla(227,100%,59%,0.09);
 }
 
-.c45.c45.c45.c45.c45[aria-selected=true]:hover {
+.c46.c46.c46.c46.c46[aria-selected=true]:hover {
   background-color: hsla(227,100%,59%,0.18);
 }
 
-.c24.c24.c24.c24.c24 {
+.c25.c25.c25.c25.c25 {
   -webkit-transition-duration: 250ms;
   transition-duration: 250ms;
   -webkit-transition-timing-function: cubic-bezier(0,0,0,1);
@@ -1065,7 +1077,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   transition-property: opacity;
 }
 
-.c27.c27.c27.c27.c27 {
+.c28.c28.c28.c28.c28 {
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -1092,7 +1104,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   z-index: 100;
 }
 
-.c27.c27.c27.c27.c27:after {
+.c28.c28.c28.c28.c28:after {
   margin: auto;
   content: '';
   width: 56px;
@@ -1101,7 +1113,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   border-radius: 16px;
 }
 
-.c25.c25.c25.c25.c25 {
+.c26.c26.c26.c26.c26 {
   background: hsla(0,0%,100%,1);
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
@@ -1136,7 +1148,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
 }
 
 @media screen and (min-width:768px) {
-  .c29.c29.c29.c29.c29 {
+  .c30.c30.c30.c30.c30 {
     padding-right: 20px;
     padding-left: 20px;
     margin-bottom: 20px;
@@ -1145,37 +1157,37 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
 }
 
 @media screen and (min-width:320px) {
-  .c40.c40.c40.c40.c40 {
+  .c41.c41.c41.c41.c41 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:480px) {
-  .c40.c40.c40.c40.c40 {
+  .c41.c41.c41.c41.c41 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c40.c40.c40.c40.c40 {
+  .c41.c41.c41.c41.c41 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c40.c40.c40.c40.c40 {
+  .c41.c41.c41.c41.c41 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1200px) {
-  .c40.c40.c40.c40.c40 {
+  .c41.c41.c41.c41.c41 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c52.c52.c52.c52.c52 {
+  .c53.c53.c53.c53.c53 {
     padding: 20px;
   }
 }
@@ -1254,11 +1266,11 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
               data-blade-component="base-box"
             >
               <div
-                class="c11 tags-slot"
+                class="c11 c12 tags-slot"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12"
+                  class="c13"
                   data-blade-component="base-box"
                 >
                   <button
@@ -1271,7 +1283,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                     aria-invalid="false"
                     aria-required="false"
                     autocomplete="off"
-                    class="c13"
+                    class="c14"
                     data-blade-component="styled-base-input"
                     id="dropdown-123"
                     placeholder="Select Option"
@@ -1280,7 +1292,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                     value=""
                   >
                     <p
-                      class="c14"
+                      class="c15"
                       data-blade-component="text"
                     >
                       Select Option
@@ -1289,20 +1301,20 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                 </div>
               </div>
               <div
-                class="c15"
+                class="c16"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c16"
+                  class="c17"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c17"
+                    class="c18"
                     data-blade-component="base-box"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c18"
+                      class="c19"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -1319,7 +1331,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                     </svg>
                     <svg
                       aria-hidden="true"
-                      class="c19"
+                      class="c20"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -1338,46 +1350,46 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                 </div>
               </div>
               <div
-                class=" c20"
+                class=" c21"
                 data-blade-component="base-box"
               />
             </div>
           </div>
           <div
-            class="c21"
+            class="c22"
             data-blade-component="base-box"
           >
             <div
-              class="c22"
+              class="c23"
               data-blade-component="base-box"
             />
           </div>
         </div>
       </div>
       <div
-        class="c23 c24"
+        class="c24 c25"
         data-blade-component="base-box"
         data-testid="bottomsheet-backdrop"
         opacity="1"
       />
       <div
         aria-modal="true"
-        class="c25"
+        class="c26"
         data-blade-component="bottom-sheet"
         data-testid="bottomsheet-surface"
         role="dialog"
         style="opacity: 1; pointer-events: all; height: 652.8px; bottom: 0px; z-index: 100;"
       >
         <div
-          class="c26"
+          class="c27"
           data-blade-component="base-box"
         >
           <div
-            class="c27"
+            class="c28"
             data-blade-component="BottomSheetGrabHandle"
           />
           <div
-            class="c28"
+            class="c29"
             data-blade-component="bottom-sheet-header"
           >
             <div
@@ -1385,34 +1397,34 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
               data-blade-component="base-box"
             >
               <div
-                class="c29"
+                class="c30"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c30"
+                  class="c31"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c31"
+                    class="c32"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c32"
+                      class="c33"
                       data-blade-component="base-box"
                     >
                       <div
-                        class="c33"
+                        class="c34"
                         data-blade-component="base-box"
                       />
                     </div>
                   </div>
                   <div
-                    class="c34"
+                    class="c35"
                     data-blade-component="box"
                   >
                     <button
                       aria-label="Close"
-                      class="c35"
+                      class="c36"
                       data-blade-component="icon-button"
                       type="button"
                     >
@@ -1485,15 +1497,15 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                         </label>
                       </div>
                       <div
-                        class=" c36 c10"
+                        class=" c37 c10"
                         data-blade-component="base-box"
                       >
                         <div
-                          class="c37 tags-slot"
+                          class="c38 c12 tags-slot"
                           data-blade-component="base-box"
                         >
                           <div
-                            class="c12"
+                            class="c13"
                             data-blade-component="base-box"
                           >
                             <input
@@ -1507,7 +1519,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                               aria-required="false"
                               autocomplete="off"
                               autofocus=""
-                              class="c38"
+                              class="c39"
                               data-blade-component="styled-base-input"
                               id="dropdown-123"
                               placeholder="Select Option"
@@ -1518,17 +1530,17 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                           </div>
                         </div>
                         <div
-                          class=" c39"
+                          class=" c40"
                           data-blade-component="base-box"
                         />
                       </div>
                     </div>
                     <div
-                      class="c21"
+                      class="c22"
                       data-blade-component="base-box"
                     >
                       <div
-                        class="c22"
+                        class="c23"
                         data-blade-component="base-box"
                       />
                     </div>
@@ -1536,29 +1548,29 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                 </div>
               </div>
               <div
-                class="c40 c41"
+                class="c41 c42"
                 data-blade-component="divider"
                 role="separator"
               />
             </div>
           </div>
           <div
-            class="c42"
+            class="c43"
             data-blade-component="bottom-sheet-body"
             data-testid="bottomsheet-body"
             style="user-select: auto; overflow: auto;"
           >
             <div
-              class="c43"
+              class="c44"
               data-blade-component="base-box"
             >
               <div
-                class=" c44"
+                class=" c45"
                 data-blade-component="base-box"
               >
                 <button
                   aria-selected="false"
-                  class=" c45 active-focus"
+                  class=" c46 active-focus"
                   data-blade-component="action-list-item"
                   data-index="0"
                   data-value="apple"
@@ -1568,26 +1580,26 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                   type="button"
                 >
                   <div
-                    class="c46"
+                    class="c47"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c47"
+                      class="c48"
                       data-blade-component="base-box"
                     />
                     <div
-                      class="c48"
+                      class="c49"
                       data-blade-component="base-box"
                     >
                       <p
-                        class="c49"
+                        class="c50"
                         data-blade-component="text"
                       >
                         Apple
                       </p>
                     </div>
                     <div
-                      class="c50"
+                      class="c51"
                       data-blade-component="base-box"
                     />
                   </div>
@@ -1598,7 +1610,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                 </button>
                 <button
                   aria-selected="false"
-                  class=" c45"
+                  class=" c46"
                   data-blade-component="action-list-item"
                   data-index="1"
                   data-value="mango"
@@ -1608,26 +1620,26 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                   type="button"
                 >
                   <div
-                    class="c46"
+                    class="c47"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c47"
+                      class="c48"
                       data-blade-component="base-box"
                     />
                     <div
-                      class="c48"
+                      class="c49"
                       data-blade-component="base-box"
                     >
                       <p
-                        class="c49"
+                        class="c50"
                         data-blade-component="text"
                       >
                         Mango
                       </p>
                     </div>
                     <div
-                      class="c50"
+                      class="c51"
                       data-blade-component="base-box"
                     />
                   </div>
@@ -1640,16 +1652,16 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
             </div>
           </div>
           <div
-            class="c51"
+            class="c52"
             data-blade-component="bottom-sheet-footer"
           >
             <div
-              class="c40 c41"
+              class="c41 c42"
               data-blade-component="divider"
               role="separator"
             />
             <div
-              class="c52"
+              class="c53"
               data-blade-component="base-box"
             >
               <div
@@ -1657,17 +1669,17 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
                 data-blade-component="box"
               >
                 <button
-                  class="c53"
+                  class="c54"
                   data-blade-component="button"
                   role="button"
                   type="button"
                 >
                   <div
-                    class="c54 c55"
+                    class="c55 c56"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c56"
+                      class="c57"
                       data-blade-component="base-text"
                     >
                       Apply
@@ -1745,13 +1757,13 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   gap: 0px;
 }
 
-.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13 {
   margin-top: -4px;
   width: 100%;
   min-width: 30px;
 }
 
-.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1768,7 +1780,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   align-self: center;
 }
 
-.c15.c15.c15.c15.c15 {
+.c16.c16.c16.c16.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1783,7 +1795,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding-right: 12px;
 }
 
-.c16.c16.c16.c16.c16 {
+.c17.c17.c17.c17.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1799,11 +1811,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   height: 100%;
 }
 
-.c20.c20.c20.c20.c20 {
+.c21.c21.c21.c21.c21 {
   margin-left: 0px;
 }
 
-.c21.c21.c21.c21.c21 {
+.c22.c22.c22.c22.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1817,18 +1829,18 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   justify-content: flex-end;
 }
 
-.c23.c23.c23.c23.c23 {
+.c24.c24.c24.c24.c24 {
   width: 100%;
   box-shadow: 0px 8px 24px 0px hsla(217,56%,17%,0.12);
 }
 
-.c25.c25.c25.c25.c25 {
+.c26.c26.c26.c26.c26 {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c26.c26.c26.c26.c26 {
+.c27.c27.c27.c27.c27 {
   padding-right: 16px;
   padding-left: 16px;
   margin-bottom: 16px;
@@ -1836,7 +1848,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   touch-action: none;
 }
 
-.c27.c27.c27.c27.c27 {
+.c28.c28.c28.c28.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1850,7 +1862,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   user-select: none;
 }
 
-.c28.c28.c28.c28.c28 {
+.c29.c29.c29.c29.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1869,13 +1881,13 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   margin-right: auto;
 }
 
-.c29.c29.c29.c29.c29 {
+.c30.c30.c30.c30.c30 {
   -webkit-flex: auto;
   -ms-flex: auto;
   flex: auto;
 }
 
-.c30.c30.c30.c30.c30 {
+.c31.c31.c31.c31.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1888,16 +1900,16 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   flex-shrink: 0;
 }
 
-.c32.c32.c32.c32.c32 {
+.c33.c33.c33.c33.c33 {
   border-bottom-color: hsla(211,20%,52%,0.18);
   border-bottom-style: solid;
 }
 
-.c41.c41.c41.c41.c41 {
+.c42.c42.c42.c42.c42 {
   padding: 16px;
 }
 
-.c22.c22.c22.c22.c22 {
+.c23.c23.c23.c23.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1905,7 +1917,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   z-index: 1002;
 }
 
-.c43.c43.c43.c43.c43 {
+.c44.c44.c44.c44.c44 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1946,7 +1958,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   min-height: 36px;
 }
 
-.c36.c36.c36.c36.c36 {
+.c37.c37.c37.c37.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1965,7 +1977,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   max-height: 20px;
 }
 
-.c37.c37.c37.c37.c37 {
+.c38.c38.c38.c38.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1980,7 +1992,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   justify-content: center;
 }
 
-.c38.c38.c38.c38.c38 {
+.c39.c39.c39.c39.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1996,11 +2008,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding-left: 0px;
 }
 
-.c40.c40.c40.c40.c40 {
+.c41.c41.c41.c41.c41 {
   margin-left: auto;
 }
 
-.c24.c24.c24.c24.c24 {
+.c25.c25.c25.c25.c25 {
   background-color: hsla(0,0%,100%,1);
   border-width: 1px;
   border-color: hsla(211,20%,52%,0.18);
@@ -2008,7 +2020,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   border-radius: 4px;
 }
 
-.c42.c42.c42.c42.c42 {
+.c43.c43.c43.c43.c43 {
   min-height: 36px;
   width: 100%;
   cursor: pointer;
@@ -2045,24 +2057,24 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   position: relative;
 }
 
-.c42.c42.c42.c42.c42:hover {
+.c43.c43.c43.c43.c43:hover {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c42.c42.c42.c42.c42:active {
+.c43.c43.c43.c43.c43:active {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
 }
 
-.c42.c42.c42.c42.c42:focus-visible {
+.c43.c43.c43.c43.c43:focus-visible {
   background-color: hsla(227,71%,51%,1);
   border-color: hsla(227,100%,59%,1);
   outline: 1px solid hsla(227,100%,59%,0.09);
   box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.18);
 }
 
-.c42.c42.c42.c42.c42 * {
+.c43.c43.c43.c43.c43 * {
   -webkit-transition-property: color,fill,opacity;
   transition-property: color,fill,opacity;
   -webkit-transition-duration: 150ms;
@@ -2110,7 +2122,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c31.c31.c31.c31.c31 {
+.c32.c32.c32.c32.c32 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 1rem;
@@ -2127,7 +2139,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c45.c45.c45.c45.c45 {
+.c46.c46.c46.c46.c46 {
   color: hsla(0,0%,100%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2145,7 +2157,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c39.c39.c39.c39.c39 {
+.c40.c40.c40.c40.c40 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2167,22 +2179,22 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   -webkit-box-orient: vertical;
 }
 
-.c18.c18.c18.c18.c18 {
+.c19.c19.c19.c19.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c17.c17.c17.c17.c17 {
+.c18.c18.c18.c18.c18 {
   display: none;
 }
 
-.c44.c44.c44.c44.c44 {
+.c45.c45.c45.c45.c45 {
   opacity: 1;
 }
 
-.c33.c33.c33.c33.c33 {
+.c34.c34.c34.c34.c34 {
   border-width: 0;
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -2192,7 +2204,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   flex-grow: 1;
 }
 
-.c13.c13.c13.c13.c13 {
+.c14.c14.c14.c14.c14 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2225,7 +2237,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   cursor: auto;
 }
 
-.c13.c13.c13.c13.c13::-webkit-input-placeholder {
+.c14.c14.c14.c14.c14::-webkit-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2243,7 +2255,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::-moz-placeholder {
+.c14.c14.c14.c14.c14::-moz-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2261,7 +2273,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:-ms-input-placeholder {
+.c14.c14.c14.c14.c14:-ms-input-placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2279,7 +2291,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13::placeholder {
+.c14.c14.c14.c14.c14::placeholder {
   color: hsla(211,20%,52%,0.32);
   font-family: "Inter",-apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
   font-size: 0.875rem;
@@ -2297,11 +2309,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   padding: 0;
 }
 
-.c13.c13.c13.c13.c13:focus {
+.c14.c14.c14.c14.c14:focus {
   outline: none;
 }
 
-.c19.c19.c19.c19.c19 {
+.c20.c20.c20.c20.c20 {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -2383,6 +2395,18 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   max-height: 37px;
 }
 
+.c12.c12.c12.c12.c12 {
+  -ms-overflow-style: none;
+  -webkit-scrollbar-width: none;
+  -moz-scrollbar-width: none;
+  -ms-scrollbar-width: none;
+  scrollbar-width: none;
+}
+
+.c12.c12.c12.c12.c12::-webkit-scrollbar {
+  display: none;
+}
+
 .c7.c7.c7.c7.c7 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -2400,17 +2424,17 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   word-wrap: normal;
 }
 
-.c34.c34.c34.c34.c34 {
+.c35.c35.c35.c35.c35 {
   overflow-y: auto;
   max-height: 300px;
   padding: 8px;
 }
 
-.c34.c34.c34.c34.c34 [role=group]:last-child > [role=separator]:last-child {
+.c35.c35.c35.c35.c35 [role=group]:last-child > [role=separator]:last-child {
   display: none;
 }
 
-.c35.c35.c35.c35.c35 {
+.c36.c36.c36.c36.c36 {
   border-width: 4px;
   border-style: solid;
   border-color: transparent;
@@ -2425,20 +2449,20 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
   display: block;
 }
 
-.c35.c35.c35.c35.c35:hover:not([aria-disabled=true]) {
+.c36.c36.c36.c36.c36:hover:not([aria-disabled=true]) {
   background-color: hsla(211,20%,52%,0.09);
 }
 
-.c35.c35.c35.c35.c35[aria-selected=true] {
+.c36.c36.c36.c36.c36[aria-selected=true] {
   background-color: hsla(227,100%,59%,0.09);
 }
 
-.c35.c35.c35.c35.c35[aria-selected=true]:hover {
+.c36.c36.c36.c36.c36[aria-selected=true]:hover {
   background-color: hsla(227,100%,59%,0.18);
 }
 
 @media screen and (min-width:768px) {
-  .c26.c26.c26.c26.c26 {
+  .c27.c27.c27.c27.c27 {
     padding-right: 20px;
     padding-left: 20px;
     margin-bottom: 20px;
@@ -2447,37 +2471,37 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
 }
 
 @media screen and (min-width:320px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:480px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:1200px) {
-  .c32.c32.c32.c32.c32 {
+  .c33.c33.c33.c33.c33 {
     border-bottom-style: solid;
   }
 }
 
 @media screen and (min-width:768px) {
-  .c41.c41.c41.c41.c41 {
+  .c42.c42.c42.c42.c42 {
     padding: 20px;
   }
 }
@@ -2545,11 +2569,11 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
               data-blade-component="base-box"
             >
               <div
-                class="c11 tags-slot"
+                class="c11 c12 tags-slot"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12"
+                  class="c13"
                   data-blade-component="base-box"
                 >
                   <input
@@ -2562,7 +2586,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                     aria-invalid="false"
                     aria-required="false"
                     autocomplete="off"
-                    class="c13"
+                    class="c14"
                     data-blade-component="styled-base-input"
                     id="dropdown-123"
                     placeholder="Select Option"
@@ -2573,20 +2597,20 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 </div>
               </div>
               <div
-                class="c14"
+                class="c15"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c15"
+                  class="c16"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c16"
+                    class="c17"
                     data-blade-component="base-box"
                   >
                     <svg
                       aria-hidden="true"
-                      class="c17"
+                      class="c18"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -2603,7 +2627,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                     </svg>
                     <svg
                       aria-hidden="true"
-                      class="c18"
+                      class="c19"
                       data-blade-component="icon"
                       fill="none"
                       height="16px"
@@ -2622,35 +2646,35 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 </div>
               </div>
               <div
-                class=" c19"
+                class=" c20"
                 data-blade-component="base-box"
               />
             </div>
           </div>
           <div
-            class="c20"
+            class="c21"
             data-blade-component="base-box"
           >
             <div
-              class="c21"
+              class="c22"
               data-blade-component="base-box"
             />
           </div>
         </div>
       </div>
       <div
-        class="c22"
+        class="c23"
         data-blade-component="base-box"
         style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 8px); width: 0px;"
       >
         <div
-          class="c23 c24"
+          class="c24 c25"
           data-blade-component="dropdown-overlay"
           elevation="midRaised"
           style="transition-property: transform,opacity; transition-duration: 200ms;"
         >
           <div
-            class="c25"
+            class="c26"
             data-blade-component="base-box"
           >
             <div
@@ -2658,27 +2682,27 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
               data-blade-component="dropdown-header"
             >
               <div
-                class="c26"
+                class="c27"
                 data-blade-component="base-box"
               >
                 <div
-                  class="c27"
+                  class="c28"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c28"
+                    class="c29"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c29"
+                      class="c30"
                       data-blade-component="base-box"
                     >
                       <div
-                        class="c30"
+                        class="c31"
                         data-blade-component="base-box"
                       >
                         <p
-                          class="c31"
+                          class="c32"
                           data-blade-component="text"
                         >
                           Recent Searches
@@ -2689,7 +2713,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 </div>
               </div>
               <div
-                class="c32 c33"
+                class="c33 c34"
                 data-blade-component="divider"
                 role="separator"
               />
@@ -2704,13 +2728,13 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
           >
             <div
               aria-multiselectable="false"
-              class=" c34"
+              class=" c35"
               data-blade-component="base-box"
               role="listbox"
             >
               <button
                 aria-selected="false"
-                class=" c35 active-focus"
+                class=" c36 active-focus"
                 data-blade-component="action-list-item"
                 data-index="0"
                 data-value="apple"
@@ -2720,26 +2744,26 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 type="button"
               >
                 <div
-                  class="c36"
+                  class="c37"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c37"
+                    class="c38"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c39"
+                      class="c40"
                       data-blade-component="text"
                     >
                       Apple
                     </p>
                   </div>
                   <div
-                    class="c40"
+                    class="c41"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -2750,7 +2774,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
               </button>
               <button
                 aria-selected="false"
-                class=" c35"
+                class=" c36"
                 data-blade-component="action-list-item"
                 data-index="1"
                 data-value="mango"
@@ -2760,26 +2784,26 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 type="button"
               >
                 <div
-                  class="c36"
+                  class="c37"
                   data-blade-component="base-box"
                 >
                   <div
-                    class="c37"
+                    class="c38"
                     data-blade-component="base-box"
                   />
                   <div
-                    class="c38"
+                    class="c39"
                     data-blade-component="base-box"
                   >
                     <p
-                      class="c39"
+                      class="c40"
                       data-blade-component="text"
                     >
                       Mango
                     </p>
                   </div>
                   <div
-                    class="c40"
+                    class="c41"
                     data-blade-component="base-box"
                   />
                 </div>
@@ -2796,12 +2820,12 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
             role="group"
           >
             <div
-              class="c32 c33"
+              class="c33 c34"
               data-blade-component="divider"
               role="separator"
             />
             <div
-              class="c41"
+              class="c42"
               data-blade-component="dropdown-footer"
             >
               <div
@@ -2809,17 +2833,17 @@ exports[`<Dropdown /> with <AutoComplete /> should render dropdown and make it v
                 data-blade-component="box"
               >
                 <button
-                  class="c42"
+                  class="c43"
                   data-blade-component="button"
                   role="button"
                   type="button"
                 >
                   <div
-                    class="c43 c44"
+                    class="c44 c45"
                     data-blade-component="base-box"
                   >
                     <div
-                      class="c45"
+                      class="c46"
                       data-blade-component="base-text"
                     >
                       Apply


### PR DESCRIPTION
## Description
Fixes 2 issues -
1. Hides scrollbar from tag slot ([reference - Internal Slack](https://razorpay.slack.com/archives/CMQ3RBHEU/p1707983918459799?thread_ts=1707983890.941129&cid=CMQ3RBHEU))
2. Click on DropdownLink and DropdownButton icon was not working which is fixed ([referrence](https://twitter.com/championswimmer/status/1758053933799690424?s=46&t=z3Gl4H0P-0tu0p7yvK1HbQ))

## Changes

- The clicks on icon of DropdownLink and DropdownButton were not working because when we click these icons, we trigger `setIsOpen(true)` and switch the icon from chevron down to chevron up. The icon that is clicked now no longer exists because of switch in icons in React DOM and DOM so our `dropdown.contains(target)` check (which checks if outside item is clicked was getting false)
- This is fixed by adding `document.body.contains` check. Which checks if item clicked exists in the DOM or not before marking it as outside click

## Additional Information


https://github.com/razorpay/blade/assets/30949385/359fa2fd-15c7-434b-a1d3-a869b69b7f7c


## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
