### PR TITLE
fix(Tag): tag truncation in Select and AutoComplete

### DIFF
--- a/.changeset/beige-scissors-warn.md
+++ b/.changeset/beige-scissors-warn.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Tag): tag truncation in Select and AutoComplete

--- a/packages/blade/src/components/Dropdown/docs/DropdownWithSelect.stories.tsx
+++ b/packages/blade/src/components/Dropdown/docs/DropdownWithSelect.stories.tsx
@@ -194,6 +194,8 @@ export const InternalMultiSelect = (): React.ReactElement => {
           <DropdownHeader title="Header Title" subtitle="Header subtitle" />
           <ActionList>
             <ActionListItem title="Mumbai" value="mumbai" />
+            <ActionListItem title="Navi Mumbai" value="navi-mumbai" />
+            <ActionListItem title="Farrukhabad Fatehgarh" value="farrukhabad-fatehgarh" />
             <ActionListItem title="Bangalore" value="bangalore" />
             <ActionListItem title="Pune" value="pune" />
             <ActionListItem title="Chennai" value="chennai" />

--- a/packages/blade/src/components/Tag/AnimatedTag.web.tsx
+++ b/packages/blade/src/components/Tag/AnimatedTag.web.tsx
@@ -44,6 +44,7 @@ const AnimatedTagContainer = styled(BaseBox)<{
     display: inline-block;
     opacity: ${props.isVisible ? TAG_OPACITY_START : TAG_OPACITY_END};
     max-width: ${makeSize(props.isVisible ? TAG_MAX_WIDTH_START : TAG_MAX_WIDTH_END)};
+    flex-shrink: 0;
   `,
 );
 

--- a/packages/blade/src/components/Tag/Tag.tsx
+++ b/packages/blade/src/components/Tag/Tag.tsx
@@ -102,7 +102,7 @@ const Tag = ({
         display={(isReactNative() ? 'flex' : 'inline-flex') as never}
         alignSelf={isReactNative() ? 'center' : undefined}
         flexDirection="row"
-        flexWrap="nowrap"
+        flexShrink={0}
         backgroundColor={backgroundColor}
         borderRadius="max"
         padding={size === 'medium' ? mediumPadding : largePadding}

--- a/packages/blade/src/components/Tag/Tag.tsx
+++ b/packages/blade/src/components/Tag/Tag.tsx
@@ -102,6 +102,7 @@ const Tag = ({
         display={(isReactNative() ? 'flex' : 'inline-flex') as never}
         alignSelf={isReactNative() ? 'center' : undefined}
         flexDirection="row"
+        flexWrap="nowrap"
         flexShrink={0}
         backgroundColor={backgroundColor}
         borderRadius="max"

--- a/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.native.test.tsx.snap
+++ b/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.native.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`<Tag /> should render tag 1`] = `
       data-blade-component="base-box"
       display="flex"
       flexDirection="row"
+      flexShrink={0}
       flexWrap="nowrap"
       style={
         [
@@ -35,6 +36,7 @@ exports[`<Tag /> should render tag 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexDirection": "row",
+            "flexShrink": 0,
             "flexWrap": "nowrap",
             "paddingBottom": 4,
             "paddingLeft": 12,

--- a/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tag /> should render tag 1`] = `"<div id="root"><div data-blade-component="tag" class="BaseBox-bmPWx ePenKG"><div data-blade-component="base-box" class="BaseBox-bmPWx Tag__FocussableTag-jmwb4r-0 gxGzeJ"><div data-blade-component="box" class="BaseBox-bmPWx laICQt"><p class="StyledBaseText-dVBfTO kBCXQA" data-blade-component="text">in:User</p></div><div data-blade-component="box" class="BaseBox-bmPWx cgXgMK"><button type="button" aria-label="Close in:User tag" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 jCUyST"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button></div></div></div></div>"`;
+exports[`<Tag /> should render tag 1`] = `"<div id="root"><div data-blade-component="tag" class="BaseBox-bmPWx ePenKG"><div data-blade-component="base-box" class="BaseBox-bmPWx Tag__FocussableTag-jmwb4r-0 fXosyT"><div data-blade-component="box" class="BaseBox-bmPWx laICQt"><p class="StyledBaseText-dVBfTO kBCXQA" data-blade-component="text">in:User</p></div><div data-blade-component="box" class="BaseBox-bmPWx cgXgMK"><button type="button" aria-label="Close in:User tag" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 jCUyST"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button></div></div></div></div>"`;
 
 exports[`<Tag /> should render tag 2`] = `
 .c0.c0.c0.c0.c0 {
@@ -21,6 +21,9 @@ exports[`<Tag /> should render tag 2`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   padding: 4px 8px 4px 12px;
   background-color: hsla(211,20%,52%,0.09);
   border-radius: 9999px;

--- a/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.web.test.tsx.snap
+++ b/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.web.test.tsx.snap
@@ -19,6 +19,9 @@ exports[`<Tag /> should render tag 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   padding: 4px 8px 4px 12px;
   background-color: hsla(211,20%,52%,0.09);
   border-radius: 9999px;


### PR DESCRIPTION
## Description

Tag component was shrinking when placed inside flex of AutoComplete and SelectInput

## Changes

- Adds `flexShrink={0}` to disable shrinking behaviour and take comfortable space

## Additional Information

<img width="40%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/4b4717a4-2ac2-48d2-b035-01a987d2cb38">
 <img width="40%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/18c5f803-d5af-4ab1-b842-de35aa9a08df">



## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
