### PR TITLE
docs: multiple docs UI fixes and unpkg installation link in installation guide

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -133,7 +133,7 @@ If your project uses a no-bundler setup or is a no-code tool, you can install fo
 ```html
 <link rel="stylesheet" href="https://unpkg.com/@razorpay/blade@<blade-version>/fonts.css" />
 <!-- 
-  Replace <blade-version> in the URL with version of blade you're using
+  Replace <blade-version> in the URL with the version of Blade you're using
   E.g. https://unpkg.com/@razorpay/blade@11.3.1/fonts.css 
 -->
 ```

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -126,6 +126,18 @@ We use 2 fonts. [TASA Orbiter](https://tasatype.localremote.co/) (for our headin
   `;
   ```
 
+#### No Bundler Setups or No Code Tools
+
+If your project uses no-bundler setup or is a no code tool, you can install fonts with `unpkg` link
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@razorpay/blade@<blade-version>/fonts.css" />
+<!-- 
+  Replace <blade-version> in the URL with version of blade you're using
+  E.g. https://unpkg.com/@razorpay/blade@11.3.1/fonts.css 
+-->
+```
+
 ### React Native Projects
 
 - Download fonts from <a href="https://github.com/razorpay/blade/tree/master/packages/blade/fonts/blade-fonts-react-native.zip">blade-fonts-react-native.zip</a> and unzip.

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -128,7 +128,7 @@ We use 2 fonts. [TASA Orbiter](https://tasatype.localremote.co/) (for our headin
 
 #### No Bundler Setups or No Code Tools
 
-If your project uses no-bundler setup or is a no code tool, you can install fonts with `unpkg` link
+If your project uses a no-bundler setup or is a no-code tool, you can install fonts with `unpkg` link
 
 ```html
 <link rel="stylesheet" href="https://unpkg.com/@razorpay/blade@<blade-version>/fonts.css" />

--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -27,7 +27,22 @@ import { Meta } from '@storybook/addon-docs';
 </div>
 <br />
 
-Blade is the Design System that powers [Razorpay](https://razorpay.com/)
+## What is Blade?
+
+Blade is the Cross-Platform, Open Source Design System that powers all of the [Razorpay](https://razorpay.com/) Products.
+
+<div style={{ textAlign: 'left' }}>
+  <iframe
+    width="560"
+    height="315"
+    src="https://www.youtube.com/embed/GH3HA6xOFEw?si=QLihQEyooEbtRPgg"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+    style={{ borderRadius: '8px' }}
+  ></iframe>
+</div>
 
 ## 💫 Blade Rebranded
 
@@ -40,6 +55,7 @@ Blade is the Design System that powers [Razorpay](https://razorpay.com/)
 ## 🔗 Links
 
 - [Docs](https://blade.razorpay.com)
+- [Figma Library](https://www.figma.com/community/file/1341658976127676210)
 - [Installation](https://blade.razorpay.com/?path=/docs/guides-installation--page)
 - [@razorpay/blade-old](https://github.com/razorpay/blade-old) (Deprecated, Private)
 

--- a/packages/blade/docs/guides/Usage.stories.mdx
+++ b/packages/blade/docs/guides/Usage.stories.mdx
@@ -90,7 +90,7 @@ Let's see how you can spot a token name from figma and write it in your code
 Whenever you get a UI mockup handed over by your designer
 
 1. Select the component whose color token you want to use in code up
-2. Click on the inspect panel on the left and click on the token name `surface.background.gray.moderate` to copy it and paste in your code.
+2. Click on the inspect panel on the left and click on the token name `surface.background.gray.moderate` to copy it and paste it into your code.
    > Remember, don't select the hardcoded `hsla` color value.
 
 ```jsx

--- a/packages/blade/docs/guides/Usage.stories.mdx
+++ b/packages/blade/docs/guides/Usage.stories.mdx
@@ -90,17 +90,14 @@ Let's see how you can spot a token name from figma and write it in your code
 Whenever you get a UI mockup handed over by your designer
 
 1. Select the component whose color token you want to use in code up
-2. Click on the inspect panel on the left and click on the token name `Surface/Background/Level3/lowContrast`.
+2. Click on the inspect panel on the left and click on the token name `surface.background.gray.moderate` to copy it and paste in your code.
    > Remember, don't select the hardcoded `hsla` color value.
-3. Now in your code paste this token and replace slashes **`/`** with **`.`**
-   > `Surface/Background/Level3/lowContrast` ➡️ `surface.background.level3.lowContrast`
 
 ```jsx
 const StyledCard = styled.div(
   ({ theme }: { theme: Theme }) => `
     width: 368px;
-    /* Surface/Background/Level3/lowContrast */
-    background-color: ${theme.colors.surface.background.level3.lowContrast};
+    background-color: ${theme.colors.surface.background.gray.moderate};
 `,
 );
 ```

--- a/packages/blade/src/components/ActionList/docs/stories.ts
+++ b/packages/blade/src/components/ActionList/docs/stories.ts
@@ -19,7 +19,7 @@ const Playground = `
 
   function App(): React.ReactElement {
     return (
-    <Box backgroundColor="surface.background.level2.lowContrast">
+    <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
         <ActionListItem
           leading={<ActionListItemIcon icon={UserIcon} />}
@@ -64,7 +64,7 @@ const ActionList = `
 
   function App(): React.ReactElement {
     return (
-    <Box backgroundColor="surface.background.level2.lowContrast">
+    <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
         <ActionListItem title="Mumbai" value="mumbai" />
         <ActionListItem title="Bangalore" value="bangalore" />
@@ -90,7 +90,7 @@ const ActionListItem = `
 
   function App(): React.ReactElement {
     return (
-    <Box backgroundColor="surface.background.level2.lowContrast">
+    <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
         <ActionListItem 
           title="Title"
@@ -123,7 +123,7 @@ const ActionListSection = `
 
   function App(): React.ReactElement {
     return (
-    <Box backgroundColor="surface.background.level2.lowContrast">
+    <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
         {/* You can multiple sections like this 👇🏼 */}
         <ActionListSection title="Account @blade">

--- a/packages/blade/src/components/Badge/Badge.stories.tsx
+++ b/packages/blade/src/components/Badge/Badge.stories.tsx
@@ -24,7 +24,7 @@ const Page = (): React.ReactElement => {
         
         function App(): React.ReactElement {
           return (
-            <Badge variant="neutral" icon={InfoIcon}>
+            <Badge color="neutral" icon={InfoIcon}>
               Boop
             </Badge>
           )

--- a/packages/blade/src/components/Box/BaseBox/BaseBox.internal.stories.tsx
+++ b/packages/blade/src/components/Box/BaseBox/BaseBox.internal.stories.tsx
@@ -44,7 +44,7 @@ export const Responsive = (args: BaseBoxProps): React.ReactElement => {
 Responsive.args = {
   display: 'flex',
   padding: { base: ['spacing.10', 'spacing.3'], l: 'spacing.3' },
-  backgroundColor: 'surface.background.level2.lowContrast',
+  backgroundColor: 'surface.background.gray.moderate',
   flexDirection: { base: 'column', l: 'row' },
 } as BaseBoxProps;
 

--- a/packages/blade/src/components/Box/Box.stories.tsx
+++ b/packages/blade/src/components/Box/Box.stories.tsx
@@ -57,7 +57,7 @@ export const Default = (args: BoxProps): React.ReactElement => {
 
 Default.args = {
   padding: { base: 'spacing.2', m: 'spacing.10' },
-  backgroundColor: 'surface.background.level1.lowContrast',
+  backgroundColor: 'surface.background.gray.intense',
 } as BoxProps;
 
 export const Responsive = (args: BoxProps): React.ReactElement => {
@@ -107,7 +107,7 @@ export const Elevations = (args: BoxProps): React.ReactElement => {
 
 Elevations.args = {
   padding: 'spacing.8',
-  backgroundColor: 'surface.background.level2.lowContrast',
+  backgroundColor: 'surface.background.gray.moderate',
   borderRadius: 'large',
 } as BoxProps;
 

--- a/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
+++ b/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
@@ -127,16 +127,16 @@ function LayoutPrimitivesDocs(): React.ReactElement {
                   padding={{ base: ['spacing.1', '9px'], m: 'spacing.3' }}
                 >
                   <Box 
-                    backgroundColor="surface.background.level3.highContrast" 
+                    backgroundColor="surface.background.cloud.intense" 
                     flex="1" 
                   >
-                    <Text margin="spacing.4" contrast="high">Box1</Text>
+                    <Text margin="spacing.4" color="surface.text.onCloud.onIntense">Box1</Text>
                   </Box>
                   <Box 
-                    backgroundColor="surface.background.level2.highContrast" 
+                    backgroundColor="surface.background.sea.intense" 
                     flex="1" 
                   >
-                    <Text margin="spacing.4" contrast="high">Box2</Text>
+                    <Text margin="spacing.4" color="surface.text.onSea.onIntense">Box2</Text>
                   </Box>
                 </Box>
               )
@@ -192,7 +192,7 @@ function LayoutPrimitivesDocs(): React.ReactElement {
                       // Uncomment next lines to see padding and margin in action
                       // padding="spacing.4"
                       // marginTop="32px"
-                      backgroundColor="surface.background.level2.lowContrast"
+                      backgroundColor="surface.background.gray.intense"
                     >
                       <Text>Some Text</Text>
                     </Box>
@@ -201,7 +201,7 @@ function LayoutPrimitivesDocs(): React.ReactElement {
                         // Uncomment this block to see padding shorthands in action
                         padding={["spacing.3", "35px"]} // We also support padding and margin shorthands similar to CSS
                         marginX="spacing.5" // adds horizontal margin
-                        backgroundColor='surface.background.level3.lowContrast'
+                        backgroundColor='surface.background.gray.moderate'
                       >
                         <Text>More Text</Text>
                       </Box>
@@ -252,17 +252,17 @@ function LayoutPrimitivesDocs(): React.ReactElement {
                   >
                     <Box
                       flex="1"
-                      backgroundColor="surface.background.level2.highContrast"
+                      backgroundColor="surface.background.cloud.intense"
                       padding="spacing.4" 
                     >
-                      <Text contrast="high">Box1</Text>
+                      <Text color="surface.text.onCloud.onIntense">Box1</Text>
                     </Box>
                     <Box 
                       flex="1" 
-                      backgroundColor="surface.background.level3.highContrast" 
+                      backgroundColor="surface.background.sea.intense" 
                       padding="spacing.4" 
                     >
-                      <Text contrast="high">Box2</Text>
+                      <Text color="surface.text.onSea.onIntense">Box2</Text>
                     </Box>
                   </Box>
                 </>

--- a/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
+++ b/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
@@ -9,6 +9,7 @@ import {
   SandboxProvider,
   SandboxHighlighter,
 } from '~utils/storybook/Sandbox/SandpackEditor';
+// import { Sandbox as Sandbox } from '~utils/storybook/Sandbox/StackblitzEditor/Sandbox';
 import { List, ListItem, ListItemCode, ListItemLink } from '~components/List';
 import { Link } from '~components/Link';
 import { castWebType } from '~utils';

--- a/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
+++ b/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
@@ -9,7 +9,6 @@ import {
   SandboxProvider,
   SandboxHighlighter,
 } from '~utils/storybook/Sandbox/SandpackEditor';
-// import { Sandbox as Sandbox } from '~utils/storybook/Sandbox/StackblitzEditor/Sandbox';
 import { List, ListItem, ListItemCode, ListItemLink } from '~components/List';
 import { Link } from '~components/Link';
 import { castWebType } from '~utils';

--- a/packages/blade/src/components/Box/styledProps/StyledProps.stories.tsx
+++ b/packages/blade/src/components/Box/styledProps/StyledProps.stories.tsx
@@ -52,7 +52,7 @@ const BoxStoryMeta = {
 
 export const StyledProps = (args: StyledPropsType): React.ReactElement => {
   return (
-    <Box backgroundColor="surface.background.level2.lowContrast">
+    <Box backgroundColor="surface.background.gray.moderate">
       <Button {...args}>Blade Button</Button>
     </Box>
   );

--- a/packages/blade/src/components/Dropdown/docs/DropdownWithSelect.stories.tsx
+++ b/packages/blade/src/components/Dropdown/docs/DropdownWithSelect.stories.tsx
@@ -281,7 +281,7 @@ export const InternalSelect = (): React.ReactElement => {
   return (
     <Box
       padding="spacing.5"
-      backgroundColor="surface.background.level3.lowContrast"
+      backgroundColor="surface.background.gray.moderate"
       width="100%"
       minHeight="100px"
       overflow="scroll"
@@ -327,7 +327,7 @@ export const InternalAutoPositioning = (): React.ReactElement => {
     <Box>
       <Box
         padding="spacing.5"
-        backgroundColor="surface.background.level3.lowContrast"
+        backgroundColor="surface.background.gray.moderate"
         width="100%"
         minHeight="100px"
         overflow="scroll"
@@ -344,7 +344,7 @@ export const InternalAutoPositioning = (): React.ReactElement => {
       </Box>
       <Box
         padding="spacing.5"
-        backgroundColor="surface.background.level3.lowContrast"
+        backgroundColor="surface.background.gray.moderate"
         width="100%"
         position="fixed"
         bottom="spacing.0"

--- a/packages/blade/src/components/Dropdown/docs/stories.ts
+++ b/packages/blade/src/components/Dropdown/docs/stories.ts
@@ -623,7 +623,7 @@ const WithAutoPositioningSelectStory = `
       <Box>
         <Box
           padding="spacing.5"
-          backgroundColor="surface.background.level3.lowContrast"
+          backgroundColor="surface.background.gray.moderate"
           width="100%"
           minHeight="100px"
           overflow="scroll"
@@ -640,7 +640,7 @@ const WithAutoPositioningSelectStory = `
         </Box>
         <Box
           padding="spacing.5"
-          backgroundColor="surface.background.level3.lowContrast"
+          backgroundColor="surface.background.gray.moderate"
           width="100%"
           position="fixed"
           bottom="spacing.0"

--- a/packages/blade/src/components/Link/Link/Link.stories.tsx
+++ b/packages/blade/src/components/Link/Link/Link.stories.tsx
@@ -162,7 +162,7 @@ const LinkColorsTemplate: StoryFn<typeof LinkComponent> = ({ icon, children = ''
           {children}
         </LinkComponent>
       </BaseBox>
-      <BaseBox padding="spacing.2" backgroundColor="brand.gray.700.lowContrast">
+      <BaseBox padding="spacing.2" backgroundColor="surface.background.cloud.intense">
         <LinkComponent {...args} color="white">
           {children}
         </LinkComponent>

--- a/packages/blade/src/components/List/List.stories.tsx
+++ b/packages/blade/src/components/List/List.stories.tsx
@@ -299,7 +299,7 @@ const ListWithListItemTextTemplate: StoryFn<typeof List> = () => {
             <ListItem>
               <ListItemText>
                 You will receive an invoice after a
-                <ListItemText as="span" weight="bold" color="feedback.text.positive.lowContrast">
+                <ListItemText as="span" weight="semibold" color="feedback.text.positive.intense">
                   {' successful '}
                 </ListItemText>
                 payment
@@ -307,7 +307,7 @@ const ListWithListItemTextTemplate: StoryFn<typeof List> = () => {
             </ListItem>
             <ListItem>
               You will receive a mail with further instruction after a
-              <ListItemText as="span" weight="bold" color="feedback.text.negative.lowContrast">
+              <ListItemText as="span" weight="semibold" color="feedback.text.negative.intense">
                 {' failed '}
               </ListItemText>{' '}
               payment

--- a/packages/blade/src/components/Popover/__tests__/Popover.test.stories.tsx
+++ b/packages/blade/src/components/Popover/__tests__/Popover.test.stories.tsx
@@ -187,7 +187,7 @@ const MyCustomTriggerButton = React.forwardRef<
   return (
     // just spread the props
     <BaseBox
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       borderRadius="medium"
       role="button"

--- a/packages/blade/src/components/Table/docs/APIStories/TableAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableAPI.stories.tsx
@@ -98,7 +98,7 @@ const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
 
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableBodyAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableBodyAPI.stories.tsx
@@ -71,7 +71,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableCellAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableCellAPI.stories.tsx
@@ -77,7 +77,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableFooterAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableFooterAPI.stories.tsx
@@ -77,7 +77,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableFooterCellAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableFooterCellAPI.stories.tsx
@@ -77,7 +77,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableFooterRowAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableFooterRowAPI.stories.tsx
@@ -77,7 +77,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableHeaderAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableHeaderAPI.stories.tsx
@@ -77,7 +77,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableHeaderCellAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableHeaderCellAPI.stories.tsx
@@ -82,7 +82,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableHeaderRowAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableHeaderRowAPI.stories.tsx
@@ -77,7 +77,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TablePaginationAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TablePaginationAPI.stories.tsx
@@ -76,7 +76,7 @@ const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
 
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableRowAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableRowAPI.stories.tsx
@@ -82,7 +82,7 @@ const data: TableData<Item> = {
 const TableTemplate: StoryFn<typeof TableRow> = ({ ...args }) => {
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableToolbarAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableToolbarAPI.stories.tsx
@@ -75,7 +75,7 @@ const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
 
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Table/docs/APIStories/TableToolbarActionsAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableToolbarActionsAPI.stories.tsx
@@ -79,7 +79,7 @@ const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
 
   return (
     <Box
-      backgroundColor="surface.background.level2.lowContrast"
+      backgroundColor="surface.background.gray.intense"
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"

--- a/packages/blade/src/components/Tooltip/__tests__/Tooltip.test.stories.tsx
+++ b/packages/blade/src/components/Tooltip/__tests__/Tooltip.test.stories.tsx
@@ -98,7 +98,7 @@ const CustomTrigger = React.forwardRef<
       <BaseBox
         width="80px"
         height="80px"
-        backgroundColor="surface.background.level2.lowContrast"
+        backgroundColor="surface.background.gray.intense"
         textAlign="center"
         ref={ref}
         tabIndex={0}

--- a/packages/blade/src/components/Typography/BaseText/BaseText.stories.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: 'Components/Typography/BaseText (Internal)',
   component: BaseTextComponent,
   args: {
-    color: 'surface.text.normal.lowContrast',
+    color: 'surface.text.gray.normal',
     fontFamily: 'text',
     fontSize: 200,
     fontWeight: 'regular',

--- a/packages/blade/src/components/Typography/Display/Display.stories.tsx
+++ b/packages/blade/src/components/Typography/Display/Display.stories.tsx
@@ -42,9 +42,7 @@ const DisplayStoryMeta: Meta<DisplayProps> = {
   component: DisplayComponent,
   args: {
     size: 'small',
-    type: 'normal',
     children: 'Power your finance, grow your business',
-    contrast: 'low',
     as: undefined,
   },
   tags: ['autodocs'],
@@ -77,7 +75,7 @@ export default DisplayStoryMeta;
 export const Display = DisplayTemplate.bind({});
 export const WithColor = DisplayTemplate.bind({});
 WithColor.args = {
-  color: 'brand.primary.500',
+  color: 'surface.text.primary.normal',
 };
 
 const Sup = isReactNative() ? DisplayComponent : 'sup';
@@ -86,13 +84,13 @@ const WithMixedColorsTemplate: StoryFn<typeof DisplayComponent> = (args) => {
     <Box>
       <DisplayComponent {...args}>
         Supercharge your business with the all‑powerful{' '}
-        <DisplayComponent {...args} as="span" color="brand.primary.500">
+        <DisplayComponent {...args} as="span" color="surface.text.primary.normal">
           Payment Gateway
         </DisplayComponent>
       </DisplayComponent>
       <DisplayComponent marginTop="spacing.5" {...args}>
         Start accepting{' '}
-        <DisplayComponent {...args} as="span" color="feedback.text.information.lowContrast">
+        <DisplayComponent {...args} as="span" color="feedback.text.information.intense">
           payments
         </DisplayComponent>{' '}
         at just 2% <Sup>*</Sup>
@@ -108,7 +106,7 @@ const AsPropTemplate: StoryFn<typeof DisplayComponent> = (args) => {
     <Box>
       <Text>
         By default{' '}
-        <Text as="span" weight="bold">
+        <Text as="span" weight="semibold">
           Display
         </Text>{' '}
         component automatically renders the <Code size="medium">h1</Code> tag.

--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -47,15 +47,12 @@ const getHeadingArgTypes = (): Meta['argTypes'] => {
   };
 };
 
-const HeadingStoryMeta: Meta<HeadingProps<{ variant: 'regular' | 'subheading' }>> = {
+const HeadingStoryMeta: Meta<HeadingProps> = {
   title: 'Components/Typography/Heading',
   component: HeadingComponent,
   args: {
-    variant: 'regular',
-    type: 'normal',
     children: 'Get Started With Payment Gateway',
-    weight: 'bold',
-    contrast: 'low',
+    weight: 'semibold',
     as: undefined,
   },
   tags: ['autodocs'],
@@ -75,7 +72,7 @@ export default HeadingStoryMeta;
 export const Heading = HeadingTemplate.bind({});
 export const WithColor = HeadingTemplate.bind({});
 WithColor.args = {
-  color: 'feedback.notice.action.text.primary.default.lowContrast',
+  color: 'surface.text.primary.normal',
 };
 
 const Sup = isReactNative() ? HeadingComponent : 'sup';
@@ -84,13 +81,13 @@ const WithMixedColorsTemplate: StoryFn<typeof HeadingComponent> = () => {
     <Box>
       <HeadingComponent>
         Supercharge your business with the all‑powerful{' '}
-        <HeadingComponent as="span" color="brand.primary.600">
+        <HeadingComponent as="span" color="surface.text.primary.normal">
           Payment Gateway
         </HeadingComponent>
       </HeadingComponent>
       <HeadingComponent marginTop="spacing.5">
         Start accepting{' '}
-        <HeadingComponent as="span" color="feedback.text.information.lowContrast">
+        <HeadingComponent as="span" color="feedback.text.information.intense">
           payments
         </HeadingComponent>{' '}
         at just 2% <Sup>*</Sup>
@@ -106,12 +103,12 @@ const AsPropTemplate: StoryFn<typeof HeadingComponent> = (args) => {
     <Box>
       <Text>
         By default{' '}
-        <Text as="span" weight="bold">
+        <Text as="span" weight="semibold">
           Heading
         </Text>{' '}
         component automatically renders the respective <Code size="medium">h*</Code> tag based on
         the{' '}
-        <Text as="span" weight="bold">
+        <Text as="span" weight="semibold">
           size prop
         </Text>{' '}
         passed

--- a/packages/blade/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.stories.tsx
@@ -40,11 +40,9 @@ const TextStoryMeta: Meta<TextProps<{ variant: 'body' | 'caption' }>> = {
     variant: 'body',
     weight: 'regular',
     size: 'medium',
-    type: 'normal',
     children:
       'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc',
     truncateAfterLines: 3,
-    contrast: 'low',
     as: undefined,
   },
   parameters: {
@@ -64,18 +62,18 @@ export default TextStoryMeta;
 export const Text = TextTemplate.bind({});
 export const WithColor = TextTemplate.bind({});
 WithColor.args = {
-  color: 'feedback.positive.action.text.primary.default.lowContrast',
+  color: 'surface.text.primary.normal',
 };
 
 const AsPropTemplate: StoryFn<typeof TextComponent> = (args) => {
   return (
     <TextComponent {...args} as="p">
       Power your{' '}
-      <TextComponent {...args} color="brand.primary.500" as="span" weight="bold">
+      <TextComponent {...args} color="surface.text.primary.normal" as="span" weight="semibold">
         finance
       </TextComponent>
       , grow your{' '}
-      <TextComponent {...args} as="span" weight="bold">
+      <TextComponent {...args} as="span" weight="semibold">
         business
       </TextComponent>
     </TextComponent>

--- a/packages/blade/src/utils/lodashButBetter/get.ts
+++ b/packages/blade/src/utils/lodashButBetter/get.ts
@@ -5,7 +5,7 @@ import type { EasingType } from '~tokens/global/motion';
 
 /**
  * @template TokenType token type generic
- * @description Tokenises objects to dot notation strings, eg: `surface.text.normal.lowContrast`
+ * @description Tokenises objects to dot notation strings, eg: `surface.text.gray.normal`
  */
 export type DotNotationToken<_TokenType, TokenType = Omit<_TokenType, 'name'>> = {
   [K in keyof TokenType]: TokenType[K] extends string | number | ElevationStyles

--- a/packages/blade/src/utils/storybook/ArgsTable.tsx
+++ b/packages/blade/src/utils/storybook/ArgsTable.tsx
@@ -1,27 +1,15 @@
-import styled from 'styled-components';
+import { Box } from '~components/Box';
 import type { BaseBoxProps } from '~components/Box/BaseBox';
-import BaseBox from '~components/Box/BaseBox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRow,
+} from '~components/Table';
 import { Code, Text } from '~components/Typography';
-
-const StyledArgsTable = styled(BaseBox)(
-  (props) => `
-  font-family: ${props.theme.typography.fonts.family.text};
-  text-align: left;
-  min-width: 500px;
-
-  &,
-  & th,
-  & td {
-    border: 1px solid ${props.theme.colors.surface.border.gray.normal};
-    border-collapse: collapse;
-  }
-
-  & td,
-  & th {
-    padding: ${props.theme.spacing[3]}px;
-  }
-`,
-);
 
 const ArgsTable = ({
   data,
@@ -32,44 +20,60 @@ const ArgsTable = ({
   marginBottom?: BaseBoxProps['marginBottom'];
   marginTop?: BaseBoxProps['marginTop'];
 }): JSX.Element => {
+  const nodes = Object.entries(data).map(([prop, type], index) => {
+    return {
+      id: index,
+      prop,
+      type,
+    };
+  });
+
   return (
-    <StyledArgsTable as="table" marginBottom={marginBottom} marginTop={marginTop}>
-      <tr>
-        <th>
-          <Text weight="semibold">Prop</Text>
-        </th>
-        <th>
-          <Text weight="semibold">Type</Text>
-        </th>
-      </tr>
-      {Object.entries(data).map(([propName, propType]) => {
-        const isTypeObject = typeof propType === 'object' && 'note' in propType;
-        const propNote = isTypeObject ? `(${propType.note})` : undefined;
-        const propTypeJSX = (() => {
-          if (typeof propType === 'string') {
-            return <Text>{propType}</Text>;
-          }
+    <div className="sb-unstyled">
+      <Box marginBottom={marginBottom} marginTop={marginTop}>
+        <Table data={{ nodes }}>
+          {(tableData) => (
+            <>
+              <TableHeader>
+                <TableHeaderRow>
+                  <TableHeaderCell>Prop</TableHeaderCell>
+                  <TableHeaderCell>Type</TableHeaderCell>
+                </TableHeaderRow>
+              </TableHeader>
+              <TableBody>
+                {tableData.map((tableItem, index) => {
+                  const propType = tableItem.type;
+                  const isTypeObject = typeof propType === 'object' && 'note' in propType;
+                  const propNote = isTypeObject ? `(${propType.note})` : undefined;
+                  const propTypeJSX = (() => {
+                    if (typeof propType === 'string') {
+                      return <Text>{propType}</Text>;
+                    }
 
-          if (isTypeObject) {
-            return <Text>{propType.type}</Text>;
-          }
+                    if (isTypeObject) {
+                      return <Text>{propType.type}</Text>;
+                    }
 
-          return propType;
-        })();
+                    return propType;
+                  })();
 
-        return (
-          <tr key={propName}>
-            <td>
-              <Text size="medium" variant="body">
-                <Code size="medium">{propName}</Code> {propNote}
-              </Text>
-            </td>
-
-            <td>{propTypeJSX}</td>
-          </tr>
-        );
-      })}
-    </StyledArgsTable>
+                  return (
+                    <TableRow key={index} item={tableItem}>
+                      <TableCell>
+                        <Text size="medium" variant="body">
+                          <Code size="medium">{tableItem.prop}</Code> {propNote}
+                        </Text>
+                      </TableCell>
+                      <TableCell>{propTypeJSX}</TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </>
+          )}
+        </Table>
+      </Box>
+    </div>
   );
 };
 

--- a/packages/blade/src/utils/storybook/Sandbox/SandpackEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/SandpackEditor/Sandbox.web.tsx
@@ -44,7 +44,7 @@ const useSandpackSetup = ({
   };
 };
 
-const CodeLineHighlighterContainer = styled(BaseBox)((_props) => ({
+const CodeLineHighlighterContainer = styled(BaseBox)((props) => ({
   '& .highlight': {
     backgroundColor: '#fffbdd',
     borderRadius: '2px',
@@ -55,6 +55,7 @@ const CodeLineHighlighterContainer = styled(BaseBox)((_props) => ({
   },
   borderRadius: '4px',
   overflow: 'auto',
+  fontFamily: props.theme.typography.fonts.family.code,
 }));
 
 const SandboxHighlighter = ({
@@ -63,7 +64,7 @@ const SandboxHighlighter = ({
   ...sandpackCodeViewerProps
 }: { children: string; theme?: 'light' | 'dark' } & CodeViewerProps): JSX.Element => {
   return (
-    <CodeLineHighlighterContainer>
+    <CodeLineHighlighterContainer className="sb-unstyled">
       <SandpackProvider
         template="vanilla-ts"
         theme={theme}
@@ -89,11 +90,17 @@ const SandboxProvider = ({
 }): JSX.Element => {
   const sandboxSetup = useSandpackSetup({ language, code });
   return (
-    <CodeLineHighlighterContainer border={castWebType(border)}>
+    <CodeLineHighlighterContainer className="sb-unstyled" border={castWebType(border)}>
       <SandpackProvider {...sandboxSetup}>{children}</SandpackProvider>
     </CodeLineHighlighterContainer>
   );
 };
+
+const StyledSandpack = styled(BaseBox)((props) => {
+  return {
+    fontFamily: props.theme.typography.fonts.family.code,
+  };
+});
 
 function Sandbox({
   children,
@@ -106,7 +113,7 @@ function Sandbox({
   const sandpackSetup = useSandpackSetup({ language, code: children });
 
   return (
-    <BaseBox padding={padding}>
+    <StyledSandpack className="sb-unstyled" padding={padding}>
       <Sandpack
         {...sandpackSetup}
         options={{
@@ -117,7 +124,7 @@ function Sandbox({
           editorWidthPercentage,
         }}
       />
-    </BaseBox>
+    </StyledSandpack>
   );
 }
 

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -21,10 +21,12 @@ const useStackblitzSetup = ({
   code,
   editorHeight,
   showConsole,
+  sandboxRef,
 }: {
   code: SandboxStackBlitzProps['children'];
   editorHeight: SandboxStackBlitzProps['editorHeight'];
   showConsole: SandboxStackBlitzProps['showConsole'];
+  sandboxRef: React.RefObject<HTMLDivElement>;
 }): Project => {
   const docsContext = React.useContext(DocsContext);
 
@@ -70,16 +72,23 @@ const useStackblitzSetup = ({
   }, [colorScheme, brandColor]);
 
   React.useEffect(() => {
-    void sdk.embedProject('sb-embed', stackblitzProject, {
-      height: editorHeight,
-      openFile: 'App.tsx',
-      terminalHeight: 0,
-      hideDevTools: true,
-      hideNavigation: true,
-      hideExplorer: true,
-      theme: 'light',
-      showSidebar: false,
-    });
+    if (sandboxRef.current) {
+      sdk
+        .embedProject(sandboxRef.current, stackblitzProject, {
+          height: editorHeight,
+          openFile: 'App.tsx',
+          terminalHeight: 0,
+          hideDevTools: true,
+          hideNavigation: true,
+          hideExplorer: true,
+          theme: 'light',
+          showSidebar: false,
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [colorScheme, brandColor]);
 
@@ -102,10 +111,13 @@ export const Sandbox = ({
   showConsole = false,
   padding = ['spacing.5', 'spacing.0', 'spacing.8'],
 }: SandboxStackBlitzProps): JSX.Element => {
+  const sandboxRef = React.useRef<HTMLDivElement>(null);
+
   useStackblitzSetup({
     code: children,
     editorHeight,
     showConsole,
+    sandboxRef,
   });
 
   return (
@@ -114,7 +126,10 @@ export const Sandbox = ({
       // Stackblitz is unable to handle string types of height correctly so we set them on styled-components
       editorHeight={typeof editorHeight !== 'number' ? editorHeight : undefined}
     >
-      <div id="sb-embed" />
+      <div ref={sandboxRef} />
+      {/* {previewURL ? (
+        <iframe title="Preview Iframe" src={previewURL} width="100%" height="300px" />
+      ) : null} */}
     </StyledEmbed>
   );
 };

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -127,9 +127,6 @@ export const Sandbox = ({
       editorHeight={typeof editorHeight !== 'number' ? editorHeight : undefined}
     >
       <div ref={sandboxRef} />
-      {/* {previewURL ? (
-        <iframe title="Preview Iframe" src={previewURL} width="100%" height="300px" />
-      ) : null} */}
     </StyledEmbed>
   );
 };

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -187,8 +187,8 @@ export const Logger = () => {
           margin="spacing.4"
           elevation="midRaised"
           borderRadius="round"
-          backgroundColor="surface.background.level3.lowContrast"
-          borderColor="surface.border.normal.lowContrast"
+          backgroundColor="surface.background.gray.moderate"
+          borderColor="surface.border.gray.normal"
           display={showLogger ? 'inline-block' : 'none'}
         >
           <IconButton
@@ -207,13 +207,13 @@ export const Logger = () => {
           overflow="auto"
           height="30vh"
           elevation="highRaised"
-          backgroundColor="surface.background.level2.lowContrast"
+          backgroundColor="surface.background.gray.intense"
           id="log-console"
           ref={consoleRef}
           display={showLogger ? 'block' : 'none'}
           textAlign="left"
           borderTopWidth="thin"
-          borderTopColor="surface.border.normal.lowContrast"
+          borderTopColor="surface.border.gray.normal"
         />
       </Box>
     </>
@@ -277,7 +277,7 @@ root.render(
     <BladeProvider themeTokens={getTheme()} colorScheme="${colorScheme}">
       <GlobalStyles />
       <Box 
-        backgroundColor="surface.background.level1.lowContrast"
+        backgroundColor="surface.background.gray.subtle"
         minHeight="100vh"
         padding={['spacing.4', 'spacing.7']}
         display="flex"

--- a/packages/blade/src/utils/types.ts
+++ b/packages/blade/src/utils/types.ts
@@ -8,7 +8,7 @@ import type { Platform } from '~utils';
 
 /**
  * @template TokenType token type generic
- * @description Tokenises objects to dot notation strings, eg: `surface.text.normal.lowContrast`
+ * @description Tokenises objects to dot notation strings, eg: `surface.text.gray.normal`
  */
 type DotNotationColorStringToken<TokenType> = {
   [K in keyof TokenType]: `${Extract<K, number | string>}.${TokenType[K] extends Record<


### PR DESCRIPTION
## Description

Multiple changes in documentation. These include small and large UI fixes and enhancements

## Changes

- Add `unpkg` link to font installation as discussed last time in Font CDN Exploration Doc
  <img width="500px" alt="image" src="https://github.com/razorpay/blade/assets/30949385/ee9d56cc-f1f5-41f9-9434-8ab52fb88735">
- Replace the table in documentation pages like Modal, Dropdown with our Table component to improve consistency
  <img width="45%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/4016ca40-d96d-4bf8-9bbe-fea26c3afd39"> <img width="45%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/b8c5baa7-b810-44cb-a861-33dc31b0deec">
- Replace all the old tokens from v10 to new v11 tokens (few were missed during rebranding)
- UI fixes of codesandbox code (storybook was overriding it with weird font)
  <img width="45%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/19d483ff-a771-4c69-810b-96c5451c657a"> <img width="45%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/34fa9209-9177-447c-8be7-4200e376a4af">
- Add new intro section with RK's video
  <img width="45%" alt="image" src="https://github.com/razorpay/blade/assets/30949385/b371c723-cfbb-4482-945e-bce4f14c8297">
- Figma Community Link added to Links section
- Removed the section that explained how to turn color tokens from `Surface / Feedback / Positive` notation to dot notation since its not relevant anymore




## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
