### PR TITLE
feat: support `defaultPlacement` prop on `DropdownOverlay`

### DIFF
--- a/.changeset/hot-dodos-sin.md
+++ b/.changeset/hot-dodos-sin.md
@@ -1,5 +1,5 @@
 ---
-"@razorpay/blade": patch
+'@razorpay/blade': patch
 ---
 
-feat: support `placement` prop on `DropdownOverlay`
+feat: support `defaultPlacement` prop on `DropdownOverlay`

--- a/.changeset/hot-dodos-sin.md
+++ b/.changeset/hot-dodos-sin.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat: support `placement` prop on `DropdownOverlay`

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
@@ -34,6 +34,7 @@ const _DropdownOverlay = ({
   testID,
   zIndex = componentZIndices.dropdownOverlay,
   width,
+  placement = 'bottom-start',
 }: DropdownOverlayProps): React.ReactElement | null => {
   const { isOpen, triggererRef, triggererWrapperRef, dropdownTriggerer, setIsOpen } = useDropdown();
   const { theme } = useTheme();
@@ -47,7 +48,7 @@ const _DropdownOverlay = ({
     open: isOpen,
     onOpenChange: setIsOpen,
     strategy: 'fixed',
-    placement: 'bottom-start',
+    placement,
     elements: {
       // Input triggers have their ref on internal input element but we want width height of overall visible input hence wrapperRef is needed
       // We fallback to use `triggererRef` for triggers like button and link where wrapper is not needed

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
@@ -34,7 +34,7 @@ const _DropdownOverlay = ({
   testID,
   zIndex = componentZIndices.dropdownOverlay,
   width,
-  placement = 'bottom-start',
+  defaultPlacement = 'bottom-start',
 }: DropdownOverlayProps): React.ReactElement | null => {
   const { isOpen, triggererRef, triggererWrapperRef, dropdownTriggerer, setIsOpen } = useDropdown();
   const { theme } = useTheme();
@@ -48,7 +48,7 @@ const _DropdownOverlay = ({
     open: isOpen,
     onOpenChange: setIsOpen,
     strategy: 'fixed',
-    placement,
+    placement: defaultPlacement,
     elements: {
       // Input triggers have their ref on internal input element but we want width height of overall visible input hence wrapperRef is needed
       // We fallback to use `triggererRef` for triggers like button and link where wrapper is not needed

--- a/packages/blade/src/components/Dropdown/types.ts
+++ b/packages/blade/src/components/Dropdown/types.ts
@@ -27,6 +27,20 @@ type DropdownOverlayProps = {
    */
   zIndex?: number;
   width?: BoxProps['width'];
+  /**
+   * Sets the placement of the DropdownOverlay
+   *
+   * @default 'bottom-start'
+   */
+  placement?:
+    | 'bottom-end'
+    | 'bottom-start'
+    | 'left-end'
+    | 'left-start'
+    | 'right-end'
+    | 'right-start'
+    | 'top-end'
+    | 'top-start';
 } & TestID;
 
 export type { DropdownProps, DropdownOverlayProps };

--- a/packages/blade/src/components/Dropdown/types.ts
+++ b/packages/blade/src/components/Dropdown/types.ts
@@ -1,7 +1,9 @@
 import type React from 'react';
+import type { Placement } from '@floating-ui/react';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import type { TestID } from '~utils/types';
 import type { BoxProps } from '~components/Box';
+
 type DropdownProps = {
   /**
    * Control open / close state of the Dropdown component
@@ -32,15 +34,7 @@ type DropdownOverlayProps = {
    *
    * @default 'bottom-start'
    */
-  placement?:
-    | 'bottom-end'
-    | 'bottom-start'
-    | 'left-end'
-    | 'left-start'
-    | 'right-end'
-    | 'right-start'
-    | 'top-end'
-    | 'top-start';
+  defaultPlacement?: Placement;
 } & TestID;
 
 export type { DropdownProps, DropdownOverlayProps };


### PR DESCRIPTION
## Description
<!-- Briefly explain the purpose of your PR -->
Allow manual placement of the dropdown.

## Changes

- Add `placement` prop.

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information
Needed for ButtonGroup component.


<!-- Include any relevant details, links to issues, or additional messages -->

<img width="1044" alt="Screenshot 2024-03-06 at 10 27 16 AM" src="https://github.com/razorpay/blade/assets/46647141/a12fcf58-5f50-464d-9ba2-a2d0842a9bac">

