### PR TITLE
fix(Table): selection toggle for multiselect table

### DIFF
--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -234,6 +234,7 @@ const TableCheckboxCell = ({
         justifyContent="center"
         flex={1}
         width={makeSize(checkboxCellWidth)}
+        onClick={(e) => e.stopPropagation()}
       >
         <Checkbox isDisabled={isDisabled} isChecked={isChecked} onChange={onChange} />
       </BaseBox>


### PR DESCRIPTION
## Description

For a Multiselect Table Component, selection does not work if we click on the checkbox. However, it works if we click on the row itself. This PR is a short term solution to fix the problem.

Provided the issue link below for more details.

## Changes

Stop event propagation while clicking on the multiselect checkbox

## Additional Information

https://github.com/razorpay/blade/issues/1978

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
