### PR TITLE
fix: additional parameters added to retain fraction digits in humanize Amount figure

### DIFF
--- a/.changeset/tiny-beds-switch.md
+++ b/.changeset/tiny-beds-switch.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+[feat]: additional parameters added to retain fraction digits in humanize Amount figure

--- a/.changeset/tiny-beds-switch.md
+++ b/.changeset/tiny-beds-switch.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-[feat]: additional parameters added to retain fraction digits in humanize Amount figure
+fix: additional parameters added to retain fraction digits in humanize Amount figure

--- a/packages/blade/src/components/Amount/Amount.tsx
+++ b/packages/blade/src/components/Amount/Amount.tsx
@@ -190,6 +190,7 @@ export const formatAmountWithSuffix = ({
           intlOptions: {
             notation: 'compact',
             minimumFractionDigits: 1,
+            maximumFractionDigits: 2,
             trailingZeroDisplay: 'stripIfInteger',
           },
         });

--- a/packages/blade/src/components/Amount/Amount.tsx
+++ b/packages/blade/src/components/Amount/Amount.tsx
@@ -189,6 +189,8 @@ export const formatAmountWithSuffix = ({
         const formatted = formatNumber(value, {
           intlOptions: {
             notation: 'compact',
+            minimumFractionDigits: 1,
+            trailingZeroDisplay: 'stripIfInteger',
           },
         });
         return {

--- a/packages/blade/src/components/Amount/Amount.tsx
+++ b/packages/blade/src/components/Amount/Amount.tsx
@@ -189,7 +189,6 @@ export const formatAmountWithSuffix = ({
         const formatted = formatNumber(value, {
           intlOptions: {
             notation: 'compact',
-            minimumFractionDigits: 1,
             maximumFractionDigits: 2,
             trailingZeroDisplay: 'stripIfInteger',
           },


### PR DESCRIPTION
Fixes #2115 

## Description
Passing below extra paramters to i18nify library to retain fraction digits in compact formatted value. 
```
minimumFractionDigits: 1,
trailingZeroDisplay: 'stripIfInteger',
```

For more detail on these attributes, refer to the [Intl API documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat). 

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
