### PR TITLE
fix(blade): phone number input dropdown not opening

### DIFF
--- a/.changeset/heavy-doors-impress.md
+++ b/.changeset/heavy-doors-impress.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): phone number input dropdown not opening

--- a/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.web.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.web.tsx
@@ -92,6 +92,13 @@ const CountrySelector = ({
           accessibilityLabel={`${countryNameFormatter.of(selectedCountry)} - Select Country`}
           icon={isDropdownOpen ? ChevronUpIcon : ChevronDownIcon}
           iconPosition="right"
+          // We need to prevent the click event from propagating to the BaseInputWrapper,
+          // Because the BaseInputWrapper is listening for click events to focus the input.
+          // We don't want that to happen when the user clicks on the dropdown button
+          // otherwise the dropdown will close immediately after opening
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
         >
           {/* @ts-expect-error */}
           <img


### PR DESCRIPTION
## Description

fixes #2136

With the #2119 PR we added an [onClick handler](https://github.com/razorpay/blade/pull/2119/files?file-filters%5B%5D=.ts&file-filters%5B%5D=.tsx&show-viewed-files=true#diff-ef9c43555213ed0ff62057f117703311509720acc1d187a6155e2e2f0c9f4d74R949-R953) to the BaseInputWrapper to be able to focus the input whenever user clicks on the Input wrapper. 


This caused the PhoneInput dropdown to fail like so: 

1. User clicks the PhoneInput
2. The Dropdown **actually** opens
3. But since the BaseInputWrapper also got clicked, the input got focused
4. Because input got focused the dropdown automatically closed (since dropdowns get closed once blurred)

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
