### PR TITLE
fix(StackblitzEditor): container alignment and minor ui fixes

### DIFF
--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -181,10 +181,10 @@ export const Logger = () => {
           right="spacing.0"
           padding="spacing.3"
           margin="spacing.4"
-          elevation="midRaised"
+          elevation="none"
           borderRadius="round"
           backgroundColor="surface.background.gray.moderate"
-          borderColor="surface.border.gray.normal"
+          borderColor="surface.border.gray.muted"
           display={showLogger ? 'inline-block' : 'none'}
         >
           <IconButton
@@ -202,14 +202,14 @@ export const Logger = () => {
           padding={['spacing.4', 'spacing.7']}
           overflow="auto"
           height="30vh"
-          elevation="highRaised"
+          elevation="midRaised"
           backgroundColor="surface.background.gray.intense"
           id="log-console"
           ref={consoleRef}
           display={showLogger ? 'block' : 'none'}
           textAlign="left"
           borderTopWidth="thin"
-          borderTopColor="surface.border.gray.normal"
+          borderTopColor="surface.border.gray.muted"
         />
       </Box>
     </>
@@ -279,7 +279,9 @@ root.render(
         display="flex"
         flexDirection="column"
       >
-        <App />
+        <Box>
+          <App />
+        </Box>
         ${showConsole ? '<Logger />' : ''}
       </Box>
     </BladeProvider>


### PR DESCRIPTION
## Description

The container had display="flex" so it was stretching our components to full width by default. Fixed it along with some minor UI fixes for borders of logger.

### Before
<img alt="image" src="https://github.com/razorpay/blade/assets/30949385/ea872f1b-8dbd-4164-ab25-61376c476b53"> 

### After
<img alt="image" src="https://github.com/razorpay/blade/assets/30949385/7780a7ba-dd96-4f63-9990-253aa2da8f21">

