### PR TITLE
chore: improve eslint performance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,11 @@ module.exports = {
     ],
     'react/display-name': 'off',
     'import/no-named-as-default': 'off',
-    'import/no-cycle': ['error', { maxDepth: '∞' }],
+    // Some bug with import/no-cycle where the ignoreExternal is not working as expected
+    // Setting ignoreExternal: true is slowing things down
+    // https://github.com/import-js/eslint-plugin-import/issues/2348
+    'import/no-cycle': ['error', { maxDepth: 4, ignoreExternal: false }],
+    'import/no-deprecated': 'off',
   },
   env: {
     browser: true,
@@ -132,7 +136,8 @@ module.exports = {
       plugins: ['@typescript-eslint', 'jsx-a11y', 'no-only-tests', 'blade'],
       rules: {
         'blade/no-cross-platform-imports': ['error', { ignoreImportsPattern: 'renderWithSSR' }],
-        'import/no-cycle': ['error', { maxDepth: '∞' }],
+        'import/no-cycle': ['error', { maxDepth: 4, ignoreExternal: false }],
+        'import/no-deprecated': 'off',
         'react/jsx-uses-react': 'off',
         'react/react-in-jsx-scope': 'off',
         'no-use-before-define': 'off',
@@ -190,6 +195,8 @@ module.exports = {
       files: ['**/*.stories.{ts,tsx}', '**/*.stories.internal.{ts,tsx}'],
       rules: {
         'react/display-name': ['off'],
+        'import/no-deprecated': 'off',
+        'import/no-cycle': 'off',
       },
     },
   ],


### PR DESCRIPTION
## Description

Eslint timing analysis before optimizations: 

Rule                                        | Time (ms) | Relative
:-------------------------------------------|----------:|--------:
import/no-cycle                             | 30863.247 |    49.3%
prettier/prettier                           | 10177.949 |    16.3%
import/no-deprecated                        |  6499.778 |    10.4%
@typescript-eslint/no-unused-vars           |  3014.236 |     4.8%
@typescript-eslint/no-floating-promises     |  1632.403 |     2.6%
@typescript-eslint/no-unnecessary-qualifier |  1472.390 |     2.4%
@typescript-eslint/no-misused-promises      |   932.970 |     1.5%
import/order                                |   644.840 |     1.0%
import/no-extraneous-dependencies           |   494.785 |     0.8%
react/default-props-match-prop-types        |   416.096 |     0.7%


- There's a [bug](https://github.com/import-js/eslint-plugin-import/issues/2348) in import/cycle where setting `ignoreExternal: true` causes the performance to tank, and also changed the maxDepth from infinity to 4, I think 4 is enough to detect any cycles. 
- Disabled `import/no-deprecated`, this rule is the 3rd most expensive rule that was being run. This rule isn't really useful for blade. 

--- 

**On average a 30s improvement.**

Before: ~2.30s

<img width="968" alt="image" src="https://github.com/razorpay/blade/assets/35374649/9e480ed7-e84d-4fa0-bdc5-9e23063146c4">

After: 2m

<img width="960" alt="image" src="https://github.com/razorpay/blade/assets/35374649/cf59e37e-40a5-458c-a597-e50125d6f36d">


Eslint timing analysis after optimizations: 

Rule                                        | Time (ms) | Relative
:-------------------------------------------|----------:|--------:
import/no-cycle                             | 14836.976 |    34.9%
prettier/prettier                           | 11104.337 |    26.1%
@typescript-eslint/no-unused-vars           |  3313.766 |     7.8%
@typescript-eslint/no-floating-promises     |  1712.215 |     4.0%
@typescript-eslint/no-unnecessary-qualifier |  1511.020 |     3.6%
import/order                                |  1191.725 |     2.8%
@typescript-eslint/no-misused-promises      |   920.061 |     2.2%
import/no-extraneous-dependencies           |   544.165 |     1.3%
react/no-unstable-nested-components         |   453.095 |     1.1%
react/default-props-match-prop-types        |   415.856 |     1.0%


## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
