### PR TITLE
fix(FileUpload): allow re-uploading the same file

### DIFF
--- a/.changeset/eight-mirrors-tap.md
+++ b/.changeset/eight-mirrors-tap.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(FileUpload): allow re-uploading of the same file

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -163,6 +163,9 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
       handleFilesChange(inputFiles);
       onChange?.({ name, fileList: allFiles });
     }
+
+    // Reset the input value to allow re-selecting the same file
+    event.target.value = '';
   };
 
   return (


### PR DESCRIPTION
## Description

> Uploading a file, deleting it and then re-uploading the same file again is not working for some reason. Can you please check.


[Reported on Slack](https://razorpay.slack.com/archives/C01H13RTF8V/p1716802715000079?thread_ts=1716802466.589119&cid=C01H13RTF8V)
<!-- Briefly explain the purpose of your PR -->

## Changes

https://github.com/razorpay/blade/assets/46647141/3d65a183-c83e-49d6-b514-37c05b6c9dc0


<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

https://stackoverflow.com/questions/4109276/how-to-detect-input-type-file-change-for-the-same-file

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
