### PR TITLE
feat(FileUpload): add `onReupload` prop in case of error state

### DIFF
--- a/.changeset/eight-elephants-grin.md
+++ b/.changeset/eight-elephants-grin.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-feat(FileUpload): error state UX enhancements
+feat(FileUpload): add `onReupload` prop to use in case of error state

--- a/.changeset/eight-elephants-grin.md
+++ b/.changeset/eight-elephants-grin.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(FileUpload): error state UX enhancements

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -313,10 +313,14 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
               setSelectedFiles(newFiles);
               inputRef.current?.click();
-              onRetry?.({ file: selectedFiles[0] });
+
               // TODO - Remove this in the next major release
-              // Fallback to onRemove to avoid breaking changes in the API
-              onRemove?.({ file: selectedFiles[0] });
+              // Fallback to onRemove if onRetry isn't provided to avoid breaking changes in the API
+              if (onRetry) {
+                onRetry({ file: selectedFiles[0] });
+              } else {
+                onRemove?.({ file: selectedFiles[0] });
+              }
             }}
             onDismiss={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
@@ -370,10 +374,13 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
                 setSelectedFiles(newFiles);
                 inputRef.current?.click();
-                onRetry?.({ file: selectedFiles[0] });
                 // TODO - Remove this in the next major release
-                // Fallback to onRemove to avoid breaking changes in the API
-                onRemove?.({ file: selectedFiles[0] });
+                // Fallback to onRemove if onRetry isn't provided to avoid breaking changes in the API
+                if (onRetry) {
+                  onRetry({ file: selectedFiles[0] });
+                } else {
+                  onRemove?.({ file: selectedFiles[0] });
+                }
               }}
               onDismiss={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -321,6 +321,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               } else {
                 onRemove?.({ file: selectedFiles[0] });
               }
+              setIsActive(false);
             }}
             onDismiss={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
@@ -381,6 +382,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                 } else {
                   onRemove?.({ file: selectedFiles[0] });
                 }
+                setIsActive(false);
               }}
               onDismiss={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, forwardRef } from 'react';
+import { useState, useCallback, useMemo, useRef, forwardRef } from 'react';
 import type { FileUploadProps, BladeFile, BladeFileList } from './types';
 import { StyledFileUploadWrapper } from './StyledFileUploadWrapper';
 import {
@@ -24,6 +24,7 @@ import type { BladeElementRef } from '~utils/types';
 import { getHintType } from '~components/Input/BaseInput/BaseInput';
 import { makeAccessible } from '~utils/makeAccessible';
 import { formHintLeftLabelMarginLeft } from '~components/Input/BaseInput/baseInputTokens';
+import { useMergeRefs } from '~utils/useMergeRefs';
 
 const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadProps> = (
   {
@@ -33,6 +34,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     onChange,
     onPreview,
     onRemove,
+    onRetry,
     onDismiss,
     onDrop,
     isDisabled,
@@ -53,6 +55,8 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
   },
   ref,
 ): React.ReactElement => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const mergedRef = useMergeRefs(ref, inputRef);
   const { platform } = useTheme();
   const [selectedFiles, setSelectedFiles] = useState<BladeFileList>(fileList ?? []);
   const [errorMessage, setErrorMessage] = useState(errorText);
@@ -262,7 +266,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                     onBlur: () => setIsActive(false),
                     ...accessibilityProps,
                   }}
-                  ref={ref}
+                  ref={mergedRef}
                 />
 
                 <Box
@@ -303,6 +307,15 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
             onRemove={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
               setSelectedFiles(newFiles);
+              onRemove?.({ file: selectedFiles[0] });
+            }}
+            onRetry={() => {
+              const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
+              setSelectedFiles(newFiles);
+              inputRef.current?.click();
+              onRetry?.({ file: selectedFiles[0] });
+              // TODO - Remove this in the next major release
+              // Fallback to onRemove to avoid breaking changes in the API
               onRemove?.({ file: selectedFiles[0] });
             }}
             onDismiss={() => {
@@ -352,6 +365,15 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
                 setSelectedFiles(newFiles);
                 onRemove?.({ file });
+              }}
+              onRetry={() => {
+                const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
+                setSelectedFiles(newFiles);
+                inputRef.current?.click();
+                onRetry?.({ file: selectedFiles[0] });
+                // TODO - Remove this in the next major release
+                // Fallback to onRemove to avoid breaking changes in the API
+                onRemove?.({ file: selectedFiles[0] });
               }}
               onDismiss={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -34,7 +34,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     onChange,
     onPreview,
     onRemove,
-    onRetry,
+    onReupload,
     onDismiss,
     onDrop,
     isDisabled,
@@ -309,15 +309,15 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               setSelectedFiles(newFiles);
               onRemove?.({ file: selectedFiles[0] });
             }}
-            onRetry={() => {
+            onReupload={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
               setSelectedFiles(newFiles);
               inputRef.current?.click();
 
               // TODO - Remove this in the next major release
-              // Fallback to onRemove if onRetry isn't provided to avoid breaking changes in the API
-              if (onRetry) {
-                onRetry({ file: selectedFiles[0] });
+              // Fallback to onRemove if onReupload isn't provided to avoid breaking changes in the API
+              if (onReupload) {
+                onReupload({ file: selectedFiles[0] });
               } else {
                 onRemove?.({ file: selectedFiles[0] });
               }
@@ -370,14 +370,14 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                 setSelectedFiles(newFiles);
                 onRemove?.({ file });
               }}
-              onRetry={() => {
+              onReupload={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
                 setSelectedFiles(newFiles);
                 inputRef.current?.click();
                 // TODO - Remove this in the next major release
-                // Fallback to onRemove if onRetry isn't provided to avoid breaking changes in the API
-                if (onRetry) {
-                  onRetry({ file: selectedFiles[0] });
+                // Fallback to onRemove if onReupload isn't provided to avoid breaking changes in the API
+                if (onReupload) {
+                  onReupload({ file: selectedFiles[0] });
                 } else {
                   onRemove?.({ file: selectedFiles[0] });
                 }

--- a/packages/blade/src/components/FileUpload/FileUploadItem.tsx
+++ b/packages/blade/src/components/FileUpload/FileUploadItem.tsx
@@ -2,23 +2,25 @@ import { memo } from 'react';
 import { StyledFileUploadItemWrapper } from './StyledFileUploadItemWrapper';
 import type { FileUploadItemProps } from './types';
 import { FileUploadItemIcon } from './FileUploadItemIcon';
-import { TrashIcon, EyeIcon, CloseIcon, CheckCircleIcon } from '~components/Icons';
+import { TrashIcon, EyeIcon, CloseIcon, CheckCircleIcon, RefreshIcon } from '~components/Icons';
 import { BaseBox } from '~components/Box/BaseBox';
 import { Text } from '~components/Typography';
 import { Divider } from '~components/Divider';
 import { IconButton } from '~components/Button/IconButton';
 import { ProgressBar } from '~components/ProgressBar';
 import isUndefined from '~utils/lodashButBetter/isUndefined';
+import { BaseLink } from '~components/Link/BaseLink';
 
 const FileUploadItem = memo(
   ({
     file,
     onPreview,
     onRemove,
+    onRetry,
     onDismiss,
     size: containerSize,
   }: FileUploadItemProps): React.ReactElement => {
-    const { name, size, uploadPercent, errorText, status } = file;
+    const { name, size, uploadPercent, errorText, errorCtaText, status } = file;
     const isUploading = status === 'uploading';
     const sizeInKB = size / 1024;
     const sizeInMB = sizeInKB / 1024;
@@ -73,13 +75,28 @@ const FileUploadItem = memo(
                   } ${isUploading && uploadPercent ? `(${uploadPercent}%)` : ''}`}
               </Text>
             </BaseBox>
-            {status === 'error' || status === 'uploading' ? (
+            {status === 'uploading' ? (
               <BaseBox>
                 <IconButton
                   accessibilityLabel="Remove File"
                   icon={CloseIcon}
                   onClick={() => onDismiss?.({ file })}
                 />
+              </BaseBox>
+            ) : status === 'error' ? (
+              <BaseBox display="flex" flexDirection="row" alignItems="center">
+                <BaseLink
+                  marginX="spacing.1"
+                  variant="button"
+                  icon={RefreshIcon}
+                  color="negative"
+                  size="small"
+                  onClick={() => {
+                    onRetry?.({ file });
+                  }}
+                >
+                  {errorCtaText ?? 'Retry'}
+                </BaseLink>
               </BaseBox>
             ) : (
               <BaseBox display="flex" flexDirection="row" alignItems="center">

--- a/packages/blade/src/components/FileUpload/FileUploadItem.tsx
+++ b/packages/blade/src/components/FileUpload/FileUploadItem.tsx
@@ -16,11 +16,11 @@ const FileUploadItem = memo(
     file,
     onPreview,
     onRemove,
-    onRetry,
+    onReupload,
     onDismiss,
     size: containerSize,
   }: FileUploadItemProps): React.ReactElement => {
-    const { name, size, uploadPercent, errorText, errorCtaText, status } = file;
+    const { name, size, uploadPercent, errorText, status } = file;
     const isUploading = status === 'uploading';
     const sizeInKB = size / 1024;
     const sizeInMB = sizeInKB / 1024;
@@ -92,10 +92,10 @@ const FileUploadItem = memo(
                   color="negative"
                   size="small"
                   onClick={() => {
-                    onRetry?.({ file });
+                    onReupload?.({ file });
                   }}
                 >
-                  {errorCtaText ?? 'Retry'}
+                  Re-upload
                 </BaseLink>
               </BaseBox>
             ) : (

--- a/packages/blade/src/components/FileUpload/StyledFileUploadItemWrapper.tsx
+++ b/packages/blade/src/components/FileUpload/StyledFileUploadItemWrapper.tsx
@@ -23,7 +23,7 @@ const StyledFileUploadItemWrapper = styled(BaseBox)<StyledFileUploadItemWrapperP
       display: 'flex',
       justifyContent: 'space-between',
       borderStyle: 'solid',
-      height: makeSize(fileUploadHeightTokens[size]),
+      minHeight: makeSize(fileUploadHeightTokens[size]),
       width: '100%',
       backgroundColor: getIn(theme.colors, fileUploadItemBackgroundColors[status].default),
       transitionProperty: 'background-color',

--- a/packages/blade/src/components/FileUpload/types.ts
+++ b/packages/blade/src/components/FileUpload/types.ts
@@ -18,6 +18,10 @@ interface BladeFile extends File {
    * Text indicating an error state
    */
   errorText?: string;
+  /**
+   * Text for the error call to action
+   */
+  errorCtaText?: string;
 }
 
 type BladeFileList = BladeFile[];
@@ -81,6 +85,10 @@ type FileUploadCommonProps = {
    * Callback function triggered when a file is removed
    */
   onRemove?: ({ file }: { file: File }) => void;
+  /**
+   * Callback function triggered when a file upload is retried
+   */
+  onRetry?: ({ file }: { file: File }) => void;
   /**
    * Callback function triggered when a file upload is dismissed
    */
@@ -146,7 +154,7 @@ type FileUploadProps = (FileUploadPropsWithA11yLabel | FileUploadPropsWithLabel)
 
 type FileUploadItemProps = Pick<
   FileUploadProps,
-  'onPreview' | 'onRemove' | 'onDismiss' | 'size'
+  'onPreview' | 'onRemove' | 'onDismiss' | 'onRetry' | 'size'
 > & {
   file: BladeFile;
 };

--- a/packages/blade/src/components/FileUpload/types.ts
+++ b/packages/blade/src/components/FileUpload/types.ts
@@ -18,10 +18,6 @@ interface BladeFile extends File {
    * Text indicating an error state
    */
   errorText?: string;
-  /**
-   * Text for the error call to action
-   */
-  errorCtaText?: string;
 }
 
 type BladeFileList = BladeFile[];
@@ -88,7 +84,7 @@ type FileUploadCommonProps = {
   /**
    * Callback function triggered when a file upload is retried
    */
-  onRetry?: ({ file }: { file: File }) => void;
+  onReupload?: ({ file }: { file: File }) => void;
   /**
    * Callback function triggered when a file upload is dismissed
    */
@@ -154,7 +150,7 @@ type FileUploadProps = (FileUploadPropsWithA11yLabel | FileUploadPropsWithLabel)
 
 type FileUploadItemProps = Pick<
   FileUploadProps,
-  'onPreview' | 'onRemove' | 'onDismiss' | 'onRetry' | 'size'
+  'onPreview' | 'onRemove' | 'onDismiss' | 'onReupload' | 'size'
 > & {
   file: BladeFile;
 };


### PR DESCRIPTION
## Description

- [Slack thread](https://razorpay.slack.com/archives/CMQ3RBHEU/p1715935302377269?thread_ts=1715935039.903429&cid=CMQ3RBHEU)
- Added `onReupload` prop, to be used in case of error state.


<!-- Briefly explain the purpose of your PR -->

## Changes

https://github.com/razorpay/blade/assets/46647141/84f911c1-ae77-4c71-bf38-9a2a840cf1e3



<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
