### PR TITLE
fix(FileUpload): correctly udpate state in controlled mode

### DIFF
--- a/.changeset/fifty-cougars-fry.md
+++ b/.changeset/fifty-cougars-fry.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(FileUpload): correctly udpate state in controlled mode

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -25,6 +25,7 @@ import { getHintType } from '~components/Input/BaseInput/BaseInput';
 import { makeAccessible } from '~utils/makeAccessible';
 import { formHintLeftLabelMarginLeft } from '~components/Input/BaseInput/baseInputTokens';
 import { useMergeRefs } from '~utils/useMergeRefs';
+import { useControllableState } from '~utils/useControllable';
 
 const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadProps> = (
   {
@@ -58,7 +59,10 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
   const inputRef = useRef<HTMLInputElement | null>(null);
   const mergedRef = useMergeRefs(ref, inputRef);
   const { platform } = useTheme();
-  const [selectedFiles, setSelectedFiles] = useState<BladeFileList>(fileList ?? []);
+  const [selectedFiles, setSelectedFiles] = useControllableState({
+    value: fileList,
+    defaultValue: fileList ?? [],
+  });
   const [errorMessage, setErrorMessage] = useState(errorText);
   const [internalValidationState, setInternalValidationState] = useState('none');
   const [isActive, setIsActive] = useState(false);
@@ -81,11 +85,6 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     disabled: Boolean(isDisabled),
     describedBy: labelId,
   });
-
-  // Update selectedFiles when fileList prop changes in controlled mode
-  useMemo(() => {
-    setSelectedFiles(fileList ?? []);
-  }, [fileList]);
 
   // In control mode attach a unique id to each file if not provided
   useMemo(() => {

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -82,6 +82,11 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     describedBy: labelId,
   });
 
+  // Update selectedFiles when fileList prop changes in controlled mode
+  useMemo(() => {
+    setSelectedFiles(fileList ?? []);
+  }, [fileList]);
+
   // In control mode attach a unique id to each file if not provided
   useMemo(() => {
     for (const file of selectedFiles) {

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -305,12 +305,12 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
             size={size}
             onRemove={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
-              setSelectedFiles(newFiles);
+              setSelectedFiles(() => newFiles);
               onRemove?.({ file: selectedFiles[0] });
             }}
             onReupload={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
-              setSelectedFiles(newFiles);
+              setSelectedFiles(() => newFiles);
               inputRef.current?.click();
 
               // TODO - Remove this in the next major release
@@ -324,7 +324,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
             }}
             onDismiss={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
-              setSelectedFiles(newFiles);
+              setSelectedFiles(() => newFiles);
               onDismiss?.({ file: selectedFiles[0] });
             }}
             onPreview={onPreview}
@@ -366,12 +366,12 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               size={size}
               onRemove={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
-                setSelectedFiles(newFiles);
+                setSelectedFiles(() => newFiles);
                 onRemove?.({ file });
               }}
               onReupload={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
-                setSelectedFiles(newFiles);
+                setSelectedFiles(() => newFiles);
                 inputRef.current?.click();
                 // TODO - Remove this in the next major release
                 // Fallback to onRemove if onReupload isn't provided to avoid breaking changes in the API
@@ -384,7 +384,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               }}
               onDismiss={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
-                setSelectedFiles(newFiles);
+                setSelectedFiles(() => newFiles);
                 onDismiss?.({ file });
               }}
               onPreview={onPreview}

--- a/packages/blade/src/components/FileUpload/__tests__/__snapshots__/FileUpload.web.test.tsx.snap
+++ b/packages/blade/src/components/FileUpload/__tests__/__snapshots__/FileUpload.web.test.tsx.snap
@@ -1487,7 +1487,7 @@ exports[`<FileUpload /> should set disabled state with isDisabled 1`] = `
     >
       <span
         data-blade-component="form-label"
-        id="fileuploadinput-25-label-30"
+        id="fileuploadinput-31-label-36"
         style="width: auto; flex-shrink: 0; margin-right: 0px;"
       >
         <div
@@ -1545,13 +1545,13 @@ exports[`<FileUpload /> should set disabled state with isDisabled 1`] = `
               </p>
               <input
                 accept="image/*"
-                aria-describedby="fileuploadinput-25-label-30"
+                aria-describedby="fileuploadinput-31-label-36"
                 aria-disabled="true"
                 aria-invalid="false"
                 aria-required="false"
                 class="c12"
                 disabled=""
-                id="fileuploadinput-25-input-26"
+                id="fileuploadinput-31-input-32"
                 name="single-file-upload-input"
                 type="file"
               />
@@ -1587,7 +1587,7 @@ exports[`<FileUpload /> should set disabled state with isDisabled 1`] = `
         <div
           class="c18"
           data-blade-component="base-box"
-          id="fileuploadinput-25-helptext-28"
+          id="fileuploadinput-31-helptext-34"
         >
           <span
             class="c19"

--- a/packages/blade/src/components/FileUpload/__tests__/__snapshots__/FileUpload.web.test.tsx.snap
+++ b/packages/blade/src/components/FileUpload/__tests__/__snapshots__/FileUpload.web.test.tsx.snap
@@ -1487,7 +1487,7 @@ exports[`<FileUpload /> should set disabled state with isDisabled 1`] = `
     >
       <span
         data-blade-component="form-label"
-        id="fileuploadinput-31-label-36"
+        id="fileuploadinput-25-label-30"
         style="width: auto; flex-shrink: 0; margin-right: 0px;"
       >
         <div
@@ -1545,13 +1545,13 @@ exports[`<FileUpload /> should set disabled state with isDisabled 1`] = `
               </p>
               <input
                 accept="image/*"
-                aria-describedby="fileuploadinput-31-label-36"
+                aria-describedby="fileuploadinput-25-label-30"
                 aria-disabled="true"
                 aria-invalid="false"
                 aria-required="false"
                 class="c12"
                 disabled=""
-                id="fileuploadinput-31-input-32"
+                id="fileuploadinput-25-input-26"
                 name="single-file-upload-input"
                 type="file"
               />
@@ -1587,7 +1587,7 @@ exports[`<FileUpload /> should set disabled state with isDisabled 1`] = `
         <div
           class="c18"
           data-blade-component="base-box"
-          id="fileuploadinput-31-helptext-34"
+          id="fileuploadinput-25-helptext-28"
         >
           <span
             class="c19"


### PR DESCRIPTION
## Description

- [Reported on slack.](https://razorpay.slack.com/archives/C01H13RTF8V/p1719212583215179?thread_ts=1719209184.597759&cid=C01H13RTF8V).

- Please check [this](https://stackblitz.com/edit/kr8qdz?file=App.tsx) link for repro.

<!-- Briefly explain the purpose of your PR -->

## Changes


https://github.com/razorpay/blade/assets/46647141/2643a592-15d9-41a0-83c3-4f515d1ac8c7




<!-- List the specific changes made, consider adding screenshots if relevant -->
