### PR TITLE
table selected ids 

### DIFF
--- a/packages/blade/src/components/Table/docs/APIStories/TableAPI.stories.tsx
+++ b/packages/blade/src/components/Table/docs/APIStories/TableAPI.stories.tsx
@@ -139,6 +139,8 @@ const TableTemplate: StoryFn<typeof TableComponent> = ({ ...args }) => {
           METHOD: (array) => array.sort((a, b) => a.method.localeCompare(b.method)),
           STATUS: (array) => array.sort((a, b) => a.status.localeCompare(b.status)),
         }}
+        selectedIds={['1', '2']}
+        defaultSelectedIds={['3', '4']}
       >
         {(tableData) => (
           <>


### PR DESCRIPTION

Add programmatic control for the selection state in the `Table` component.

* **Table Component (`packages/blade/src/components/Table/Table.web.tsx`):**
  - Add new props `selectedIds` and `defaultSelectedIds` to the `Table` component.
  - Use the `useControllableState` hook to manage the controlled and uncontrolled selection state.
  - Update the `onSelectChange` function to set the selected rows without calling `onSelectionChange` directly.
  - Update the `Table` component to use the `selectedIds` prop for managing selection state.

* **API Stories (`packages/blade/src/components/Table/docs/APIStories/TableAPI.stories.tsx`):**
  - Add examples of using the `selectedIds` and `defaultSelectedIds` props in the `Table` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/razorpay/blade/issues/2316?shareId=fa5a2381-0c94-4b16-aaef-c59082ef92b5).