### PR TITLE
chore: keep the prerequisite accordion open

### DIFF
--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -38,7 +38,7 @@ Before you install the package, make sure that you have performed the following 
   </ListItem>
 </List>
 
-<Accordion maxWidth="100%" variant="filled">
+<Accordion maxWidth="100%" variant="filled" defaultExpandedIndex={0}>
   <AccordionItem>
     <AccordionItemHeader><Text size="small">Razorpay Employees have to point @razorpay scope to GitHub Package Registry. Follow the steps below</Text></AccordionItemHeader>
     <AccordionItemBody>


### PR DESCRIPTION
## Description

Accordion says "follow steps below" and we expect people to click on it to expand but there are other setup steps after the accordion which may lead to confusion and people not expanding the accordion

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
