### PR TITLE
fix(blade): Table cell text truncation

### DIFF
--- a/.changeset/yellow-avocados-brake.md
+++ b/.changeset/yellow-avocados-brake.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): Table cell text truncation

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -214,7 +214,7 @@ const _TableCell = ({ children }: TableCellProps): React.ReactElement => {
           // for custom cells components, consumers can handle pointer events themselves
           pointerEvents={isChildrenString && isSelectable ? 'none' : 'auto'}
           // allow text to wrap, so that if the <Text> overflows it can truncate
-          whiteSpace={isChildrenString ? 'normal' : 'unset'}
+          whiteSpace="normal"
         >
           {isChildrenString ? (
             <Text size="medium" truncateAfterLines={1}>

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -162,10 +162,10 @@ export const StyledCell = styled(Cell)<{
 }));
 
 export const CellWrapper = styled(BaseBox)<{
-  rowDensity: NonNullable<TableProps<unknown>['rowDensity']>;
+  $rowDensity: NonNullable<TableProps<unknown>['rowDensity']>;
   showStripedRows?: boolean;
   hasPadding?: boolean;
-}>(({ theme, rowDensity, showStripedRows, hasPadding = true }) => {
+}>(({ theme, $rowDensity, showStripedRows, hasPadding = true }) => {
   const rowBackgroundTransition = `background-color ${makeMotionTime(
     getIn(theme.motion, tableRow.backgroundColorMotionDuration),
   )} ${getIn(theme.motion, tableRow.backgroundColorMotionEasing)}`;
@@ -174,9 +174,11 @@ export const CellWrapper = styled(BaseBox)<{
     '&&&': {
       transition: rowBackgroundTransition,
       backgroundColor: tableRow.nonStripeWrapper.backgroundColor,
-      paddingLeft: hasPadding ? makeSpace(getIn(theme, tableRow.paddingLeft[rowDensity])) : '0px',
-      paddingRight: hasPadding ? makeSpace(getIn(theme, tableRow.paddingRight[rowDensity])) : '0px',
-      minHeight: makeSize(getIn(size, tableRow.minHeight[rowDensity])),
+      paddingLeft: hasPadding ? makeSpace(getIn(theme, tableRow.paddingLeft[$rowDensity])) : '0px',
+      paddingRight: hasPadding
+        ? makeSpace(getIn(theme, tableRow.paddingRight[$rowDensity]))
+        : '0px',
+      minHeight: makeSize(getIn(size, tableRow.minHeight[$rowDensity])),
       height: '100%',
       width: '100%',
       ...(!showStripedRows && {
@@ -203,7 +205,7 @@ const _TableCell = ({ children }: TableCellProps): React.ReactElement => {
       <BaseBox className="cell-wrapper-base" display="flex" alignItems="center" height="100%">
         <CellWrapper
           className="cell-wrapper"
-          rowDensity={rowDensity}
+          $rowDensity={rowDensity}
           showStripedRows={showStripedRows}
           display="flex"
           alignItems="center"
@@ -211,8 +213,16 @@ const _TableCell = ({ children }: TableCellProps): React.ReactElement => {
           // when a direct string child is passed we want to disable pointer events
           // for custom cells components, consumers can handle pointer events themselves
           pointerEvents={isChildrenString && isSelectable ? 'none' : 'auto'}
+          // allow text to wrap, so that if the <Text> overflows it can truncate
+          whiteSpace={isChildrenString ? 'normal' : 'unset'}
         >
-          {isChildrenString ? <Text size="medium">{children}</Text> : children}
+          {isChildrenString ? (
+            <Text size="medium" truncateAfterLines={1}>
+              {children}
+            </Text>
+          ) : (
+            children
+          )}
         </CellWrapper>
       </BaseBox>
     </StyledCell>

--- a/packages/blade/src/components/Table/TableEditableCell.web.tsx
+++ b/packages/blade/src/components/Table/TableEditableCell.web.tsx
@@ -20,12 +20,12 @@ import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { Dropdown } from '~components/Dropdown';
 
 const StyledEditableCell = styled(StyledCell)<{
-  rowDensity: NonNullable<TableProps<unknown>['rowDensity']>;
-}>(({ theme, rowDensity }) => ({
+  $rowDensity: NonNullable<TableProps<unknown>['rowDensity']>;
+}>(({ theme, $rowDensity }) => ({
   '&&&': {
     '&:focus-visible': { outline: '1px solid' },
     '&:focus-within': {
-      ...(rowDensity !== 'comfortable' ? getFocusRingStyles({ theme, negativeOffset: true }) : {}),
+      ...($rowDensity !== 'comfortable' ? getFocusRingStyles({ theme, negativeOffset: true }) : {}),
     },
   },
 }));
@@ -75,13 +75,13 @@ const _TableEditableCell = ({
     <StyledEditableCell
       role="cell"
       $backgroundColor={backgroundColor}
-      rowDensity={rowDensity}
+      $rowDensity={rowDensity}
       {...metaAttribute({ name: MetaConstants.TableCell })}
     >
       <BaseBox className="cell-wrapper-base" display="flex" alignItems="center" height="100%">
         <CellWrapper
           className="cell-wrapper"
-          rowDensity={rowDensity}
+          $rowDensity={rowDensity}
           showStripedRows={showStripedRows}
           display="flex"
           alignItems="center"
@@ -140,7 +140,7 @@ const TableEditableDropdownCell = (
       <StyledEditableCell
         role="cell"
         $backgroundColor={backgroundColor}
-        rowDensity={rowDensity}
+        $rowDensity={rowDensity}
         {...metaAttribute({ name: MetaConstants.TableCell })}
       >
         <BaseBox
@@ -152,7 +152,7 @@ const TableEditableDropdownCell = (
         >
           <CellWrapper
             className="cell-wrapper"
-            rowDensity={rowDensity}
+            $rowDensity={rowDensity}
             showStripedRows={showStripedRows}
             display="flex"
             alignItems="center"

--- a/packages/blade/src/components/Table/__tests__/__snapshots__/Table.web.test.tsx.snap
+++ b/packages/blade/src/components/Table/__tests__/__snapshots__/Table.web.test.tsx.snap
@@ -70,22 +70,6 @@ exports[`<Table /> should render table 1`] = `
   pointer-events: auto;
 }
 
-.c17.c17.c17.c17.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  white-space: unset;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  pointer-events: auto;
-}
-
 .c5.c5.c5.c5.c5 {
   color: hsla(211,26%,34%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
@@ -228,19 +212,19 @@ exports[`<Table /> should render table 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 {
+.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 tr:last-child th {
+.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 tr:last-child th {
   border-bottom: none;
 }
 
-.c19.c19.c19.c19.c19 th:last-child {
+.c18.c18.c18.c18.c18 th:last-child {
   border-right: none;
 }
 
-.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20 {
+.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -251,7 +235,7 @@ exports[`<Table /> should render table 1`] = `
   border-top-style: solid;
 }
 
-.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20 > div {
+.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -355,36 +339,6 @@ exports[`<Table /> should render table 1`] = `
 
 @media screen and (min-width:1200px) {
   .c14.c14.c14.c14.c14 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:320px) {
-  .c17.c17.c17.c17.c17 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:480px) {
-  .c17.c17.c17.c17.c17 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c17.c17.c17.c17.c17 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c17.c17.c17.c17.c17 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1200px) {
-  .c17.c17.c17.c17.c17 {
     pointer-events: auto;
   }
 }
@@ -601,7 +555,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c17 c15 cell-wrapper"
+                  class="c14 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -766,7 +720,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c17 c15 cell-wrapper"
+                  class="c14 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -931,7 +885,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c17 c15 cell-wrapper"
+                  class="c14 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -1096,7 +1050,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c17 c15 cell-wrapper"
+                  class="c14 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -1261,7 +1215,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c17 c15 cell-wrapper"
+                  class="c14 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -1381,18 +1335,18 @@ exports[`<Table /> should render table 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c18 css-1a28xfp-Header"
+        class="c17 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c19 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c18 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1409,7 +1363,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1426,7 +1380,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1443,7 +1397,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1460,7 +1414,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1477,7 +1431,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -2845,22 +2799,6 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   pointer-events: auto;
 }
 
-.c12.c12.c12.c12.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  white-space: unset;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  pointer-events: auto;
-}
-
 .c4.c4.c4.c4.c4 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
@@ -2986,19 +2924,19 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
+.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
+.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 tr:last-child th {
   border-bottom: none;
 }
 
-.c14.c14.c14.c14.c14 th:last-child {
+.c13.c13.c13.c13.c13 th:last-child {
   border-right: none;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -3009,7 +2947,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   border-top-style: solid;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -3108,36 +3046,6 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
 
 @media screen and (min-width:1200px) {
   .c9.c9.c9.c9.c9 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:320px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:480px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1200px) {
-  .c12.c12.c12.c12.c12 {
     pointer-events: auto;
   }
 }
@@ -3328,7 +3236,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12 c10 cell-wrapper"
+                  class="c9 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -3493,7 +3401,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12 c10 cell-wrapper"
+                  class="c9 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -3613,18 +3521,18 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c13 css-1a28xfp-Header"
+        class="c12 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c13 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3641,7 +3549,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3658,7 +3566,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3675,7 +3583,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3692,7 +3600,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3709,7 +3617,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3768,22 +3676,6 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   pointer-events: auto;
 }
 
-.c12.c12.c12.c12.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  white-space: unset;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  pointer-events: auto;
-}
-
 .c4.c4.c4.c4.c4 {
   color: hsla(212,39%,16%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
@@ -3909,19 +3801,19 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
+.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
+.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 tr:last-child th {
   border-bottom: none;
 }
 
-.c14.c14.c14.c14.c14 th:last-child {
+.c13.c13.c13.c13.c13 th:last-child {
   border-right: none;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -3932,7 +3824,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   border-top-style: solid;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -4031,36 +3923,6 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
 
 @media screen and (min-width:1200px) {
   .c9.c9.c9.c9.c9 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:320px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:480px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1200px) {
-  .c12.c12.c12.c12.c12 {
     pointer-events: auto;
   }
 }
@@ -4251,7 +4113,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12 c10 cell-wrapper"
+                  class="c9 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -4416,7 +4278,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12 c10 cell-wrapper"
+                  class="c9 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -4536,18 +4398,18 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c13 css-1a28xfp-Header"
+        class="c12 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c13 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4564,7 +4426,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4581,7 +4443,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4598,7 +4460,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4615,7 +4477,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4632,7 +4494,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4823,22 +4685,6 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   pointer-events: auto;
 }
 
-.c16.c16.c16.c16.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  white-space: unset;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  pointer-events: auto;
-}
-
 .c4.c4.c4.c4.c4 {
   padding: 1px;
   width: -webkit-max-content;
@@ -4983,19 +4829,19 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 {
+.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 tr:last-child th {
+.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 tr:last-child th {
   border-bottom: none;
 }
 
-.c18.c18.c18.c18.c18 th:last-child {
+.c17.c17.c17.c17.c17 th:last-child {
   border-right: none;
 }
 
-.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 {
+.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -5006,7 +4852,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   border-top-style: solid;
 }
 
-.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 > div {
+.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -5105,36 +4951,6 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
 
 @media screen and (min-width:1200px) {
   .c13.c13.c13.c13.c13 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:320px) {
-  .c16.c16.c16.c16.c16 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:480px) {
-  .c16.c16.c16.c16.c16 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c16.c16.c16.c16.c16 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c16.c16.c16.c16.c16 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1200px) {
-  .c16.c16.c16.c16.c16 {
     pointer-events: auto;
   }
 }
@@ -5373,7 +5189,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c16 c14 cell-wrapper"
+                  class="c13 c14 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -5538,7 +5354,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c16 c14 cell-wrapper"
+                  class="c13 c14 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -5658,18 +5474,18 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c17 css-1a28xfp-Header"
+        class="c16 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c18 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c17 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5686,7 +5502,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5703,7 +5519,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5720,7 +5536,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5737,7 +5553,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5754,7 +5570,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5803,22 +5619,6 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   display: -ms-flexbox;
   display: flex;
   white-space: normal;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  pointer-events: auto;
-}
-
-.c12.c12.c12.c12.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -5959,19 +5759,19 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
+.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
+.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 tr:last-child th {
   border-bottom: none;
 }
 
-.c14.c14.c14.c14.c14 th:last-child {
+.c13.c13.c13.c13.c13 th:last-child {
   border-right: none;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -5982,7 +5782,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   border-top-style: solid;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -6081,36 +5881,6 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
 
 @media screen and (min-width:1200px) {
   .c9.c9.c9.c9.c9 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:320px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:480px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c12.c12.c12.c12.c12 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1200px) {
-  .c12.c12.c12.c12.c12 {
     pointer-events: auto;
   }
 }
@@ -6301,7 +6071,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12 c10 cell-wrapper"
+                  class="c9 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -6466,7 +6236,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c12 c10 cell-wrapper"
+                  class="c9 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -6586,18 +6356,18 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c13 css-1a28xfp-Header"
+        class="c12 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c13 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6614,7 +6384,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6631,7 +6401,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6648,7 +6418,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6665,7 +6435,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6682,7 +6452,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6731,22 +6501,6 @@ exports[`<Table /> should render table with sticky header, footer & first column
   display: -ms-flexbox;
   display: flex;
   white-space: normal;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  pointer-events: auto;
-}
-
-.c13.c13.c13.c13.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -6886,19 +6640,19 @@ exports[`<Table /> should render table with sticky header, footer & first column
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 tr:last-child th {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
   border-bottom: none;
 }
 
-.c15.c15.c15.c15.c15 th:last-child {
+.c14.c14.c14.c14.c14 th:last-child {
   border-right: none;
 }
 
-.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -6909,7 +6663,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
   border-top-style: solid;
 }
 
-.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 > div {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -7008,36 +6762,6 @@ exports[`<Table /> should render table with sticky header, footer & first column
 
 @media screen and (min-width:1200px) {
   .c10.c10.c10.c10.c10 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:320px) {
-  .c13.c13.c13.c13.c13 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:480px) {
-  .c13.c13.c13.c13.c13 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c13.c13.c13.c13.c13 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c13.c13.c13.c13.c13 {
-    pointer-events: auto;
-  }
-}
-
-@media screen and (min-width:1200px) {
-  .c13.c13.c13.c13.c13 {
     pointer-events: auto;
   }
 }
@@ -7228,7 +6952,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7393,7 +7117,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7558,7 +7282,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7723,7 +7447,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7888,7 +7612,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8053,7 +7777,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8218,7 +7942,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8383,7 +8107,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8548,7 +8272,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8713,7 +8437,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c11 cell-wrapper"
+                  class="c10 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8833,18 +8557,18 @@ exports[`<Table /> should render table with sticky header, footer & first column
         </tr>
       </tbody>
       <tfoot
-        class="c14 css-1a28xfp-Header"
+        class="c13 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c15 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8861,7 +8585,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8878,7 +8602,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8895,7 +8619,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8912,7 +8636,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8929,7 +8653,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"

--- a/packages/blade/src/components/Table/__tests__/__snapshots__/Table.web.test.tsx.snap
+++ b/packages/blade/src/components/Table/__tests__/__snapshots__/Table.web.test.tsx.snap
@@ -59,6 +59,23 @@ exports[`<Table /> should render table 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.c17.c17.c17.c17.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -118,6 +135,12 @@ exports[`<Table /> should render table 1`] = `
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c10.c10.c10.c10.c10.c10.c10.c10.c10.c10.c10.c10.c10.c10.c10 {
@@ -205,19 +228,19 @@ exports[`<Table /> should render table 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 {
+.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 tr:last-child th {
+.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 tr:last-child th {
   border-bottom: none;
 }
 
-.c18.c18.c18.c18.c18 th:last-child {
+.c19.c19.c19.c19.c19 th:last-child {
   border-right: none;
 }
 
-.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 {
+.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -228,7 +251,7 @@ exports[`<Table /> should render table 1`] = `
   border-top-style: solid;
 }
 
-.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 > div {
+.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20.c20 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -332,6 +355,36 @@ exports[`<Table /> should render table 1`] = `
 
 @media screen and (min-width:1200px) {
   .c14.c14.c14.c14.c14 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c17.c17.c17.c17.c17 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c17.c17.c17.c17.c17 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c17.c17.c17.c17.c17 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c17.c17.c17.c17.c17 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c17.c17.c17.c17.c17 {
     pointer-events: auto;
   }
 }
@@ -548,7 +601,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c14 c15 cell-wrapper"
+                  class="c17 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -713,7 +766,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c14 c15 cell-wrapper"
+                  class="c17 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -878,7 +931,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c14 c15 cell-wrapper"
+                  class="c17 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -1043,7 +1096,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c14 c15 cell-wrapper"
+                  class="c17 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -1208,7 +1261,7 @@ exports[`<Table /> should render table 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c14 c15 cell-wrapper"
+                  class="c17 c15 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -1328,18 +1381,18 @@ exports[`<Table /> should render table 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c17 css-1a28xfp-Header"
+        class="c18 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c18 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c19 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1356,7 +1409,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1373,7 +1426,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1390,7 +1443,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1407,7 +1460,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1424,7 +1477,7 @@ exports[`<Table /> should render table 1`] = `
             </div>
           </th>
           <th
-            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c20 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -1506,6 +1559,7 @@ exports[`<Table /> should render table with TableEditableCell and Bordered cells
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -1592,6 +1646,12 @@ exports[`<Table /> should render table with TableEditableCell and Bordered cells
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c2.c2.c2.c2.c2 {
@@ -2267,7 +2327,6 @@ exports[`<Table /> should render table with TableEditableCell and Bordered cells
             data-blade-component="table-cell"
             data-table-library_td=""
             role="cell"
-            rowdensity="normal"
           >
             <div>
               <div
@@ -2468,7 +2527,6 @@ exports[`<Table /> should render table with TableEditableCell and Bordered cells
             data-blade-component="table-cell"
             data-table-library_td=""
             role="cell"
-            rowdensity="normal"
           >
             <div>
               <div
@@ -2776,6 +2834,23 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.c12.c12.c12.c12.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -2818,6 +2893,12 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5 {
@@ -2905,19 +2986,19 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 tr:last-child th {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
   border-bottom: none;
 }
 
-.c13.c13.c13.c13.c13 th:last-child {
+.c14.c14.c14.c14.c14 th:last-child {
   border-right: none;
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -2928,7 +3009,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
   border-top-style: solid;
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 > div {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -3027,6 +3108,36 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
 
 @media screen and (min-width:1200px) {
   .c9.c9.c9.c9.c9 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c12.c12.c12.c12.c12 {
     pointer-events: auto;
   }
 }
@@ -3217,7 +3328,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c9 c10 cell-wrapper"
+                  class="c12 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -3382,7 +3493,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c9 c10 cell-wrapper"
+                  class="c12 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -3502,18 +3613,18 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c12 css-1a28xfp-Header"
+        class="c13 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c13 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3530,7 +3641,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3547,7 +3658,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3564,7 +3675,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3581,7 +3692,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3598,7 +3709,7 @@ exports[`<Table /> should render table with comfortable rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -3646,6 +3757,23 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.c12.c12.c12.c12.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -3688,6 +3816,12 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5 {
@@ -3775,19 +3909,19 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 tr:last-child th {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
   border-bottom: none;
 }
 
-.c13.c13.c13.c13.c13 th:last-child {
+.c14.c14.c14.c14.c14 th:last-child {
   border-right: none;
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -3798,7 +3932,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
   border-top-style: solid;
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 > div {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -3897,6 +4031,36 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
 
 @media screen and (min-width:1200px) {
   .c9.c9.c9.c9.c9 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c12.c12.c12.c12.c12 {
     pointer-events: auto;
   }
 }
@@ -4087,7 +4251,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c9 c10 cell-wrapper"
+                  class="c12 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -4252,7 +4416,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c9 c10 cell-wrapper"
+                  class="c12 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -4372,18 +4536,18 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c12 css-1a28xfp-Header"
+        class="c13 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c13 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4400,7 +4564,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4417,7 +4581,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4434,7 +4598,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4451,7 +4615,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4468,7 +4632,7 @@ exports[`<Table /> should render table with compact rowDensity 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -4648,6 +4812,23 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.c16.c16.c16.c16.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -4703,6 +4884,12 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c2.c2.c2.c2.c2 {
@@ -4796,19 +4983,19 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 {
+.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 tr:last-child th {
+.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17.c17 tr:last-child th {
   border-bottom: none;
 }
 
-.c17.c17.c17.c17.c17 th:last-child {
+.c18.c18.c18.c18.c18 th:last-child {
   border-right: none;
 }
 
-.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 {
+.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -4819,7 +5006,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
   border-top-style: solid;
 }
 
-.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18.c18 > div {
+.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19.c19 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -4918,6 +5105,36 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
 
 @media screen and (min-width:1200px) {
   .c13.c13.c13.c13.c13 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c16.c16.c16.c16.c16 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c16.c16.c16.c16.c16 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c16.c16.c16.c16.c16 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c16.c16.c16.c16.c16 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c16.c16.c16.c16.c16 {
     pointer-events: auto;
   }
 }
@@ -5156,7 +5373,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c14 cell-wrapper"
+                  class="c16 c14 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -5321,7 +5538,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c13 c14 cell-wrapper"
+                  class="c16 c14 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -5441,18 +5658,18 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c16 css-1a28xfp-Header"
+        class="c17 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c17 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c18 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5469,7 +5686,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5486,7 +5703,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5503,7 +5720,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5520,7 +5737,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5537,7 +5754,7 @@ exports[`<Table /> should render table with isRefreshing 1`] = `
             </div>
           </th>
           <th
-            class="th c18 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c19 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -5585,6 +5802,23 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.c12.c12.c12.c12.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -5627,6 +5861,12 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5.c5 {
@@ -5719,19 +5959,19 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12.c12 tr:last-child th {
+.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
   border-bottom: none;
 }
 
-.c13.c13.c13.c13.c13 th:last-child {
+.c14.c14.c14.c14.c14 th:last-child {
   border-right: none;
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -5742,7 +5982,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
   border-top-style: solid;
 }
 
-.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 > div {
+.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -5841,6 +6081,36 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
 
 @media screen and (min-width:1200px) {
   .c9.c9.c9.c9.c9 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c12.c12.c12.c12.c12 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c12.c12.c12.c12.c12 {
     pointer-events: auto;
   }
 }
@@ -6031,7 +6301,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c9 c10 cell-wrapper"
+                  class="c12 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -6196,7 +6466,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
                 data-blade-component="base-box"
               >
                 <div
-                  class="c9 c10 cell-wrapper"
+                  class="c12 c10 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -6316,18 +6586,18 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
         </tr>
       </tbody>
       <tfoot
-        class="c12 css-1a28xfp-Header"
+        class="c13 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c13 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6344,7 +6614,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6361,7 +6631,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6378,7 +6648,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6395,7 +6665,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6412,7 +6682,7 @@ exports[`<Table /> should render table with showStripedRows 1`] = `
             </div>
           </th>
           <th
-            class="th c14 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c15 css-1mmxnzc-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -6460,6 +6730,23 @@ exports[`<Table /> should render table with sticky header, footer & first column
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  white-space: normal;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.c13.c13.c13.c13.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: unset;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -6502,6 +6789,12 @@ exports[`<Table /> should render table with sticky header, footer & first column
   letter-spacing: 0px;
   margin: 0;
   padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
 }
 
 .c1.c1.c1.c1.c1.c1.c1.c1.c1.c1.c1.c1.c1.c1.c1 {
@@ -6593,19 +6886,19 @@ exports[`<Table /> should render table with sticky header, footer & first column
   transition-timing-function: cubic-bezier(0.3,0,0.2,1);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 {
   background-color: hsla(211,20%,52%,0.12);
 }
 
-.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13.c13 tr:last-child th {
+.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14.c14 tr:last-child th {
   border-bottom: none;
 }
 
-.c14.c14.c14.c14.c14 th:last-child {
+.c15.c15.c15.c15.c15 th:last-child {
   border-right: none;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 {
+.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 {
   height: 100%;
   background-color: hsla(0,0%,100%,1);
   border-bottom-width: 1px;
@@ -6616,7 +6909,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
   border-top-style: solid;
 }
 
-.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15.c15 > div {
+.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16.c16 > div {
   background-color: hsla(211,20%,52%,0.12);
   display: -webkit-box;
   display: -webkit-flex;
@@ -6715,6 +7008,36 @@ exports[`<Table /> should render table with sticky header, footer & first column
 
 @media screen and (min-width:1200px) {
   .c10.c10.c10.c10.c10 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c13.c13.c13.c13.c13 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c13.c13.c13.c13.c13 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c13.c13.c13.c13.c13 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c13.c13.c13.c13.c13 {
+    pointer-events: auto;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c13.c13.c13.c13.c13 {
     pointer-events: auto;
   }
 }
@@ -6905,7 +7228,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7070,7 +7393,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7235,7 +7558,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7400,7 +7723,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7565,7 +7888,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7730,7 +8053,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -7895,7 +8218,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8060,7 +8383,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8225,7 +8548,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8390,7 +8713,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
                 data-blade-component="base-box"
               >
                 <div
-                  class="c10 c11 cell-wrapper"
+                  class="c13 c11 cell-wrapper"
                   data-blade-component="base-box"
                   pointer-events="auto"
                 >
@@ -8510,18 +8833,18 @@ exports[`<Table /> should render table with sticky header, footer & first column
         </tr>
       </tbody>
       <tfoot
-        class="c13 css-1a28xfp-Header"
+        class="c14 css-1a28xfp-Header"
         data-blade-component="table-footer"
         role="rowgroup"
       >
         <tr
-          class="tr c14 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
+          class="tr c15 tr-footer css-19bs4cg-getHeaderRowContainerStyle-HeaderRow"
           data-blade-component="table-footer-row"
           data-table-library_tr-header=""
           role="rowfooter"
         >
           <th
-            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8538,7 +8861,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8555,7 +8878,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8572,7 +8895,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8589,7 +8912,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"
@@ -8606,7 +8929,7 @@ exports[`<Table /> should render table with sticky header, footer & first column
             </div>
           </th>
           <th
-            class="th c15 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
+            class="th c16 css-c0u6i8-HEADER_CELL_CONTAINER_STYLE-HeaderCell"
             data-blade-component="table-footer-cell"
             data-hide="false"
             data-resize-min-width="75"


### PR DESCRIPTION
## Description

Fixes #2222 


Code: 
```jsx
<TableCell>E03CXQ6CAQ6/C074E2N774G</TableCell>
```
Result: 
<img width="240" alt="image" src="https://github.com/user-attachments/assets/fc86883f-32b0-4294-87b5-44df11fc1917">


-----

Code:
```jsx
<TableCell>
  <Text truncateAfterLines={1}>E03CXQ6CAQ6/C074E2N774G</Text>
</TableCell>
```

Result:
<img width="185" alt="image" src="https://github.com/user-attachments/assets/9194e62e-0729-4123-a32a-c0c99f580134">


<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
