### PR TITLE
fix: Mobile View in Intro Page of https://blade.razorpay.com/?path=/docs/guides-intro--docs

### DIFF
--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -33,7 +33,7 @@ Blade is the Cross-Platform, Open Source Design System that powers all of the [R
 
 <div style={{ textAlign: 'left' }}>
   <iframe
-    width="560"
+    width="100%"
     height="315"
     src="https://www.youtube.com/embed/GH3HA6xOFEw?si=QLihQEyooEbtRPgg"
     title="YouTube video player"

--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -33,14 +33,14 @@ Blade is the Cross-Platform, Open Source Design System that powers all of the [R
 
 <div style={{ textAlign: 'left' }}>
   <iframe
-    width="100%"
+    width="560"
     height="315"
     src="https://www.youtube.com/embed/GH3HA6xOFEw?si=QLihQEyooEbtRPgg"
     title="YouTube video player"
     frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
     allowfullscreen
-    style={{ borderRadius: '8px' }}
+    style={{ borderRadius: '8px', maxWidth: '100%' }}
   ></iframe>
 </div>
 


### PR DESCRIPTION
## Description
Fixes [#2380]
When we view the intro page https://blade.razorpay.com/?path=/docs/guides-intro--docs, the screen looks odd.

<img width="324" alt="Screenshot 2024-10-17 at 12 21 27 AM" src="https://github.com/user-attachments/assets/3e689d47-145f-4406-83aa-8703423d654f">
<img width="326" alt="Screenshot 2024-10-17 at 12 21 41 AM" src="https://github.com/user-attachments/assets/cf36adbf-c24e-4d74-a720-9c531daa1461">


## Changes
After fix
<img width="321" alt="Screenshot 2024-10-17 at 12 22 07 AM" src="https://github.com/user-attachments/assets/ea4612db-cd39-4241-9428-5436c5818304">


## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
