### PR TITLE
fix: Fixed url in https://blade.razorpay.com/

### DIFF
--- a/packages/blade/docs/guides/Intro.stories.mdx
+++ b/packages/blade/docs/guides/Intro.stories.mdx
@@ -49,7 +49,7 @@ Blade is the Cross-Platform, Open Source Design System that powers all of the [R
 - This is the new rebranded version of Blade which is under active development
 - We are currently working on migrating all the components from the old version of Blade to this new rebranded version.
 - Read more about the [rebranding & migration steps here](https://docs.google.com/document/d/1PLwUqx8LyfMeDW4u9CjwKHtSCpT1_sYUYtW_jwpLyDA/edit)
-- Check the current [availability status of rebranded components here](http://localhost:9009/?path=/docs/guides-component-status--docs)
+- Check the current [availability status of rebranded components here](https://blade.razorpay.com/?path=/docs/guides-component-status--docs)
 - Refer the older [documentation of Blade (before v11.0.0) here](https://v10--61c19ee8d3d282003ac1d81c.chromatic.com/)
 
 ## 🔗 Links


### PR DESCRIPTION
## Description
Fixes [#2381]
The url for Check the current [availability status of rebranded components here](http://localhost:9009/?path=/docs/guides-component-status--docs) points to localhost instead of https://blade.razorpay.com/?path=/docs/guides-component-status--docs.

## Changes
Have updated the url.
<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
