### PR TITLE
feat(Carousel): Auto hide navigation buttons if total slides are less than visible items

### DIFF
--- a/packages/blade/src/components/Carousel/Carousel.web.tsx
+++ b/packages/blade/src/components/Carousel/Carousel.web.tsx
@@ -39,6 +39,7 @@ type ControlsProp = Required<
   onIndicatorButtonClick: (index: number) => void;
   onNextButtonClick: () => void;
   onPreviousButtonClick: () => void;
+  showControls: boolean;
 };
 
 const Controls = ({
@@ -51,43 +52,46 @@ const Controls = ({
   onPreviousButtonClick,
   indicatorVariant,
   navigationButtonVariant,
+  showControls,
 }: ControlsProp): React.ReactElement => {
-  if (navigationButtonPosition === 'bottom') {
-    return (
-      <Box marginTop="spacing.7" display="flex" alignItems="center" gap="spacing.4">
-        <NavigationButton
-          type="previous"
-          variant={navigationButtonVariant}
-          onClick={onPreviousButtonClick}
-        />
-        {showIndicators ? (
+  if (showControls) {
+    if (navigationButtonPosition === 'bottom') {
+      return (
+        <Box marginTop="spacing.7" display="flex" alignItems="center" gap="spacing.4">
+          <NavigationButton
+            type="previous"
+            variant={navigationButtonVariant}
+            onClick={onPreviousButtonClick}
+          />
+          {showIndicators ? (
+            <Indicators
+              onClick={onIndicatorButtonClick}
+              activeIndex={activeIndicator}
+              totalItems={totalSlides}
+              variant={indicatorVariant}
+            />
+          ) : null}
+          <NavigationButton
+            onClick={onNextButtonClick}
+            type="next"
+            variant={navigationButtonVariant}
+          />
+        </Box>
+      );
+    }
+
+    if (showIndicators && navigationButtonPosition === 'side') {
+      return (
+        <Box marginTop="spacing.7">
           <Indicators
             onClick={onIndicatorButtonClick}
             activeIndex={activeIndicator}
             totalItems={totalSlides}
             variant={indicatorVariant}
           />
-        ) : null}
-        <NavigationButton
-          onClick={onNextButtonClick}
-          type="next"
-          variant={navigationButtonVariant}
-        />
-      </Box>
-    );
-  }
-
-  if (showIndicators && navigationButtonPosition === 'side') {
-    return (
-      <Box marginTop="spacing.7">
-        <Indicators
-          onClick={onIndicatorButtonClick}
-          activeIndex={activeIndicator}
-          totalItems={totalSlides}
-          variant={indicatorVariant}
-        />
-      </Box>
-    );
+        </Box>
+      );
+    }
   }
 
   return <></>;
@@ -308,6 +312,7 @@ const Carousel = ({
   const shouldNavButtonsFloat = isResponsive && navigationButtonPosition === 'side';
   const totalNumberOfSlides = React.Children.count(children);
   const numberOfIndicators = Math.ceil(totalNumberOfSlides / _visibleItems);
+  const shouldShowControls = totalNumberOfSlides > _visibleItems;
 
   // hide next/prev button on reaching start/end when carousel is responsive
   // in non-responsive carousel we always show the next/prev buttons to allow looping
@@ -586,6 +591,7 @@ const Carousel = ({
           onPreviousButtonClick={goToPreviousSlide}
           indicatorVariant={indicatorVariant}
           navigationButtonVariant={navigationButtonVariant}
+          showControls={shouldShowControls}
         />
       </BaseBox>
     </CarouselContext.Provider>

--- a/packages/blade/src/components/Carousel/Carousel.web.tsx
+++ b/packages/blade/src/components/Carousel/Carousel.web.tsx
@@ -534,7 +534,7 @@ const Carousel = ({
           flexDirection="row"
           height="100%"
         >
-          {shouldShowPrevButton && shouldNavButtonsFloat ? (
+          {shouldShowPrevButton && shouldNavButtonsFloat && shouldShowControls ? (
             <BaseBox zIndex={2} position="absolute" left="spacing.11">
               <NavigationButton
                 type="previous"
@@ -543,7 +543,7 @@ const Carousel = ({
               />
             </BaseBox>
           ) : null}
-          {isNavButtonsOnSide ? (
+          {isNavButtonsOnSide && shouldShowControls ? (
             <NavigationButton
               type="previous"
               variant={navigationButtonVariant}
@@ -564,7 +564,7 @@ const Carousel = ({
           >
             {children}
           </CarouselBody>
-          {shouldShowNextButton && shouldNavButtonsFloat ? (
+          {shouldShowNextButton && shouldNavButtonsFloat && shouldShowControls ? (
             <BaseBox zIndex={2} position="absolute" right="spacing.11">
               <NavigationButton
                 onClick={goToNextSlide}
@@ -573,7 +573,7 @@ const Carousel = ({
               />
             </BaseBox>
           ) : null}
-          {isNavButtonsOnSide ? (
+          {isNavButtonsOnSide && shouldShowControls ? (
             <NavigationButton
               onClick={goToNextSlide}
               type="next"


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/7123c11e-0d7a-490b-acc0-a6188ce05a4c

The navigation buttons do not appear when the total slides to display are less than the visible items. In the demo video there are 3 total slides in the carousel.

## Changes

- Created a boolean `shouldShowControls` that checks if totalSlides > visibleItems
- `showControls` is passed as a prop to the Controls component that carries this value
- if true, we render the navigation controls  

## Additional Information

Implements  #1833 

## Component Checklist

- [ ] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
