### PR TITLE
fix(blade):  Date Picker does not fire onInput event [DSSUP-127]

### DIFF
--- a/.changeset/tender-oranges-kick.md
+++ b/.changeset/tender-oranges-kick.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade) : Date Picker does not fire onInput event

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -35,6 +35,7 @@ export default {
     value: baseProp,
     isOpen: baseProp,
     onChange: baseProp,
+    onInput: baseProp,
     selectionType: baseProp,
     presets: baseProp,
     minDate: baseProp,
@@ -122,6 +123,9 @@ const DatePickerTemplate: StoryFn<typeof DatePickerComponent> = ({ ...args }) =>
       onChange={(date) => {
         console.log(date);
       }}
+      onInput={(e) => {
+        console.log(e);
+      }}
       {...args}
     />
   );
@@ -132,6 +136,12 @@ SingleDatePicker.storyName = 'SingleDatePicker';
 SingleDatePicker.args = {
   label: 'Select a date',
   selectionType: 'single',
+  onInput: (e) => {
+    console.log(e);
+  },
+  onChange: (e) => {
+    console.log(e);
+  },
 };
 
 export const RangeDatePicker = DatePickerTemplate.bind({});
@@ -139,6 +149,12 @@ RangeDatePicker.storyName = 'RangeDatePicker';
 RangeDatePicker.args = {
   label: { start: 'Start Date', end: 'End Date' },
   selectionType: 'range',
+  onInput: (e) => {
+    console.log(e);
+  },
+  onChange: (e) => {
+    console.log(e);
+  },
 };
 
 export const DatePickerPresets: StoryFn<typeof DatePickerComponent> = ({ ...args }) => {
@@ -167,6 +183,20 @@ export const DatePickerPresets: StoryFn<typeof DatePickerComponent> = ({ ...args
           console.log(date);
         }}
         presets={[
+          {
+            label: 'Today',
+            value: (date) => [
+              dayjs(date).startOf('day').toDate(),
+              dayjs(date).endOf('day').toDate(),
+            ],
+          },
+          {
+            label: 'Tomorrow',
+            value: (date) => [
+              dayjs(date).add(1, 'day').startOf('day').toDate(),
+              dayjs(date).add(1, 'day').endOf('day').toDate(),
+            ],
+          },
           {
             label: 'Past 7 days',
             value: (date) => [dayjs(date).subtract(7, 'days').toDate(), date],

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -41,6 +41,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   value,
   defaultValue,
   onChange,
+  onInput,
   onApply,
   presets,
   isOpen,
@@ -97,6 +98,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
     defaultValue,
     onChange: (date) => {
       onChange?.(date as never);
+      onInput?.(date as never);
       if (isSingle) return;
       // sync selected preset with value
       setSelectedPreset(date as DatesRangeValue);
@@ -124,6 +126,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   const handleApply = (): void => {
     if (isSingle) {
       onChange?.(controlledValue);
+      onInput?.(controlledValue);
       setOldValue(controlledValue);
       onApply?.(controlledValue);
       close();
@@ -132,6 +135,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
     // only apply if both dates are selected
     if (hasBothDatesSelected) {
       onChange?.(controlledValue);
+      onInput?.(controlledValue);
       setOldValue(controlledValue);
       onApply?.(controlledValue);
       close();

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -38,7 +38,13 @@ type MantineInternalProps =
 
 type CalendarProps<SelectionType extends DateSelectionType> = Pick<
   MantineDatePickerProps<SelectionType extends 'single' ? 'default' : 'range'>,
-  MantineInternalProps | 'value' | 'defaultValue' | 'onChange' | 'onMonthSelect' | 'onYearSelect'
+  | MantineInternalProps
+  | 'value'
+  | 'defaultValue'
+  | 'onChange'
+  | 'onMonthSelect'
+  | 'onYearSelect'
+  | 'onInput'
 > & {
   /**
    * Sets the selection mode of the calendar


### PR DESCRIPTION
## Description

Date picker component does not fire change or input event when the value is changed or committed. Expectation is to behave like an input field with type as date. 

## Changes
This pr - 
- [x] adds onInput prop in Datepicker
- [x] add mode presets in Datepicker with Presets example 

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset
