### PR TITLE
Fix(blade) : File upload does not fire change input when file is dropped

### DIFF
--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -38,6 +38,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     onReupload,
     onDismiss,
     onDrop,
+    onInput,
     isDisabled,
     isRequired,
     necessityIndicator,
@@ -146,6 +147,17 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     setIsActive(false);
   };
 
+  const handleFileChangeEvents = ({
+    fileList,
+    name,
+  }: {
+    fileList: BladeFileList;
+    name?: string;
+  }): void => {
+    onChange?.({ name, fileList });
+    onInput?.({ name, fileList });
+  };
+
   const handleDrop = (event: React.DragEvent): void => {
     event.preventDefault();
     setIsActive(false);
@@ -158,6 +170,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     if (!hasValidationErrors) {
       handleFilesChange(droppedFiles);
       onDrop?.({ name, fileList: allFiles });
+      handleFileChangeEvents({ name, fileList: allFiles });
     }
   };
 
@@ -169,7 +182,7 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
 
     if (!hasValidationErrors) {
       handleFilesChange(inputFiles);
-      onChange?.({ name, fileList: allFiles });
+      handleFileChangeEvents({ name, fileList: allFiles });
     }
 
     // Reset the input value to allow re-selecting the same file
@@ -421,6 +434,9 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
             accept=".jpg, .jpeg, .png"
             onChange={({ fileList }) => {
               setSelectedFile(fileList[0]);
+            }}
+            onInput={({ fileList }) => {
+              console.log(fileList);
             }}
             onDrop={({ fileList }) => {
               setSelectedFile(fileList[0]);

--- a/packages/blade/src/components/FileUpload/docs/FileUpload.stories.tsx
+++ b/packages/blade/src/components/FileUpload/docs/FileUpload.stories.tsx
@@ -144,10 +144,13 @@ const CustomPreviewTemplate: StoryFn<typeof FileUploadComponent> = (args) => {
               {...args}
               fileList={uploadedFiles}
               onChange={({ fileList }) => handleFileChange({ fileList })}
-              onDrop={({ fileList }) => handleFileChange({ fileList })}
+              onDrop={({ fileList }) => console.log('onDrop', fileList)}
               onPreview={({ file }) => {
                 setIsOpen(true);
                 setImageFileSource(URL.createObjectURL(file));
+              }}
+              onInput={({ fileList }) => {
+                console.log('onInput', fileList);
               }}
             />
             <Button

--- a/packages/blade/src/components/FileUpload/docs/stories.tsx
+++ b/packages/blade/src/components/FileUpload/docs/stories.tsx
@@ -93,7 +93,7 @@ function App(): React.ReactElement {
                     setSelectedFile(fileList[0]);
                   }}
                   onDrop={({ fileList }: FileUploadProps['onDrop']) => {
-                    setSelectedFile(fileList[0]);
+                   console.log('onDrop', fileList);
                   }}
                   isRequired
                   necessityIndicator="required"
@@ -253,7 +253,7 @@ const MultiFileUploadStory = `
                     setSelectedFiles(fileList);
                   }}
                   onDrop={({ fileList }: FileUploadProps['onDrop']) => {
-                    setSelectedFiles(fileList);
+                    console.log("onDrop", fileList);
                   }}
                   isRequired
                   necessityIndicator="required"
@@ -400,7 +400,7 @@ import {
                 accept=".jpg, .jpeg, .png"
                 fileList={uploadedFiles}
                 onChange={({ fileList }: FileUploadProps['onChange']) => handleFileChange({ fileList })}
-                onDrop={({ fileList }: FileUploadProps['onDrop']) => handleFileChange({ fileList })}
+                onDrop={({ fileList }: FileUploadProps['onDrop']) => {console.log("onDrop",fileList)})}
                 isRequired
                 necessityIndicator="required"
               />
@@ -579,7 +579,6 @@ const AutoFileUploadWithProgressStory = `
                 accept=".jpg, .jpeg, .png"
                 fileList={uploadedFiles}
                 onChange={handleFileChange}
-                onDrop={handleFileChange}
                 isRequired
                 necessityIndicator="required"
               />
@@ -772,8 +771,9 @@ import {
                 onChange={({ fileList }: { fileList: BladeFileList }) =>
                   handleFileChange({ fileList })
                 }
-                onDrop={({ fileList }: { fileList: BladeFileList }) =>
-                  handleFileChange({ fileList })
+                onDrop={({ fileList }: { fileList: BladeFileList }) => {
+                 console.log("onDrop", fileList);
+                }
                 }
                 onPreview={({ file }: { file: BladeFile }) => {
                   setIsOpen(true);

--- a/packages/blade/src/components/FileUpload/types.ts
+++ b/packages/blade/src/components/FileUpload/types.ts
@@ -70,9 +70,13 @@ type FileUploadCommonProps = {
    */
   maxSize?: number;
   /**
-   * Callback function triggered when files are selected
+   * Callback function triggered when files are selected or when a file is dropped into the upload area
    */
   onChange?: ({ name, fileList }: { name?: string; fileList: BladeFileList }) => void;
+  /**
+   * Callback function triggered when files are selected or when a file is dropped into the upload area
+   */
+  onInput?: ({ name, fileList }: { name?: string; fileList: BladeFileList }) => void;
   /**
    * Callback function triggered when the preview icon is clicked
    */


### PR DESCRIPTION
## Description

FileUpload component does not fire `change` or `input `event when the file is dropped. 

## Changes

- Add onInput as  prop in FileUpload
- now, file Input fires onChange , onInput when a file is dropped.

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
