### PR TITLE
fix: Retained Accordion Consistency in Docs

### DIFF
--- a/packages/blade/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.stories.tsx
@@ -289,6 +289,7 @@ const AccordionWithCustomHeaderBodyTemplate: StoryFn<typeof AccordionComponent> 
               title="Custom slot"
               description="You can render anything here along with description"
               onDismiss={() => setIsVisible(false)}
+              isFullWidth
             />
           )}
         </AccordionItemBody>


### PR DESCRIPTION
## Description

This PR addresses the problem discussed in [Issue#2323](https://github.com/razorpay/blade/issues/2323)

## Changes

Modified the Docs Accordion Code Statement to let the Users Know AccordionItemBody "max item width" functionalities and also provide UI Consistency in the Documentation Guide

## Additional Information

Minor UI and Docs Update for Cleaner Code Guide

## Component Checklist

- [ ] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
