### PR TITLE
fix: dropdown not opening if user clicks on dropdown backdrop

### DIFF
--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -326,7 +326,10 @@ type BaseInputCommonProps = FormInputLabelProps &
      * @default true
      **/
     isTableInputCell?: boolean;
-
+    /**
+     * Callback to be invoked when the backdrop is clicked
+     */
+    onBackdropClick?: () => void;
     /**
      * Hides the form hints and shows them as tooltip of trailing
      */
@@ -825,6 +828,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
     valueComponentType = 'text',
     isTableInputCell = false,
     showHintsAsTooltip = false,
+    onBackdropClick,
     ...styledProps
   },
   ref,
@@ -971,6 +975,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
               if (!isReactNative) {
                 inputRef.current?.focus();
               }
+              onBackdropClick?.();
             }}
             isTableInputCell={isTableInputCell}
           >

--- a/packages/blade/src/components/Input/DropdownInputTriggers/BaseDropdownInputTrigger.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/BaseDropdownInputTrigger.tsx
@@ -316,6 +316,7 @@ const _BaseDropdownInputTrigger = (
       onChange={props.isSelectInput ? undefined : props.onInputValueChange}
       onKeyDown={props.onTriggerKeydown}
       size={props.size}
+      onBackdropClick={onTriggerClick}
       trailingInteractionElement={
         isAutoCompleteInHeader || (isInsideTableEditableCell && !isValidationStateNone) ? null : (
           <InputChevronIcon


### PR DESCRIPTION
## Description

bug - 
https://github.com/user-attachments/assets/a135e5a2-e283-466e-b58d-76785ed0e10b

RCA -
let's say currently we have a structure like - 
<Box>
 <Input/>
<TriggerElement/>
</Box> 
so we have added onClick listner to input and triggerElement and if user clicks on backdrop of tiggerElement if triggerelement does not takes full space. thier is nothing to fire. this was causing the issue.
![image](https://github.com/user-attachments/assets/4ce4bb97-10a7-4970-946a-b1d02d998222)


## Changes
![image](https://github.com/user-attachments/assets/11d4cb44-7edc-42e7-bbf3-8649c0700b13)
added an additional prop onBackdropClick , which is added on the wrapper so that when ever use clicks on backdrop we ca decide what need to be done.

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
