### PR TITLE
fix: maxCharacters alignment in Input field

### DIFF
--- a/.changeset/late-eels-live.md
+++ b/.changeset/late-eels-live.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): maxCharacters alignment in Input field

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -897,7 +897,10 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
     activeDescendant,
   });
 
-  const willRenderHintText = Boolean(helpText) || (validationState === 'success' && Boolean(successText)) || (validationState === 'error' && Boolean(errorText));
+  const willRenderHintText =
+    Boolean(helpText) ||
+    (validationState === 'success' && Boolean(successText)) ||
+    (validationState === 'error' && Boolean(errorText));
 
   if (__DEV__) {
     if (

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -897,7 +897,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
     activeDescendant,
   });
 
-  const willRenderHintText = Boolean(helpText) || Boolean(successText) || Boolean(errorText);
+  const willRenderHintText = Boolean(helpText) || (validationState === 'success' && Boolean(successText)) || (validationState === 'error' && Boolean(errorText));
 
   if (__DEV__) {
     if (


### PR DESCRIPTION
## Description

Fix for `maxCharacters` alignment in Input component

## Changes

### Issue:
When `maxCharacters` and `successText` props are passed to the component, but `validationState` prop is set to `none`, then `maxCharacters` indication is aligned to the left.

<img width="1001" alt="Screenshot 2024-11-18 at 17 11 13" src="https://github.com/user-attachments/assets/15ac9f90-308d-42ea-93be-ee1796e049dd">

### Fix:
Made changes to `willRenderHintText` boolean condition to return true on the below scenarios:

- when `helpText` prop is passed
- when `successText` prop is passed and `validationState` prop is set to `success`
- when `errorText` prop is passed and `validationState` prop is set to `error`

<img width="995" alt="Screenshot 2024-11-18 at 17 12 48" src="https://github.com/user-attachments/assets/641eb29d-5ccb-4b69-8491-238ae04bc6a3">

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
