### PR TITLE
Add hideClearButton Prop to SearchInput Component

### DIFF
--- a/packages/blade/src/components/Input/SearchInput/SearchInput.stories.tsx
+++ b/packages/blade/src/components/Input/SearchInput/SearchInput.stories.tsx
@@ -70,6 +70,7 @@ export default {
     labelPosition: 'top',
     helpText: undefined,
     autoCapitalize: undefined,
+    hideClearButton: false,
   },
   tags: ['autodocs'],
   argTypes: {
@@ -185,6 +186,14 @@ export default {
         category: propsCategory.KEYBOARD_PROPS,
       },
     },
+     hideClearButton: { 
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        category: propsCategory.TRAILING_VISUAL_PROPS,
+      },
+    },
     ...getStyledPropsArgTypes(),
   },
   parameters: {
@@ -256,6 +265,11 @@ const SearchInputTemplate: StoryFn<typeof SearchInputComponent> = (args) => {
 export const Default = SearchInputTemplate.bind({});
 Default.storyName = 'Default';
 
+export const SearchInputWithClearButtonHidden = SearchInputTemplate.bind({});
+SearchInputWithClearButtonHidden.storyName = 'SearchInput with Clear Button Hidden';
+SearchInputWithClearButtonHidden.args = {
+  hideClearButton: true, // Set the new prop to true
+};
 export const SearchInputHelpText = SearchInputTemplate.bind({});
 SearchInputHelpText.storyName = 'SearchInput with Help Text';
 SearchInputHelpText.args = {

--- a/packages/blade/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/blade/src/components/Input/SearchInput/SearchInput.tsx
@@ -54,6 +54,12 @@ type SearchInputCommonProps = Pick<
    * @default true
    */
   showSearchIcon?: boolean;
+   /**
+   * Toggle the visibility of the clear button.
+   *
+   * @default false
+   */
+  hideClearButton?: boolean; // New prop
 } & StyledPropsBlade;
 
 /*
@@ -85,7 +91,9 @@ type SearchInputPropsWithLabel = {
 };
 
 type SearchInputProps = (SearchInputPropsWithA11yLabel | SearchInputPropsWithLabel) &
-  SearchInputCommonProps;
+  SearchInputCommonProps & {
+    hideClearButton?: boolean; // Add a line to include the new prop
+  }
 
 // need to do this to tell TS to infer type as SearchInput of React Native and make it believe that `ref.current.clear()` exists
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -116,6 +124,7 @@ const _SearchInput: React.ForwardRefRenderFunction<BladeElementRef, SearchInputP
     testID,
     size = 'medium',
     showSearchIcon = true,
+    hideClearButton = false,
     ...styledProps
   },
   ref,
@@ -140,7 +149,7 @@ const _SearchInput: React.ForwardRefRenderFunction<BladeElementRef, SearchInputP
       return <Spinner accessibilityLabel="Loading Content" color="primary" />;
     }
 
-    if (shouldShowClearButton) {
+    if (!hideClearButton && shouldShowClearButton) {
       return (
         <IconButton
           size="medium"


### PR DESCRIPTION
This pull request introduces a new prop, hideClearButton, to the SearchInput component. This prop allows users to control the visibility of the clear button in the input field, enhancing the component's flexibility for various use cases.

Changes Made:
1. Added hideClearButton Prop: This boolean prop determines whether the clear button should be displayed when there is text in the input field.
2. Updated Storybook:
Created new stories to demonstrate the functionality of the hideClearButton prop.
Included examples for both scenarios: with the clear button visible and hidden.

Documentation: Updated the component documentation to include details about the new prop and its usage.

Related Issues
#2377 