### PR TITLE
fix: speed up stackblitz

### DIFF
--- a/packages/blade/.storybook/react-native/Storybook.tsx
+++ b/packages/blade/.storybook/react-native/Storybook.tsx
@@ -8,7 +8,7 @@ import './storybook.requires';
 
 import { name as appName } from '../../app.json';
 
-const App = (): React.ReactElement => {
+const App = () => {
   const Storybook = getStorybookUI({
     shouldPersistSelection: true,
     // keeping in comments becuase this is not documented properly in the docs

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -201,7 +201,7 @@
     "@storybook/react": "7.1.0",
     "@storybook/react-native": "7.0.0-alpha.5",
     "@storybook/react-webpack5": "7.1.0",
-    "@stackblitz/sdk": "1.9.0",
+    "@stackblitz/sdk": "1.11.0",
     "storybook-react-router": "1.0.8",
     "react-router-dom": "5.3.4",
     "@testing-library/jest-dom": "5.16.4",

--- a/packages/blade/src/components/ActionList/ActionList.stories.tsx
+++ b/packages/blade/src/components/ActionList/ActionList.stories.tsx
@@ -50,7 +50,7 @@ const Page = (): React.ReactElement => {
               Button 
           } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
               return (
                   <Box backgroundColor="surface.background.gray.intense">
                   <ActionList>

--- a/packages/blade/src/components/ActionList/docs/stories.ts
+++ b/packages/blade/src/components/ActionList/docs/stories.ts
@@ -17,7 +17,7 @@ const Playground = `
     Button 
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
     <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
@@ -62,7 +62,7 @@ const Playground = `
 const ActionList = `
   import { Box, ActionList, ActionListItem } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
     <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
@@ -88,7 +88,7 @@ const ActionListItem = `
     HomeIcon 
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
     <Box backgroundColor="surface.background.gray.intense">
       <ActionList>
@@ -121,7 +121,7 @@ const ActionListSection = `
     ActionListSection,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
     <Box backgroundColor="surface.background.gray.intense">
       <ActionList>

--- a/packages/blade/src/components/Amount/Amount.stories.tsx
+++ b/packages/blade/src/components/Amount/Amount.stories.tsx
@@ -33,7 +33,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Amount } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return <Amount value={10000} />;
         }
         export default App;

--- a/packages/blade/src/components/Avatar/docs/Avatar.stories.tsx
+++ b/packages/blade/src/components/Avatar/docs/Avatar.stories.tsx
@@ -25,7 +25,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Avatar } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Avatar name="Nitin Kumar" src="https://avatars.githubusercontent.com/u/46647141?v=4" />
           )

--- a/packages/blade/src/components/Avatar/docs/AvatarGroup.stories.tsx
+++ b/packages/blade/src/components/Avatar/docs/AvatarGroup.stories.tsx
@@ -21,7 +21,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Avatar, AvatarGroup } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <AvatarGroup>
               <Avatar color="primary" name="Kamlesh Chandnani" />

--- a/packages/blade/src/components/Badge/Badge.stories.tsx
+++ b/packages/blade/src/components/Badge/Badge.stories.tsx
@@ -22,7 +22,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Badge, InfoIcon } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Badge color="neutral" icon={InfoIcon}>
               Boop

--- a/packages/blade/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -84,7 +84,7 @@ const Page = (): React.ReactElement => {
             Text,
           } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             const [isOpen, setIsOpen] = React.useState(false);
 
             return (

--- a/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
+++ b/packages/blade/src/components/Box/LayoutPrimitivesDocs.tsx
@@ -118,7 +118,7 @@ function LayoutPrimitivesDocs(): React.ReactElement {
           {`
             import { Box, Text } from '@razorpay/blade/components'
 
-            function App(): React.ReactElement {
+            function App() {
               return (
                 <Box 
                   as="section" // renders as <section> tag instead of <div>
@@ -185,7 +185,7 @@ function LayoutPrimitivesDocs(): React.ReactElement {
             {`
               import { Box, Text } from '@razorpay/blade/components'
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   <>
                     <Box 
@@ -238,7 +238,7 @@ function LayoutPrimitivesDocs(): React.ReactElement {
             code={`
              import { Box, Text } from '@razorpay/blade/components';
 
-             function App(): React.ReactElement {
+             function App() {
                return (
                 <>
                   <Box display={{ base: 'none', m: 'block' }}><Text>🖥 Desktop View</Text></Box>
@@ -310,7 +310,7 @@ function LayoutPrimitivesDocs(): React.ReactElement {
           {`
                 import { Text } from '@razorpay/blade/components'
 
-                function App(): React.ReactElement {
+                function App() {
                   return (
                     <>
                       {/** ❌ No need of Box wrappers */}

--- a/packages/blade/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/blade/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -31,7 +31,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Box, Breadcrumb, BreadcrumbItem, HomeIcon } from '@razorpay/blade/components';
 
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Box padding="spacing.4">
               <Breadcrumb>

--- a/packages/blade/src/components/Button/Button/Button.stories.tsx
+++ b/packages/blade/src/components/Button/Button/Button.stories.tsx
@@ -32,7 +32,7 @@ const Page = (): ReactElement => {
         {`
         import { Button } from '@razorpay/blade/components'
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             // Try changing variant here to secondary
             <Button 

--- a/packages/blade/src/components/ButtonGroup/docs/ButtonGroup.stories.tsx
+++ b/packages/blade/src/components/ButtonGroup/docs/ButtonGroup.stories.tsx
@@ -30,7 +30,7 @@ const Page = (): React.ReactElement => {
           DownloadIcon,
         } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <ButtonGroup>
               <Button icon={RefreshIcon}>Sync</Button>

--- a/packages/blade/src/components/Card/CardInteractive.stories.tsx
+++ b/packages/blade/src/components/Card/CardInteractive.stories.tsx
@@ -70,7 +70,7 @@ const Page = (): React.ReactElement => {
           );
         };
 
-        const App = (): React.ReactElement => {
+        const App = () => {
           const [selected, setSelected] = React.useState('free');
 
           return (

--- a/packages/blade/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/blade/src/components/Checkbox/Checkbox.stories.tsx
@@ -23,7 +23,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Checkbox } from '@razorpay/blade/components'
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             // Check console
             <Checkbox onChange={(e) => console.log(e.isChecked)}>

--- a/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/blade/src/components/Checkbox/CheckboxGroup.stories.tsx
@@ -23,7 +23,7 @@ const Page = (): React.ReactElement => {
         {`
           import { CheckboxGroup, Checkbox } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <CheckboxGroup 
                 label="Where do you want to collect payments?"

--- a/packages/blade/src/components/Chip/ChipGroup.stories.tsx
+++ b/packages/blade/src/components/Chip/ChipGroup.stories.tsx
@@ -46,7 +46,7 @@ const Page = (): React.ReactElement => {
         {`
           import { Box, Chip, ChipGroup, Text } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Box>
                 <ChipGroup

--- a/packages/blade/src/components/Counter/Counter.stories.tsx
+++ b/packages/blade/src/components/Counter/Counter.stories.tsx
@@ -21,7 +21,7 @@ const Page = (): ReactElement => {
         {`
           import { Counter } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               // Change values to anything less than 99 to see change
               <Counter max={99} value={140} />

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -87,7 +87,7 @@ export default {
             {`
               import { DatePicker } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   <DatePicker 
                     label="Name"

--- a/packages/blade/src/components/Divider/Divider.stories.tsx
+++ b/packages/blade/src/components/Divider/Divider.stories.tsx
@@ -32,7 +32,7 @@ const Page = (): React.ReactElement => {
             CardBody
           } from "@razorpay/blade/components";
           
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Card>
                 <CardBody>

--- a/packages/blade/src/components/Drawer/docs/stories.ts
+++ b/packages/blade/src/components/Drawer/docs/stories.ts
@@ -435,7 +435,7 @@ const DrawerWithTableStory = `import React, { useState } from 'react';
     );
   };
 
-  function App(): React.ReactElement {
+  function App() {
     const [selectedItem, setSelectedItem] = useState<Item | undefined>(undefined);
     const [showDrawer, setShowDrawer] = useState(false);
     const { theme } = useTheme();

--- a/packages/blade/src/components/Dropdown/docs/autoCompleteStories.tsx
+++ b/packages/blade/src/components/Dropdown/docs/autoCompleteStories.tsx
@@ -81,7 +81,7 @@ export const controlledFiltering = `
     },
   ];
 
-  const App = (): React.ReactElement => {
+  const App = () => {
     const cityValues = cities.map((city) => city.value);
     const [filteredValues, setFilteredValues] = React.useState<string[]>(cityValues);
 
@@ -188,7 +188,7 @@ export const controlledFilteringWithBottomSheet = `
     },
   ];
 
-  const App = (): React.ReactElement => {
+  const App = () => {
     const cityValues = cities.map((city) => city.value);
     const [filteredValues, setFilteredValues] = React.useState<string[]>(cityValues);
 
@@ -406,7 +406,7 @@ export const creatableItems = `
   } from '@razorpay/blade/components';
 
 
-  const App = (): React.ReactElement => {
+  const App = () => {
     const [items, setItems] = React.useState(['Mumbai', 'Pune', 'Bangalore']);
     const [inputValue, setInputValue] = React.useState('');
     const autoCompleteRef = React.useRef<HTMLInputElement>(null);
@@ -467,7 +467,7 @@ export const clearOnDismiss = `
   } from '@razorpay/blade/components';
 
 
-  const App = (): React.ReactElement => {
+  const App = () => {
     const [inputValue, setInputValue] = React.useState('');
 
     return (
@@ -510,7 +510,7 @@ export const maxRowsStates = `
   } from '@razorpay/blade/components';
 
 
-  const App = (): React.ReactElement => {
+  const App = () => {
     return (
       <Box maxWidth="300px" paddingBottom="400px" display="flex" flexDirection="column" gap="300px">
         <Dropdown selectionType="multiple">

--- a/packages/blade/src/components/Dropdown/docs/autoCompleteStories.tsx
+++ b/packages/blade/src/components/Dropdown/docs/autoCompleteStories.tsx
@@ -13,7 +13,7 @@ export const getSimpleAutoComplete = (
     ActionListItem,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
       <Dropdown 
         selectionType="${selectionType}"
@@ -265,7 +265,7 @@ export const tagsOutside = `
     Tag,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [selections, setSelections] = React.useState([]);
 
     return (
@@ -354,7 +354,7 @@ export const responsiveBottomSheet = `
     )
   }
 
-  function App(): React.ReactElement {
+  function App() {
     return (
       <Box>
         <Text textAlign="center" marginBottom="spacing.8">Change the <Code>isMobile</Code> flag in code and refresh the sandbox preview</Text>
@@ -592,7 +592,7 @@ export const withErrorState = `
 
   const cities = ['Mumbai', 'Pune', 'Bangalore', 'Mysore'];
 
-  function App(): React.ReactElement {
+  function App() {
     const [isError, setIsError] = React.useState(false);
     const [currentInputValue, setCurrentInputValue] = React.useState('');
     const [isDismissed, setIsDismissed] = React.useState(false);
@@ -655,7 +655,7 @@ import {
   Box,
 } from '@razorpay/blade/components';
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box>
       <Heading size="medium" marginBottom="spacing.3">

--- a/packages/blade/src/components/Dropdown/docs/stories.ts
+++ b/packages/blade/src/components/Dropdown/docs/stories.ts
@@ -23,7 +23,7 @@ const Playground = `
     Button
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
       <Dropdown 
         // Uncomment next line to make it multiselectable
@@ -89,7 +89,7 @@ const getSimpleSelectCode = (selectionType: DropdownProps['selectionType']): str
     ActionListItem,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
       <Dropdown 
         selectionType="${selectionType}"
@@ -140,7 +140,7 @@ const WithHeaderFooterScroll = `
     Button
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
 
     return (
@@ -248,7 +248,7 @@ const WithValueDisplayStory = `
     Box,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [currentSelections, setCurrentSelections] = React.useState([]);
     
     console.log({currentSelections});
@@ -302,7 +302,7 @@ const WithHTMLFormSubmissionStory = `
     Text,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [submissionValues, setSubmissionValues] = React.useState('');
     
     return (
@@ -362,7 +362,7 @@ const WithValidationStateStory = `
   } from '@razorpay/blade/components';
   import type { SelectInputProps } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [validationState, setValidationState] = React.useState<SelectInputProps['validationState']>('none');
 
     return (
@@ -424,7 +424,7 @@ const WithRefUsageStory = `
     Text
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const selectRef = React.useRef<HTMLElement>(null);
 
 
@@ -478,7 +478,7 @@ const WithMultipleDropdownsStory = `
   } from '@razorpay/blade/components';
 
 
-  function App(): React.ReactElement {  
+  function App() {  
     return (
       <Box display="flex" flexDirection="row" minHeight="300px" gap="spacing.2">
         <Box flex={1}>
@@ -618,7 +618,7 @@ const WithAutoPositioningSelectStory = `
     Box,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     return (
       <Box>
         <Box
@@ -816,7 +816,7 @@ const WithControlledMenuStory = `
     CloseIcon
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [status, setStatus] = React.useState<string | undefined>();
 
     return (
@@ -881,7 +881,7 @@ const WithControlledMultiSelectMenuStory = `
     Tag,
   } from '@razorpay/blade/components';
 
-  function App(): React.ReactElement {
+  function App() {
     const [filters, setFilters] = React.useState<string[]>([]);
 
     const toggleSelection = ({ name, value }: { name: string; value?: boolean }): void => {
@@ -1025,7 +1025,7 @@ import {
   Heading,
 } from '@razorpay/blade/components';
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box>
       <Heading size="medium" marginBottom="spacing.3">

--- a/packages/blade/src/components/FileUpload/docs/stories.tsx
+++ b/packages/blade/src/components/FileUpload/docs/stories.tsx
@@ -13,7 +13,7 @@ const SingleFileUploadStory = `
   } from '@razorpay/blade/components';
   import React, { useState } from 'react';
 
-function App(): React.ReactElement {
+function App() {
     const [selectedFile, setSelectedFile] = useState<BladeFile>();
     const [isLoading, setIsLoading] = useState(false);
     const [responseData, setResponseData] = useState<{
@@ -132,7 +132,7 @@ const MultiFileUploadStory = `
   } from '@razorpay/blade/components';
   import React, { useState } from 'react';
   
-  function App(): React.ReactElement {
+  function App() {
     const [selectedFiles, setSelectedFiles] = useState<BladeFileList>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [responseData, setResponseData] = useState<
@@ -295,7 +295,7 @@ import {
   } from '@razorpay/blade/components';
   import React, { useState } from 'react';
 
-  function App(): React.ReactElement {
+  function App() {
     const [productName, setProductName] = useState<string>();
     const [uploadedFiles, setUploadedFiles] = useState<BladeFileList>([]);
     const [responseData, setResponseData] = useState([]);
@@ -453,7 +453,7 @@ const AutoFileUploadWithProgressStory = `
   } from '@razorpay/blade/components';
   import React, { useState } from 'react';
   
-  function App(): React.ReactElement {
+  function App() {
     const [uploadedFiles, setUploadedFiles] = useState<BladeFileList>();
     const [productName, setProductName] = useState<string | undefined>();
     const [responseData, setResponseData] = useState([]);
@@ -650,7 +650,7 @@ import {
   } from '@razorpay/blade/components';
   import React, { useState } from 'react';
   
-  function App(): React.ReactElement {
+  function App() {
     const [productName, setProductName] = useState<string>();
     const [uploadedFiles, setUploadedFiles] = useState<BladeFileList>([]);
     const [responseData, setResponseData] = useState([]);

--- a/packages/blade/src/components/Icons/Icons.stories.tsx
+++ b/packages/blade/src/components/Icons/Icons.stories.tsx
@@ -24,7 +24,7 @@ const Page = (): ReactElement => {
         {`
         import { Button, ArrowRightIcon } from '@razorpay/blade/components';
 
-        function App(): React.ReactElement {
+        function App() {
           // Icon component is meant to be used inside \`icon\` prop 
           // along with other components like \`Button\`, \`Badge\`, etc
           return (

--- a/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.stories.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/AutoComplete.stories.tsx
@@ -207,7 +207,7 @@ export default {
             {`
               import { AutoComplete, Dropdown, DropdownOverlay, ActionList, ActionListItem } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   // Only works inside Dropdown component
                   <Dropdown>

--- a/packages/blade/src/components/Input/DropdownInputTriggers/SelectInput.stories.tsx
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/SelectInput.stories.tsx
@@ -191,7 +191,7 @@ export default {
             {`
               import { SelectInput, Dropdown, DropdownOverlay, ActionList, ActionListItem } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   // Only works inside Dropdown component
                   <Dropdown>

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
@@ -182,7 +182,7 @@ export default {
             {`
               import { OTPInput } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   // Fill OTP and check console
                   <OTPInput 

--- a/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/blade/src/components/Input/PasswordInput/PasswordInput.stories.tsx
@@ -26,7 +26,7 @@ const Page = (): ReactElement => {
         {`
           import { PasswordInput } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <PasswordInput 
                 label="Enter Password" 

--- a/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -238,7 +238,7 @@ const meta: Meta<PhoneNumberInputProps> = {
             {`
               import { PhoneNumberInput } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   <PhoneNumberInput 
                     label="Enter phone number" 

--- a/packages/blade/src/components/Input/SearchInput/SearchInput.stories.tsx
+++ b/packages/blade/src/components/Input/SearchInput/SearchInput.stories.tsx
@@ -201,7 +201,7 @@ export default {
             {`
               import { SearchInput } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   <SearchInput 
                     label="Name" 

--- a/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
@@ -197,7 +197,7 @@ export default {
             {`
               import { TextArea } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   <TextArea 
                     label="Description" 

--- a/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInput.stories.tsx
@@ -287,7 +287,7 @@ export default {
             {`
               import { TextInput } from '@razorpay/blade/components';
 
-              function App(): React.ReactElement {
+              function App() {
                 return (
                   <TextInput 
                     label="Name" 

--- a/packages/blade/src/components/Link/Link/Link.stories.tsx
+++ b/packages/blade/src/components/Link/Link/Link.stories.tsx
@@ -27,7 +27,7 @@ const Page = (): ReactElement => {
         {`
           import { Link } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Link 
                 href="https://razorpay.com" 

--- a/packages/blade/src/components/List/List.stories.tsx
+++ b/packages/blade/src/components/List/List.stories.tsx
@@ -30,7 +30,7 @@ const Page = (): ReactElement => {
         {`
           import { List, ListItem } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <List>
                 <ListItem>

--- a/packages/blade/src/components/Menu/docs/Menu.stories.tsx
+++ b/packages/blade/src/components/Menu/docs/Menu.stories.tsx
@@ -78,7 +78,7 @@ const Page = (): React.ReactElement => {
           UserIcon
         } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Box>
               <Menu>

--- a/packages/blade/src/components/Modal/docs/ModalExamples.stories.tsx
+++ b/packages/blade/src/components/Modal/docs/ModalExamples.stories.tsx
@@ -30,7 +30,7 @@ const ModalMeta: Meta = {
 
 const ModalTemplate: StoryFn<typeof Modal> = () => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {BasicModalStory}
     </Sandbox>
   );
@@ -40,7 +40,7 @@ export const BasicModal = ModalTemplate.bind({});
 
 export const ModalWithHeaderFooter = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {ModalWithHeaderFooterStory}
     </Sandbox>
   );
@@ -48,7 +48,7 @@ export const ModalWithHeaderFooter = (): React.ReactElement => {
 
 export const ModalWithScrollableBackground = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {ModalWithScrollableBackgroundStory}
     </Sandbox>
   );
@@ -56,7 +56,7 @@ export const ModalWithScrollableBackground = (): React.ReactElement => {
 
 export const ModalWithScrollableContent = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {ModalWithScrollableContentStory}
     </Sandbox>
   );
@@ -64,7 +64,7 @@ export const ModalWithScrollableContent = (): React.ReactElement => {
 
 export const ModalStacking = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {ModalStackingStory}
     </Sandbox>
   );
@@ -72,7 +72,7 @@ export const ModalStacking = (): React.ReactElement => {
 
 export const ModalWithNoBodyPadding = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {ModalWithNoBodyPaddingStory}
     </Sandbox>
   );

--- a/packages/blade/src/components/Modal/docs/stories.ts
+++ b/packages/blade/src/components/Modal/docs/stories.ts
@@ -13,7 +13,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const buttonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   return (
@@ -64,7 +64,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const buttonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   return (
@@ -103,7 +103,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const buttonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   return (
@@ -158,7 +158,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const buttonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   return (
@@ -220,7 +220,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const buttonRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   return (
@@ -342,7 +342,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const buttonRef = React.useRef(null);
   const [is1stOpen, set1stIsOpen] = React.useState(false);
   const [is2ndOpen, setIs2ndOpen] = React.useState(false);
@@ -505,7 +505,7 @@ import {
 } from "@razorpay/blade/components";
 import React from "react";
 
-function App(): React.ReactElement {
+function App() {
   const [isOpen, setIsOpen] = React.useState(false);
   return (
     <>

--- a/packages/blade/src/components/Popover/Popover.stories.tsx
+++ b/packages/blade/src/components/Popover/Popover.stories.tsx
@@ -40,7 +40,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Popover, Button } from '@razorpay/blade/components'
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Popover content="Hello world" placement="bottom">
               <Button>Hover over me</Button>

--- a/packages/blade/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/blade/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -22,7 +22,7 @@ const Page = (): ReactElement => {
         {`
           import { ProgressBar } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <ProgressBar 
                 label="Label" 

--- a/packages/blade/src/components/Radio/Radio.stories.tsx
+++ b/packages/blade/src/components/Radio/Radio.stories.tsx
@@ -25,7 +25,7 @@ const Page = (): React.ReactElement => {
         {`
           import { RadioGroup, Radio } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <RadioGroup
                 helpText="Select only one"

--- a/packages/blade/src/components/SideNav/docs/SideNav.stories.tsx
+++ b/packages/blade/src/components/SideNav/docs/SideNav.stories.tsx
@@ -74,7 +74,7 @@ const DocsPage = (): React.ReactElement => {
         files={sideNavWithReactRouter}
         editorHeight={600}
         hideNavigation={false}
-        openFile="App.tsx,navItemsJSON.tsx,SideNavExample.tsx"
+        openFile="App.js,navItemsJSON.js,SideNavExample.js"
       />
     </StoryPageWrapper>
   );

--- a/packages/blade/src/components/SideNav/docs/code.ts
+++ b/packages/blade/src/components/SideNav/docs/code.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 
 export const sideNavWithReactRouter = {
-  'App.tsx': dedent`import React from 'react';
+  'App.js': dedent`import React from 'react';
   import { BrowserRouter } from 'react-router-dom';
   import SideNavExample from './SideNavExample';
   
@@ -15,7 +15,7 @@ export const sideNavWithReactRouter = {
 
   export default App;
   `,
-  'SideNavExample.tsx': dedent`import React from 'react';
+  'SideNavExample.js': dedent`import React from 'react';
   import {
     matchPath,
     useLocation,
@@ -41,11 +41,9 @@ export const sideNavWithReactRouter = {
     UserIcon,
     MenuIcon,
   } from '@razorpay/blade/components';
-  import type { SideNavLinkProps } from '@razorpay/blade/components';
   import { navItemsJSON } from './navItemsJSON';
-  import type {  NavItemsJSONType, ItemsType } from './navItemsJSON';
 
-  const Page = ({ match }: { match: any }): React.ReactElement => (
+  const Page = ({ match }) => (
     <Box padding={{ base: 'spacing.2', m: 'spacing.6' }}>
       <pre>
         <code>{JSON.stringify(match, null, 4)}</code>
@@ -57,9 +55,9 @@ export const sideNavWithReactRouter = {
    * Returns all hrefs in child tree for given item
    */ 
   const getAllChildHrefs = (
-    items: (ItemsType & { items?: ItemsType[] })[] | undefined
-  ): string[] => {
-    const hrefs: string[] = [];
+    items
+  ) => {
+    const hrefs = [];
 
     if (!items) {
       return [];
@@ -80,8 +78,8 @@ export const sideNavWithReactRouter = {
   /**
    * Loops over JSON to return all routes including child routes 
    */ 
-  const getAllRoutesFromJSON = (): string[] => {
-    let allHrefs: string[] = [];
+  const getAllRoutesFromJSON = () => {
+    let allHrefs = [];
 
     navItemsJSON.forEach((section) => {
       if (section.items) {
@@ -96,9 +94,9 @@ export const sideNavWithReactRouter = {
    * Returns if the given href or one of the items from activeOnLinks are active
    */ 
   const isItemActive = (
-    location: { pathname: string },
-    { href, activeOnLinks }: { href?: string; activeOnLinks?: string[] }
-  ): boolean => {
+    location,
+    { href, activeOnLinks }
+  ) => {
     const isCurrentPathActive = Boolean(matchPath(location.pathname, href ?? ''));
 
     const isSubItemActive = Boolean(
@@ -111,11 +109,7 @@ export const sideNavWithReactRouter = {
   /**
    * React Router v6 Wrapper around Blade's SideNavLink that passes active state of item based on react router state
    */ 
-  const NavLink = (
-    props: Omit<SideNavLinkProps, 'as'> & {
-      activeOnLinks?: string[];
-    }
-  ): React.ReactElement => {
+  const NavLink = (props) => {
     const location = useLocation();
 
     return (
@@ -138,7 +132,7 @@ export const sideNavWithReactRouter = {
     /**
      * Keeps the section expanded on load if one if the items are active
      */ 
-    const getDefaultSectionExpanded = (items: NavItemsJSONType['items']): boolean => {
+    const getDefaultSectionExpanded = (items) => {
       const activeItem = items.find((l1Item) =>
         isItemActive(location, {
           href: l1Item.href,
@@ -288,7 +282,8 @@ export const sideNavWithReactRouter = {
 
   export default SideNavExample;
   `,
-  'navItemsJSON.tsx': dedent`import {
+  'navItemsJSON.js': dedent`import React from 'react';
+  import {
     ArrowUpRightIcon,
     BillIcon,
     BuildingIcon,
@@ -310,26 +305,8 @@ export const sideNavWithReactRouter = {
     Button,
   } from '@razorpay/blade/components';
 
-  import type {
-    SideNavLinkProps,
-    SideNavSectionProps,
-  } from '@razorpay/blade/components';
 
-  export type ItemsType = Pick<
-    SideNavLinkProps,
-    'icon' | 'title' | 'href' | 'trailing' | 'tooltip'
-  >;
-
-  export type NavItemsJSONType = {
-    type: 'section';
-    title?: SideNavSectionProps['title'];
-    maxItemsVisible?: SideNavSectionProps['maxVisibleItems'];
-    items: (ItemsType & {
-      items?: (ItemsType & { items?: ItemsType[] })[];
-    })[];
-  };
-
-  export const navItemsJSON: NavItemsJSONType[] = [
+  export const navItemsJSON = [
     {
       type: 'section',
       title: undefined,

--- a/packages/blade/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/blade/src/components/Skeleton/Skeleton.stories.tsx
@@ -36,7 +36,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Skeleton } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Skeleton width="100%" height="50px" margin="spacing.4" />
           )

--- a/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
+++ b/packages/blade/src/components/SkipNav/SkipNav.stories.tsx
@@ -29,7 +29,7 @@ const Page = (): ReactElement => {
             Box 
           } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Box>
                 <Text>Click somewhere on the text here to focus on this window and press <Code>TAB</Code> key to see it in action</Text>

--- a/packages/blade/src/components/Spinner/Spinner/Spinner.stories.tsx
+++ b/packages/blade/src/components/Spinner/Spinner/Spinner.stories.tsx
@@ -23,7 +23,7 @@ const Page = (): ReactElement => {
           import { useEffect, useState } from 'react';
           import { Spinner, Text } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             const [isLoading, setIsLoading] = useState(true);
 
             useEffect(() => {

--- a/packages/blade/src/components/SpotlightPopoverTour/docs/examples.ts
+++ b/packages/blade/src/components/SpotlightPopoverTour/docs/examples.ts
@@ -76,7 +76,7 @@ export const BasicExample = `
     },
   ];
 
-  function App(): React.ReactElement {
+  function App() {
     const [activeStep, setActiveStep] = React.useState(0);
     const [isOpen, setIsOpen] = React.useState(false);
 

--- a/packages/blade/src/components/StepGroup/StepGroup.stories.tsx
+++ b/packages/blade/src/components/StepGroup/StepGroup.stories.tsx
@@ -46,7 +46,7 @@ const Page = (): React.ReactElement => {
           HeartIcon,
         } from '@razorpay/blade/components';
 
-        function App(): React.ReactElement {
+        function App() {
           return (
             // Check console
             <StepGroup orientation="vertical" size="medium">

--- a/packages/blade/src/components/Switch/Switch.stories.tsx
+++ b/packages/blade/src/components/Switch/Switch.stories.tsx
@@ -30,7 +30,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Switch } from '@razorpay/blade/components';
 
-        function App(): React.ReactElement {
+        function App() {
           return (
             // Check console
             <Switch

--- a/packages/blade/src/components/Table/docs/TableExamples.stories.tsx
+++ b/packages/blade/src/components/Table/docs/TableExamples.stories.tsx
@@ -37,7 +37,7 @@ const TableMeta: Meta = {
 
 const TableTemplate: StoryFn<typeof Table> = () => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {BasicTableStory}
     </Sandbox>
   );
@@ -47,7 +47,7 @@ export const BasicTable = TableTemplate.bind({});
 
 export const TableWithCustomCellComponents = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithCustomCellComponentsStory}
     </Sandbox>
   );
@@ -55,7 +55,7 @@ export const TableWithCustomCellComponents = (): React.ReactElement => {
 
 export const SortableTable = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {SortableTableStory}
     </Sandbox>
   );
@@ -63,7 +63,7 @@ export const SortableTable = (): React.ReactElement => {
 
 export const TableWithStickyHeaderAndFooter = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithStickyHeaderAndFooterStory}
     </Sandbox>
   );
@@ -71,7 +71,7 @@ export const TableWithStickyHeaderAndFooter = (): React.ReactElement => {
 
 export const TableWithStickyFirstColumn = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithStickyFirstColumnStory}
     </Sandbox>
   );
@@ -79,7 +79,7 @@ export const TableWithStickyFirstColumn = (): React.ReactElement => {
 
 export const SingleSelectableTable = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {SingleSelectableTableStory}
     </Sandbox>
   );
@@ -87,7 +87,7 @@ export const SingleSelectableTable = (): React.ReactElement => {
 
 export const MultiSelectableTableWithToolbar = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {MultiSelectableWithToolbarTableStory}
     </Sandbox>
   );
@@ -95,7 +95,7 @@ export const MultiSelectableTableWithToolbar = (): React.ReactElement => {
 
 export const MultiSelectableWithZebraStripes = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {MultiSelectableWithZebraStripesStory}
     </Sandbox>
   );
@@ -103,7 +103,7 @@ export const MultiSelectableWithZebraStripes = (): React.ReactElement => {
 
 export const TableWithDisabledRows = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithDisabledRowsStory}
     </Sandbox>
   );
@@ -111,7 +111,7 @@ export const TableWithDisabledRows = (): React.ReactElement => {
 
 export const TableWithBackgroundColor = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithBackgroundColorStory}
     </Sandbox>
   );
@@ -119,7 +119,7 @@ export const TableWithBackgroundColor = (): React.ReactElement => {
 
 export const TableWithIsLoading = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithIsLoadingStory}
     </Sandbox>
   );
@@ -127,7 +127,7 @@ export const TableWithIsLoading = (): React.ReactElement => {
 
 export const TableWithIsRefreshing = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithIsRefreshingStory}
     </Sandbox>
   );
@@ -135,7 +135,7 @@ export const TableWithIsRefreshing = (): React.ReactElement => {
 
 export const TableWithEditableCells = (): React.ReactElement => {
   return (
-    <Sandbox padding="spacing.0" editorHeight="90vh">
+    <Sandbox padding="spacing.0" editorHeight="100vh">
       {TableWithEditableCellsStory}
     </Sandbox>
   );

--- a/packages/blade/src/components/Table/docs/stories.ts
+++ b/packages/blade/src/components/Table/docs/stories.ts
@@ -10,18 +10,9 @@ import {
   TableRow,
   TableCell,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  method: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -38,7 +29,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -109,18 +100,9 @@ import {
   IconButton,
   Tooltip,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -135,7 +117,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -289,18 +271,9 @@ import {
   Amount,
   Badge,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -315,7 +288,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -414,18 +387,9 @@ import {
   Badge,
   Text,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React, { useState } from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -440,12 +404,12 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
 function App() {
-  const [selectedItem, setSelectedItem] = useState<Item | undefined>(undefined);
+  const [selectedItem, setSelectedItem] = useState(undefined);
   return (
     <Box
       backgroundColor="surface.background.gray.intense"
@@ -545,18 +509,9 @@ import {
   useTheme,
   Text,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React, { useState } from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -571,12 +526,12 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
 function App() {
-  const [selectedItems, setSelectedItems] = useState<Item[]>([]);
+  const [selectedItems, setSelectedItems] = useState([]);
   const { platform } = useTheme();
   const onMobile = platform === 'onMobile';
   const selectedItemsLength = selectedItems.length;
@@ -691,18 +646,9 @@ import {
   Button,
   useTheme,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -717,7 +663,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -826,18 +772,9 @@ import {
   TableFooterRow,
   TableFooterCell,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 20 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -852,7 +789,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -951,21 +888,9 @@ import {
   Amount,
   Badge,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-  account: string;
-  method: string;
-  name: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 20 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -994,7 +919,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -1092,18 +1017,9 @@ import {
   TablePagination,
   Text,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 100 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -1118,7 +1034,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -1173,9 +1089,9 @@ function App() {
             <TableHeader>
               <TableHeaderRow>
                 <TableHeaderCell>ID</TableHeaderCell>
-                <TableHeaderCell>Amount</TableHeaderCell>
                 <TableHeaderCell>Date</TableHeaderCell>
                 <TableHeaderCell>Method</TableHeaderCell>
+                <TableHeaderCell>Amount</TableHeaderCell>
               </TableHeaderRow>
             </TableHeader>
             <TableBody>
@@ -1183,9 +1099,6 @@ function App() {
                 <TableRow key={index} item={tableItem}>
                   <TableCell>
                     <Code size="medium">{tableItem.paymentId}</Code>
-                  </TableCell>
-                  <TableCell>
-                    <Amount value={tableItem.amount} />
                   </TableCell>
                   <TableCell>
                     {tableItem.date?.toLocaleDateString('en-IN', {
@@ -1209,6 +1122,9 @@ function App() {
                     >
                       {tableItem.status}
                     </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Amount value={tableItem.amount} />
                   </TableCell>
                 </TableRow>
               ))}
@@ -1244,18 +1160,9 @@ import {
   TrashIcon,
   CopyIcon,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 10 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -1270,7 +1177,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
@@ -1381,18 +1288,9 @@ import {
   TableFooterRow,
   TableFooterCell,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React, { useState } from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  method: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -1409,17 +1307,15 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 
-type Emphasis = 'subtle' | 'intense' | 'moderate'
-
 function App() {
-  const [emphasis, setEmphasis] = useState<Emphasis>('subtle');
+  const [emphasis, setEmphasis] = useState('subtle');
   return (
     <Box
-      backgroundColor={\`surface.background.gray\${emphasis}\`}
+      backgroundColor={\`surface.background.gray.\${emphasis}\`}
       padding="spacing.5"
       overflow="auto"
       minHeight="400px"
@@ -1431,7 +1327,7 @@ function App() {
         <RadioGroup
           label="Select Emphasis Level"
           onChange={({ value }) =>
-            setEmphasis(Number(value) as Emphasis)
+            setEmphasis(value)
           }
           value={\`\${emphasis}\`}
         >
@@ -1512,18 +1408,9 @@ import {
   TablePagination,
   Link,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React, { useEffect, useState } from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 100 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -1548,7 +1435,7 @@ function App() {
   }, [showData]);
 
   const onMobile = platform === 'onMobile';
-  const data: TableData<Item> = {
+  const data = {
     nodes: nodes,
   };
 
@@ -1586,15 +1473,6 @@ function App() {
               </TableToolbarActions>
             </TableToolbar>
           }
-          pagination={
-            <TablePagination
-              onPageChange={console.log}
-              defaultPageSize={10}
-              onPageSizeChange={console.log}
-              showPageSizePicker
-              showPageNumberSelector
-            />
-          }
           isLoading={!showData}
         >
           {(tableData) => (
@@ -1603,8 +1481,7 @@ function App() {
                 <TableHeaderRow>
                   <TableHeaderCell>ID</TableHeaderCell>
                   <TableHeaderCell>Amount</TableHeaderCell>
-                  <TableHeaderCell>Date</TableHeaderCell>
-                  <TableHeaderCell>Method</TableHeaderCell>
+                  <TableHeaderCell>Action</TableHeaderCell>
                 </TableHeaderRow>
               </TableHeader>
               <TableBody>
@@ -1617,27 +1494,7 @@ function App() {
                       <Amount value={tableItem.amount} />
                     </TableCell>
                     <TableCell>
-                      {tableItem.date?.toLocaleDateString('en-IN', {
-                        year: 'numeric',
-                        month: '2-digit',
-                        day: '2-digit',
-                      })}
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        size="medium"
-                        color={
-                          tableItem.status === 'Completed'
-                            ? 'positive'
-                            : tableItem.status === 'Pending'
-                            ? 'notice'
-                            : tableItem.status === 'Failed'
-                            ? 'negative'
-                            : 'default'
-                        }
-                      >
-                        {tableItem.status}
-                      </Badge>
+                      <Badge>{tableItem.status}</Badge>
                     </TableCell>
                   </TableRow>
                 ))}
@@ -1673,19 +1530,10 @@ import {
   useTheme,
   TablePagination,
   Text,
-  TableProps,
 } from '@razorpay/blade/components';
 import React, { useState } from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  status: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 100 }, (_, i) => ({
     id: (i + 1).toString(),
     paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
@@ -1700,7 +1548,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableProps<Item>['data'] = {
+const data = {
   nodes,
 };
 
@@ -1710,7 +1558,7 @@ function App() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const onMobile = platform === 'onMobile';
 
-  const handlePageChange = ({ page }: { page: number }) => {
+  const handlePageChange = ({ page }) => {
     if (currentPage !== page) {
       setIsRefreshing(true);
       setTimeout(() => {
@@ -1833,21 +1681,7 @@ import {
 } from '@razorpay/blade/components';
 import React, { useEffect, useState } from 'react';
 
-type APIResult = {
-  info: {
-    count: number;
-    pages: number;
-  };
-  results: {
-    id: number;
-    name: string;
-    species: string;
-    status: string;
-    origin: { name: string };
-  }[];
-};
-
-const fetchData = async ({ page }: { page: number }): Promise<APIResult> => {
+const fetchData = async ({ page }) => {
   const response = await fetch(
     \`https://rickandmortyapi.com/api/character?page=\${page}\`,
     {
@@ -1856,7 +1690,7 @@ const fetchData = async ({ page }: { page: number }): Promise<APIResult> => {
     }
   );
   const result = await response.json();
-  return result as APIResult;
+  return result;
 };
 
 function App() {
@@ -1877,7 +1711,7 @@ function App() {
     }
   }, []);
 
-  const handlePageChange = ({ page }: { page: number }) => {
+  const handlePageChange = ({ page }) => {
     setIsRefreshing(true);
     fetchData({ page: page + 1 }).then((res) => {
       // rick & morty api returns 20 items and we cannot change that. Hence limiting to show only first 10 items from the result of this API. Ideally an API should have \`limit\` & \`offset\` params that help us define the response we get.
@@ -1958,21 +1792,12 @@ import {
   ActionList,
   ActionListItem,
 } from '@razorpay/blade/components';
-import type { TableData } from '@razorpay/blade/components';
 import React from 'react';
 
-type Item = {
-  id: string;
-  paymentId: string;
-  amount: number;
-  date: Date;
-  method: string;
-};
-
-const nodes: Item[] = [
+const nodes = [
   ...Array.from({ length: 5 }, (_, i) => ({
     id: (i + 1).toString(),
-    paymentId: \`rzp${Math.floor(Math.random() * 1000000)}\`,
+    paymentId: \`rzp\${Math.floor(Math.random() * 1000000)}\`,
     amount: Number((Math.random() * 10000).toFixed(2)),
     date: new Date(
       2021,
@@ -1986,7 +1811,7 @@ const nodes: Item[] = [
   })),
 ];
 
-const data: TableData<Item> = {
+const data = {
   nodes,
 };
 

--- a/packages/blade/src/components/Table/docs/stories.ts
+++ b/packages/blade/src/components/Table/docs/stories.ts
@@ -42,7 +42,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box
       backgroundColor="surface.background.gray.intense"
@@ -139,7 +139,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box
       backgroundColor="surface.background.gray.intense"
@@ -319,7 +319,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box
       backgroundColor="surface.background.gray.intense"
@@ -444,7 +444,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const [selectedItem, setSelectedItem] = useState<Item | undefined>(undefined);
   return (
     <Box
@@ -575,7 +575,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const [selectedItems, setSelectedItems] = useState<Item[]>([]);
   const { platform } = useTheme();
   const onMobile = platform === 'onMobile';
@@ -721,7 +721,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const { platform } = useTheme();
   const onMobile = platform === 'onMobile';
   return (
@@ -856,7 +856,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const totalAmount = nodes.reduce((acc, curr) => acc + curr.amount, 0);
 
   return (
@@ -998,7 +998,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box
       backgroundColor="surface.background.gray.intense"
@@ -1122,7 +1122,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const { platform } = useTheme();
   const onMobile = platform === 'onMobile';
 
@@ -1274,7 +1274,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const { platform } = useTheme();
   const onMobile = platform === 'onMobile';
 
@@ -1415,7 +1415,7 @@ const data: TableData<Item> = {
 
 type Emphasis = 'subtle' | 'intense' | 'moderate'
 
-function App(): React.ReactElement {
+function App() {
   const [emphasis, setEmphasis] = useState<Emphasis>('subtle');
   return (
     <Box
@@ -1538,7 +1538,7 @@ const nodes: Item[] = [
   })),
 ];
 
-function App(): React.ReactElement {
+function App() {
   const { platform } = useTheme();
   const [showData, setShowData] = useState(false);
   useEffect(() => {
@@ -1704,7 +1704,7 @@ const data: TableProps<Item>['data'] = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   const { platform } = useTheme();
   const [currentPage, setCurrentPage] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -1859,7 +1859,7 @@ const fetchData = async ({ page }: { page: number }): Promise<APIResult> => {
   return result as APIResult;
 };
 
-function App(): React.ReactElement {
+function App() {
   const [apiData, setApiData] = useState<{ nodes: APIResult['results'] }>({
     nodes: [],
   });
@@ -1990,7 +1990,7 @@ const data: TableData<Item> = {
   nodes,
 };
 
-function App(): React.ReactElement {
+function App() {
   return (
     <Box
       backgroundColor="surface.background.gray.intense"

--- a/packages/blade/src/components/Tag/Tag.stories.tsx
+++ b/packages/blade/src/components/Tag/Tag.stories.tsx
@@ -27,7 +27,7 @@ const Page = (): React.ReactElement => {
         import React from 'react';
         import { Tag, FileTextIcon } from '@razorpay/blade/components';
         
-        function App(): React.ReactElement {
+        function App() {
           const [isTagVisible, setIsTagVisible] = React.useState(true);
 
           return (

--- a/packages/blade/src/components/Toast/Toast.stories.tsx
+++ b/packages/blade/src/components/Toast/Toast.stories.tsx
@@ -27,7 +27,7 @@ const Page = (): React.ReactElement => {
         {`
         import { ToastContainer, useToast } from '@razorpay/blade/components';
 
-        function App(): React.ReactElement {
+        function App() {
           const toast = useToast();
 
           // Integrating Blade Toast in your App

--- a/packages/blade/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.stories.tsx
@@ -31,7 +31,7 @@ const Page = (): React.ReactElement => {
         {`
         import { Tooltip, Button } from '@razorpay/blade/components'
         
-        function App(): React.ReactElement {
+        function App() {
           return (
             <Tooltip content="Hello world" placement="bottom">
               <Button>Hover over me</Button>

--- a/packages/blade/src/components/TopNav/docs/TabNav.stories.tsx
+++ b/packages/blade/src/components/TopNav/docs/TabNav.stories.tsx
@@ -30,7 +30,7 @@ const DocsPage = (): React.ReactElement => {
       componentName="TabNav"
       componentDescription="TabNav is a subcomponent of TopNav which can be used inside or outside TopNav"
     >
-      <Sandbox files={tabNavExample} editorHeight={600} hideNavigation={false} openFile="App.tsx" />
+      <Sandbox files={tabNavExample} editorHeight={600} hideNavigation={false} openFile="App.js" />
     </StoryPageWrapper>
   );
 };

--- a/packages/blade/src/components/TopNav/docs/TopNav.stories.tsx
+++ b/packages/blade/src/components/TopNav/docs/TopNav.stories.tsx
@@ -79,7 +79,7 @@ const DocsPage = (): React.ReactElement => {
         files={topNavFullExample}
         editorHeight={600}
         hideNavigation={false}
-        openFile="SideNavExample.tsx,utils.tsx,App.tsx,TopNavExample.tsx"
+        openFile="SideNavExample.js,utils.js,App.js,TopNavExample.js"
       />
     </StoryPageWrapper>
   );

--- a/packages/blade/src/components/TopNav/docs/code.ts
+++ b/packages/blade/src/components/TopNav/docs/code.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 
 export const topNavFullExample = {
-  'App.tsx': dedent`import React from 'react';
+  'App.js': dedent`import React from 'react';
   import { BrowserRouter } from 'react-router-dom';
   import { TopNavExample } from './TopNavExample';
   
@@ -15,7 +15,7 @@ export const topNavFullExample = {
 
   export default App;
   `,
-  'TopNavExample.tsx': dedent`import React from "react";
+  'TopNavExample.js': dedent`import React from "react";
   import styled from "styled-components";
   import { Link, useLocation, useNavigate } from "react-router-dom";
   import { SideNavExample } from "./SideNavExample";
@@ -58,17 +58,9 @@ export const topNavFullExample = {
     SIDE_NAV_EXPANDED_L1_WIDTH_XL,
   } from "@razorpay/blade/components";
   import { makeSize } from "@razorpay/blade/utils";
-  import type {
-    TabNavItemProps,
-    IconComponent,
-  } from "@razorpay/blade/components";
 
-  const TabNavItemLink = React.forwardRef<
-    HTMLAnchorElement,
-    Omit<TabNavItemProps, "as"> & {
-      activeOnLinks?: string[];
-    }
-  >((props, ref) => {
+
+  const TabNavItemLink = React.forwardRef((props, ref) => {
     const location = useLocation();
     return (
       <TabNavItem
@@ -87,11 +79,7 @@ export const topNavFullExample = {
     icon: Icon,
     title,
     description,
-  }: {
-    icon: IconComponent;
-    title?: string;
-    description: string;
-  }): React.ReactElement => {
+  }) => {
     return (
       <Box display="flex" gap="spacing.4">
         <Box
@@ -121,12 +109,12 @@ export const topNavFullExample = {
     };
   });
 
-  const TopNavExample = (): React.ReactElement => {
+  const TopNavExample = () => {
     const { platform } = useTheme();
     const navigate = useNavigate();
     const isMobile = platform === "onMobile";
     const [isSideBarOpen, setIsSideBarOpen] = React.useState(false);
-    const [selectedProduct, setSelectedProduct] = React.useState<string | null>(
+    const [selectedProduct, setSelectedProduct] = React.useState(
       null
     );
 
@@ -255,14 +243,14 @@ export const topNavFullExample = {
                                     <MenuItem
                                       key={item.href}
                                       onClick={() => {
-                                        navigate(item.href!);
-                                        setSelectedProduct(item.href!);
+                                        navigate(item.href);
+                                        setSelectedProduct(item.href);
                                       }}
                                     >
                                       <ExploreItem
-                                        icon={item.icon!}
+                                        icon={item.icon}
                                         title={item.title}
-                                        description={item.description!}
+                                        description={item.description}
                                       />
                                     </MenuItem>
                                   );
@@ -390,13 +378,9 @@ export const topNavFullExample = {
 
   export { TopNavExample };
   `,
-  'SideNavExample.tsx': dedent`import React from "react";
+  'SideNavExample.js': dedent`import React from "react";
   import { Link, useLocation } from "react-router-dom";
   import { isItemActive } from "./utils";
-  import type {
-    SideNavProps,
-    SideNavLinkProps,
-  } from "@razorpay/blade/components";
   import {
     SideNav,
     SideNavBody,
@@ -412,10 +396,8 @@ export const topNavFullExample = {
   } from "@razorpay/blade/components";
 
   const NavLink = (
-    props: Omit<SideNavLinkProps, "as"> & {
-      activeOnLinks?: string[];
-    }
-  ): React.ReactElement => {
+    props
+  ) => {
     const location = useLocation();
 
     return (
@@ -433,7 +415,7 @@ export const topNavFullExample = {
   const SideNavExample = ({
     isOpen,
     onDismiss,
-  }: Pick<SideNavProps, "isOpen" | "onDismiss">): React.ReactElement => {
+  }) => {
     return (
       <SideNav isOpen={isOpen} onDismiss={onDismiss} position="absolute">
         <SideNavBody>
@@ -472,22 +454,23 @@ export const topNavFullExample = {
 
   export { SideNavExample };
 `,
-  'utils.tsx': dedent`import { matchPath } from "react-router-dom";
+  'utils.js': dedent`import React from 'react';
+  import { matchPath } from "react-router-dom";
 
   const isItemActive = (
-    location: { pathname: string },
-    { href, activeOnLinks }: { href?: string; activeOnLinks?: string[] }
-  ): boolean => {
-    const isCurrentPathActive = Boolean(matchPath(location.pathname, href!));
+    location,
+    { href, activeOnLinks }
+  ) => {
+    const isCurrentPathActive = Boolean(matchPath(location.pathname, href));
 
     const isSubItemActive = Boolean(
-      activeOnLinks?.find((href) => matchPath(location.pathname, href!))
+      activeOnLinks?.find((href) => matchPath(location.pathname, href))
     );
 
     return isCurrentPathActive || isSubItemActive;
   };
 
-  const RazorpayLogo = (): React.ReactElement => {
+  const RazorpayLogo = () => {
     return (
       <svg
         width="116"
@@ -517,11 +500,12 @@ export const topNavFullExample = {
 };
 
 export const tabNavExample = {
-  'App.tsx': dedent`import React from 'react';
+  'App.js': dedent`import React from 'react';
   import { 
     Box, 
     TabNav, 
     TabNavItem,
+    TabNavItems,
     Text,
     HomeIcon,
     RazorpayxPayrollIcon,

--- a/packages/blade/src/components/Typography/Code/Code.stories.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.stories.tsx
@@ -21,7 +21,7 @@ const Page = (): ReactElement => {
         {`
           import { Code, Text } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               // For React Native, you will have to use flex layout to align Code component properly
               <Text>You can use <Code>Code</Code> component to add inlined Code, token names, variable names, etc</Text>

--- a/packages/blade/src/components/Typography/Display/Display.stories.tsx
+++ b/packages/blade/src/components/Typography/Display/Display.stories.tsx
@@ -24,7 +24,7 @@ const Page = (): ReactElement => {
         {`
           import { Display } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Display size="large">Blade by Razorpay</Display>
             )

--- a/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.stories.tsx
@@ -25,7 +25,7 @@ const Page = (): ReactElement => {
         {`
           import { Heading } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Heading size="large">Blade by Razorpay</Heading>
             )

--- a/packages/blade/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.stories.tsx
@@ -20,7 +20,7 @@ const Page = (): ReactElement => {
         {`
           import { Text } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Text>Lorem Ipsum</Text>
             )

--- a/packages/blade/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/blade/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -32,7 +32,7 @@ const Page = (): ReactElement => {
         {`
           import { VisuallyHidden, Checkbox, Text, Box } from '@razorpay/blade/components';
 
-          function App(): React.ReactElement {
+          function App() {
             return (
               <Box>
                 <Text>If you focus on checkbox below with voice over enabled, you will hear "Hidden Label" announcement</Text>

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -46,6 +46,9 @@ const useStackblitzSetup = ({
   const filesObj = files ?? {};
 
   const stackblitzProject: Project = React.useMemo(() => {
+    // since its javascript template, it doesn't autoimport react in examples. Here I'm just injecting react if its not imported
+    const reactImport = code?.includes('import React') ? '' : "import React from 'react'";
+
     return {
       title: 'Blade Example by Razorpay',
       description: "Example of Razorpay's Design System, Blade",
@@ -70,7 +73,7 @@ const useStackblitzSetup = ({
           brandColor,
           showConsole,
         }),
-        [`App.${fileExtension}`]: code ? `import React from 'react';\n${dedent(code)}` : '',
+        [`App.${fileExtension}`]: code ? `${reactImport};\n${dedent(code)}` : '',
         [`Logger.${fileExtension}`]: logger,
         ...(isPR ? { 'package.json': vitePackageJSON, 'vite.config.js': viteConfigTS } : {}),
         '.npmrc': `auto-install-peers = false`,

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -6,7 +6,14 @@ import { DocsContext } from '@storybook/addon-docs';
 
 import type { Project } from '@stackblitz/sdk';
 import styled from 'styled-components';
-import { getIndexTSX, getViteReactTSDependencies, indexHTML, logger } from '../baseCode';
+import {
+  getIndexTSX,
+  getViteReactTSDependencies,
+  indexHTML,
+  isPR,
+  logger,
+  vitePackageJSON,
+} from '../baseCode';
 import type { SandboxStackBlitzProps } from '../types';
 import BaseBox from '~components/Box/BaseBox';
 
@@ -33,12 +40,11 @@ const useStackblitzSetup = ({
   const colorScheme = docsContext?.store?.globals?.globals?.colorScheme ?? 'light';
   // @ts-expect-error docsContext.store exists
   const brandColor = docsContext?.store?.globals?.globals?.brandColor;
-
   const stackblitzProject: Project = React.useMemo(() => {
     return {
       title: 'Blade Example by Razorpay',
       description: "Example of Razorpay's Design System, Blade",
-      template: 'javascript',
+      template: isPR ? 'node' : 'javascript',
       files: {
         '.vscode/settings.json': JSON.stringify(
           {
@@ -62,12 +68,13 @@ const useStackblitzSetup = ({
         'App.js': code ? `import React from 'react';\n${dedent(code)}` : '',
         'Logger.js': logger,
         '.npmrc': `auto-install-peers = false`,
+        ...(isPR ? { 'package.json': vitePackageJSON } : {}),
         ...files,
       },
       dependencies: getViteReactTSDependencies().dependencies,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [colorScheme, brandColor]);
+  }, [colorScheme, brandColor, isPR]);
 
   React.useEffect(() => {
     if (sandboxRef.current) {

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -6,14 +6,7 @@ import { DocsContext } from '@storybook/addon-docs';
 
 import type { Project } from '@stackblitz/sdk';
 import styled from 'styled-components';
-import {
-  getIndexTSX,
-  indexHTML,
-  logger,
-  tsConfigJSON,
-  viteConfigTS,
-  vitePackageJSON,
-} from '../baseCode';
+import { getIndexTSX, getViteReactTSDependencies, indexHTML, logger } from '../baseCode';
 import type { SandboxStackBlitzProps } from '../types';
 import BaseBox from '~components/Box/BaseBox';
 
@@ -45,7 +38,7 @@ const useStackblitzSetup = ({
     return {
       title: 'Blade Example by Razorpay',
       description: "Example of Razorpay's Design System, Blade",
-      template: 'node',
+      template: 'javascript',
       files: {
         '.vscode/settings.json': JSON.stringify(
           {
@@ -60,20 +53,18 @@ const useStackblitzSetup = ({
           4,
         ),
         'index.html': indexHTML,
-        'index.tsx': getIndexTSX({
+        'index.js': getIndexTSX({
           themeTokenName: 'bladeTheme',
           colorScheme,
           brandColor,
           showConsole,
         }),
-        'App.tsx': code ? dedent(code) : '',
-        'Logger.tsx': logger,
-        'vite.config.ts': viteConfigTS,
-        'tsconfig.json': tsConfigJSON,
-        'package.json': vitePackageJSON,
+        'App.js': code ? `import React from 'react';\n${dedent(code)}` : '',
+        'Logger.js': logger,
         '.npmrc': `auto-install-peers = false`,
         ...files,
       },
+      dependencies: getViteReactTSDependencies().dependencies,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [colorScheme, brandColor]);
@@ -117,7 +108,7 @@ export const Sandbox = ({
   editorHeight = 500,
   showConsole = false,
   files,
-  openFile = 'App.tsx',
+  openFile = 'App.js',
   padding = ['spacing.5', 'spacing.0', 'spacing.8'],
   hideNavigation = true,
 }: SandboxStackBlitzProps): JSX.Element => {

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -73,7 +73,7 @@ export const getViteReactTSDependencies = (): Dependencies => {
       'react-router-dom': '^6',
       '@types/react': '^18',
       '@types/react-dom': '^18',
-      '@razorpay/blade': 'https://pkg.csb.dev/razorpay/blade/commit/06db577a/@razorpay/blade',
+      '@razorpay/blade': getBladeVersion(),
       'styled-components': packageJson.peerDependencies['styled-components'],
       '@razorpay/i18nify-js': packageJson.peerDependencies['@razorpay/i18nify-js'],
       '@razorpay/i18nify-react': packageJson.peerDependencies['@razorpay/i18nify-react'],
@@ -92,7 +92,7 @@ export const vitePackageJSON = JSON.stringify(
       build: 'vite build',
     },
     stackblitz: {
-      startCommand: 'yarn install && yarn dev',
+      startCommand: 'pnpm install && pnpm dev',
       installDependencies: false,
     },
     ...getViteReactTSDependencies(),

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -3,6 +3,8 @@ import dedent from 'dedent';
 // @ts-expect-error We don't resolve JSON files right now. didn't want to change TS config for single JSON
 import packageJson from '../../../../package.json'; // eslint-disable-line
 
+export const isPR = Boolean(process.env.GITHUB_SHA);
+
 const getBladeVersion = (): string => {
   // We don't publish codesandbox ci on master so version is not present
   const isMaster = process.env.GITHUB_REF === 'refs/heads/master';
@@ -71,7 +73,7 @@ export const getViteReactTSDependencies = (): Dependencies => {
       'react-router-dom': '^6',
       '@types/react': '^18',
       '@types/react-dom': '^18',
-      '@razorpay/blade': getBladeVersion(),
+      '@razorpay/blade': 'https://pkg.csb.dev/razorpay/blade/commit/06db577a/@razorpay/blade',
       'styled-components': packageJson.peerDependencies['styled-components'],
       '@razorpay/i18nify-js': packageJson.peerDependencies['@razorpay/i18nify-js'],
       '@razorpay/i18nify-react': packageJson.peerDependencies['@razorpay/i18nify-react'],
@@ -134,7 +136,7 @@ export const indexHTML = dedent`
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/index.tsx"></script>
+    <script type="module" src="/index.js"></script>
   </body>
 </html>
 `;

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -117,6 +117,20 @@ export const indexHTML = dedent`
     <link rel="icon" href="https://raw.githubusercontent.com/razorpay/blade/1e77f0b35172654037a431a916b3190b545fd232/branding/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blade Example</title>
+    <style>
+    /* 
+      You should ideally write these styles in styled-component's createGlobalStyles.
+      We're adding it here because that is not working in stackblitz example
+    */
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      margin: 0px;
+      padding: 0px;
+    }
+    </style>
   </head>
   <body>
     <div id="root"></div>
@@ -132,7 +146,7 @@ import React from 'react';
 const overrideConsoleLog = () => {
   const actualConsoleLog = console.log;
   const customConsole = {
-    log: function (message: any) {
+    log: function (message) {
       const logMessage = document.createElement('p');
       logMessage.style.fontSize = '14px';
       logMessage.textContent = '> ' + JSON.stringify(message, null, 4);
@@ -234,7 +248,6 @@ export const getIndexTSX = ({
 }): string => dedent`
 import React from 'react';
 import { createRoot } from "react-dom/client";
-import { createGlobalStyle } from "styled-components";
 
 import { BladeProvider, Box } from "@razorpay/blade/components";
 import { ${themeTokenName}, createTheme } from "@razorpay/blade/tokens";
@@ -242,18 +255,6 @@ import { ${themeTokenName}, createTheme } from "@razorpay/blade/tokens";
 import App from "./App";
 ${showConsole ? 'import { Logger } from "./Logger";' : ''}
 import '@razorpay/blade/fonts.css';
-
-
-const GlobalStyles = createGlobalStyle\`
-  * { 
-    box-sizing: border-box;
-  }
-  body {
-    margin: 0;
-    padding: 0;
-    font-family: 'Lato', sans-serif;
-  }
-\`;
 
 const rootElement = document.getElementById("root");
 
@@ -273,7 +274,6 @@ const getTheme = () => {
 
 root.render(
   <BladeProvider themeTokens={getTheme()} colorScheme="${colorScheme}">
-    <GlobalStyles />
     <Box 
       backgroundColor="surface.background.gray.subtle"
       minHeight="100vh"

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -63,7 +63,7 @@ export const getReactScriptsJSDependencies = (): Dependencies => {
   };
 };
 
-const getViteReactTSDependencies = (): Dependencies => {
+export const getViteReactTSDependencies = (): Dependencies => {
   return {
     dependencies: {
       react: '^18',
@@ -232,6 +232,7 @@ export const getIndexTSX = ({
   colorScheme: any;
   showConsole?: boolean;
 }): string => dedent`
+import React from 'react';
 import { createRoot } from "react-dom/client";
 import { createGlobalStyle } from "styled-components";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4828,10 +4828,10 @@
     nanoid "^3.3.4"
     webpack "^5.75.0"
 
-"@stackblitz/sdk@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@stackblitz/sdk/-/sdk-1.9.0.tgz#b5174f3f45a51b6c1b9e67f1ef4e2e783ab105e9"
-  integrity sha512-3m6C7f8pnR5KXys/Hqx2x6ylnpqOak6HtnZI6T5keEO0yT+E4Spkw37VEbdwuC+2oxmjdgq6YZEgiKX7hM1GmQ==
+"@stackblitz/sdk@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@stackblitz/sdk/-/sdk-1.11.0.tgz#ba30c837decca221ce8d605ff768a774c0f92f89"
+  integrity sha512-DFQGANNkEZRzFk1/rDP6TcFdM82ycHE+zfl9C/M/jXlH68jiqHWHFMQURLELoD8koxvu/eW5uhg94NSAZlYrUQ==
 
 "@stitches/core@^1.2.6":
   version "1.2.8"


### PR DESCRIPTION
## Description

Speeds up stackblitz examples 

## Changes

- Move from node template to javascript template of stackblitz as it support autocomplete now
- Remove typescript from our examples as it throws runtime errors in javascript template
