### PR TITLE
fix(stackblitz): move examples to react 19

### DIFF
--- a/.changeset/smart-pots-complain.md
+++ b/.changeset/smart-pots-complain.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat: update use-presence hook to latest for react 19 support

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -137,7 +137,7 @@
     "@babel/runtime": "7.20.0",
     "body-scroll-lock-upgrade": "1.1.0",
     "ts-deepmerge": "6.2.0",
-    "use-presence": "1.1.0",
+    "use-presence": "1.3.0",
     "@use-gesture/react": "10.2.24",
     "@floating-ui/react": "0.26.13",
     "react-hot-toast": "2.4.1",

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -47,7 +47,7 @@ const useStackblitzSetup = ({
 
   const stackblitzProject: Project = React.useMemo(() => {
     // since its javascript template, it doesn't autoimport react in examples. Here I'm just injecting react if its not imported
-    const reactImport = code?.includes('import React') ? '' : "import React from 'react'";
+    const reactImport = code?.includes('import React') ? '' : "import React from 'react';\n";
 
     return {
       title: 'Blade Example by Razorpay',
@@ -73,7 +73,7 @@ const useStackblitzSetup = ({
           brandColor,
           showConsole,
         }),
-        [`App.${fileExtension}`]: code ? `${reactImport};\n${dedent(code)}` : '',
+        [`App.${fileExtension}`]: code ? `${reactImport}${dedent(code)}` : '',
         [`Logger.${fileExtension}`]: logger,
         ...(isPR ? { 'package.json': vitePackageJSON, 'vite.config.js': viteConfigTS } : {}),
         '.npmrc': `auto-install-peers = false`,

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -52,7 +52,7 @@ const useStackblitzSetup = ({
     return {
       title: 'Blade Example by Razorpay',
       description: "Example of Razorpay's Design System, Blade",
-      template: isPR ? 'node' : 'javascript',
+      template: isPR ? 'node' : 'create-react-app',
       files: {
         '.vscode/settings.json': JSON.stringify(
           {
@@ -76,6 +76,7 @@ const useStackblitzSetup = ({
         [`App.${fileExtension}`]: code ? `${reactImport}${dedent(code)}` : '',
         [`Logger.${fileExtension}`]: logger,
         ...(isPR ? { 'package.json': vitePackageJSON, 'vite.config.js': viteConfigTS } : {}),
+        'package.json': vitePackageJSON,
         '.npmrc': `auto-install-peers = false`,
         ...Object.fromEntries(
           Object.entries(filesObj).map(([fileKey, fileValue]) => [

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -70,11 +70,11 @@ export const getReactScriptsJSDependencies = (): Dependencies => {
 export const getViteReactTSDependencies = (): Dependencies => {
   return {
     dependencies: {
-      react: '^18',
-      'react-dom': '^18',
+      react: '19.0.0',
+      'react-dom': '19.0.0',
       'react-router-dom': '^6',
-      '@types/react': '^18',
-      '@types/react-dom': '^18',
+      '@types/react': '^19',
+      '@types/react-dom': '^19',
       '@razorpay/blade': getBladeVersion(),
       'styled-components': packageJson.peerDependencies['styled-components'],
       '@razorpay/i18nify-js': packageJson.peerDependencies['@razorpay/i18nify-js'],

--- a/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
+++ b/packages/blade/src/utils/storybook/Sandbox/baseCode.ts
@@ -70,9 +70,10 @@ export const getReactScriptsJSDependencies = (): Dependencies => {
 export const getViteReactTSDependencies = (): Dependencies => {
   return {
     dependencies: {
-      react: '19.0.0',
-      'react-dom': '19.0.0',
+      react: '^19',
+      'react-dom': '^19',
       'react-router-dom': '^6',
+      'react-scripts': '4.0.3',
       '@types/react': '^19',
       '@types/react-dom': '^19',
       '@razorpay/blade': getBladeVersion(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -28016,10 +28016,10 @@ use-latest@^1.2.1:
   dependencies:
     use-isomorphic-layout-effect "^1.1.1"
 
-use-presence@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/use-presence/-/use-presence-1.1.0.tgz#890b82e656f3a72fc15ee61be521ae1062afcedc"
-  integrity sha512-Tol+g7q81LLjhFMvrzhKXa4CCyZ0Tg4MRcPC2eSqdDLGQEA1MnjNc/jMFDKSB8CZDFchd7FOsq33glZyFX3zuw==
+use-presence@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-presence/-/use-presence-1.3.0.tgz#85dd579af3bc1e0a1033a9d5445a1190a9e09d38"
+  integrity sha512-jq7lFpf67tKtCZ9wBfb29R4ijgGbVQAVkM2zBNZAtXEbmClE0DjgulkM9PGk3iKeyqx215j5CPFFA1zx3Kdpbw==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
## Description

For some reason stackblitz is trying to find package in react 19 even though we have react 18 marked in dependencies 🤦🏼 . Just updating to react 19 in examples for now. There aren't any major breaking changes apart from deprecated APIs being removed

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/4cec564c-d6d8-4131-b6b2-7f6a96fc3d81">
