### PR TITLE
fix: remove js check that allows brand token for Box backgroundColor

### DIFF
--- a/.changeset/mean-guests-reflect.md
+++ b/.changeset/mean-guests-reflect.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: remove js check that allows brand token for Box backgroundColor

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -13,12 +13,11 @@ const validateBackgroundString = (stringBackgroundColorValue: string): void => {
   if (__DEV__) {
     if (
       !stringBackgroundColorValue.startsWith('surface.background') &&
-      !stringBackgroundColorValue.startsWith('brand.') &&
       !stringBackgroundColorValue.startsWith('overlay.') &&
       stringBackgroundColorValue !== 'transparent'
     ) {
       throwBladeError({
-        message: `Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, \`overlay.*\` and \`brand.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
+        message: `Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`overlay.*\` tokens with backgroundColor property but we received \`${stringBackgroundColorValue}\` instead.\n\n Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨`,
         moduleName: 'Box',
       });
     }

--- a/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.native.test.tsx
@@ -61,7 +61,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, \`overlay.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`overlay.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);

--- a/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
+++ b/packages/blade/src/components/Box/__tests__/Box.web.test.tsx
@@ -71,7 +71,7 @@ describe('<Box />', () => {
       );
     } catch (err: unknown) {
       expect(err).toMatchInlineSnapshot(`
-        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, \`overlay.*\` and \`brand.*\` tokens with backgroundColor property but we received \`red\` instead.
+        [Error: [Blade: Box]: Oops! Currently you can only use \`transparent\`, \`surface.background.*\`, and \`overlay.*\` tokens with backgroundColor property but we received \`red\` instead.
 
          Do you have a usecase of using other values? Create an issue on https://github.com/razorpay/blade repo to let us know and we can discuss ✨]
       `);


### PR DESCRIPTION
## Description
Remove JS check that was allowing brand colors in box background color
<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
