### PR TITLE
fix: cleanup bodyscroll locks if bottomsheet is force unmounted

### DIFF
--- a/.changeset/chatty-dolphins-care.md
+++ b/.changeset/chatty-dolphins-care.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): cleanup bodyscroll locks if bottomsheet is force unmounted

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { rubberbandIfOutOfBounds, useDrag } from '@use-gesture/react';
 import usePresence from 'use-presence';
-import { clearAllBodyScrollLocks } from 'body-scroll-lock-upgrade';
+import { clearAllBodyScrollLocks, enableBodyScroll } from 'body-scroll-lock-upgrade';
 import { BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetFooter } from './BottomSheetFooter';
 import { BottomSheetBody } from './BottomSheetBody';
@@ -432,6 +432,22 @@ const _BottomSheet = ({
       removeBottomSheetFromStack(id);
     }
   }, [addBottomSheetToStack, id, isMounted, removeBottomSheetFromStack]);
+
+  // Remove the bottomsheet from the stack, if it's unmounted forcefully
+  React.useEffect(() => {
+    return () => {
+      if (id === undefined) return;
+      removeBottomSheetFromStack(id);
+    };
+  }, [id, removeBottomSheetFromStack]);
+
+  // Disable body scroll lock when the component is unmounted forcefully
+  React.useEffect(() => {
+    const lockTarget = scrollRef.current!;
+    return () => {
+      enableBodyScroll(lockTarget);
+    };
+  }, []);
 
   // We will need to reset these values otherwise the next time the bottomsheet opens
   // this will be populated and the animations won't run


### PR DESCRIPTION
## Description

fixes: DSSUP-184

<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
