### PR TITLE
fix: fileUpload onRemove clashes with onChange [FC-1234]

### DIFF
--- a/.changeset/modern-geckos-relate.md
+++ b/.changeset/modern-geckos-relate.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix: fileupload on remove clashes with onchage

--- a/.changeset/modern-geckos-relate.md
+++ b/.changeset/modern-geckos-relate.md
@@ -2,4 +2,4 @@
 '@razorpay/blade': patch
 ---
 
-fix: fileupload on remove clashes with onchage
+fix(FileUpload): fileupload on remove clashes with onchage

--- a/.changeset/modern-geckos-relate.md
+++ b/.changeset/modern-geckos-relate.md
@@ -3,3 +3,7 @@
 ---
 
 fix(FileUpload): fileupload on remove clashes with onchage
+
+> [!NOTE]
+>
+> Previously, onChange did not provide an updated value when a file was removed. Now, when a file is removed from FileUpload, onChange will return the updated value.

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -314,7 +314,8 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
               setSelectedFiles(() => newFiles);
               onRemove?.({ file: selectedFiles[0] });
-              fireNativeEvent(inputRef, ['change', 'input']);
+              onChange?.({ fileList: newFiles });
+              fireNativeEvent(getOuterMotionRef({ _motionMeta, ref }), ['change', 'input']);
             }}
             onReupload={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
@@ -376,7 +377,8 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
                 setSelectedFiles(() => newFiles);
                 onRemove?.({ file });
-                fireNativeEvent(inputRef, ['change', 'input']);
+                onChange?.({ fileList: newFiles });
+                fireNativeEvent(getOuterMotionRef({ _motionMeta, ref }), ['change', 'input']);
               }}
               onReupload={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useRef, forwardRef } from 'react';
+import { flushSync } from 'react-dom';
 import type { FileUploadProps, BladeFile, BladeFileList } from './types';
 import { StyledFileUploadWrapper } from './StyledFileUploadWrapper';
 import {
@@ -312,10 +313,11 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
             size={size}
             onRemove={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
-              setSelectedFiles(() => newFiles);
+              flushSync(() => {
+                setSelectedFiles(() => newFiles);
+              });
               onRemove?.({ file: selectedFiles[0] });
-              onChange?.({ fileList: newFiles });
-              fireNativeEvent(getOuterMotionRef({ _motionMeta, ref }), ['change', 'input']);
+              fireNativeEvent(inputRef, ['change', 'input']);
             }}
             onReupload={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
@@ -375,10 +377,11 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               size={size}
               onRemove={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
-                setSelectedFiles(() => newFiles);
+                flushSync(() => {
+                  setSelectedFiles(() => newFiles);
+                });
                 onRemove?.({ file });
-                onChange?.({ fileList: newFiles });
-                fireNativeEvent(getOuterMotionRef({ _motionMeta, ref }), ['change', 'input']);
+                fireNativeEvent(inputRef, ['change', 'input']);
               }}
               onReupload={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);


### PR DESCRIPTION
## Description

 fileUpload component's onRemove behavior clashes with onChange.

I believe onChange should be triggered when onRemove is called, but it should provide the latest value instead of returning outdated values. Currently, we are using onRemove to handle file removal. However, ideally, this should be managed by onChange, similar to how an input's onChange event reflects both the addition and removal of characters in a string.

## Additional Information

this pr should go with a major release. 
## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [x] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [x] Add KitchenSink Story
- [x] Add Interaction Tests (if applicable)
- [x] Add changeset
