### PR TITLE
feat: add dateformat and placeholder prop for datepicker input [DSSUP-199]

### DIFF
--- a/.changeset/yellow-cameras-knock.md
+++ b/.changeset/yellow-cameras-knock.md
@@ -1,0 +1,6 @@
+---
+'@razorpay/blade': patch
+---
+
+feat(blade): add dateformat and placeholder prop for datepicker input
+fix(blade): Removed the chevron icon when the picker prop is used.

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -28,11 +28,13 @@ const Calendar = <Type extends DateSelectionType>({
   onNext,
   onPrevious,
   presets,
+  showLevelChangeLink,
   ...props
 }: CalendarProps<Type> & {
   date?: Date;
   defaultDate?: Date;
   onDateChange?: (date: DateValue) => void;
+  showLevelChangeLink?: boolean;
 }): React.ReactElement => {
   const isRange = selectionType === 'range';
 
@@ -125,6 +127,7 @@ const Calendar = <Type extends DateSelectionType>({
         onPreviousDecade={handlePreviousDecade}
         onNextYear={handleNextYear}
         onPreviousYear={handlePreviousYear}
+        showLevelChangeLink={showLevelChangeLink}
       />
       <CalendarGradientStyles isRange={isRange} date={currentDate}>
         <DatePicker

--- a/packages/blade/src/components/DatePicker/CalendarHeader.web.tsx
+++ b/packages/blade/src/components/DatePicker/CalendarHeader.web.tsx
@@ -14,6 +14,7 @@ type CalendarHeaderProps = {
   isRange: boolean;
   date: DateValue | DatesRangeValue;
   pickerType: PickerType;
+  showLevelChangeLink?: boolean;
   onNextMonth: () => void;
   onPreviousMonth: () => void;
   onNextYear: () => void;
@@ -21,6 +22,35 @@ type CalendarHeaderProps = {
   onNextDecade: () => void;
   onPreviousDecade: () => void;
   onLevelChange: (level: MantineCalendarLevel) => void;
+};
+const CalendarLevelIndicator = ({
+  onClick,
+  showLevelChangeLink,
+  accessibilityLabel,
+  text,
+}: {
+  onClick: () => void;
+  showLevelChangeLink?: boolean;
+  accessibilityLabel: string;
+  text: string;
+}): React.ReactElement => {
+  return showLevelChangeLink ? (
+    <Link
+      onClick={onClick}
+      size="large"
+      variant="button"
+      color="neutral"
+      iconPosition="right"
+      icon={ChevronDownIcon}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {text}
+    </Link>
+  ) : (
+    <Text size="large" weight="medium" color="interactive.text.neutral.normal">
+      {text}
+    </Text>
+  );
 };
 
 const CalendarHeader = ({
@@ -34,7 +64,10 @@ const CalendarHeader = ({
   onPreviousYear,
   onPreviousDecade,
   onLevelChange,
-}: CalendarHeaderProps): React.ReactElement => {
+  showLevelChangeLink,
+}: CalendarHeaderProps & {
+  showLevelChangeLink?: boolean;
+}): React.ReactElement => {
   const { i18nState } = useI18nContext();
   const locale = convertIntlToDayjsLocale(i18nState?.locale ?? 'en-IN');
 
@@ -135,34 +168,21 @@ const CalendarHeader = ({
       ) : (
         <Box display="flex" gap="spacing.5" alignItems="center">
           {pickerType === 'day' && (
-            <Link
-              onClick={() => {
-                onLevelChange('year');
-              }}
-              size="large"
-              variant="button"
-              color="neutral"
-              iconPosition="right"
-              icon={ChevronDownIcon}
+            <CalendarLevelIndicator
+              onClick={() => onLevelChange('month')}
+              showLevelChangeLink={showLevelChangeLink}
               accessibilityLabel="Change month"
-            >
-              {month} {year}
-            </Link>
+              text={`${month} ${year}`}
+            />
           )}
+
           {pickerType === 'month' && (
-            <Link
-              onClick={() => {
-                onLevelChange('decade');
-              }}
-              size="large"
-              variant="button"
-              color="neutral"
-              iconPosition="right"
-              icon={ChevronDownIcon}
+            <CalendarLevelIndicator
+              onClick={() => onLevelChange('decade')}
+              showLevelChangeLink={showLevelChangeLink}
               accessibilityLabel="Change decade"
-            >
-              {year}
-            </Link>
+              text={year}
+            />
           )}
           {pickerType === 'year' && (
             <Text size="large" weight="medium" color="interactive.text.neutral.normal">

--- a/packages/blade/src/components/DatePicker/DateInput.web.tsx
+++ b/packages/blade/src/components/DatePicker/DateInput.web.tsx
@@ -92,7 +92,7 @@ const _DatePickerInput = (
     successText,
     errorText,
     helpText,
-    dateFormat,
+    format,
     placeholder,
     ...props
   }: DatePickerInputProps,
@@ -110,7 +110,7 @@ const _DatePickerInput = (
   if (selectionType == 'single') {
     const dateValue = getFormattedDate({
       date,
-      format: dateFormat,
+      format,
       labelSeparator: '-',
       locale,
       type: 'default',
@@ -128,7 +128,7 @@ const _DatePickerInput = (
           id="start-date"
           labelPosition={labelPosition}
           label={label}
-          placeholder={placeholder || dateFormat}
+          placeholder={placeholder || format}
           popupId={referenceProps['aria-controls']}
           isPopupExpanded={referenceProps['aria-expanded']}
           size={size}
@@ -165,14 +165,14 @@ const _DatePickerInput = (
     const startValue = getFormattedDate({
       type: 'default',
       date: date[0],
-      format: dateFormat,
+      format,
       labelSeparator: '-',
       locale,
     });
     const endValue = getFormattedDate({
       type: 'default',
       date: date[1],
-      format: dateFormat,
+      format,
       labelSeparator: '-',
       locale,
     });
@@ -198,7 +198,7 @@ const _DatePickerInput = (
             leadingIcon={CalendarIcon}
             label={label?.start}
             labelPosition={labelPosition}
-            placeholder={placeholder || dateFormat}
+            placeholder={placeholder}
             popupId={referenceProps['aria-controls']}
             isPopupExpanded={referenceProps['aria-expanded']}
             size={size}
@@ -236,7 +236,7 @@ const _DatePickerInput = (
           />
           <DateInput
             id="end-date"
-            placeholder={placeholder || dateFormat}
+            placeholder={placeholder}
             leadingIcon={CalendarIcon}
             label={shouldRenderEndLabel()}
             labelPosition={isLabelPositionLeft ? undefined : labelPosition}

--- a/packages/blade/src/components/DatePicker/DateInput.web.tsx
+++ b/packages/blade/src/components/DatePicker/DateInput.web.tsx
@@ -92,12 +92,13 @@ const _DatePickerInput = (
     successText,
     errorText,
     helpText,
+    dateFormat,
+    placeholder,
     ...props
   }: DatePickerInputProps,
   ref: React.ForwardedRef<any>,
 ): React.ReactElement => {
   const isMobile = useIsMobile();
-  const format = 'DD/MM/YYYY';
   const isLarge = size === 'large';
   const hasLabel = typeof label === 'string' ? Boolean(label) : Boolean(label?.start || label?.end);
   const isLabelPositionLeft = labelPosition === 'left';
@@ -109,7 +110,7 @@ const _DatePickerInput = (
   if (selectionType == 'single') {
     const dateValue = getFormattedDate({
       date,
-      format,
+      format: dateFormat,
       labelSeparator: '-',
       locale,
       type: 'default',
@@ -127,7 +128,7 @@ const _DatePickerInput = (
           id="start-date"
           labelPosition={labelPosition}
           label={label}
-          placeholder={format}
+          placeholder={placeholder || dateFormat}
           popupId={referenceProps['aria-controls']}
           isPopupExpanded={referenceProps['aria-expanded']}
           size={size}
@@ -164,14 +165,14 @@ const _DatePickerInput = (
     const startValue = getFormattedDate({
       type: 'default',
       date: date[0],
-      format,
+      format: dateFormat,
       labelSeparator: '-',
       locale,
     });
     const endValue = getFormattedDate({
       type: 'default',
       date: date[1],
-      format,
+      format: dateFormat,
       labelSeparator: '-',
       locale,
     });
@@ -197,7 +198,7 @@ const _DatePickerInput = (
             leadingIcon={CalendarIcon}
             label={label?.start}
             labelPosition={labelPosition}
-            placeholder={format}
+            placeholder={placeholder || dateFormat}
             popupId={referenceProps['aria-controls']}
             isPopupExpanded={referenceProps['aria-expanded']}
             size={size}
@@ -235,7 +236,7 @@ const _DatePickerInput = (
           />
           <DateInput
             id="end-date"
-            placeholder={format}
+            placeholder={placeholder || dateFormat}
             leadingIcon={CalendarIcon}
             label={shouldRenderEndLabel()}
             labelPosition={isLabelPositionLeft ? undefined : labelPosition}

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -66,7 +66,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   picker,
   onPickerChange,
   zIndex = componentZIndices.popover,
-  dateFormat,
+  format,
   inputPlaceHolder,
   ...props
 }: DatePickerProps<Type> & StyledPropsBlade & DataAnalyticsAttribute): React.ReactElement => {
@@ -85,9 +85,9 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
       onPickerChange?.(picker);
     },
   });
-  const finalDateFormat = React.useMemo(() => {
-    if (dateFormat) {
-      return dateFormat;
+  const finalFormat = React.useMemo(() => {
+    if (format) {
+      return format;
     }
     if (picker === 'day') {
       return 'DD';
@@ -99,7 +99,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
       return 'YYYY';
     }
     return 'DD/MM/YYYY';
-  }, [dateFormat, picker]);
+  }, [format, picker]);
 
   const finalInputPlaceHolder = React.useMemo(() => {
     if (inputPlaceHolder) {
@@ -337,7 +337,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
             validationState={validationState}
             autoFocus={autoFocus}
             necessityIndicator={necessityIndicator}
-            dateFormat={finalDateFormat}
+            format={finalFormat}
             placeholder={finalInputPlaceHolder}
             {...makeAnalyticsAttribute(props)}
           />

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -66,7 +66,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   picker,
   onPickerChange,
   zIndex = componentZIndices.popover,
-  format,
+  format = 'DD/MM/YYYY',
   inputPlaceHolder,
   ...props
 }: DatePickerProps<Type> & StyledPropsBlade & DataAnalyticsAttribute): React.ReactElement => {
@@ -88,9 +88,6 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   const finalFormat = React.useMemo(() => {
     if (format) {
       return format;
-    }
-    if (picker === 'day') {
-      return 'DD';
     }
     if (picker === 'month') {
       return 'MMMM';

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -66,6 +66,8 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   picker,
   onPickerChange,
   zIndex = componentZIndices.popover,
+  dateFormat = 'DD/MM/YYYY',
+  inputPlaceHolder,
   ...props
 }: DatePickerProps<Type> & StyledPropsBlade & DataAnalyticsAttribute): React.ReactElement => {
   const { i18nState } = useI18nContext();
@@ -304,6 +306,8 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
             validationState={validationState}
             autoFocus={autoFocus}
             necessityIndicator={necessityIndicator}
+            dateFormat={dateFormat}
+            placeholder={inputPlaceHolder}
             {...makeAnalyticsAttribute(props)}
           />
           {isMobile ? (

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -237,6 +237,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
             forceRerender();
           }}
           picker={_picker}
+          showLevelChangeLink={!picker}
           onPickerChange={(picker) => {
             setPicker(() => picker);
             forceRerender();

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -66,7 +66,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   picker,
   onPickerChange,
   zIndex = componentZIndices.popover,
-  dateFormat = 'DD/MM/YYYY',
+  dateFormat,
   inputPlaceHolder,
   ...props
 }: DatePickerProps<Type> & StyledPropsBlade & DataAnalyticsAttribute): React.ReactElement => {
@@ -85,6 +85,37 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
       onPickerChange?.(picker);
     },
   });
+  const finalDateFormat = React.useMemo(() => {
+    if (dateFormat) {
+      return dateFormat;
+    }
+    if (picker === 'day') {
+      return 'DD';
+    }
+    if (picker === 'month') {
+      return 'MMMM';
+    }
+    if (picker === 'year') {
+      return 'YYYY';
+    }
+    return 'DD/MM/YYYY';
+  }, [dateFormat, picker]);
+
+  const finalInputPlaceHolder = React.useMemo(() => {
+    if (inputPlaceHolder) {
+      return inputPlaceHolder;
+    }
+    if (picker === 'day') {
+      return 'Day';
+    }
+    if (picker === 'month') {
+      return 'Month';
+    }
+    if (picker === 'year') {
+      return 'Year';
+    }
+    return 'DD/MM/YYYY';
+  }, [inputPlaceHolder, picker]);
 
   const {
     onDateChange,
@@ -306,8 +337,8 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
             validationState={validationState}
             autoFocus={autoFocus}
             necessityIndicator={necessityIndicator}
-            dateFormat={dateFormat}
-            placeholder={inputPlaceHolder}
+            dateFormat={finalDateFormat}
+            placeholder={finalInputPlaceHolder}
             {...makeAnalyticsAttribute(props)}
           />
           {isMobile ? (

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -102,9 +102,6 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
     if (inputPlaceHolder) {
       return inputPlaceHolder;
     }
-    if (picker === 'day') {
-      return 'Day';
-    }
     if (picker === 'month') {
       return 'Month';
     }

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -166,7 +166,7 @@ type DatePickerProps<Type extends DateSelectionType> = Omit<
      * Sets the date format to be displayed in the input field.
      * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
      */
-    format?: string;
+    format?: 'DD/MM/YYYY' | 'MMM' | 'MMMM' | 'YYYY';
     /**
      *  Placeholder text for the datepicker input , when no date is selected.
      * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -164,7 +164,7 @@ type DatePickerProps<Type extends DateSelectionType> = Omit<
     labelPosition?: BaseInputProps['labelPosition'];
     /**
      * Sets the date format to be displayed in the input field.
-     * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
+     * @default 'DD/MM/YYYY'  if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
      */
     format?: 'DD/MM/YYYY' | 'MMM' | 'MMMM' | 'YYYY';
     /**

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -162,6 +162,14 @@ type DatePickerProps<Type extends DateSelectionType> = Omit<
      */
     onApply?: Type extends 'single' ? (value: DateValue) => void : (value: DatesRangeValue) => void;
     labelPosition?: BaseInputProps['labelPosition'];
+    /**
+     * Sets the date format to be displayed in the input field.
+     */
+    dateFormat?: string;
+    /**
+     *  Placeholder text for the datepicker input , when no date is selected. Default value is formatType.
+     */
+    inputPlaceHolder?: string;
   };
 
 type DatePickerRangeInputProps = {
@@ -195,7 +203,10 @@ type DatePickerCommonInputProps = {
   FormInputValidationProps;
 
 type DatePickerInputProps = DatePickerCommonInputProps &
-  (DatePickerRangeInputProps | DatePickerSingleInputProps);
+  (DatePickerRangeInputProps | DatePickerSingleInputProps) & {
+    dateFormat: string;
+    placeholder?: string;
+  };
 
 export type {
   CalendarProps,

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -166,7 +166,7 @@ type DatePickerProps<Type extends DateSelectionType> = Omit<
      * Sets the date format to be displayed in the input field.
      * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
      */
-    dateFormat?: string;
+    format?: string;
     /**
      *  Placeholder text for the datepicker input , when no date is selected.
      * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
@@ -206,7 +206,7 @@ type DatePickerCommonInputProps = {
 
 type DatePickerInputProps = DatePickerCommonInputProps &
   (DatePickerRangeInputProps | DatePickerSingleInputProps) & {
-    dateFormat: string;
+    format: string;
     placeholder?: string;
   };
 

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -164,10 +164,12 @@ type DatePickerProps<Type extends DateSelectionType> = Omit<
     labelPosition?: BaseInputProps['labelPosition'];
     /**
      * Sets the date format to be displayed in the input field.
+     * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
      */
     dateFormat?: string;
     /**
-     *  Placeholder text for the datepicker input , when no date is selected. Default value is formatType.
+     *  Placeholder text for the datepicker input , when no date is selected.
+     * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
      */
     inputPlaceHolder?: string;
   };

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -169,7 +169,7 @@ type DatePickerProps<Type extends DateSelectionType> = Omit<
     format?: 'DD/MM/YYYY' | 'MMM' | 'MMMM' | 'YYYY';
     /**
      *  Placeholder text for the datepicker input , when no date is selected.
-     * @default 'DD/MM/YYYY' if pickerType is 'date' then 'DD', if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
+     * @default 'DD/MM/YYYY'  if pickerType is 'month' then 'MMMM', 'YYYY' if pickerType is 'year'
      */
     inputPlaceHolder?: string;
   };


### PR DESCRIPTION
## Description

- Added dateFormat and placeholder props:
The dateFormat prop allows custom formatting for the date displayed in the input.
The placeholder prop enables customization of the placeholder text, which defaults to the date format. This is useful since the placeholder text might differ from the date format or could be unclear to users.
- Removed the chevron icon when the picker prop is used.



## Additional Information
this fixes - 
https://github.com/razorpay/blade/issues/2469 
https://github.com/razorpay/blade/issues/2470 

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
