### PR TITLE
fix: remove file icon button alignment while uploading

### DIFF
--- a/.changeset/soft-numbers-divide.md
+++ b/.changeset/soft-numbers-divide.md
@@ -2,4 +2,4 @@
 '@razorpay/blade': patch
 ---
 
-fix(blade): remove file aligment while uploading
+fix(blade): remove file icon aligment while uploading

--- a/.changeset/soft-numbers-divide.md
+++ b/.changeset/soft-numbers-divide.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade): remove file aligment while uploading

--- a/packages/blade/src/components/FileUpload/FileUploadItem.tsx
+++ b/packages/blade/src/components/FileUpload/FileUploadItem.tsx
@@ -76,7 +76,7 @@ const FileUploadItem = memo(
               </Text>
             </BaseBox>
             {status === 'uploading' ? (
-              <BaseBox>
+              <BaseBox display="flex" alignItems="center">
                 <IconButton
                   accessibilityLabel="Remove File"
                   icon={CloseIcon}


### PR DESCRIPTION
## Description
Had a discussion with @~RK. Other actions like preview and delete are center-aligned, so we should center-align the 'Remove File' action while uploading.

Prev - 
<img width="600" alt="Screenshot 2025-01-17 at 3 45 42 PM" src="https://github.com/user-attachments/assets/dad2e89b-6844-459b-9efa-7515b5bec02b" />

Now - 
<img width="472" alt="Screenshot 2025-01-17 at 3 49 05 PM" src="https://github.com/user-attachments/assets/6c775b6d-2fab-4a39-bbcc-736234057f8c" />


<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
