### PR TITLE
chore: memoized otp input and added example for using onOTPFilled

### DIFF
--- a/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.stories.tsx
@@ -293,6 +293,40 @@ const OTPInputControlledTemplate: StoryFn<typeof OTPInputComponent> = () => {
 };
 export const OTPInputControlled = OTPInputControlledTemplate.bind({});
 
+export const onOtpFilled = (): React.ReactElement => {
+  return (
+    <Sandbox padding="spacing.0" editorHeight="100vh">
+      {` 
+      import React, { memo, useCallback, useState } from 'react';
+      import { OTPInput } from '@razorpay/blade/components';
+
+       function App() {
+         const [state, setState] = useState('');
+       
+         // consider wrapping this function in useCallback.
+         // since this case we are updating state which will cause App to re-render and hence the function reference will change.
+         // which will cause the OTPInput to re-render. 
+         const sendOtpToServer = useCallback(({ value }) => {
+           setState(Math.random().toString());
+         }, []); // Dependency array ensures the function reference remains stable.
+       
+         console.log(state);
+       
+       
+         return (
+           <>
+             <OTPInput label="Enter OTP" onOTPFilled={sendOtpToServer} />
+           </>
+         );
+       }
+       
+       export default App;
+
+      `}
+    </Sandbox>
+  );
+};
+
 export const OTPInputRef: StoryFn<typeof OTPInputComponent> = () => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const [focusOn, setFocusOn] = React.useState(0);

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useImperativeHandle, useState } from 'react';
+import React, { memo, useEffect, useImperativeHandle, useState } from 'react';
 import type { BaseInputProps } from '../BaseInput';
 import { BaseInput } from '../BaseInput';
 import { getHintType } from '../BaseInput/BaseInput';
@@ -419,7 +419,7 @@ const _OTPInput: React.ForwardRefRenderFunction<HTMLInputElement[], OTPInputProp
   );
 };
 
-const OTPInput = React.forwardRef<HTMLInputElement[], OTPInputProps>(_OTPInput);
+const OTPInput = memo(React.forwardRef<HTMLInputElement[], OTPInputProps>(_OTPInput));
 
 export type { OTPInputProps };
 export { OTPInput };


### PR DESCRIPTION
## Description


This PR fixes the issue with the OTPInput component where the onOTPFilled callback was causing infinite re-renders.

To avoid re-renders, we can wrap OTPInput in React.memo. I have implemented this. Additionally, the function passed to onOTPFilled should be wrapped in useCallback. I have added an example for this in the documentation.



## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
