### PR TITLE
fix: data analytics attribute from another external module

### DIFF
--- a/.changeset/sour-cherries-fry.md
+++ b/.changeset/sour-cherries-fry.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade): fix: data analytics attribute from another external module

--- a/packages/blade/src/utils/types.ts
+++ b/packages/blade/src/utils/types.ts
@@ -147,9 +147,9 @@ type DataAnalyticsKey = `data-analytics-${string}`;
  * eg: `data-analytics-action="click"`
  * eg: `data-analytics-section="header"`
  */
-interface DataAnalyticsAttribute {
+type DataAnalyticsAttribute = {
   [key: DataAnalyticsKey]: string;
-}
+};
 
 export type {
   DotNotationColorStringToken,


### PR DESCRIPTION
## Description

fix: data analytics attribute from another external module

The problem occurred because interface requires proper name resolution, but type avoids this by inlining the structure. Switching to type fixed the issue because it removed the dependency on DataAnalyticsAttribute being explicitly resolvable across modules.

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
