### PR TITLE
fix(FileUpload): revert to not calling onChange on file remove

### DIFF
--- a/.changeset/moody-coats-clean.md
+++ b/.changeset/moody-coats-clean.md
@@ -1,0 +1,18 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(FileUpload): revert to not calling onChange on file remove
+
+> [!NOTE]
+>
+> Check the below timeline if you're upgrading from 11.34.1+ version to this version
+
+**Timeline of FileUpload changes**
+
+- In 11.34.1: We did not call onChange on removing of file. Only onRemove was called
+- In 11:36.2: We added dispatchEvent call which started calling onChange on onRemove (since React treats `input type="file"` differently than `input type="text"` - [CodeSandbox Link](https://codesandbox.io/p/sandbox/friendly-ishizaka-yk7mm3))
+- In 12.4.0: We released a fix thinking onChange call was expected behaviour and we just updated the state value for it
+- **This version:** Reverts back to 11.34.1 behaviour. If you're upgrading to this version from 11.34.1 or previous versions, the behaviour will stay same. If you're upgrading from 11.34.1+ and use FileUpload component, its recommended to test out FileUpload instances.
+
+

--- a/packages/blade/src/components/FileUpload/FileUpload.web.tsx
+++ b/packages/blade/src/components/FileUpload/FileUpload.web.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useMemo, useRef, forwardRef } from 'react';
-import { flushSync } from 'react-dom';
 import type { FileUploadProps, BladeFile, BladeFileList } from './types';
 import { StyledFileUploadWrapper } from './StyledFileUploadWrapper';
 import {
@@ -29,7 +28,6 @@ import { useMergeRefs } from '~utils/useMergeRefs';
 import { useControllableState } from '~utils/useControllable';
 import { getInnerMotionRef, getOuterMotionRef } from '~utils/getMotionRefs';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
-import { fireNativeEvent } from '~utils/fireNativeEvent';
 
 const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadProps> = (
   {
@@ -163,7 +161,6 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
     if (!hasValidationErrors) {
       handleFilesChange(droppedFiles);
       onDrop?.({ name, fileList: allFiles });
-      fireNativeEvent(inputRef, ['change', 'input']);
     }
   };
 
@@ -313,11 +310,9 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
             size={size}
             onRemove={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
-              flushSync(() => {
-                setSelectedFiles(() => newFiles);
-              });
+              setSelectedFiles(() => newFiles);
+
               onRemove?.({ file: selectedFiles[0] });
-              fireNativeEvent(inputRef, ['change', 'input']);
             }}
             onReupload={() => {
               const newFiles = selectedFiles.filter(({ id }) => id !== selectedFiles[0].id);
@@ -377,11 +372,8 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
               size={size}
               onRemove={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
-                flushSync(() => {
-                  setSelectedFiles(() => newFiles);
-                });
+                setSelectedFiles(() => newFiles);
                 onRemove?.({ file });
-                fireNativeEvent(inputRef, ['change', 'input']);
               }}
               onReupload={() => {
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
@@ -400,7 +392,6 @@ const _FileUpload: React.ForwardRefRenderFunction<BladeElementRef, FileUploadPro
                 const newFiles = selectedFiles.filter(({ id }) => id !== file.id);
                 setSelectedFiles(() => newFiles);
                 onDismiss?.({ file });
-                fireNativeEvent(inputRef, ['change', 'input']);
               }}
               onPreview={onPreview}
             />


### PR DESCRIPTION
## Description

Issue Context: https://razorpay.slack.com/archives/CMQ3RBHEU/p1738568779980839?thread_ts=1738140484.133379&cid=CMQ3RBHEU

Timeline:

In 11.34.1: We did not call `onChange` on removing of file. Only `onRemove` was called
In 11:36.2: We added dispatchEvent call which started calling onChange on onRemove
In 12.4.0: We released a fix thinking onChange call was expected behaviour and we just updated the state value for it


So for consumers upgrading from 11.34.1 -> 12.4.0, it becomes breaking change because onChange was not previously called

### Why is onChange getting called on dispatchEvent?

Hmm this is wild. So React apparently treats dispatchEvent with input type="text" differently than it treats input type="file"

Reproduction: https://codesandbox.io/p/sandbox/friendly-ishizaka-yk7mm3

I've added more details in issue here - https://github.com/facebook/react/issues/32300

## Changes


- For now, I am removing the dispatchEvent from FileUpload to unblock the dashboard team. We'll have to add it again though for analytics sdk
- I am also removing flushSync changes because we added it to fix onChange arguments which is not needed now


New behaviour: We'll revert back to behaviour of 11.34.1 where onChange is not called on removing file


## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
