### PR TITLE
feat: OTPInput field value clear behaviour changes

### DIFF
--- a/.changeset/eighty-doors-yell.md
+++ b/.changeset/eighty-doors-yell.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat: Improve OTPInput field value clear behaviour

--- a/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
+++ b/packages/blade/src/components/Input/OTPInput/OTPInput.tsx
@@ -294,8 +294,15 @@ const _OTPInput: React.ForwardRefRenderFunction<HTMLInputElement[], OTPInputProp
   }: FormInputOnKeyDownEvent & { currentOtpIndex: number }): void => {
     if (key === 'Backspace' || code === 'Backspace' || code === 'Delete' || key === 'Delete') {
       event.preventDefault?.();
-      handleOnChange({ value: '', currentOtpIndex });
-      focusOnOtpByIndex(--currentOtpIndex);
+      if (otpValue[currentOtpIndex]) {
+        // Clear the value at the current index if value exists
+        handleOnChange({ value: '', currentOtpIndex });
+      } else {
+        // Move focus to the previous input if the current input is empty
+        // and clear the value at the new active (previous) index
+        focusOnOtpByIndex(--currentOtpIndex);
+        handleOnChange({ value: '', currentOtpIndex });
+      }
     } else if (key === 'ArrowLeft' || code === 'ArrowLeft') {
       event.preventDefault?.();
       focusOnOtpByIndex(--currentOtpIndex);

--- a/packages/blade/src/components/Input/OTPInput/__tests__/OTPInput.web.test.tsx
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/OTPInput.web.test.tsx
@@ -247,10 +247,10 @@ describe('<OTPInput />', () => {
     expect(allInputs[5]).toHaveFocus();
     await user.keyboard('{Backspace}');
     expect(allInputs[5]).toHaveValue('');
-    expect(allInputs[4]).toHaveFocus();
+    expect(allInputs[5]).toHaveFocus();
     await user.keyboard('{Delete}');
     expect(allInputs[4]).toHaveValue('');
-    expect(allInputs[3]).toHaveFocus();
+    expect(allInputs[4]).toHaveFocus();
   });
 
   it('should pass a11y', async () => {


### PR DESCRIPTION
## Description

In OTPInput, when a value is cleared in one of the input field, persisting the focus in the same input field instead of shifting the focus to previous input field

## Changes

### Current behaviour:
When user wants to update a particular input field value in OTPInput component, the focus gets shifted to previous input field on clearing the value and user have to shift to the corresponding input field again to enter the updated value

https://github.com/user-attachments/assets/c10a9de6-d959-4d10-8f7b-3d2d19da4965

### Changes made:
When `Backspace` or `Delete` key is pressed on an input field in OTPInput component,
- if value existed, then it will be cleared and focus will be persisted on the same input field allowing user to update
- if value is empty, then focus will be shifted to previous input field and its value will be cleared

https://github.com/user-attachments/assets/53caae98-9b12-4878-8643-a2a7fb2c5099

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
