### PR TITLE
test(BaseMotion): expose BaseMotion utils for testing

### DIFF
--- a/packages/blade/src/components/BaseMotion/BaseMotion.tsx
+++ b/packages/blade/src/components/BaseMotion/BaseMotion.tsx
@@ -48,6 +48,8 @@ const _BaseMotionBox = (
     isInsideStaggerContainer ? staggerType : type,
   );
 
+  console.log('BaseMotionBox', { motionVariants, animationVariables, rest, ref, children });
+
   return (
     <MotionDiv
       ref={ref as never}
@@ -70,6 +72,8 @@ const _BaseMotionEnhancerBox: React.ForwardRefRenderFunction<HTMLDivElement, Bas
   { children, ...motionBoxArgs },
   ref,
 ) => {
+  console.log('BaseMotionEnhancerBox', { motionBoxArgs, children });
+
   return (
     <BaseMotionBox
       // we need the ref of this item in AnimateInteractions to pass down ref that adds focusWithin logic
@@ -115,6 +119,17 @@ const BaseMotionEntryExit = ({
     };
     // @ts-expect-error: ref does exist on children prop
   }, [children.ref]);
+
+  console.log('BaseMotionEntryExit', {
+    motionVariants,
+    motionTriggers,
+    type,
+    isVisible,
+    shouldUnmountWhenHidden,
+    children,
+    isMounted,
+    motionMeta,
+  });
 
   return (
     <AnimateWrapper>

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -64,3 +64,4 @@ export * from './TopNav';
 export * from './types';
 export * from './Typography';
 export * from './VisuallyHidden';
+export * from './BaseMotion';


### PR DESCRIPTION
## Description

Exposing these utils since One Home was facing some challenges in debugging motion presets issue. We can try each base component and see where things are breaking.

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
