### PR TITLE
feat(TextArea): expose onKeydown on TextArea

### DIFF
--- a/.changeset/twenty-planets-tell.md
+++ b/.changeset/twenty-planets-tell.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(TextArea): expose `onKeydown` on TextArea and allow `numOfLines={1}`

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -229,7 +229,7 @@ type BaseInputCommonProps = FormInputLabelProps &
     /**
      * Sets the textarea's number of lines
      */
-    numberOfLines?: 2 | 3 | 4 | 5;
+    numberOfLines?: 1 | 2 | 3 | 4 | 5;
     /**
      * Sets the accessibility label for the input
      */

--- a/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
@@ -10,6 +10,7 @@ import { Button } from '~components/Button';
 import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
 import { Box } from '~components/Box';
 import { Text } from '~components/Typography';
+import { ToastContainer, useToast } from '~components/Toast';
 
 const propsCategory = {
   BASE_PROPS: 'TextArea Props',
@@ -456,6 +457,26 @@ export const TextAreaWithTags: StoryFn<typeof TextAreaComponent> = ({ ...args })
         onTagChange={({ tags }) => {
           console.log({ tags });
           setTags(tags);
+        }}
+      />
+    </Box>
+  );
+};
+
+export const TextAreaWithEnterSubmit: StoryFn<typeof TextAreaComponent> = ({ ...args }) => {
+  const toast = useToast();
+  return (
+    <Box display="flex" flexDirection="column">
+      <ToastContainer />
+      <TextAreaComponent
+        {...args}
+        numberOfLines={3}
+        placeholder="Press Shift + Enter for next line and Enter for submit"
+        onKeyDown={({ event }) => {
+          if (!event.shiftKey && event.key === 'Enter') {
+            event.preventDefault();
+            toast.show({ content: 'Submit', color: 'positive', type: 'informational' });
+          }
         }}
       />
     </Box>

--- a/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.stories.tsx
@@ -472,10 +472,10 @@ export const TextAreaWithEnterSubmit: StoryFn<typeof TextAreaComponent> = ({ ...
         {...args}
         numberOfLines={3}
         placeholder="Press Shift + Enter for next line and Enter for submit"
-        onKeyDown={({ event }) => {
+        onKeyDown={({ event, value }) => {
           if (!event.shiftKey && event.key === 'Enter') {
             event.preventDefault();
-            toast.show({ content: 'Submit', color: 'positive', type: 'informational' });
+            toast.show({ content: `Submit: ${value}`, color: 'positive', type: 'informational' });
           }
         }}
       />

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -21,6 +21,7 @@ import type {
   DataAnalyticsAttribute,
 } from '~utils/types';
 import { hintMarginTop } from '~components/Form/formTokens';
+import type { FormInputOnKeyDownEvent } from '~components/Form/FormTypes';
 
 type TextAreaCommonProps = Pick<
   BaseInputProps,
@@ -39,7 +40,6 @@ type TextAreaCommonProps = Pick<
   | 'onFocus'
   | 'onBlur'
   | 'onSubmit'
-  | 'onKeyDown'
   | 'value'
   | 'isDisabled'
   | 'isRequired'
@@ -58,6 +58,16 @@ type TextAreaCommonProps = Pick<
    * Event handler to handle the onClick event for clear button. Used when `showClearButton` is `true`
    */
   onClearButtonClick?: () => void;
+
+  onKeyDown?: ({
+    name,
+    value,
+    event,
+  }: {
+    name?: FormInputOnKeyDownEvent['name'];
+    value: string;
+    event: FormInputOnKeyDownEvent['event'];
+  }) => void;
 } & TaggedInputProps &
   StyledPropsBlade;
 
@@ -246,7 +256,11 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
       }}
       onKeyDown={(e) => {
         handleTaggedInputKeydown(e);
-        onKeyDown?.(e);
+        onKeyDown?.({
+          name: e.name,
+          value: e.event.currentTarget.value,
+          event: e.event,
+        });
       }}
       onSubmit={onSubmit}
       trailingFooterSlot={(value) => {

--- a/packages/blade/src/components/Input/TextArea/TextArea.tsx
+++ b/packages/blade/src/components/Input/TextArea/TextArea.tsx
@@ -39,6 +39,7 @@ type TextAreaCommonProps = Pick<
   | 'onFocus'
   | 'onBlur'
   | 'onSubmit'
+  | 'onKeyDown'
   | 'value'
   | 'isDisabled'
   | 'isRequired'
@@ -114,6 +115,7 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
     onFocus,
     onBlur,
     onSubmit,
+    onKeyDown,
     placeholder,
     value,
     maxCharacters,
@@ -244,6 +246,7 @@ const _TextArea: React.ForwardRefRenderFunction<BladeElementRef, TextAreaProps> 
       }}
       onKeyDown={(e) => {
         handleTaggedInputKeydown(e);
+        onKeyDown?.(e);
       }}
       onSubmit={onSubmit}
       trailingFooterSlot={(value) => {


### PR DESCRIPTION
## Description

- add `numberOfLines={1}`
- expose `onKeyDown` on TextArea. 

onKeyDown will be exposed with these arg type-
```
onKeyDown={(args) => 
  args.name
  args.value
  args.event
}
```

Currently other handlers of TextArea expose name and value so it feels inconsistent to have one handler that exposes just event. So using the same type that we internally also use where we append event on top of existing name and value


## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
