### PR TITLE
fix: date picker height issue

### DIFF
--- a/.changeset/polite-crews-accept.md
+++ b/.changeset/polite-crews-accept.md
@@ -1,5 +1,5 @@
 ---
-'@razorpay/blade': major
+'@razorpay/blade': patch
 ---
 
 fix(blade): datepicker height change issue

--- a/.changeset/polite-crews-accept.md
+++ b/.changeset/polite-crews-accept.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': major
+---
+
+fix(blade): datepicker height change issue

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -225,7 +225,11 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
         flexDirection="column"
         gap="spacing.5"
         padding={{ m: 'spacing.6', s: 'spacing.0' }}
+        /* We only need to set height for day picker, for year picker
+         or month  it should be auto. */
+        height={_picker === 'day' ? '447px' : 'auto'}
         backgroundColor="surface.background.gray.intense"
+        justifyContent="space-between"
       >
         <Calendar
           {...props}


### PR DESCRIPTION
## Description


currently date picker have height issue. if month have 4 weeks , it will take less space. and if month have 6 week it will take more space.  due to which height changes and it causes a layout shift.

we have decided  fix its height .


[co-pilot generated summary] 🤖 🌟  - 
This pull request includes a small change to the `DatePicker` component in `packages/blade/src/components/DatePicker/DatePicker.web.tsx`. The change ensures that the height is set only for the day picker, while the year and month pickers will have an automatic height. Additionally, it adds a `justifyContent` property to space the content appropriately.

Changes in `DatePicker` component:

* Set height conditionally for day picker and auto for year/month pickers.
* Added `justifyContent` property to `DatePicker` component.


## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
