### PR TITLE
WIP: Code block - without prism

### DIFF
--- a/packages/blade/docs/components/CodeBlock.stories.mdx
+++ b/packages/blade/docs/components/CodeBlock.stories.mdx
@@ -1,0 +1,61 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="Components/CodeBlock/Docs" />
+
+# CodeBlock
+
+CodeBlock is a component used to display and highlight code snippets with proper syntax highlighting. It automatically adapts to the current theme (light or dark) using GitHub-like syntax highlighting colors.
+
+## Overview
+
+The CodeBlock component provides a clean and readable way to present code snippets in your application. It currently supports the following languages:
+
+- JSON
+- Protobuf
+
+CodeBlock automatically applies syntax highlighting based on the language specified, making it easier for users to read and understand the code.
+
+## Features
+
+- GitHub-like syntax highlighting
+- Theme adaptation (light/dark mode)
+- Support for JSON and Protobuf languages
+- Configurable background display
+- Clean, readable code formatting
+
+## Props
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| children | string | - | The code content to display and highlight |
+| lang | 'json' \| 'protobuf' | 'json' | The language for syntax highlighting |
+| showBackground | boolean | true | Whether to show a background color |
+| testID | string | - | Test ID for testing frameworks |
+
+## Theme Support
+
+CodeBlock automatically adapts to the current theme (light or dark) using the Blade design system's theme variables. The syntax highlighting colors are derived from GitHub-like color schemes:
+
+- **Light Theme**: 
+  - Uses GitHub's light syntax highlighting colors for a clean, readable appearance
+  - Background color is pure white (#ffffff) to match GitHub's code display
+  - Property names and numbers are blue (#0550ae)
+  - Strings are dark blue (#0a3069)
+  - Keywords (true, false, null) are red (#cf222e)
+  - Comments are gray (#6e7781)
+
+- **Dark Theme**: 
+  - Uses GitHub's dark syntax highlighting colors for reduced eye strain in dark environments
+  - Background color is GitHub's dark mode code background (#0d1117)
+  - Property names and numbers are light blue (#75beff)
+  - Strings are light blue (#a5d6ff)
+  - Keywords are red-orange (#ff7b72)
+  - Comments are muted gray (#8b949e)
+
+## Guidelines
+
+- Use CodeBlock when you need to present code snippets to users
+- Always provide meaningful and properly formatted code for better readability
+- Consider using the `showBackground` prop to visually separate the code from surrounding content
+- Ensure the code is syntactically correct for the selected language
+- For long code snippets, consider using CodeBlock within a scrollable container 

--- a/packages/blade/src/components/CodeBlock/CodeBlock.stories.tsx
+++ b/packages/blade/src/components/CodeBlock/CodeBlock.stories.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Card, CardBody } from '~components/Card';
+import { StoryFn } from '@storybook/react';
+import { CodeBlock } from './CodeBlock';
+
+export default {
+    title: 'Components/CodeBlock',
+    component: CodeBlock,
+};
+
+export const JsonExample: StoryFn = () => {
+    const jsonExample = `{
+  "name": "John Doe",
+  "age": 30,
+  "isActive": true,
+  "address": {
+    "street": "123 Main St",
+    "city": "Anytown",
+    "zipCode": 12345
+  },
+  "tags": ["developer", "designer", "product"],
+  "projects": null
+}`;
+
+    return (
+        <Card>
+            <CardBody>
+                <CodeBlock lang="json">{jsonExample}</CodeBlock>
+            </CardBody>
+        </Card>
+    );
+};
+
+JsonExample.storyName = 'JSON';
+
+export const ProtobufExample: StoryFn = () => {
+    const protobufExample = `syntax = "proto3";
+
+package example;
+
+
+// User profile information
+message User {
+  string name = 1;
+  int32 age = 2;
+  bool is_active = 3;
+  
+  enum Role {
+    ADMIN = 0;
+    MEMBER = 1;
+    GUEST = 2;
+  }
+  
+  Role role = 4;
+  
+  message Address {
+    string street = 1;
+    string city = 2;
+    int32 zip_code = 3;
+  }
+  
+  Address address = 5;
+  repeated string tags = 6;
+}
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc ListUsers(ListUsersRequest) returns (stream User);
+}`;
+
+    return (
+        <Card>
+            <CardBody>
+                <CodeBlock lang="protobuf">{protobufExample}</CodeBlock>
+            </CardBody>
+        </Card>
+    );
+};
+
+ProtobufExample.storyName = 'Protobuf';
+
+export const WithoutBackground: StoryFn = () => {
+    const jsonExample = `{
+  "name": "John Doe",
+  "age": 30,
+  "isActive": true
+}`;
+
+    return (
+        <Card>
+            <CardBody>
+                <CodeBlock lang="json" showBackground={false}>{jsonExample}</CodeBlock>
+            </CardBody>
+        </Card>
+    );
+};
+
+WithoutBackground.storyName = 'Without Background'; 

--- a/packages/blade/src/components/CodeBlock/CodeBlock.stories.tsx
+++ b/packages/blade/src/components/CodeBlock/CodeBlock.stories.tsx
@@ -1,12 +1,81 @@
 import React from 'react';
 import { Card, CardBody } from '~components/Card';
-import { StoryFn } from '@storybook/react';
+import { StoryFn, Meta } from '@storybook/react';
 import { CodeBlock } from './CodeBlock';
+import { Title } from '@storybook/addon-docs';
+import { Sandbox } from '~utils/storybook/Sandbox';
+import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
+
+// Documentation page component
+const Page = (): React.ReactElement => {
+    return (
+        <StoryPageWrapper
+            componentName="CodeBlock"
+            componentDescription="CodeBlock is a component used to display and highlight code snippets with proper syntax highlighting. It automatically adapts to the current theme (light or dark) using GitHub-like syntax highlighting colors."
+            figmaURL="https://www.figma.com/proto/jubmQL9Z8V7881ayUD95ps/Blade-DSL"
+        >
+            <Title>Usage</Title>
+            <Sandbox editorHeight={500}>
+                {`
+import React from 'react';
+import { CodeBlock } from '@razorpay/blade/components';
+
+function App() {
+  // Sample JSON data
+  const jsonExample = \`{
+  "name": "John Doe",
+  "age": 30,
+  "isActive": true,
+  "address": {
+    "street": "123 Main St",
+    "city": "Anytown"
+  },
+  "tags": ["developer", "designer"]
+}\`;
+
+  return (
+    <div style={{ padding: '1rem', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <div>
+        <h3>JSON Example with Line Numbers (Default)</h3>
+        <CodeBlock lang="json">
+          {jsonExample}
+        </CodeBlock>
+      </div>
+      
+      <div>
+        <h3>JSON Example without Line Numbers</h3>
+        <CodeBlock lang="json" showLineNumbers={false}>
+          {jsonExample}
+        </CodeBlock>
+      </div>
+      
+      <div>
+        <h3>JSON Example without Background</h3>
+        <CodeBlock lang="json" showBackground={false}>
+          {jsonExample}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}
+
+export default App;
+                `}
+            </Sandbox>
+        </StoryPageWrapper>
+    );
+};
 
 export default {
     title: 'Components/CodeBlock',
     component: CodeBlock,
-};
+    parameters: {
+        docs: {
+            page: Page,
+        },
+    },
+    tags: ['autodocs'],
+} as Meta<typeof CodeBlock>;
 
 export const JsonExample: StoryFn = () => {
     const jsonExample = `{
@@ -23,11 +92,7 @@ export const JsonExample: StoryFn = () => {
 }`;
 
     return (
-        <Card>
-            <CardBody>
-                <CodeBlock lang="json">{jsonExample}</CodeBlock>
-            </CardBody>
-        </Card>
+        <CodeBlock lang="json">{jsonExample}</CodeBlock>
     );
 };
 
@@ -37,7 +102,6 @@ export const ProtobufExample: StoryFn = () => {
     const protobufExample = `syntax = "proto3";
 
 package example;
-
 
 // User profile information
 message User {
@@ -69,11 +133,7 @@ service UserService {
 }`;
 
     return (
-        <Card>
-            <CardBody>
-                <CodeBlock lang="protobuf">{protobufExample}</CodeBlock>
-            </CardBody>
-        </Card>
+        <CodeBlock lang="protobuf">{protobufExample}</CodeBlock>
     );
 };
 
@@ -87,12 +147,27 @@ export const WithoutBackground: StoryFn = () => {
 }`;
 
     return (
-        <Card>
-            <CardBody>
-                <CodeBlock lang="json" showBackground={false}>{jsonExample}</CodeBlock>
-            </CardBody>
-        </Card>
+        <CodeBlock lang="json" showBackground={false}>{jsonExample}</CodeBlock>
     );
 };
 
-WithoutBackground.storyName = 'Without Background'; 
+WithoutBackground.storyName = 'Without Background';
+
+export const WithoutLineNumbers: StoryFn = () => {
+    const jsonExample = `{
+  "name": "John Doe",
+  "age": 30,
+  "isActive": true,
+  "address": {
+    "street": "123 Main St",
+    "city": "Anytown",
+    "zipCode": 12345
+  }
+}`;
+
+    return (
+        <CodeBlock lang="json" showLineNumbers={false}>{jsonExample}</CodeBlock>
+    );
+};
+
+WithoutLineNumbers.storyName = 'Without Line Numbers'; 

--- a/packages/blade/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/blade/src/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components';
+import BaseBox from '~components/Box/BaseBox';
+import { getStyledProps } from '~components/Box/styledProps';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import { getPlatformType } from '~utils';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import type { BladeElementRef, TestID } from '~utils/types';
+import { makeSpace } from '~utils/makeSpace';
+import { SupportedLanguages, formatters as codeFormatters } from './formatters';
+
+type CodeBlockProps = {
+    /**
+     * The code content to display and highlight
+     */
+    children: string;
+    /**
+     * The language for syntax highlighting
+     * Currently supports "json" and "protobuf"
+     *
+     * @default 'json'
+     */
+    lang?: SupportedLanguages;
+    /**
+     * Whether to show a background color
+     *
+     * @default true
+     */
+    showBackground?: boolean;
+} & TestID &
+    StyledPropsBlade;
+
+type CodeBlockContainerProps = {
+    showBackground: boolean;
+};
+
+const CodeBlockContainer = styled(BaseBox)<CodeBlockContainerProps>((props) => {
+    const padding = makeSpace(props.theme.spacing[4]);
+    return {
+        padding,
+        backgroundColor: props.showBackground
+            ? props.theme.colors.surface.background.gray.subtle
+            : undefined,
+        borderRadius: props.theme.border.radius.medium,
+        fontFamily: props.theme.typography.fonts.family.code,
+        fontSize: '0.875rem',
+        lineHeight: '1.5',
+        overflowX: 'auto',
+        whiteSpace: 'pre',
+    };
+});
+
+const _CodeBlock = ({
+    children,
+    lang = 'json',
+    testID,
+    showBackground = true,
+    ...rest
+}: CodeBlockProps) => {
+    // Get the formatter for the specified language
+    const formatter = codeFormatters[lang] || codeFormatters.json;
+
+    // Format the code using the formatters from the formatters directory
+    const formattedCode = formatter.format(children);
+
+    return (
+        <CodeBlockContainer
+            showBackground={showBackground}
+            {...metaAttribute({ name: MetaConstants.CodeBlock, testID })}
+            {...getStyledProps(rest)}
+        >
+            {formattedCode}
+        </CodeBlockContainer>
+    );
+};
+
+/**
+ * CodeBlock displays code with syntax highlighting.
+ * Currently supports JSON and Protobuf languages.
+ */
+const CodeBlock = React.forwardRef<BladeElementRef, CodeBlockProps>(
+    (props, ref) => <_CodeBlock {...props} />
+);
+
+CodeBlock.displayName = 'CodeBlock';
+
+export { _CodeBlock, CodeBlock };
+export type { CodeBlockProps }; 

--- a/packages/blade/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/blade/src/components/CodeBlock/CodeBlock.tsx
@@ -27,6 +27,12 @@ type CodeBlockProps = {
      * @default true
      */
     showBackground?: boolean;
+    /**
+     * Whether to show line numbers
+     * 
+     * @default true
+     */
+    showLineNumbers?: boolean;
 } & TestID &
     StyledPropsBlade;
 
@@ -35,18 +41,11 @@ type CodeBlockContainerProps = {
 };
 
 const CodeBlockContainer = styled(BaseBox)<CodeBlockContainerProps>((props) => {
-    const padding = makeSpace(props.theme.spacing[4]);
     return {
-        padding,
-        backgroundColor: props.showBackground
-            ? props.theme.colors.surface.background.gray.subtle
-            : undefined,
+        // No padding here - the CodePre component already has padding
+        backgroundColor: undefined, // Background handled by CodePre
         borderRadius: props.theme.border.radius.medium,
-        fontFamily: props.theme.typography.fonts.family.code,
-        fontSize: '0.875rem',
-        lineHeight: '1.5',
         overflowX: 'auto',
-        whiteSpace: 'pre',
     };
 });
 
@@ -55,13 +54,14 @@ const _CodeBlock = ({
     lang = 'json',
     testID,
     showBackground = true,
+    showLineNumbers = true,
     ...rest
 }: CodeBlockProps) => {
     // Get the formatter for the specified language
     const formatter = codeFormatters[lang] || codeFormatters.json;
 
     // Format the code using the formatters from the formatters directory
-    const formattedCode = formatter.format(children);
+    const formattedCode = formatter.format(children, showBackground, showLineNumbers);
 
     return (
         <CodeBlockContainer

--- a/packages/blade/src/components/CodeBlock/README.md
+++ b/packages/blade/src/components/CodeBlock/README.md
@@ -1,0 +1,219 @@
+# CodeBlock
+
+CodeBlock is a component used to display and highlight code snippets with proper syntax highlighting.
+
+## Usage
+
+```tsx
+import { CodeBlock } from '@razorpay/blade';
+
+// JSON Example
+<CodeBlock lang="json">
+{`
+{
+  "name": "John Doe",
+  "age": 30,
+  "isActive": true,
+  "address": {
+    "street": "123 Main St",
+    "city": "Anytown"
+  }
+}
+`}
+</CodeBlock>
+
+// Protobuf Example
+<CodeBlock lang="protobuf">
+{`
+syntax = "proto3";
+
+package example;
+
+// User profile information
+message User {
+  string name = 1;
+  int32 age = 2;
+  bool is_active = 3;
+}
+`}
+</CodeBlock>
+
+// Without Background
+<CodeBlock lang="json" showBackground={false}>
+{`{"name": "John Doe"}`}
+</CodeBlock>
+```
+
+## Props
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| children | string | - | The code content to display and highlight |
+| lang | 'json' \| 'protobuf' | 'json' | The language for syntax highlighting |
+| showBackground | boolean | true | Whether to show a background color |
+| testID | string | - | Test ID for testing frameworks |
+
+## Theme Support
+
+CodeBlock automatically adapts to the current theme (light or dark) using the Blade design system's theme variables. The syntax highlighting colors are derived from the theme's color palette to ensure consistency across the application.
+
+- In light theme: Syntax highlighting provides clear distinction between different code elements with appropriate contrast
+- In dark theme: Colors are adjusted automatically to maintain readability while reducing eye strain
+
+## Accessibility
+
+CodeBlock uses semantic HTML elements and appropriate styling to ensure good contrast for code syntax highlighting in both light and dark themes. The component maintains WCAG compliance for text contrast ratios.
+
+## Guidelines
+
+- Use CodeBlock when you need to present code snippets to users
+- Always provide meaningful and properly formatted code for better readability
+- Consider using the `showBackground` prop to visually separate the code from surrounding content
+- Ensure the code is syntactically correct for the selected language
+- For long code snippets, consider using CodeBlock within a scrollable container
+
+## Examples
+
+### JSON Example
+
+A simple JSON object with syntax highlighting:
+
+```tsx
+<Card>
+  <CardBody>
+    <CodeBlock lang="json">
+    {`
+    {
+      "name": "John Doe",
+      "age": 30,
+      "isActive": true,
+      "hobbies": ["Reading", "Hiking", "Coding"],
+      "address": {
+        "street": "123 Main St",
+        "city": "Anytown",
+        "zipCode": 12345
+      }
+    }
+    `}
+    </CodeBlock>
+  </CardBody>
+</Card>
+```
+
+### Protobuf Example
+
+A Protobuf definition with syntax highlighting:
+
+```tsx
+<Card>
+  <CardBody>
+    <CodeBlock lang="protobuf">
+    {`
+    syntax = "proto3";
+
+    package example;
+
+    // User profile information
+    message User {
+      string name = 1;
+      int32 age = 2;
+      bool is_active = 3;
+      
+      enum Role {
+        ADMIN = 0;
+        MEMBER = 1;
+        GUEST = 2;
+      }
+      
+      Role role = 4;
+    }
+
+    service UserService {
+      rpc GetUser(GetUserRequest) returns (User);
+    }
+    `}
+    </CodeBlock>
+  </CardBody>
+</Card>
+```
+
+### Without Background
+
+Code without background styling:
+
+```tsx
+<Card>
+  <CardBody>
+    <CodeBlock lang="json" showBackground={false}>
+    {`
+    {
+      "name": "John Doe",
+      "age": 30,
+      "isActive": true
+    }
+    `}
+    </CodeBlock>
+  </CardBody>
+</Card>
+```
+
+### Server-Side Rendering
+
+CodeBlock works seamlessly with server-side rendering (SSR). Here's an example of using CodeBlock in a server-rendered Next.js application:
+
+```tsx
+// pages/api-docs.tsx
+import { CodeBlock } from '@razorpay/blade';
+import { GetServerSideProps } from 'next';
+
+// Example API response
+const apiResponseExample = {
+  status: "success",
+  data: {
+    user: {
+      id: "usr_123456",
+      name: "John Doe",
+      email: "john@example.com",
+      created_at: "2023-01-15T08:30:00Z"
+    }
+  }
+};
+
+export default function ApiDocsPage() {
+  return (
+    <div className="container">
+      <h1>API Documentation</h1>
+      
+      <h2>Example Response</h2>
+      <CodeBlock lang="json">
+        {JSON.stringify(apiResponseExample, null, 2)}
+      </CodeBlock>
+      
+      <h2>Example Protobuf Definition</h2>
+      <CodeBlock lang="protobuf">
+      {`syntax = "proto3";
+
+package api;
+
+message User {
+  string id = 1;
+  string name = 2;
+  string email = 3;
+  string created_at = 4;
+}
+
+message ApiResponse {
+  string status = 1;
+  User user = 2;
+}`}
+      </CodeBlock>
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  // You can fetch data here if needed
+  return {
+    props: {}
+  };
+}; 

--- a/packages/blade/src/components/CodeBlock/_KitchenSink.CodeBlock.stories.tsx
+++ b/packages/blade/src/components/CodeBlock/_KitchenSink.CodeBlock.stories.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { StoryFn } from '@storybook/react';
+import { CodeBlock } from './CodeBlock';
+import { Card, CardBody } from '~components/Card';
+
+export default {
+    title: 'Components/CodeBlock/_KitchenSink',
+    component: CodeBlock,
+};
+
+export const JsonExamples: StoryFn = () => {
+    const complexJson = `{
+  "person": {
+    "name": "John Doe",
+    "age": 30,
+    "isActive": true,
+    "address": {
+      "street": "123 Main St",
+      "city": "Anytown",
+      "zipCode": 12345
+    },
+    "tags": ["developer", "designer", "product"],
+    "projects": null,
+    "scores": [98, 95, 92, 87],
+    "contactInfo": {
+      "email": "john.doe@example.com",
+      "phone": "+1-555-555-5555"
+    }
+  },
+  "company": "Acme Inc.",
+  "department": "Engineering",
+  "startDate": "2023-01-15"
+}`;
+
+    return (
+        <Card>
+            <CardBody>
+                <h3>JSON Example - Complex Object</h3>
+                <CodeBlock lang="json">{complexJson}</CodeBlock>
+            </CardBody>
+        </Card>
+    );
+};
+
+export const ProtobufExamples: StoryFn = () => {
+    const protoExample = `syntax = "proto3";
+
+package example;
+
+
+// User profile information
+message User {
+  string name = 1;
+  int32 age = 2;
+  bool is_active = 3;
+  
+  enum Role {
+    ADMIN = 0;
+    MEMBER = 1;
+    GUEST = 2;
+  }
+  
+  Role role = 4;
+  
+  message Address {
+    string street = 1;
+    string city = 2;
+    int32 zip_code = 3;
+  }
+  
+  Address address = 5;
+  repeated string tags = 6;
+  map<string, string> attributes = 7;
+}
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc ListUsers(ListUsersRequest) returns (stream User);
+  rpc UpdateUser(UpdateUserRequest) returns (User);
+  rpc DeleteUser(DeleteUserRequest) returns (google.protobuf.Empty);
+}`;
+
+    return (
+        <Card>
+            <CardBody>
+                <h3>Protobuf Example</h3>
+                <CodeBlock lang="protobuf">{protoExample}</CodeBlock>
+            </CardBody>
+        </Card>
+    );
+};
+
+export const WithoutBackground: StoryFn = () => {
+    const simpleJson = `{
+  "name": "John Doe",
+  "age": 30,
+  "isActive": true
+}`;
+
+    return (
+        <Card>
+            <CardBody>
+                <h3>Without Background</h3>
+                <CodeBlock lang="json" showBackground={false}>{simpleJson}</CodeBlock>
+            </CardBody>
+        </Card>
+    );
+}; 

--- a/packages/blade/src/components/CodeBlock/__tests__/CodeBlock.web.test.tsx
+++ b/packages/blade/src/components/CodeBlock/__tests__/CodeBlock.web.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { CodeBlock } from '../CodeBlock';
+import renderWithTheme from '~utils/testing/renderWithTheme.web';
+import 'jest-styled-components';
+
+describe('<CodeBlock />', () => {
+    it('should render CodeBlock with default properties', () => {
+        const { container } = renderWithTheme(<CodeBlock>{`{"test": "json"}`}</CodeBlock>);
+        expect(container).toMatchSnapshot();
+    });
+
+    it('should render CodeBlock without background', () => {
+        const { container } = renderWithTheme(
+            <CodeBlock showBackground={false}>{`{"test": "json"}`}</CodeBlock>,
+        );
+        expect(container).toMatchSnapshot();
+    });
+
+    it('should handle invalid JSON gracefully', () => {
+        const { container } = renderWithTheme(<CodeBlock>This is not valid JSON</CodeBlock>);
+        expect(container).toMatchSnapshot();
+    });
+}); 

--- a/packages/blade/src/components/CodeBlock/formatters/components.ts
+++ b/packages/blade/src/components/CodeBlock/formatters/components.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+/**
+ * Styled components for syntax highlighting
+ * These components are used by the various language formatters
+ */
+
+// Property names and keys
+export const PropertyName = styled.span`
+    color: ${(props) => props.theme.colors.interactive.text.primary.normal};
+`;
+
+// String values
+export const StringValue = styled.span`
+    color: ${(props) => props.theme.colors.feedback.text.positive.intense};
+`;
+
+// Numeric values
+export const NumberValue = styled.span`
+    color: ${(props) => props.theme.colors.feedback.text.negative.intense};
+`;
+
+// Keywords, operators and language constructs
+export const KeywordValue = styled.span`
+    color: ${(props) => props.theme.colors.feedback.text.notice.intense};
+`;
+
+// Comments
+export const CommentValue = styled.span`
+    color: ${(props) => props.theme.colors.surface.text.gray.muted};
+    font-style: italic;
+`;
+
+// Data types
+export const TypeValue = styled.span`
+    color: ${(props) => props.theme.colors.interactive.text.primary.subtle};
+`; 

--- a/packages/blade/src/components/CodeBlock/formatters/index.ts
+++ b/packages/blade/src/components/CodeBlock/formatters/index.ts
@@ -1,0 +1,526 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+/**
+ * Supported language types for syntax highlighting
+ */
+export type SupportedLanguages = 'json' | 'protobuf';
+
+/**
+ * Interface for language formatters
+ */
+export interface LanguageFormatter {
+    /**
+     * Format the provided code string with syntax highlighting
+     * @param code The code string to format
+     * @returns React nodes with syntax highlighting
+     */
+    format: (code: string) => React.ReactNode;
+}
+
+// Define types for matched parts to ensure type safety
+interface MatchedPart {
+    index: number;
+    element: React.ReactElement;
+    length?: number;
+}
+
+/**
+ * Theme-aware GitHub-like syntax highlighting colors
+ */
+const getThemeColors = (theme: any) => {
+    const isDarkTheme = theme.colorScheme === 'dark';
+
+    return {
+        // GitHub-like colors for light/dark themes
+        propertyName: isDarkTheme ? '#75beff' : '#0550ae',      // Blue
+        stringValue: isDarkTheme ? '#a5d6ff' : '#0a3069',       // Dark blue
+        numberValue: isDarkTheme ? '#75beff' : '#0550ae',       // Blue
+        keywordValue: isDarkTheme ? '#ff7b72' : '#cf222e',      // Red
+        commentValue: isDarkTheme ? '#8b949e' : '#6e7781',      // Gray
+        typeValue: isDarkTheme ? '#ffa657' : '#953800',         // Brown
+        background: isDarkTheme ? '#0d1117' : '#f6f8fa',        // GitHub bg color
+        text: isDarkTheme ? '#c9d1d9' : '#24292f',              // Text
+        border: isDarkTheme ? '#30363d' : '#d0d7de',            // Border
+        lineNumberColor: isDarkTheme ? '#6e7681' : '#6e7781',   // Line number color
+    };
+};
+
+/**
+ * Styled components for syntax highlighting
+ * These components use GitHub-like colors for syntax highlighting that adapt to light/dark themes
+ */
+
+// Property names and keys for JSON
+export const PropertyName = styled.span`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      color: ${colors.propertyName};
+      font-weight: 600;
+    `;
+    }}
+`;
+
+// String values
+export const StringValue = styled.span`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      color: ${colors.stringValue};
+    `;
+    }}
+`;
+
+// Numeric values
+export const NumberValue = styled.span`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      color: ${colors.numberValue};
+    `;
+    }}
+`;
+
+// Keywords, operators and language constructs (true, false, null)
+export const KeywordValue = styled.span`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      color: ${colors.keywordValue};
+      font-weight: bold;
+    `;
+    }}
+`;
+
+// Comments
+export const CommentValue = styled.span`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      color: ${colors.commentValue};
+      font-style: italic;
+    `;
+    }}
+`;
+
+// Data types
+export const TypeValue = styled.span`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      color: ${colors.typeValue};
+    `;
+    }}
+`;
+
+// Styled pre element for code blocks that exactly matches GitHub styling
+export const CodePre = styled.pre`
+  ${({ theme }) => {
+        const colors = getThemeColors(theme);
+        return css`
+      margin: 0;
+      white-space: pre-wrap;
+      font-family: ${theme.typography.fonts.family.code};
+      font-size: 0.875rem;
+      line-height: 1.5;
+      background-color: ${colors.background};
+      color: ${colors.text};
+      padding: 1rem;
+      border-radius: 6px;
+      border: 1px solid ${colors.border};
+      
+      /* Ensure line spacing is consistent */
+      & > div {
+        min-height: 1.5em;
+      }
+      
+      /* Add extra spacing for empty lines */
+      & > div:empty:before {
+        content: "\\00a0"; /* Non-breaking space to preserve empty lines */
+        display: inline-block;
+      }
+    `;
+    }}
+`;
+
+/**
+ * Enhanced JSON formatter with GitHub-like syntax highlighting
+ */
+export const jsonFormatter: LanguageFormatter = {
+    format: (code: string): React.ReactNode => {
+        try {
+            // Parse the JSON and re-format it with proper indentation
+            const parsedJSON = JSON.parse(code);
+            const formattedJSON = JSON.stringify(parsedJSON, null, 2);
+
+            // Split the code into lines for line-by-line processing
+            const lines = formattedJSON.split('\n');
+            const outputLines: React.ReactElement[] = [];
+
+            // Process each line
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+
+                // Handle empty lines
+                if (line.trim() === '') {
+                    outputLines.push(
+                        React.createElement('div', { key: `line-${i}` }, '\u00A0') // Non-breaking space to preserve the line
+                    );
+                    continue;
+                }
+
+                const parts: React.ReactNode[] = [];
+
+                // Process property names (e.g. "propertyName":)
+                const propertyRegex = /"([^"]+)":/g;
+                let propMatch: RegExpExecArray | null;
+                let lastIndex = 0;
+
+                while ((propMatch = propertyRegex.exec(line)) !== null) {
+                    // Add any text before the property
+                    if (propMatch.index > lastIndex) {
+                        parts.push(line.substring(lastIndex, propMatch.index));
+                    }
+
+                    // Add the property name with styling - GitHub style has quotes in the default color
+                    // and only highlights the name itself
+                    const fullMatch = propMatch[0]; // e.g. "name":
+                    const propName = propMatch[1]; // e.g. name
+
+                    // Create property name with styled inner text
+                    parts.push('"');
+                    parts.push(
+                        React.createElement(
+                            PropertyName,
+                            { key: `prop-${i}-${propMatch.index}` },
+                            propName
+                        )
+                    );
+                    parts.push('":');
+
+                    lastIndex = propMatch.index + fullMatch.length;
+                }
+
+                // Process the rest of the line
+                if (lastIndex < line.length) {
+                    const restOfLine = line.substring(lastIndex);
+                    const restParts: React.ReactNode[] = [];
+                    let restLastIndex = 0;
+
+                    // Process string values
+                    const stringRegex = / "([^"\\]|\\.)*"/g;
+                    let stringMatch: RegExpExecArray | null;
+
+                    while ((stringMatch = stringRegex.exec(restOfLine)) !== null) {
+                        // Add any text before the string
+                        if (stringMatch.index > restLastIndex) {
+                            restParts.push(restOfLine.substring(restLastIndex, stringMatch.index));
+                        }
+
+                        // Add the string with styling
+                        const stringElement = React.createElement(
+                            StringValue,
+                            { key: `str-${i}-${stringMatch.index}` },
+                            stringMatch[0]
+                        );
+                        restParts.push(stringElement);
+
+                        restLastIndex = stringMatch.index + stringMatch[0].length;
+                    }
+
+                    // Process numbers
+                    const numberRegex = /\b\d+(\.\d+)?([eE][+-]?\d+)?\b/g;
+                    let numMatch: RegExpExecArray | null;
+                    let numParts: React.ReactNode[] = [];
+                    let numLastIndex = 0;
+
+                    const remainingText = restLastIndex < restOfLine.length
+                        ? restOfLine.substring(restLastIndex)
+                        : '';
+
+                    while ((numMatch = numberRegex.exec(remainingText)) !== null) {
+                        // Add any text before the number
+                        if (numMatch.index > numLastIndex) {
+                            numParts.push(remainingText.substring(numLastIndex, numMatch.index));
+                        }
+
+                        // Add the number with styling
+                        const numElement = React.createElement(
+                            NumberValue,
+                            { key: `num-${i}-${numMatch.index}` },
+                            numMatch[0]
+                        );
+                        numParts.push(numElement);
+
+                        numLastIndex = numMatch.index + numMatch[0].length;
+                    }
+
+                    // Process keywords (true, false, null)
+                    if (numLastIndex < remainingText.length) {
+                        const keywordText = remainingText.substring(numLastIndex);
+                        const keywordRegex = /\b(true|false|null)\b/g;
+                        let keywordMatch: RegExpExecArray | null;
+                        let keywordParts: React.ReactNode[] = [];
+                        let keywordLastIndex = 0;
+
+                        while ((keywordMatch = keywordRegex.exec(keywordText)) !== null) {
+                            // Add any text before the keyword
+                            if (keywordMatch.index > keywordLastIndex) {
+                                keywordParts.push(keywordText.substring(keywordLastIndex, keywordMatch.index));
+                            }
+
+                            // Add the keyword with styling
+                            const keywordElement = React.createElement(
+                                KeywordValue,
+                                { key: `key-${i}-${keywordMatch.index}` },
+                                keywordMatch[0]
+                            );
+                            keywordParts.push(keywordElement);
+
+                            keywordLastIndex = keywordMatch.index + keywordMatch[0].length;
+                        }
+
+                        // Add any remaining text
+                        if (keywordLastIndex < keywordText.length) {
+                            keywordParts.push(keywordText.substring(keywordLastIndex));
+                        }
+
+                        // Add keyword parts to numParts if they exist
+                        if (keywordParts.length > 0) {
+                            numParts.push(...keywordParts);
+                        }
+                    }
+
+                    // Add any remaining text
+                    if (numLastIndex < remainingText.length && numParts.length === 0) {
+                        numParts.push(remainingText.substring(numLastIndex));
+                    }
+
+                    // Add numParts to restParts if they exist
+                    if (numParts.length > 0) {
+                        restParts.push(...numParts);
+                    }
+
+                    // Add restParts to main parts array if they exist
+                    if (restParts.length > 0) {
+                        parts.push(...restParts);
+                    }
+                }
+
+                // Create a div for this line
+                outputLines.push(
+                    React.createElement('div', { key: `line-${i}` }, parts.length > 0 ? parts : line)
+                );
+            }
+
+            // Combine all lines into the final output
+            return React.createElement(CodePre, null, outputLines);
+        } catch (error) {
+            // Return the original code if parsing fails
+            return React.createElement(CodePre, null, code);
+        }
+    }
+};
+
+/**
+ * Enhanced Protobuf formatter with syntax highlighting
+ */
+export const protobufFormatter: LanguageFormatter = {
+    format: (code: string): React.ReactNode => {
+        // Split the code into lines for line-by-line processing
+        const lines = code.split('\n');
+        const outputLines: React.ReactElement[] = [];
+
+        // Define protobuf language elements with GitHub-like highlighting
+        const keywords = [
+            'syntax', 'package', 'import', 'option', 'message', 'enum', 'service',
+            'rpc', 'returns', 'stream', 'oneof', 'reserved', 'extend', 'extensions',
+            'repeated', 'map', 'Config', 'map', 'string', 'MerchantConfig', 'BillConfig'
+        ];
+
+        const types = [
+            'double', 'float', 'int32', 'int64', 'uint32', 'uint64',
+            'sint32', 'sint64', 'fixed32', 'fixed64', 'sfixed32',
+            'sfixed64', 'bool', 'string', 'bytes'
+        ];
+
+        // Process each line
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+
+            // Handle empty lines
+            if (line.trim() === '') {
+                outputLines.push(
+                    React.createElement('div', { key: `line-${i}` }, '\u00A0') // Non-breaking space to preserve the line
+                );
+                continue;
+            }
+
+            const parts: MatchedPart[] = [];
+
+            // Process comments first
+            const commentMatch = line.match(/(\/\/.*$)|(\/\*[\s\S]*?\*\/)/);
+            let lineWithoutComment = line;
+
+            if (commentMatch && commentMatch.index !== undefined) {
+                // Add text before comment
+                if (commentMatch.index > 0) {
+                    lineWithoutComment = line.substring(0, commentMatch.index);
+                    // We'll process this part for other syntax highlighting
+                } else {
+                    lineWithoutComment = "";
+                }
+
+                // Add the comment at the end
+                const commentElement = React.createElement(
+                    CommentValue,
+                    { key: `comment-${i}` },
+                    commentMatch[0]
+                );
+                parts.push({ index: commentMatch.index, element: commentElement });
+            }
+
+            // Process the rest of the line (excluding comments)
+            if (lineWithoutComment.length > 0) {
+                // Process keywords
+                for (const keyword of keywords) {
+                    const keywordRegex = new RegExp(`\\b${keyword}\\b`, 'g');
+                    let match: RegExpExecArray | null;
+
+                    while ((match = keywordRegex.exec(lineWithoutComment)) !== null) {
+                        const keywordElement = React.createElement(
+                            KeywordValue,
+                            { key: `keyword-${i}-${match.index}` },
+                            match[0]
+                        );
+                        parts.push({
+                            index: match.index,
+                            element: keywordElement,
+                            length: match[0].length
+                        });
+                    }
+                }
+
+                // Process = and ; symbols with regular text color
+                const operatorRegex = /[=;]/g;
+                let operatorMatch: RegExpExecArray | null;
+
+                while ((operatorMatch = operatorRegex.exec(lineWithoutComment)) !== null) {
+                    // Use regular text for operators (no special highlighting)
+                    parts.push({
+                        index: operatorMatch.index,
+                        element: React.createElement('span', { key: `op-${i}-${operatorMatch.index}` }, operatorMatch[0]),
+                        length: operatorMatch[0].length
+                    });
+                }
+
+                // Process types
+                for (const type of types) {
+                    const typeRegex = new RegExp(`\\b${type}\\b`, 'g');
+                    let match: RegExpExecArray | null;
+
+                    while ((match = typeRegex.exec(lineWithoutComment)) !== null) {
+                        const typeElement = React.createElement(
+                            TypeValue,
+                            { key: `type-${i}-${match.index}` },
+                            match[0]
+                        );
+                        parts.push({
+                            index: match.index,
+                            element: typeElement,
+                            length: match[0].length
+                        });
+                    }
+                }
+
+                // Process string literals
+                const stringRegex = /"([^"\\]|\\.)*"/g;
+                let stringMatch: RegExpExecArray | null;
+
+                while ((stringMatch = stringRegex.exec(lineWithoutComment)) !== null) {
+                    const stringElement = React.createElement(
+                        StringValue,
+                        { key: `string-${i}-${stringMatch.index}` },
+                        stringMatch[0]
+                    );
+                    parts.push({
+                        index: stringMatch.index,
+                        element: stringElement,
+                        length: stringMatch[0].length
+                    });
+                }
+
+                // Process numbers
+                const numberRegex = /\b\d+\b/g;
+                let numberMatch: RegExpExecArray | null;
+
+                while ((numberMatch = numberRegex.exec(lineWithoutComment)) !== null) {
+                    const numberElement = React.createElement(
+                        NumberValue,
+                        { key: `number-${i}-${numberMatch.index}` },
+                        numberMatch[0]
+                    );
+                    parts.push({
+                        index: numberMatch.index,
+                        element: numberElement,
+                        length: numberMatch[0].length
+                    });
+                }
+            }
+
+            // Sort all parts by their index
+            parts.sort((a, b) => a.index - b.index);
+
+            // Build the final line with highlighted parts
+            const finalLineParts: React.ReactNode[] = [];
+            let lastIndex = 0;
+
+            for (const part of parts) {
+                // Add any plain text before this part
+                if (part.index > lastIndex) {
+                    finalLineParts.push(line.substring(lastIndex, part.index));
+                }
+
+                // Add the highlighted part
+                finalLineParts.push(part.element);
+
+                // Update lastIndex - use part.length if available, otherwise calculate it safely
+                if (part.length) {
+                    lastIndex = part.index + part.length;
+                } else if (part.element.props && part.element.props.children) {
+                    // If it's a string, use its length
+                    if (typeof part.element.props.children === 'string') {
+                        lastIndex = part.index + part.element.props.children.length;
+                    } else {
+                        // Otherwise, just use 1 as a fallback
+                        lastIndex = part.index + 1;
+                    }
+                } else {
+                    lastIndex = part.index + 1;
+                }
+            }
+
+            // Add any remaining text
+            if (lastIndex < line.length) {
+                finalLineParts.push(line.substring(lastIndex));
+            }
+
+            // Create a div for this line
+            outputLines.push(
+                React.createElement('div', { key: `line-${i}` }, finalLineParts)
+            );
+        }
+
+        // Combine all lines into the final output
+        return React.createElement(CodePre, null, outputLines);
+    }
+};
+
+/**
+ * Registry of formatters
+ */
+export const formatters: Record<SupportedLanguages, LanguageFormatter> = {
+    json: jsonFormatter,
+    protobuf: protobufFormatter
+}; 

--- a/packages/blade/src/components/CodeBlock/formatters/jsonFormatter.ts
+++ b/packages/blade/src/components/CodeBlock/formatters/jsonFormatter.ts
@@ -1,0 +1,135 @@
+import React from 'react';
+import { LanguageFormatter } from './types';
+import { PropertyName, StringValue, NumberValue, KeywordValue } from './components';
+
+// Define interfaces for regex matches
+interface TypedMatch {
+    type: 'string' | 'number' | 'keyword';
+    match: RegExpMatchArray;
+}
+
+/**
+ * Formatter for JSON syntax highlighting
+ */
+export const JsonFormatter: LanguageFormatter = {
+    format: (json: string): React.ReactNode => {
+        try {
+            // Parse and reformat with proper indentation
+            const parsedJSON = JSON.parse(json);
+            const formattedJSON = JSON.stringify(parsedJSON, null, 2);
+
+            // Split by newlines and format each line
+            return formattedJSON.split('\n').map((line, lineIndex) => {
+                const parts: React.ReactNode[] = [];
+                let remainingLine = line;
+
+                // Find property names (e.g., "name":)
+                const propertyNameRegex = /"([^"]+)":/g;
+                let match: RegExpExecArray | null;
+                let lastIndex = 0;
+
+                while ((match = propertyNameRegex.exec(line)) !== null) {
+                    // Add any text before the match
+                    if (match.index > lastIndex) {
+                        parts.push(line.substring(lastIndex, match.index));
+                    }
+
+                    // Add the property name with styling
+                    parts.push(
+                        React.createElement(
+                            PropertyName,
+                            { key: `prop-${lineIndex}-${parts.length}` },
+                            match[0]
+                        )
+                    );
+
+                    lastIndex = match.index + match[0].length;
+                }
+
+                // Add any remaining text
+                if (lastIndex < line.length) {
+                    remainingLine = line.substring(lastIndex);
+                } else {
+                    remainingLine = '';
+                }
+
+                // Process the rest of the line for other values
+                if (remainingLine) {
+                    // Find string values
+                    const stringValueRegex = / "([^"]+)"/g;
+                    const stringMatches = [...remainingLine.matchAll(stringValueRegex)];
+
+                    // Find number values
+                    const numberValueRegex = / ([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)/g;
+                    const numberMatches = [...remainingLine.matchAll(numberValueRegex)];
+
+                    // Find boolean/null values
+                    const keywordValueRegex = / (true|false|null)(?=[,}\]\\]|$)/g;
+                    const keywordMatches = [...remainingLine.matchAll(keywordValueRegex)];
+
+                    // Combine all matches and sort by index
+                    const allMatches: TypedMatch[] = [
+                        ...stringMatches.map(m => ({ type: 'string' as const, match: m })),
+                        ...numberMatches.map(m => ({ type: 'number' as const, match: m })),
+                        ...keywordMatches.map(m => ({ type: 'keyword' as const, match: m }))
+                    ].sort((a, b) => {
+                        // Safely handle possibly undefined indices
+                        const aIndex = a.match.index !== undefined ? a.match.index : 0;
+                        const bIndex = b.match.index !== undefined ? b.match.index : 0;
+                        return aIndex - bIndex;
+                    });
+
+                    let currentIndex = 0;
+
+                    // Process each match in order
+                    for (const { type, match } of allMatches) {
+                        // Safely handle possibly undefined index
+                        const matchIndex = match.index !== undefined ? match.index : 0;
+
+                        if (matchIndex > currentIndex) {
+                            parts.push(remainingLine.substring(currentIndex, matchIndex));
+                        }
+
+                        if (type === 'string') {
+                            parts.push(
+                                React.createElement(
+                                    StringValue,
+                                    { key: `str-${lineIndex}-${parts.length}` },
+                                    match[0]
+                                )
+                            );
+                        } else if (type === 'number') {
+                            parts.push(
+                                React.createElement(
+                                    NumberValue,
+                                    { key: `num-${lineIndex}-${parts.length}` },
+                                    match[0]
+                                )
+                            );
+                        } else if (type === 'keyword') {
+                            parts.push(
+                                React.createElement(
+                                    KeywordValue,
+                                    { key: `key-${lineIndex}-${parts.length}` },
+                                    match[0]
+                                )
+                            );
+                        }
+
+                        currentIndex = matchIndex + match[0].length;
+                    }
+
+                    // Add any remaining text
+                    if (currentIndex < remainingLine.length) {
+                        parts.push(remainingLine.substring(currentIndex));
+                    }
+                }
+
+                return React.createElement('div', { key: `line-${lineIndex}` }, parts);
+            });
+        } catch (error) {
+            // Return the original string if it's not valid JSON
+            return json;
+        }
+    }
+}; 

--- a/packages/blade/src/components/CodeBlock/formatters/protobufFormatter.ts
+++ b/packages/blade/src/components/CodeBlock/formatters/protobufFormatter.ts
@@ -1,0 +1,116 @@
+import React from 'react';
+import { LanguageFormatter } from './types';
+import { CommentValue, KeywordValue, TypeValue } from './components';
+
+/**
+ * Formatter for Protobuf syntax highlighting
+ */
+export const ProtobufFormatter: LanguageFormatter = {
+    format: (protobuf: string): React.ReactNode => {
+        // Split by newlines and format each line
+        return protobuf.split('\n').map((line, lineIndex) => {
+            const parts: React.ReactNode[] = [];
+            let currentLine = line;
+
+            // Handle comments (both // and /* */)
+            const commentRegex = /(\/\/.*$)|(\/\*[\s\S]*?\*\/)/;
+            const commentMatch = currentLine.match(commentRegex);
+
+            if (commentMatch && commentMatch.index !== undefined) {
+                // Add any text before the comment
+                if (commentMatch.index > 0) {
+                    parts.push(currentLine.substring(0, commentMatch.index));
+                }
+
+                // Add the comment with styling
+                parts.push(
+                    React.createElement(
+                        CommentValue,
+                        { key: `comment-${lineIndex}` },
+                        commentMatch[0]
+                    )
+                );
+
+                // Remove the comment from further processing
+                currentLine = currentLine.substring(0, commentMatch.index);
+            }
+
+            // Handle keywords (syntax, message, service, rpc, returns, etc.)
+            const keywords = [
+                'syntax', 'package', 'import', 'option', 'message', 'enum', 'service',
+                'rpc', 'returns', 'stream', 'oneof', 'reserved', 'extend', 'extensions'
+            ];
+            const keywordRegex = new RegExp(`\\b(${keywords.join('|')})\\b`, 'g');
+
+            let keywordMatch: RegExpExecArray | null;
+            let lastKeywordIndex = 0;
+
+            while ((keywordMatch = keywordRegex.exec(currentLine)) !== null) {
+                // Add any text before the keyword
+                if (keywordMatch.index > lastKeywordIndex) {
+                    parts.push(currentLine.substring(lastKeywordIndex, keywordMatch.index));
+                }
+
+                // Add the keyword with styling
+                parts.push(
+                    React.createElement(
+                        KeywordValue,
+                        { key: `keyword-${lineIndex}-${parts.length}` },
+                        keywordMatch[0]
+                    )
+                );
+
+                lastKeywordIndex = keywordMatch.index + keywordMatch[0].length;
+            }
+
+            // Add any remaining text after the last keyword
+            if (lastKeywordIndex < currentLine.length) {
+                const remainingText = currentLine.substring(lastKeywordIndex);
+
+                // Handle types (int32, string, bool, etc.)
+                const types = [
+                    'double', 'float', 'int32', 'int64', 'uint32', 'uint64',
+                    'sint32', 'sint64', 'fixed32', 'fixed64', 'sfixed32',
+                    'sfixed64', 'bool', 'string', 'bytes', 'map'
+                ];
+                const typeRegex = new RegExp(`\\b(${types.join('|')})\\b`, 'g');
+
+                let typeMatch: RegExpExecArray | null;
+                let lastTypeIndex = 0;
+                let typeParts: React.ReactNode[] = [];
+
+                while ((typeMatch = typeRegex.exec(remainingText)) !== null) {
+                    // Add any text before the type
+                    if (typeMatch.index > lastTypeIndex) {
+                        typeParts.push(remainingText.substring(lastTypeIndex, typeMatch.index));
+                    }
+
+                    // Add the type with styling
+                    typeParts.push(
+                        React.createElement(
+                            TypeValue,
+                            { key: `type-${lineIndex}-${typeParts.length}` },
+                            typeMatch[0]
+                        )
+                    );
+
+                    lastTypeIndex = typeMatch.index + typeMatch[0].length;
+                }
+
+                // Add any remaining text after the last type
+                if (lastTypeIndex < remainingText.length) {
+                    typeParts.push(remainingText.substring(lastTypeIndex));
+                }
+
+                // Add the processed type parts to the main parts array
+                parts.push(...typeParts);
+            }
+
+            return React.createElement(
+                'div',
+                { key: `line-${lineIndex}` },
+                parts.length > 0 ? parts : line
+            );
+        });
+    }
+}; 

--- a/packages/blade/src/components/CodeBlock/formatters/types.ts
+++ b/packages/blade/src/components/CodeBlock/formatters/types.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+/**
+ * Supported language types for syntax highlighting
+ */
+export type SupportedLanguages = 'json' | 'protobuf';
+
+/**
+ * Interface for language formatters
+ * Each formatter needs to implement this interface
+ */
+export interface LanguageFormatter {
+    /**
+     * Format the provided code string with syntax highlighting
+     * @param code The code string to format
+     * @returns React nodes with syntax highlighting
+     */
+    format: (code: string) => React.ReactNode;
+} 

--- a/packages/blade/src/components/CodeBlock/index.ts
+++ b/packages/blade/src/components/CodeBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './CodeBlock'; 

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './Card';
 export * from './Carousel';
 export * from './Checkbox';
 export * from './ChatMessage';
+export * from './CodeBlock';
 export * from './Chip';
 export * from './Collapsible';
 export * from './Counter';

--- a/packages/blade/src/utils/metaAttribute/metaConstants.ts
+++ b/packages/blade/src/utils/metaAttribute/metaConstants.ts
@@ -31,6 +31,7 @@ export const MetaConstants = {
   ChipGroup: 'chip-group',
   ChipLabel: 'chip-label',
   Code: 'code',
+  CodeBlock: 'code-block',
   Component: 'blade-component',
   Counter: 'counter',
   Display: 'display',


### PR DESCRIPTION
## Description

Support for Code block - json, protobuf


<img width="937" alt="Screenshot 2025-03-18 at 1 53 13 AM" src="https://github.com/user-attachments/assets/6877c7be-e90c-4191-a7a7-f57afd970011" />


<img width="1075" alt="Screenshot 2025-03-18 at 1 53 00 AM" src="https://github.com/user-attachments/assets/3686b3e1-f6a9-46ce-94df-d49cbd2f7508" />

## Changes

This added code blocks support without using ext library.

Check this [PR](https://github.com/razorpay/blade/pull/2572) for support of code block with prism https://github.com/razorpay/blade/pull/2572

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [x] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [x] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
