### PR TITLE
fix(FormLabel): label color difference between figma and code

### DIFF
--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -119,7 +119,7 @@ const FormLabel = ({
       <Text
         variant="body"
         size={labelTextSize[isLabelLeftPositioned ? 'left' : 'top'][size]}
-        color="surface.text.gray.subtle"
+        color={isLabelLeftPositioned ? 'surface.text.gray.subtle' : 'surface.text.gray.muted'}
         truncateAfterLines={2}
         weight="semibold"
         wordBreak={isLabelLeftPositioned ? 'break-word' : undefined}


### PR DESCRIPTION
## Description

There was discrepancy between label's color on figma vs code. Fixed it in this PR
 
## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
