### PR TITLE
fix: datepicker autofocus not working when date change programmatically

### DIFF
--- a/.changeset/selfish-socks-vanish.md
+++ b/.changeset/selfish-socks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': minor
+---
+
+fix(blade): datepicker autofocus not working on programmatically changing date

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -29,14 +29,14 @@ const Calendar = <Type extends DateSelectionType>({
   onPrevious,
   presets,
   showLevelChangeLink,
-  oldValue,
+  selectedValue,
   ...props
 }: CalendarProps<Type> & {
   date?: Date;
   defaultDate?: Date;
   onDateChange?: (date: DateValue) => void;
   showLevelChangeLink?: boolean;
-  oldValue: DatesRangeValue | null;
+  selectedValue: DatesRangeValue | null;
 }): React.ReactElement => {
   const isRange = selectionType === 'range';
 
@@ -70,15 +70,15 @@ const Calendar = <Type extends DateSelectionType>({
     if (_date) {
       return _date;
     }
-    const isRangeSelection = Array.isArray(oldValue);
-    if (isRangeSelection && oldValue[0]) {
-      return oldValue[0];
+    const isRangeSelection = Array.isArray(selectedValue);
+    if (isRangeSelection && selectedValue[0]) {
+      return selectedValue[0];
     }
-    if (!isRangeSelection && oldValue) {
-      return oldValue;
+    if (!isRangeSelection && selectedValue) {
+      return selectedValue;
     }
     return shiftTimezone('add', new Date());
-  }, [_date, oldValue]);
+  }, [_date, selectedValue]);
   const numberOfColumns = isMobile || !isRange ? 1 : 2;
   const columnsToScroll = numberOfColumns;
 

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -10,6 +10,7 @@ import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
 import { Sandbox } from '~utils/storybook/Sandbox';
 import { Code, Text } from '~components/Typography';
 import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
+import { Button } from '~components/Button';
 
 const propsCategory = {
   BASE_PROPS: 'DatePicker Props',
@@ -86,6 +87,7 @@ export default {
           <Sandbox>
             {`
               import { DatePicker } from '@razorpay/blade/components';
+import { m } from 'framer-motion';
 
               function App() {
                 return (
@@ -197,10 +199,11 @@ DatePickerPresets.args = {
 
 export const DatePickerControlled: StoryFn<typeof DatePickerComponent> = () => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [date, setDate] = React.useState<DatesRangeValue>([
-    new Date(),
-    dayjs().add(3, 'day').toDate(),
+  const [dateRange, setDateRange] = React.useState<DatesRangeValue>([
+    dayjs().subtract(3, 'months').toDate(),
+    dayjs().add(3, 'day').subtract(3, 'months').toDate(),
   ]);
+  const [date, setDate] = React.useState(dayjs().subtract(3, 'months').toDate());
 
   return (
     <Box>
@@ -210,7 +213,8 @@ export const DatePickerControlled: StoryFn<typeof DatePickerComponent> = () => {
       </Text>
       <Box marginBottom="spacing.5">
         <Text>
-          Selected: [{dayjs(date[0]).format('DD-MM-YYYY')}, {dayjs(date[1]).format('DD-MM-YYYY')}]
+          Selected: [{dayjs(dateRange[0]).format('DD-MM-YYYY')},{' '}
+          {dayjs(dateRange[1]).format('DD-MM-YYYY')}]
         </Text>
         <Text marginTop="spacing.2">IsOpen: {JSON.stringify(isOpen)}</Text>
       </Box>
@@ -219,11 +223,37 @@ export const DatePickerControlled: StoryFn<typeof DatePickerComponent> = () => {
         selectionType="range"
         isOpen={isOpen}
         onOpenChange={({ isOpen }) => setIsOpen(isOpen)}
-        value={date}
+        value={dateRange}
         onChange={(date) => {
-          setDate(date);
+          setDateRange(date);
         }}
       />
+      <Box marginTop="spacing.5">
+        <Text marginBottom="spacing.5">Single Date Picker</Text>
+        <Text>Selected: {dayjs(date).format('DD-MM-YYYY')}</Text>
+        <DatePickerComponent
+          label="Select a date"
+          selectionType="single"
+          value={date}
+          onChange={(date) => {
+            setDate(date);
+          }}
+        />
+      </Box>
+
+      <Button
+        onClick={() => {
+          setDate(
+            dayjs()
+              .subtract(Math.round(Math.random() * 10), 'month')
+              .toDate(),
+          );
+        }}
+        marginTop="spacing.5"
+      >
+        {' '}
+        Change Date
+      </Button>
     </Box>
   );
 };

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -142,7 +142,10 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   });
 
   const currentDate = shiftTimezone('add', new Date());
-  const [oldValue, setOldValue] = React.useState<DatesRangeValue | null>(controlledValue);
+  const [oldValue, setOldValue] = useControllableState({
+    value: controlledValue,
+    defaultValue: controlledValue,
+  });
   const hasBothDatesSelected = controlledValue?.[0] && controlledValue?.[1];
   let applyButtonDisabled = !hasBothDatesSelected;
   if (isSingle) {

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -142,10 +142,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
   });
 
   const currentDate = shiftTimezone('add', new Date());
-  const [oldValue, setOldValue] = useControllableState({
-    value: controlledValue,
-    defaultValue: controlledValue,
-  });
+  const [oldValue, setOldValue] = React.useState<DatesRangeValue | null>(controlledValue);
   const hasBothDatesSelected = controlledValue?.[0] && controlledValue?.[1];
   let applyButtonDisabled = !hasBothDatesSelected;
   if (isSingle) {
@@ -276,7 +273,7 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
             setPicker(() => picker);
             forceRerender();
           }}
-          oldValue={oldValue}
+          selectedValue={controlledValue}
         />
         {isMobile ? null : (
           <CalendarFooter


### PR DESCRIPTION
## Description

when we changed date programmatically , date picker does not foucs on selected date. this is because previousDate is not being update. instead of using that we should use controlledValue.

## Changes


## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
