### PR TITLE
fix: date picker reseting date to prev. value

### DIFF
--- a/.changeset/thin-bobcats-invite.md
+++ b/.changeset/thin-bobcats-invite.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade): date picker resetting to prev value

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -134,15 +134,19 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
       setSelectedPreset(date as DatesRangeValue);
     },
   });
+  const [oldValue, setOldValue] = React.useState<DatesRangeValue | null>(controlledValue);
 
   const [controllableIsOpen, controllableSetIsOpen] = useControllableState({
     value: isOpen,
     defaultValue: defaultIsOpen,
-    onChange: (isOpen) => onOpenChange?.({ isOpen }),
+    onChange: (isOpen) => {
+      onOpenChange?.({ isOpen });
+      // we need to update old value everytime datepicker is opened or closed
+      setOldValue(controlledValue);
+    },
   });
 
   const currentDate = shiftTimezone('add', new Date());
-  const [oldValue, setOldValue] = React.useState<DatesRangeValue | null>(controlledValue);
   const hasBothDatesSelected = controlledValue?.[0] && controlledValue?.[1];
   let applyButtonDisabled = !hasBothDatesSelected;
   if (isSingle) {
@@ -290,12 +294,6 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
       locale,
     };
   }, [i18nState?.locale]);
-  // we need to update old value everytime datepicker is opened or closed
-  React.useEffect(() => {
-    setOldValue(controlledValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [controllableIsOpen]);
-
   // Dynamically load dayjs locales
   React.useLayoutEffect(() => {
     try {

--- a/packages/blade/src/components/DatePicker/DatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.web.tsx
@@ -157,7 +157,6 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
     if (isSingle) {
       onChange?.(controlledValue);
       fireNativeEvent(referenceRef, ['change']);
-      setOldValue(controlledValue);
       onApply?.(controlledValue);
       close();
       return;
@@ -166,7 +165,6 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
     if (hasBothDatesSelected) {
       onChange?.(controlledValue);
       fireNativeEvent(referenceRef, ['change']);
-      setOldValue(controlledValue);
       onApply?.(controlledValue);
       close();
     }
@@ -292,6 +290,11 @@ const DatePicker = <Type extends DateSelectionType = 'single'>({
       locale,
     };
   }, [i18nState?.locale]);
+  // we need to update old value everytime datepicker is opened or closed
+  React.useEffect(() => {
+    setOldValue(controlledValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [controllableIsOpen]);
 
   // Dynamically load dayjs locales
   React.useLayoutEffect(() => {


### PR DESCRIPTION
## Description

fix: date picker reseting date to prev. value

controlled datepicker was setting value to prevValue if date's value is change programmatically. 

Prev- 

https://github.com/user-attachments/assets/61c17962-43a4-4abf-9135-834cca76643c


Current - 

https://github.com/user-attachments/assets/803caf09-5fd8-4c7f-88a7-5d1005b8b343





