### PR TITLE
fix(storybook): turn sidenav js examples to tsx

### DIFF
--- a/packages/blade/src/components/FileUpload/docs/stories.tsx
+++ b/packages/blade/src/components/FileUpload/docs/stories.tsx
@@ -5,7 +5,8 @@ const SingleFileUploadStory = `
     FileUpload,
     TextInput,
     Heading,
-    ProgressBar
+    ProgressBar,
+    Text,
   } from '@razorpay/blade/components';
   import type {
     FileUploadProps,

--- a/packages/blade/src/components/SideNav/docs/SideNav.stories.tsx
+++ b/packages/blade/src/components/SideNav/docs/SideNav.stories.tsx
@@ -74,7 +74,7 @@ const DocsPage = (): React.ReactElement => {
         files={sideNavWithReactRouter}
         editorHeight={600}
         hideNavigation={false}
-        openFile="App.js,navItemsJSON.js,SideNavExample.js"
+        openFile="App.tsx,navItemsJSON.tsx,SideNavExample.tsx"
       />
     </StoryPageWrapper>
   );

--- a/packages/blade/src/components/SideNav/docs/code.ts
+++ b/packages/blade/src/components/SideNav/docs/code.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 
 export const sideNavWithReactRouter = {
-  'App.js': dedent`import React from 'react';
+  'App.tsx': dedent`import React from 'react';
   import { BrowserRouter } from 'react-router-dom';
   import SideNavExample from './SideNavExample';
   
@@ -15,7 +15,7 @@ export const sideNavWithReactRouter = {
 
   export default App;
   `,
-  'SideNavExample.js': dedent`import React from 'react';
+  'SideNavExample.tsx': dedent`import React from 'react';
   import {
     matchPath,
     useLocation,
@@ -282,7 +282,7 @@ export const sideNavWithReactRouter = {
 
   export default SideNavExample;
   `,
-  'navItemsJSON.js': dedent`import React from 'react';
+  'navItemsJSON.tsx': dedent`import React from 'react';
   import {
     ArrowUpRightIcon,
     BillIcon,

--- a/packages/blade/src/components/TopNav/docs/TabNav.stories.tsx
+++ b/packages/blade/src/components/TopNav/docs/TabNav.stories.tsx
@@ -30,7 +30,7 @@ const DocsPage = (): React.ReactElement => {
       componentName="TabNav"
       componentDescription="TabNav is a subcomponent of TopNav which can be used inside or outside TopNav"
     >
-      <Sandbox files={tabNavExample} editorHeight={600} hideNavigation={false} openFile="App.js" />
+      <Sandbox files={tabNavExample} editorHeight={600} hideNavigation={false} openFile="App.tsx" />
     </StoryPageWrapper>
   );
 };

--- a/packages/blade/src/components/TopNav/docs/TopNav.stories.tsx
+++ b/packages/blade/src/components/TopNav/docs/TopNav.stories.tsx
@@ -79,7 +79,7 @@ const DocsPage = (): React.ReactElement => {
         files={topNavFullExample}
         editorHeight={600}
         hideNavigation={false}
-        openFile="SideNavExample.js,utils.js,App.js,TopNavExample.js"
+        openFile="SideNavExample.tsx,utils.tsx,App.tsx,TopNavExample.tsx"
       />
     </StoryPageWrapper>
   );

--- a/packages/blade/src/components/TopNav/docs/code.ts
+++ b/packages/blade/src/components/TopNav/docs/code.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent';
 
 export const topNavFullExample = {
-  'App.js': dedent`import React from 'react';
+  'App.tsx': dedent`import React from 'react';
   import { BrowserRouter } from 'react-router-dom';
   import { TopNavExample } from './TopNavExample';
   
@@ -15,7 +15,7 @@ export const topNavFullExample = {
 
   export default App;
   `,
-  'TopNavExample.js': dedent`import React from "react";
+  'TopNavExample.tsx': dedent`import React from "react";
   import styled from "styled-components";
   import { Link, useLocation, useNavigate } from "react-router-dom";
   import { SideNavExample } from "./SideNavExample";
@@ -378,7 +378,7 @@ export const topNavFullExample = {
 
   export { TopNavExample };
   `,
-  'SideNavExample.js': dedent`import React from "react";
+  'SideNavExample.tsx': dedent`import React from "react";
   import { Link, useLocation } from "react-router-dom";
   import { isItemActive } from "./utils";
   import {
@@ -454,7 +454,7 @@ export const topNavFullExample = {
 
   export { SideNavExample };
 `,
-  'utils.js': dedent`import React from 'react';
+  'utils.tsx': dedent`import React from 'react';
   import { matchPath } from "react-router-dom";
 
   const isItemActive = (
@@ -500,7 +500,7 @@ export const topNavFullExample = {
 };
 
 export const tabNavExample = {
-  'App.js': dedent`import React from 'react';
+  'App.tsx': dedent`import React from 'react';
   import { 
     Box, 
     TabNav, 

--- a/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
+++ b/packages/blade/src/utils/storybook/Sandbox/StackblitzEditor/Sandbox.web.tsx
@@ -185,10 +185,9 @@ const lockFileFetchFn = async (): Promise<string> => {
     return lockFileContentGlobal;
   }
 
-  console.log('DATA FETCH STARTED');
   const res = await fetch(lockFilePath);
   if (res.status !== 200) {
-    throw new Error(`Failed to fetch. Status: ${res.status}`);
+    return '';
   }
 
   lockFileContentGlobal = await res.text();


### PR DESCRIPTION
## Description

We were explicitly defining `.js` extension in some examples. Turned them into `.tsx` so that vite doesn't fail and resolving JSX syntax

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
