### PR TITLE
chore/disable-restrict-plus-operands

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,6 +135,7 @@ module.exports = {
       ],
       plugins: ['@typescript-eslint', 'jsx-a11y', 'no-only-tests', 'blade'],
       rules: {
+        '@typescript-eslint/restrict-plus-operands': 'off',
         'blade/no-cross-platform-imports': ['error', { ignoreImportsPattern: 'renderWithSSR' }],
         'import/no-cycle': ['error', { maxDepth: 4, ignoreExternal: false }],
         'import/no-deprecated': 'off',

--- a/packages/blade/src/components/BaseMenu/BaseMenuItem/tokens.ts
+++ b/packages/blade/src/components/BaseMenu/BaseMenuItem/tokens.ts
@@ -32,10 +32,8 @@ const getActionListItemHeight = (
 } => {
   return {
     itemHeightMobile:
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       itemFirstRowHeight + getItemPadding(theme).itemPaddingMobile * 2 + getItemMargin(theme) * 2,
     itemHeightDesktop:
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       itemFirstRowHeight + getItemPadding(theme).itemPaddingDesktop * 2 + getItemMargin(theme) * 2,
   };
 };

--- a/packages/blade/src/components/Drawer/Drawer.web.tsx
+++ b/packages/blade/src/components/Drawer/Drawer.web.tsx
@@ -102,7 +102,6 @@ const _Drawer: React.ForwardRefRenderFunction<BladeElementRef, DrawerProps> = (
   });
 
   const { stackingLevel, isFirstDrawerInStack } = React.useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     const level = Object.keys(drawerStack).indexOf(drawerId) + 1;
     return {
       stackingLevel: level,
@@ -126,7 +125,6 @@ const _Drawer: React.ForwardRefRenderFunction<BladeElementRef, DrawerProps> = (
   // When z-index is not defined by user, we use default drawer z index and add stackingLevel to ensure
   // new drawer that opens, always opens on top of previous one.
   React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     setZIndexState(zIndex + stackingLevel);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMounted]);

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.web.tsx
@@ -70,7 +70,6 @@ const _DropdownOverlay = ({
         mainAxis: OVERLAY_OFFSET,
       }),
       flip({
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
         padding: OVERLAY_OFFSET + OVERLAY_PADDING,
       }),
       sizeMiddleware({

--- a/packages/blade/src/components/Dropdown/useDropdown.ts
+++ b/packages/blade/src/components/Dropdown/useDropdown.ts
@@ -409,7 +409,6 @@ const useDropdown = (): UseDropdownReturnValue => {
     searchTimeout = window.setTimeout(() => {
       searchString = '';
     }, 500);
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     searchString = searchString + letter;
     const optionTitles = options.map((option) => option.title);
     const searchIndex = getIndexByLetter(optionTitles, searchString, activeIndex + 1);

--- a/packages/blade/src/components/StepGroup/tokens.ts
+++ b/packages/blade/src/components/StepGroup/tokens.ts
@@ -23,7 +23,6 @@ const getMarkerLineSpacings = (
       markerBackgroundSize: sizeTokens['24'],
       markerMargin: sizeTokens['2'],
       indentationWidth: sizeTokens['33'],
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     },
     medium: {
       markerBackgroundSize: sizeTokens['20'],
@@ -33,12 +32,10 @@ const getMarkerLineSpacings = (
   } as const;
 
   const markerLeftAlignment =
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     (LINE_SPACINGS[size].markerBackgroundSize + LINE_SPACINGS[size].markerMargin) / 2;
 
   const markerTopAlignment =
     (-1 *
-      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       (LINE_SPACINGS[size].markerBackgroundSize +
         LINE_SPACINGS[size].markerMargin * 2 +
         markerLineWidth)) /


### PR DESCRIPTION
This was discussed and tracked in #2475, originally requested by @anuraghazra and broken into its own issue by @saurabhdaware.

✅ Checklist
 Rule disabled in .eslintrc.js

 Lint runs successfully

Description
Disables the @typescript-eslint/restrict-plus-operands rule globally as it's overly restrictive and causes false positives in legitimate use cases.

This was requested in [#2475](https://github.com/razorpay/blade/issues/2475) and originally discussed in [#2471 (comment)](https://github.com/razorpay/blade/issues/2471#issuecomment-1906478051).

Changes
Updated ESLint config (.eslintrc.js) to disable @typescript-eslint/restrict-plus-operands for all .ts and .tsx files

Additional Information
This change will also allow removal of local disable comments across the codebase over time

Effort level: low

Label: good first issue
