### PR TITLE
fix: auto-shifting of the date picker on picker change.

### DIFF
--- a/.changeset/smooth-peaches-decide.md
+++ b/.changeset/smooth-peaches-decide.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade): autoshifting of datepicker

--- a/.changeset/smooth-peaches-decide.md
+++ b/.changeset/smooth-peaches-decide.md
@@ -2,4 +2,4 @@
 '@razorpay/blade': patch
 ---
 
-fix(blade): autoshifting of datepicker
+fix: auto-shifting of the date picker on picker change. 

--- a/packages/blade/src/components/DatePicker/usePopup.ts
+++ b/packages/blade/src/components/DatePicker/usePopup.ts
@@ -54,7 +54,10 @@ const usePopup = ({
       flip({ padding: GAP, fallbackAxisSideDirection: 'end' }),
       offset(GAP),
     ],
-    whileElementsMounted: autoUpdate,
+    whileElementsMounted: (reference, floating, update) =>
+      autoUpdate(reference, floating, update, {
+        elementResize: false,
+      }),
   });
 
   // we need to animate from the offset of the computed placement


### PR DESCRIPTION
## Description

 prev - 
 
The position of the DatePicker changes when switching from the date picker to the year picker.

https://github.com/user-attachments/assets/a16ec32b-668c-4598-b3d2-9c0c2e0effef

now - 


https://github.com/user-attachments/assets/001e0844-7d90-4bf8-9feb-63a4c54b8534



## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
