### PR TITLE
fix(blade): broken padding logic in action list item 

### DIFF
--- a/.changeset/ten-buttons-accept.md
+++ b/.changeset/ten-buttons-accept.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade): actionlistitem padding logic broken

--- a/packages/blade/src/components/ActionList/ActionListItem.tsx
+++ b/packages/blade/src/components/ActionList/ActionListItem.tsx
@@ -284,35 +284,28 @@ const ActionListItemText = assignWithoutSideEffects(_ActionListItemText, {
 
 const BaseMenuLeadingItem = ({
   isSelected,
-  leading,
-  selectionType,
   isDisabled,
 }: {
   isSelected?: boolean;
-  leading?: React.ReactNode;
-  selectionType: string | undefined;
   isDisabled?: boolean;
-}): React.ReactElement | null => {
-  if (selectionType === 'multiple') {
-    return (
-      <BaseBox
-        pointerEvents="none"
-        // Adding aria-hidden because the listbox item in multiselect in itself explains the behaviour so announcing checkbox is unneccesary and just a nice UI tweak for us
-        {...makeAccessible({
-          hidden: true,
-        })}
-      >
-        <Checkbox isChecked={isSelected} tabIndex={-1} isDisabled={isDisabled}>
-          {/*
+}): React.ReactElement => {
+  return (
+    <BaseBox
+      pointerEvents="none"
+      // Adding aria-hidden because the listbox item in multiselect in itself explains the behaviour so announcing checkbox is unneccesary and just a nice UI tweak for us
+      {...makeAccessible({
+        hidden: true,
+      })}
+    >
+      <Checkbox isChecked={isSelected} tabIndex={-1} isDisabled={isDisabled}>
+        {/*
         Checkbox requires children. Didn't want to make it optional because its helpful for consumers
         But for this case in particular, we just want to use Text separately so that we can control spacing and color and keep it consistent with non-multiselect dropdowns
       */}
-          {null}
-        </Checkbox>
-      </BaseBox>
-    );
-  }
-  return React.isValidElement(leading) ? leading : null;
+        {null}
+      </Checkbox>
+    </BaseBox>
+  );
 };
 
 type ClickHandlerType = (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -432,13 +425,15 @@ const _ActionListItem = (props: ActionListItemProps): React.ReactElement => {
       title={props.title}
       description={props.description}
       leading={
-        <BaseMenuLeadingItem
-          key={`${dropdownBaseId}-${props._index}-leading-${isSelected}`}
-          isSelected={isSelected}
-          leading={props.leading}
-          selectionType={selectionType}
-          isDisabled={props.isDisabled}
-        />
+        selectionType === 'multiple' ? (
+          <BaseMenuLeadingItem
+            key={`${dropdownBaseId}-${props._index}-leading-${isSelected}`}
+            isSelected={isSelected}
+            isDisabled={props.isDisabled}
+          />
+        ) : (
+          props.leading
+        )
       }
       trailing={props.trailing}
       titleSuffix={props.titleSuffix}

--- a/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.web.test.tsx.snap
+++ b/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.web.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`<BottomSheet /> should compose with DropdownButton 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding-right: 8px;
-  padding-left: 8px;
+  padding-left: 0px;
 }
 
 .c22.c22.c22.c22.c22 {

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
@@ -1186,7 +1186,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                               {
                                 "display": "flex",
                                 "flexDirection": "column",
-                                "paddingLeft": 8,
+                                "paddingLeft": 0,
                                 "paddingRight": 8,
                               },
                             ]
@@ -1365,7 +1365,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                               {
                                 "display": "flex",
                                 "flexDirection": "column",
-                                "paddingLeft": 8,
+                                "paddingLeft": 0,
                                 "paddingRight": 8,
                               },
                             ]

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
@@ -861,7 +861,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   -ms-flex-direction: column;
   flex-direction: column;
   padding-right: 8px;
-  padding-left: 8px;
+  padding-left: 0px;
 }
 
 .c48.c48.c48.c48.c48 {


### PR DESCRIPTION
## Description

fix(blade): broken padding logic in action list item 


RCA: 


I refactored the leading logic from:

```tsx
leading={
   <BaseBox
            pointerEvents="none"
            // Adding aria-hidden because the listbox item in multiselect in itself explains the behaviour so announcing checkbox is unneccesary and just a nice UI tweak for us
            {...makeAccessible({
              hidden: true,
            })}
          >
            <Checkbox isChecked={isSelected} tabIndex={-1} isDisabled={props.isDisabled}>
              {/* 
      Checkbox requires children. Didn't want to make it optional because its helpful for consumers
      But for this case in particular, we just want to use Text separately so that we can control spacing and color and keep it consistent with non-multiselect dropdowns
    */}
              {null}
            </Checkbox>
          </BaseBox>
}
```
to:

```tsx
leading={
  <BaseMenuLeadingItem
    key={`${dropdownBaseId}-${props._index}-leading-${isSelected}`}
    isSelected={isSelected}
    leading={props.leading}
    selectionType={selectionType}
    isDisabled={props.isDisabled}
  />
}
```
Even though BaseMenuLeadingItem returns null, 
it is still a valid React component. 
for padding We have logic like ```paddingLeft={leading ? spacing.3 : spacing.0} ```, 
and since leading is now always a component (not null or undefined),
 the padding was being applied regardless—causing the issue.




## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
