### PR TITLE
feat: remove universal-base64 library

### DIFF
--- a/.changeset/silly-coats-behave.md
+++ b/.changeset/silly-coats-behave.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(StepGroup): remove universal-base64 library

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -145,7 +145,6 @@
     "@emotion/react": "11.11.1",
     "@table-library/react-table-library": "4.1.7",
     "tinycolor2": "1.6.0",
-    "universal-base64": "2.1.0",
     "@mantine/core": "6.0.21",
     "@mantine/dates": "6.0.21",
     "@mantine/hooks": "6.0.21",

--- a/packages/blade/src/components/StepGroup/StepLine.web.tsx
+++ b/packages/blade/src/components/StepGroup/StepLine.web.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
-import { encode } from 'universal-base64';
 import type { StepItemProps } from './types';
 import { StepItemIndicator } from './StepItemMarker';
 import { useStepGroup } from './StepGroupContext';
@@ -16,6 +15,25 @@ import BaseBox from '~components/Box/BaseBox';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import Svg, { Path } from '~components/Icons/_Svg';
 import { makeSize, useTheme } from '~utils';
+import { throwBladeError } from '~utils/logger';
+
+// universal base64 encode
+const encode = (svgString: string): string => {
+  try {
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(svgString).toString('base64');
+    }
+
+    return window.btoa(svgString);
+  } catch (error: unknown) {
+    throwBladeError({
+      message: `Failed to encode SVG string: ${error}`,
+      moduleName: 'StepLine',
+    });
+
+    return '';
+  }
+};
 
 type StepLineSvgProps = {
   isDotted?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -27878,11 +27878,6 @@ unist-util-visit@^4.0.0, unist-util-visit@^4.1.2:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^5.1.1"
 
-universal-base64@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/universal-base64/-/universal-base64-2.1.0.tgz#511af92b3a07340fc2647036045aadb3bedcc320"
-  integrity sha512-WeOkACVnIXJZr/qlv7++Rl1zuZOHN96v2yS5oleUuv8eJOs5j9M5U3xQEIoWqn1OzIuIcgw0fswxWnUVGDfW6g==
-
 universal-user-agent@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.1.tgz#15f20f55da3c930c57bddbf1734c6654d5fd35aa"


### PR DESCRIPTION
## Description

Removes the `universal-base64` library and adds custom base64 encoding function.

The library used `"browser"` key in package.json which required special handling in bundler. Old projects like admin dashboard don't have setup to handle that and anyways that library was fairly small.

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
