### PR TITLE
feat: createTheme color override changes for disabled state

### DIFF
--- a/.changeset/curvy-eggs-think.md
+++ b/.changeset/curvy-eggs-think.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+fix(create-theme): disabled state colors in createTheme 

--- a/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.native.test.tsx.snap
+++ b/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.native.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsla(240, 20%, 99%, 1)",
+            "disabled": "hsla(332, 100%, 26%, 0.24)",
             "muted": "hsla(240, 20%, 99%, 1)",
             "normal": "hsla(240, 20%, 99%, 1)",
             "subtle": "hsla(240, 20%, 99%, 1)",
@@ -350,7 +350,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsla(240, 20%, 99%, 1)",
+            "disabled": "hsla(332, 100%, 26%, 0.24)",
             "muted": "hsla(240, 20%, 99%, 1)",
             "normal": "hsla(240, 20%, 99%, 1)",
             "subtle": "hsla(240, 20%, 99%, 1)",
@@ -738,7 +738,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsl(332, 100%, 26%)",
+            "disabled": "hsla(332, 100%, 26%, 0.18)",
             "muted": "hsl(332, 100%, 26%)",
             "normal": "hsl(332, 100%, 26%)",
             "subtle": "hsl(332, 100%, 26%)",
@@ -800,7 +800,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsl(332, 100%, 26%)",
+            "disabled": "hsla(332, 100%, 26%, 0.18)",
             "muted": "hsl(332, 100%, 26%)",
             "normal": "hsl(332, 100%, 26%)",
             "subtle": "hsl(332, 100%, 26%)",
@@ -1658,7 +1658,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsl(60, 100%, 55%)",
+            "disabled": "hsla(57, 100%, 52%, 0.24)",
             "muted": "hsl(60, 100%, 55%)",
             "normal": "hsl(60, 100%, 55%)",
             "subtle": "hsl(60, 100%, 55%)",
@@ -1720,7 +1720,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsl(60, 100%, 55%)",
+            "disabled": "hsla(57, 100%, 52%, 0.24)",
             "muted": "hsl(60, 100%, 55%)",
             "normal": "hsl(60, 100%, 55%)",
             "subtle": "hsl(60, 100%, 55%)",
@@ -2108,7 +2108,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsla(211, 33%, 21%, 1)",
+            "disabled": "hsla(57, 100%, 52%, 0.18)",
             "muted": "hsla(211, 33%, 21%, 1)",
             "normal": "hsla(211, 33%, 21%, 1)",
             "subtle": "hsla(211, 33%, 21%, 1)",
@@ -2170,7 +2170,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsla(211, 33%, 21%, 1)",
+            "disabled": "hsla(57, 100%, 52%, 0.18)",
             "muted": "hsla(211, 33%, 21%, 1)",
             "normal": "hsla(211, 33%, 21%, 1)",
             "subtle": "hsla(211, 33%, 21%, 1)",

--- a/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.web.test.tsx.snap
+++ b/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.web.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsla(240, 20%, 99%, 1)",
+            "disabled": "hsla(332, 100%, 26%, 0.24)",
             "muted": "hsla(240, 20%, 99%, 1)",
             "normal": "hsla(240, 20%, 99%, 1)",
             "subtle": "hsla(240, 20%, 99%, 1)",
@@ -350,7 +350,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsla(240, 20%, 99%, 1)",
+            "disabled": "hsla(332, 100%, 26%, 0.24)",
             "muted": "hsla(240, 20%, 99%, 1)",
             "normal": "hsla(240, 20%, 99%, 1)",
             "subtle": "hsla(240, 20%, 99%, 1)",
@@ -738,7 +738,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsl(332, 100%, 26%)",
+            "disabled": "hsla(332, 100%, 26%, 0.18)",
             "muted": "hsl(332, 100%, 26%)",
             "normal": "hsl(332, 100%, 26%)",
             "subtle": "hsl(332, 100%, 26%)",
@@ -800,7 +800,7 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsl(332, 100%, 26%)",
+            "disabled": "hsla(332, 100%, 26%, 0.18)",
             "muted": "hsl(332, 100%, 26%)",
             "normal": "hsl(332, 100%, 26%)",
             "subtle": "hsl(332, 100%, 26%)",
@@ -1553,7 +1553,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsl(60, 100%, 55%)",
+            "disabled": "hsla(57, 100%, 52%, 0.24)",
             "muted": "hsl(60, 100%, 55%)",
             "normal": "hsl(60, 100%, 55%)",
             "subtle": "hsl(60, 100%, 55%)",
@@ -1615,7 +1615,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 37%, 1)",
           },
           "primary": {
-            "disabled": "hsl(60, 100%, 55%)",
+            "disabled": "hsla(57, 100%, 52%, 0.24)",
             "muted": "hsl(60, 100%, 55%)",
             "normal": "hsl(60, 100%, 55%)",
             "subtle": "hsl(60, 100%, 55%)",
@@ -2003,7 +2003,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsla(211, 33%, 21%, 1)",
+            "disabled": "hsla(57, 100%, 52%, 0.18)",
             "muted": "hsla(211, 33%, 21%, 1)",
             "normal": "hsla(211, 33%, 21%, 1)",
             "subtle": "hsla(211, 33%, 21%, 1)",
@@ -2065,7 +2065,7 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(150, 100%, 32%, 1)",
           },
           "primary": {
-            "disabled": "hsla(211, 33%, 21%, 1)",
+            "disabled": "hsla(57, 100%, 52%, 0.18)",
             "muted": "hsla(211, 33%, 21%, 1)",
             "normal": "hsla(211, 33%, 21%, 1)",
             "subtle": "hsla(211, 33%, 21%, 1)",

--- a/packages/blade/src/tokens/theme/createTheme.ts
+++ b/packages/blade/src/tokens/theme/createTheme.ts
@@ -144,7 +144,7 @@ const getOnLightOverrides = (
       text: {
         primary: {
           normal: foregroundOnSurface,
-          disabled: foregroundOnSurface,
+          disabled: brandColors.a200,
           muted: foregroundOnSurface,
           subtle: foregroundOnSurface,
         },
@@ -158,7 +158,7 @@ const getOnLightOverrides = (
       icon: {
         primary: {
           normal: foregroundOnSurface,
-          disabled: foregroundOnSurface,
+          disabled: brandColors.a200,
           muted: foregroundOnSurface,
           subtle: foregroundOnSurface,
         },
@@ -243,7 +243,7 @@ const getOnDarkOverrides = (
       text: {
         primary: {
           normal: foregroundOnSurface,
-          disabled: foregroundOnSurface,
+          disabled: brandColors.a400,
           muted: foregroundOnSurface,
           subtle: foregroundOnSurface,
         },
@@ -257,7 +257,7 @@ const getOnDarkOverrides = (
       icon: {
         primary: {
           normal: foregroundOnSurface,
-          disabled: foregroundOnSurface,
+          disabled: brandColors.a400,
           muted: foregroundOnSurface,
           subtle: foregroundOnSurface,
         },


### PR DESCRIPTION
## Description

Updated the create-theme color override util for `disabled` state similar to the ones we have in pre-built `Blade` Theme, as in disabled state the button text looks like in `enabled` mode

- light scheme --> interactive.text.primary.disabled
- light scheme --> interactive.icon.primary.disabled
- dark scheme --> interactive.text.primary.disabled
- dark scheme --> interactive.icon.primary.disabled

### Note:
For Pre-built Blade Theme, the display state for `disabled` mode is looking as expected and not working only when we use `createTheme` with custom brand color passed

## Changes

Using `foregroundOnSurface` token for `disabled` state (where button text looks like in `enabled` mode):

Light scheme:
<img width="1000" alt="Screenshot 2025-05-14 at 10 46 01" src="https://github.com/user-attachments/assets/030b6626-1cab-4662-a63e-bee690c4d8dc" />

Dark scheme:
<img width="1012" alt="Screenshot 2025-05-14 at 10 46 16" src="https://github.com/user-attachments/assets/6a427df7-f26f-4e9d-943c-97ac5897a1b8" />

Updated token with opacity as we have in pre-built `Blade` Theme for `interactive.[text || icon].primary.disabled`:

Light scheme:
<img width="1127" alt="Screenshot 2025-05-14 at 10 40 11" src="https://github.com/user-attachments/assets/fc744a6a-deed-45d9-b21f-4b7dcc38424d" />

Dark scheme:
<img width="1015" alt="Screenshot 2025-05-14 at 10 40 26" src="https://github.com/user-attachments/assets/2218b5f7-17ee-4e97-9e6d-fab9ac0fe806" />


## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
