### PR TITLE
fix: createTheme surface primary border color override changes

### DIFF
--- a/.changeset/thirty-rockets-warn.md
+++ b/.changeset/thirty-rockets-warn.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix: surface primary border color when using custom brand color

--- a/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.native.test.tsx.snap
+++ b/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.native.test.tsx.snap
@@ -412,8 +412,8 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(217, 27%, 21%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.32)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(332, 100%, 26%, 0.18)",
+            "normal": "hsl(332, 100%, 26%)",
           },
         },
         "icon": {
@@ -862,8 +862,8 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(214, 28%, 84%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.18)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(332, 100%, 26%, 0.18)",
+            "normal": "hsl(332, 100%, 26%)",
           },
         },
         "icon": {
@@ -1234,7 +1234,7 @@ exports[`createTheme should create a theme with the correct brand colors 3`] = `
     defaultBorderColor="hsl(332, 100%, 26%)"
     focusBackgroundColor="hsl(332, 100%, 23%)"
     focusBorderColor="hsl(332, 100%, 23%)"
-    focusRingColor="hsla(227, 100%, 59%, 0.18)"
+    focusRingColor="hsla(332, 100%, 26%, 0.18)"
     focusable={true}
     hoverBackgroundColor="hsl(332, 100%, 23%)"
     hoverBorderColor="hsl(332, 100%, 23%)"
@@ -1782,8 +1782,8 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(217, 27%, 21%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.32)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(57, 100%, 52%, 0.18)",
+            "normal": "hsl(57, 100%, 52%)",
           },
         },
         "icon": {
@@ -2232,8 +2232,8 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(214, 28%, 84%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.18)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(57, 100%, 52%, 0.18)",
+            "normal": "hsl(57, 100%, 52%)",
           },
         },
         "icon": {
@@ -2604,7 +2604,7 @@ exports[`createTheme should create a theme with the correct brand colors 6`] = `
     defaultBorderColor="hsl(57, 100%, 52%)"
     focusBackgroundColor="hsl(57, 100%, 47%)"
     focusBorderColor="hsl(57, 100%, 47%)"
-    focusRingColor="hsla(227, 100%, 59%, 0.32)"
+    focusRingColor="hsla(57, 100%, 52%, 0.18)"
     focusable={true}
     hoverBackgroundColor="hsl(57, 100%, 47%)"
     hoverBorderColor="hsl(57, 100%, 47%)"

--- a/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.web.test.tsx.snap
+++ b/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.web.test.tsx.snap
@@ -412,8 +412,8 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(217, 27%, 21%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.32)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(332, 100%, 26%, 0.18)",
+            "normal": "hsl(332, 100%, 26%)",
           },
         },
         "icon": {
@@ -862,8 +862,8 @@ exports[`createTheme should create a theme with the correct brand colors 1`] = `
             "subtle": "hsla(214, 28%, 84%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.18)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(332, 100%, 26%, 0.18)",
+            "normal": "hsl(332, 100%, 26%)",
           },
         },
         "icon": {
@@ -1174,7 +1174,7 @@ exports[`createTheme should create a theme with the correct brand colors 3`] = `
   background-color: hsl(332,100%,23%);
   border-color: hsl(332,100%,23%);
   outline: 1px solid hsl(332,52%,49%);
-  box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.18);
+  box-shadow: 0px 0px 0px 4px hsla(332,100%,26%,0.18);
 }
 
 .c0.c0.c0.c0.c0 * {
@@ -1677,8 +1677,8 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(217, 27%, 21%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.32)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(57, 100%, 52%, 0.18)",
+            "normal": "hsl(57, 100%, 52%)",
           },
         },
         "icon": {
@@ -2127,8 +2127,8 @@ exports[`createTheme should create a theme with the correct brand colors 4`] = `
             "subtle": "hsla(214, 28%, 84%, 1)",
           },
           "primary": {
-            "muted": "hsla(227, 100%, 59%, 0.18)",
-            "normal": "hsla(227, 100%, 59%, 1)",
+            "muted": "hsla(57, 100%, 52%, 0.18)",
+            "normal": "hsl(57, 100%, 52%)",
           },
         },
         "icon": {
@@ -2439,7 +2439,7 @@ exports[`createTheme should create a theme with the correct brand colors 6`] = `
   background-color: hsl(57,100%,47%);
   border-color: hsl(57,100%,47%);
   outline: 1px solid hsl(60,100%,58%);
-  box-shadow: 0px 0px 0px 4px hsla(227,100%,59%,0.32);
+  box-shadow: 0px 0px 0px 4px hsla(57,100%,52%,0.18);
 }
 
 .c0.c0.c0.c0.c0 * {

--- a/packages/blade/src/tokens/theme/createTheme.ts
+++ b/packages/blade/src/tokens/theme/createTheme.ts
@@ -334,9 +334,5 @@ export const createTheme = ({
     },
   });
 
-  // @ts-expect-error window
-  window.brandTheme = brandedThemeTokens;
-  console.log('brandedThemeTokens ', brandedThemeTokens);
-
   return { theme: brandedThemeTokens, brandColors: chromaticBrandColors };
 };

--- a/packages/blade/src/tokens/theme/createTheme.ts
+++ b/packages/blade/src/tokens/theme/createTheme.ts
@@ -177,6 +177,12 @@ const getOnLightOverrides = (
           subtle: brandColors[200],
         },
       },
+      border: {
+        primary: {
+          normal: brandColors[600],
+          muted: brandColors.a200,
+        },
+      },
       icon: {
         primary: {
           normal: brandColors[600],
@@ -276,6 +282,12 @@ const getOnDarkOverrides = (
           subtle: brandColors[200],
         },
       },
+      border: {
+        primary: {
+          normal: brandColors[600],
+          muted: brandColors.a200,
+        },
+      },
       icon: {
         primary: {
           normal: brandColors[600],
@@ -321,6 +333,10 @@ export const createTheme = ({
       },
     },
   });
+
+  // @ts-expect-error window
+  window.brandTheme = brandedThemeTokens;
+  console.log('brandedThemeTokens ', brandedThemeTokens);
 
   return { theme: brandedThemeTokens, brandColors: chromaticBrandColors };
 };


### PR DESCRIPTION
## Description
- Fixes the `createTheme` util (border color) used to create custom theme for specific brand color

## Changes
- Updated the logic used by `createTheme` to add the correct override mapping for `surface.border.primary` and `surface.border.muted`

<!-- List the specific changes made, consider adding screenshots if relevant -->

--- 
### Before (border color not in sync with brand color)
![image](https://github.com/user-attachments/assets/39d68b41-cb55-4e97-814a-8d91528acc41)
![image](https://github.com/user-attachments/assets/c6ed94f5-4801-4b07-92b9-b3c4ed2fce70)
![image](https://github.com/user-attachments/assets/36882453-29ae-4cec-868d-35865ff63b0b)

--- 
### After (border color in sync with brand color)
![image](https://github.com/user-attachments/assets/bfaa2f04-cca3-4cd1-9ca3-34c7974a849a)
![image](https://github.com/user-attachments/assets/43f692d6-5446-4b91-8d7c-95f7da6245ce)
![image](https://github.com/user-attachments/assets/40845f62-b3b6-4872-8f0d-99fcebaba0da)

--- 

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [x] Perform Manual Testing in Other Browsers
- [x] Updated snapshot
- [x] Add changeset
