### PR TITLE
feat: minwidth for stepitem

### DIFF
--- a/.changeset/green-cameras-kneel.md
+++ b/.changeset/green-cameras-kneel.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+feat(StepItem): expose minwidth for StepItem

--- a/packages/blade/src/components/StepGroup/StepItem.stories.tsx
+++ b/packages/blade/src/components/StepGroup/StepItem.stories.tsx
@@ -47,6 +47,10 @@ export default {
       options: Object.keys(markerMapping),
       mapping: markerMapping,
     },
+    minWidth: {
+      description: 'Minimum width of the StepItem. Only applies in horizontal orientation.',
+      control: 'text',
+    },
     _nestingLevel: {
       table: {
         disable: true,

--- a/packages/blade/src/components/StepGroup/StepItem.web.tsx
+++ b/packages/blade/src/components/StepGroup/StepItem.web.tsx
@@ -98,6 +98,7 @@ const _StepItem = ({
   _index = 0,
   _totalIndex = 0,
   _nestingLevel = 0,
+  minWidth,
   ...rest
 }: StepItemProps): React.ReactElement => {
   const {
@@ -189,7 +190,7 @@ const _StepItem = ({
       className={`step-item step-index-${_index} step-nesting-level-${_nestingLevel}`}
       textAlign={isVertical ? 'left' : 'center'}
       alignItems={isVertical ? undefined : 'center'}
-      minWidth={isVertical ? undefined : `min(${makeSize(sizeTokens['120'])}, 100%)`}
+      minWidth={isVertical ? undefined : minWidth ?? `min(${makeSize(sizeTokens['120'])}, 100%)`}
       width={isVertical ? '100%' : undefined}
       flex={isVertical ? undefined : '1'}
       marginX={isVertical ? 'spacing.4' : 'spacing.0'}

--- a/packages/blade/src/components/StepGroup/__tests__/StepGroup.web.test.tsx
+++ b/packages/blade/src/components/StepGroup/__tests__/StepGroup.web.test.tsx
@@ -64,6 +64,30 @@ describe('<StepGroup />', () => {
     expect(clickHandler).toBeCalledTimes(1);
   });
 
+  it('should use custom minWidth in horizontal orientation when minWidth is provided', () => {
+    const { container } = renderWithTheme(
+      <StepGroup orientation="horizontal">
+        <StepItem title="Introduction" minWidth="200px" />
+      </StepGroup>,
+    );
+    const stepItem = container.querySelector('.step-item');
+    expect(stepItem).toHaveStyle({
+      minWidth: '200px',
+    });
+  });
+
+  it('should have a default minWidth in horizontal orientation when minWidth is not provided', () => {
+    const { container } = renderWithTheme(
+      <StepGroup orientation="horizontal">
+        <StepItem title="Introduction" />
+      </StepGroup>,
+    );
+    const stepItem = container.querySelector('.step-item');
+    expect(stepItem).toHaveStyle({
+      minWidth: 'min(120px,100%)',
+    });
+  });
+
   it('should throw an error when trailing is passed in horizontal orientation', () => {
     // hiding error from terminal
     const tempConsoleError = console.error;
@@ -143,35 +167,6 @@ describe('<StepGroup />', () => {
       const { container } = renderWithTheme(
         <StepGroup data-analytics-step-group="StepGroup">
           <StepItem title="Introduction" data-analytics-step-item="Introduction" />
-        </StepGroup>,
-      );
-      expect(container).toMatchSnapshot();
-    });
-  });
-
-  describe('minWidth prop', () => {
-    it('should use default minWidth when not provided', () => {
-      const { container } = renderWithTheme(
-        <StepGroup orientation="horizontal">
-          <StepItem title="Introduction" />
-        </StepGroup>,
-      );
-      expect(container).toMatchSnapshot();
-    });
-
-    it('should use custom minWidth when provided', () => {
-      const { container } = renderWithTheme(
-        <StepGroup orientation="horizontal">
-          <StepItem title="Introduction" minWidth="200px" />
-        </StepGroup>,
-      );
-      expect(container).toMatchSnapshot();
-    });
-
-    it('should not apply minWidth in vertical orientation', () => {
-      const { container } = renderWithTheme(
-        <StepGroup orientation="vertical">
-          <StepItem title="Introduction" minWidth="200px" />
         </StepGroup>,
       );
       expect(container).toMatchSnapshot();

--- a/packages/blade/src/components/StepGroup/__tests__/StepGroup.web.test.tsx
+++ b/packages/blade/src/components/StepGroup/__tests__/StepGroup.web.test.tsx
@@ -148,4 +148,33 @@ describe('<StepGroup />', () => {
       expect(container).toMatchSnapshot();
     });
   });
+
+  describe('minWidth prop', () => {
+    it('should use default minWidth when not provided', () => {
+      const { container } = renderWithTheme(
+        <StepGroup orientation="horizontal">
+          <StepItem title="Introduction" />
+        </StepGroup>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should use custom minWidth when provided', () => {
+      const { container } = renderWithTheme(
+        <StepGroup orientation="horizontal">
+          <StepItem title="Introduction" minWidth="200px" />
+        </StepGroup>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should not apply minWidth in vertical orientation', () => {
+      const { container } = renderWithTheme(
+        <StepGroup orientation="vertical">
+          <StepItem title="Introduction" minWidth="200px" />
+        </StepGroup>,
+      );
+      expect(container).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/blade/src/components/StepGroup/types.ts
+++ b/packages/blade/src/components/StepGroup/types.ts
@@ -89,6 +89,11 @@ type StepItemProps = {
   description?: string;
 
   /**
+   * minWidth prop of StepItem
+   */
+  minWidth?: BoxProps['minWidth'];
+
+  /**
    * Progress line of step. When its start only starting part is highlighted and rest is kept dotted
    *
    * @default full


### PR DESCRIPTION
## Description
The `minWidth` property has been exposed in the `StepItem` component for horizontal orientation. While the `minWidth` prop will be accessible for both vertical and horizontal orientations, it will only be effective in the horizontal orientation.

<!-- Briefly explain the purpose of your PR -->

## Changes

- Before and after in horizontal orientation.

https://github.com/user-attachments/assets/001b25e8-4fd5-47a1-a712-bd55c18013ca

- Sanity on vertical orientation

https://github.com/user-attachments/assets/16749fd7-f6c7-4c1d-bc68-2c461f9f29a4



<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

Files updated
- packages/blade/src/components/StepGroup/StepItem.stories.tsx
- packages/blade/src/components/StepGroup/StepItem.web.tsx
- packages/blade/src/components/StepGroup/types.ts
- packages/blade/src/components/StepGroup/__tests__/StepGroup.web.test.tsx

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [x] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [x] Add KitchenSink Story
- [x] Add Interaction Tests (if applicable)
- [x] Add changeset
