### PR TITLE
fix: label position to 'top' for CheckboxGroup and RadioGroup on mobile viewports

### DIFF
--- a/.changeset/old-timers-smile.md
+++ b/.changeset/old-timers-smile.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: label position to 'top' for CheckboxGroup and RadioGroup on mobile viewports

--- a/packages/blade/src/components/Form/Selector/SelectorGroupField.tsx
+++ b/packages/blade/src/components/Form/Selector/SelectorGroupField.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import type { CSSObject } from 'styled-components';
 import { metaAttribute } from '~utils/metaAttribute';
 import BaseBox from '~components/Box/BaseBox';
 import type { DataAnalyticsAttribute, TestID } from '~utils/types';
 import type { AriaRoles } from '~utils/makeAccessible';
 import { makeAccessible } from '~utils/makeAccessible';
-import { getPlatformType } from '~utils';
+import { getPlatformType, useBreakpoint } from '~utils';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { useTheme } from '~components/BladeProvider';
 
 type SelectorGroupFieldProps = {
   children: React.ReactNode;
@@ -26,15 +26,18 @@ const SelectorGroupField = ({
   testID,
   ...props
 }: SelectorGroupFieldProps): React.ReactElement => {
+  const { theme } = useTheme();
+  const { matchedDeviceType } = useBreakpoint({ breakpoints: theme.breakpoints });
   const isReactNative = getPlatformType() === 'react-native';
-  let labelPosition: CSSObject['flexDirection'] = position === 'top' ? 'column' : 'row';
-  if (isReactNative) labelPosition = 'column';
+
+  let isLabelLeftPositioned = position === 'left' && matchedDeviceType === 'desktop';
+  if (isReactNative) isLabelLeftPositioned = false;
   const role = accessibilityRole === 'group' && isReactNative ? undefined : accessibilityRole;
 
   return (
     <BaseBox
       display="flex"
-      flexDirection={labelPosition}
+      flexDirection={isLabelLeftPositioned ? 'row' : 'column'}
       {...makeAccessible({
         role,
         labelledBy,


### PR DESCRIPTION
## Description

<!-- Briefly explain the purpose of your PR -->

## Changes

Fix: labelPosition 'top' for CheckboxGroup & RadioGroup on mobile

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
