### PR TITLE
feat: added 9 more table cell types to table component

### DIFF
--- a/packages/plugin-blade-table-creator/src/code.ts
+++ b/packages/plugin-blade-table-creator/src/code.ts
@@ -88,6 +88,42 @@ figma.ui.onmessage = async (msg) => {
             console.log('Bodyamount', tableBodyCellTextInstance.componentProperties);
             tableBodyCellTextInstance.setProperties({ contentType: 'Amount' });
             break;
+          case 'BADGE (GROUP)':
+            console.log('Bodybadge', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Badges Group' });
+            break;
+          case 'BUTTON (GROUP)':
+            console.log('Bodybutton', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Button Group' });
+            break;
+          case 'STATUS':
+            console.log('Bodystatus', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Status' });
+            break;
+          case 'NUMBER':
+            console.log('Bodynumber', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Numbers' });
+            break;
+          case 'ACTIONS/LINKS':
+            console.log('Bodyaction', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Actions / Link' });
+            break;
+          case 'ICON':
+            console.log('Bodyicon', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Icon' });
+            break;
+          case 'SLOT':
+            console.log('Bodyslot', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Slot' });
+            break;
+          case 'INPUT TEXT':
+            console.log('Bodyinputtext', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Input (Text/Number)' });
+            break;
+          case 'INPUT SELECT':
+            console.log('Bodyinputselect', tableBodyCellTextInstance.componentProperties);
+            tableBodyCellTextInstance.setProperties({ contentType: 'Input (Select)' });
+            break;
           case 'TEXT':
           default:
             console.log('Bodytext', tableBodyCellTextInstance.componentProperties);

--- a/packages/plugin-blade-table-creator/src/ui.html
+++ b/packages/plugin-blade-table-creator/src/ui.html
@@ -111,7 +111,7 @@
         selectInput.id = `column-type-${i}`;
         selectInput.value = columnTypes[i] || 'TEXT';
 
-        const options = ['TEXT', 'CHECKBOX', 'SPACER', 'AMOUNT'].map(type => {
+        const options = ['TEXT', 'AMOUNT', 'NUMBER', 'CHECKBOX', 'SPACER', 'STATUS', 'BADGE (GROUP)', 'BUTTON (GROUP)', 'ACTIONS/LINKS', 'ICON', 'SLOT', 'INPUT TEXT', 'INPUT SELECT'].map(type => {
           const option = document.createElement('option');
           option.value = type;
           option.textContent = type.charAt(0) + type.slice(1).toLowerCase();


### PR DESCRIPTION
## Description

Added **9** more table-cell types in the [Table creator plugin](https://www.figma.com/community/plugin/1494767773383094405/blade-table-creator).

## Changes

Now users can create the following types of **`table cell types`**
- Text
- Amount
- Checkbox
- Spacer
- **Number** 🆕
- **Status** 🆕
- **Action/Link** 🆕
- **Badge (group)** 🆕
- **Button (group)** 🆕
- **Icon** 🆕
- **Slot** 🆕
- **Input (text)** 🆕
- **Input (select)** 🆕

![image](https://github.com/user-attachments/assets/c697574e-125a-465d-8f3e-8219af3c25a6)