### PR TITLE
fix: table editable cell dropdown issue

### DIFF
--- a/.changeset/neat-vans-begin.md
+++ b/.changeset/neat-vans-begin.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(blade): table editable cell dropdown issue

--- a/packages/blade/src/components/Table/TableEditableCell.web.tsx
+++ b/packages/blade/src/components/Table/TableEditableCell.web.tsx
@@ -159,7 +159,7 @@ const TableEditableDropdownCell = (
             flex={1}
             hasPadding={false}
           >
-            <Dropdown _width="100%" margin="spacing.2" {...dropdownProps} />
+            <Dropdown _width="calc(100% - 8px)" margin="spacing.2" {...dropdownProps} />
           </CellWrapper>
         </BaseBox>
       </StyledEditableCell>


### PR DESCRIPTION
## Description
 Table Editable Cell seems to take extra width then required. 
issue link - 
https://razorpay.slack.com/archives/CMQ3RBHEU/p1749728867850799 

current behaviour - 


https://github.com/user-attachments/assets/c2bdbac8-3a5d-4e5d-b8ac-733499bd4a9d



after fix in this pr - 


https://github.com/user-attachments/assets/0eb109bf-bd01-4f08-8279-a55aada475ae


more testing - 



https://github.com/user-attachments/assets/c8ca3e2b-f972-4c21-ba13-722a0cbc03c5


Code Sand Box link with this pr - 
https://codesandbox.io/p/sandbox/busy-mayer-gctxgf 

Stack blitz link with master - 
https://stackblitz.com/edit/zz6jnhab-3nwgrw1d?file=App.tsx,package.json 

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
