### PR TITLE
fix: console error fix for BottomSheet and update margin for TableEditableDropdownCell

### DIFF
--- a/packages/blade/.storybook/react/preview.tsx
+++ b/packages/blade/.storybook/react/preview.tsx
@@ -93,7 +93,6 @@ export const parameters = {
   },
   docs: {
     container: ({ children, context }) => {
-      console.log('----', context);
       const getThemeTokens = () => {
         if (context.store.globals.globals.brandColor) {
           return createTheme({ brandColor: context.store.globals.globals.brandColor }).theme;

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -443,13 +443,14 @@ const _BottomSheet = ({
   // Disable body scroll lock when the component is unmounted forcefully
   React.useEffect(() => {
     const lockTarget = scrollRef.current;
-    return function () {
+    return () => {
       if (lockTarget) {
         enableBodyScroll(lockTarget);
       }
     };
   // when BottomSheet is mounted with isOpen={false}, then BottomSheetBody does not set scrollRef
-  // so, we added scrollRef to dependencies to ensure that we update lockTarget when scrollRef is updated
+  // so, we added scrollRef to dependencies array to ensure that we update lockTarget when scrollRef is updated
+  // which will avoid passing null to enableBodyScroll
   }, [scrollRef]);
 
   // We will need to reset these values otherwise the next time the bottomsheet opens

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -442,11 +442,15 @@ const _BottomSheet = ({
 
   // Disable body scroll lock when the component is unmounted forcefully
   React.useEffect(() => {
-    const lockTarget = scrollRef.current!;
-    return () => {
-      enableBodyScroll(lockTarget);
+    const lockTarget = scrollRef.current;
+    return function () {
+      if (lockTarget) {
+        enableBodyScroll(lockTarget);
+      }
     };
-  }, []);
+  // when BottomSheet is mounted with isOpen={false}, then BottomSheetBody does not set scrollRef
+  // so, we added scrollRef to dependencies to ensure that we update lockTarget when scrollRef is updated
+  }, [scrollRef]);
 
   // We will need to reset these values otherwise the next time the bottomsheet opens
   // this will be populated and the animations won't run

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -448,9 +448,9 @@ const _BottomSheet = ({
         enableBodyScroll(lockTarget);
       }
     };
-  // when BottomSheet is mounted with isOpen={false}, then BottomSheetBody does not set scrollRef
-  // so, we added scrollRef to dependencies array to ensure that we update lockTarget when scrollRef is updated
-  // which will avoid passing null to enableBodyScroll
+    // when BottomSheet is mounted with isOpen={false}, then BottomSheetBody does not set scrollRef
+    // so, we added scrollRef to dependencies array to ensure that we update lockTarget when scrollRef is updated
+    // which will avoid passing null to enableBodyScroll
   }, [scrollRef]);
 
   // We will need to reset these values otherwise the next time the bottomsheet opens

--- a/packages/blade/src/components/Table/TableEditableCell.web.tsx
+++ b/packages/blade/src/components/Table/TableEditableCell.web.tsx
@@ -159,7 +159,11 @@ const TableEditableDropdownCell = (
             flex={1}
             hasPadding={false}
           >
-            <Dropdown _width="calc(100% - 8px)" margin={getEditableInputMargin({ rowDensity })} {...dropdownProps} />
+            <Dropdown
+              _width="calc(100% - 8px)"
+              margin={getEditableInputMargin({ rowDensity })}
+              {...dropdownProps}
+            />
           </CellWrapper>
         </BaseBox>
       </StyledEditableCell>

--- a/packages/blade/src/components/Table/TableEditableCell.web.tsx
+++ b/packages/blade/src/components/Table/TableEditableCell.web.tsx
@@ -159,7 +159,7 @@ const TableEditableDropdownCell = (
             flex={1}
             hasPadding={false}
           >
-            <Dropdown _width="calc(100% - 8px)" margin="spacing.2" {...dropdownProps} />
+            <Dropdown _width="calc(100% - 8px)" margin={getEditableInputMargin({ rowDensity })} {...dropdownProps} />
           </CellWrapper>
         </BaseBox>
       </StyledEditableCell>


### PR DESCRIPTION
## Description

#### BottomSheet:
- When `BottomSheet` component was mounted with `isOpen={false}`, the `scrollRef` was not updated with an actual reference to DOM element even after `BottomSheetBody` was rendered into DOM later

#### TableEditableDropdownCell:
- The field margin was not passed with the updated value for `rowDensity` - `comfortable` prop type


## Changes

#### BottomSheet:
- Added `scrollRef` to `useEffect` dependencies array, to update the `lockTarget` with the updated value
- with this, we could avoid passing `null` to `enableBodyScroll` as we will be getting the updated `ref` element even when `BottomSheetBody` component was rendered later

#### TableEditableDropdownCell:
- Consumed `getEditableInputMargin` util which will return the margin for the `Dropdown` element based on `rowDensity` prop


## Additional Information

#### TableEditableDropdownCell - before margin computation:

<img width="1195" alt="Screenshot 2025-06-16 at 12 15 37" src="https://github.com/user-attachments/assets/2216804e-2fca-4d58-b439-4aad8c765317" />

#### TableEditableDropdownCell - after margin computation:

<img width="1189" alt="Screenshot 2025-06-16 at 12 18 26" src="https://github.com/user-attachments/assets/ec1e5304-f2ae-49c4-99ab-4b5f8a38991c" />

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
