### PR TITLE
feat: add text transform support for typography components

### DIFF
--- a/packages/blade/src/components/Typography/BaseText/BaseText.native.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.native.tsx
@@ -20,6 +20,7 @@ const StyledBaseText = styled.Text<StyledBaseTextProps>(
     lineHeight,
     letterSpacing,
     textAlign,
+    textTransform,
     as,
     opacity,
     ...props
@@ -39,6 +40,7 @@ const StyledBaseText = styled.Text<StyledBaseTextProps>(
         letterSpacing,
         textAlign,
         opacity,
+        textTransform,
         theme: props.theme,
       }),
       ...styledPropsCSSObject,
@@ -59,6 +61,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
     textAlign,
     children,
     truncateAfterLines,
+    textTransform,
     opacity,
     className,
     style,
@@ -87,6 +90,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
       className={className}
       style={style}
       id={id}
+      textTransform={textTransform}
       {...makeAccessible(accessibilityProps)}
       {...metaAttribute({ name: componentName, testID })}
     >

--- a/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
@@ -26,6 +26,7 @@ const StyledBaseText = styled.div.withConfig({
     textAlign,
     wordBreak,
     opacity,
+    textTransform,
     ...props
   }) => {
     const styledPropsCSSObject = useStyledProps(props);
@@ -43,6 +44,7 @@ const StyledBaseText = styled.div.withConfig({
         textAlign,
         wordBreak,
         opacity,
+        textTransform,
         theme: props.theme,
       }),
       ...styledPropsCSSObject,
@@ -68,6 +70,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
     wordBreak,
     opacity,
     className,
+    textTransform,
     style,
     accessibilityProps = {},
     componentName = MetaConstants.BaseText,
@@ -96,6 +99,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
       className={className}
       style={style}
       id={id}
+      textTransform={textTransform}
       {...makeAccessible(accessibilityProps)}
       {...metaAttribute({ name: componentName, testID })}
     >

--- a/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
+++ b/packages/blade/src/components/Typography/BaseText/getBaseTextStyles.ts
@@ -19,6 +19,7 @@ const getBaseTextStyles = ({
   textAlign,
   opacity,
   theme,
+  textTransform,
 }: StyledBaseTextProps): CSSObject => {
   const textColor = color === 'currentColor' ? 'currentColor' : getIn(theme.colors, color);
   const themeFontFamily = theme.typography.fonts.family[fontFamily];
@@ -71,6 +72,7 @@ const getBaseTextStyles = ({
     margin: 0,
     padding: 0,
     opacity,
+    textTransform,
     ...truncateStyles,
     ...wordBreakStyles,
   };

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import type { Theme } from '~components/BladeProvider';
 import type { AccessibilityProps } from '~utils/makeAccessible/types';
 import type { DataAnalyticsAttribute, TestID } from '~utils/types';
@@ -37,6 +38,7 @@ export type BaseTextProps = {
   fontWeight?: keyof Theme['typography']['fonts']['weight'];
   fontStyle?: 'italic' | 'normal';
   textDecorationLine?: 'line-through' | 'none' | 'underline';
+  textTransform?: CSSProperties['textTransform'];
   lineHeight?: keyof Theme['typography']['lineHeights'];
   letterSpacing?: keyof Theme['typography']['letterSpacings'];
   wordBreak?: 'normal' | 'break-all' | 'keep-all' | 'break-word';
@@ -76,6 +78,7 @@ export type StyledBaseTextProps = Pick<
   | 'truncateAfterLines'
   | 'wordBreak'
   | 'opacity'
+  | 'textTransform'
 > & { theme: Theme };
 
 export type BaseTextSizes = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | '2xlarge';

--- a/packages/blade/src/components/Typography/Code/Code.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.tsx
@@ -26,6 +26,7 @@ type CodeCommonProps = {
   size?: Extract<BaseTextSizes, 'small' | 'medium'>;
   weight?: Extract<BaseTextProps['fontWeight'], 'regular' | 'bold'>;
   isHighlighted?: boolean;
+  textTransform?: BaseTextProps['textTransform'];
   color?: BaseTextProps['color'];
 } & TestID &
   StyledPropsBlade;
@@ -132,6 +133,7 @@ const _Code = (
     isHighlighted = true,
     color,
     testID,
+    textTransform,
     ...styledProps
   }: CodeProps,
   ref: React.Ref<BladeElementRef>,
@@ -158,6 +160,7 @@ const _Code = (
         fontWeight={weight}
         as={isPlatformWeb ? 'code' : undefined}
         lineHeight={lineHeight}
+        textTransform={textTransform}
       >
         {children}
       </BaseText>

--- a/packages/blade/src/components/Typography/Display/Display.tsx
+++ b/packages/blade/src/components/Typography/Display/Display.tsx
@@ -22,6 +22,7 @@ export type DisplayProps = {
   children: React.ReactNode;
   textAlign?: BaseTextProps['textAlign'];
   textDecorationLine?: BaseTextProps['textDecorationLine'];
+  textTransform?: BaseTextProps['textTransform'];
 } & TestID &
   StyledPropsBlade;
 
@@ -80,6 +81,7 @@ const _Display = (
     testID,
     textAlign,
     textDecorationLine,
+    textTransform,
     ...styledProps
   }: DisplayProps,
   ref: React.Ref<BladeElementRef>,
@@ -94,6 +96,7 @@ const _Display = (
       {...props}
       textAlign={textAlign}
       textDecorationLine={textDecorationLine}
+      textTransform={textTransform}
       {...getStyledProps(styledProps)}
     >
       {children}

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -23,6 +23,7 @@ export type HeadingProps = {
   textAlign?: BaseTextProps['textAlign'];
   textDecorationLine?: BaseTextProps['textDecorationLine'];
   size?: Extract<BaseTextSizes, 'small' | 'medium' | 'large' | 'xlarge' | '2xlarge'>;
+  textTransform?: BaseTextProps['textTransform'];
   wordBreak?: BaseTextProps['wordBreak'];
 } & TestID &
   StyledPropsBlade;
@@ -87,6 +88,7 @@ const _Heading = (
     textAlign,
     textDecorationLine,
     wordBreak,
+    textTransform,
     ...styledProps
   }: HeadingProps,
   ref: React.Ref<BladeElementRef>,
@@ -101,6 +103,7 @@ const _Heading = (
       ref={ref}
       textAlign={textAlign}
       textDecorationLine={textDecorationLine}
+      textTransform={textTransform}
       wordBreak={wordBreak}
       {...getStyledProps(styledProps)}
     >

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -23,6 +23,7 @@ type TextCommonProps = {
    */
   color?: BaseTextProps['color'];
   textAlign?: BaseTextProps['textAlign'];
+  textTransform?: BaseTextProps['textTransform'];
   textDecorationLine?: BaseTextProps['textDecorationLine'];
   wordBreak?: BaseTextProps['wordBreak'];
 } & TestID &
@@ -51,7 +52,14 @@ export type TextProps<T> = T extends { variant: infer Variant }
 type GetTextPropsReturn = Omit<BaseTextProps, 'children'>;
 type GetTextProps<T extends { variant: TextVariant }> = Pick<
   TextProps<T>,
-  'variant' | 'weight' | 'size' | 'color' | 'testID' | 'textAlign' | 'textDecorationLine'
+  | 'variant'
+  | 'weight'
+  | 'size'
+  | 'color'
+  | 'testID'
+  | 'textAlign'
+  | 'textDecorationLine'
+  | 'textTransform'
 >;
 
 const getTextProps = <T extends { variant: TextVariant }>({
@@ -139,6 +147,7 @@ const _Text = <T extends { variant: TextVariant }>(
     textAlign,
     textDecorationLine,
     wordBreak,
+    textTransform,
     ...styledProps
   }: TextProps<T>,
   ref: React.Ref<BladeElementRef>,
@@ -147,6 +156,7 @@ const _Text = <T extends { variant: TextVariant }>(
     as,
     truncateAfterLines,
     wordBreak,
+    textTransform,
     ...getTextProps({
       variant,
       weight,


### PR DESCRIPTION
## Description

Adds support for `textTransform` property for all typography components for both React and React Native

## Changes

- Updated `Text`, `Heading`, `Code` and `Display` as well as `BaseText` to add `text-transform` property support
- Added support for both react native component as well as react component

## Additional Information

![image](https://github.com/user-attachments/assets/dd1526c4-5926-46eb-8423-73087ae3edc6)


## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
