### PR TITLE
fix: ref update for 'Tooltip' component

### DIFF
--- a/.changeset/many-kings-ring.md
+++ b/.changeset/many-kings-ring.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Tooltip): re-render issue on mobile tooltip

--- a/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.web.test.tsx.snap
@@ -2293,7 +2293,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
       >
         <label
           data-blade-component="form-label"
-          for="coupon-166-input-167"
+          for="coupon-165-input-166"
           style="width: auto; flex-shrink: 0; margin-right: 0px;"
         >
           <div
@@ -2338,7 +2338,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
             aria-required="false"
             class="c9"
             data-blade-component="styled-base-input"
-            id="coupon-166-input-167"
+            id="coupon-165-input-166"
             type="text"
             value=""
           />
@@ -2721,7 +2721,7 @@ exports[`<BaseInput /> should support passing data-analytics-* attributes to the
       >
         <label
           data-blade-component="form-label"
-          for="name-556-input-557"
+          for="name-555-input-556"
           style="width: auto; flex-shrink: 0; margin-right: 0px;"
         >
           <div
@@ -2767,7 +2767,7 @@ exports[`<BaseInput /> should support passing data-analytics-* attributes to the
             class="c9"
             data-analytics-name="base-input"
             data-blade-component="styled-base-input"
-            id="name-556-input-557"
+            id="name-555-input-556"
             type="text"
             value=""
           />

--- a/packages/blade/src/components/Tooltip/Tooltip.web.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.web.tsx
@@ -33,7 +33,7 @@ import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { componentZIndices } from '~utils/componentZIndices';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
-import { mergeRefs } from '~utils/useMergeRefs';
+import { useMergeRefs } from '~utils/useMergeRefs';
 
 const _Tooltip = ({
   title,
@@ -97,7 +97,7 @@ const _Tooltip = ({
     <TooltipContext.Provider value={true}>
       {React.cloneElement(children, {
         // @ts-expect-error: ref does exist on children prop
-        ref: mergeRefs(refs.setReference, children.ref),
+        ref: useMergeRefs(refs.setReference, children.ref),
         ...makeAccessible({ label: content }),
         ...mergeProps(children.props, getReferenceProps()),
       })}


### PR DESCRIPTION
## Description

Updated `Tooltip` component to consume `useMergeRefs` instead of `mergeRefs` util

## Changes

The `mergeRefs` util which is consumed in `Tooltip` component is creating a new ref callback function on every render which is causing infinite update loop and crashing with `Maximum update depth exceeded` error

https://blade.razorpay.com/?path=/story/components-tooltip--default

<img width="1410" alt="Screenshot 2025-06-24 at 11 31 25" src="https://github.com/user-attachments/assets/0ee96c68-3102-442d-b2f3-7c95bc00e2d4" />

Updated to consume `useMergeRefs` in `Tooltip` component, which uses `useMemo` hook to memoize the merged ref callback

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
