### PR TITLE
feat: add background blur prop option for Box component

### DIFF
--- a/packages/blade/src/components/Box/BaseBox/baseBoxStyles.ts
+++ b/packages/blade/src/components/Box/BaseBox/baseBoxStyles.ts
@@ -287,6 +287,7 @@ const getAllProps = (
     transform: getResponsiveValue(props.transform as string, breakpoint),
     transformOrigin: getResponsiveValue(props.transformOrigin, breakpoint),
     clipPath: getResponsiveValue(props.clipPath, breakpoint),
+    backdropFilter: getResponsiveValue(props.backdropFilter, breakpoint),
   };
 };
 

--- a/packages/blade/src/components/Box/BaseBox/storybookArgTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/storybookArgTypes.ts
@@ -215,6 +215,11 @@ const getBoxArgTypes = (): StorybookArgTypes<BoxProps> => {
         options: ['lowRaised', 'midRaised', 'highRaised'],
       },
     },
+    backdropFilter: {
+      ...commonProperties,
+      description:
+        '**CSS property `backdrop-filter`**\n\nApplies a backdrop filter effect to the area behind the element. Commonly used for blur effects on overlays and glassmorphism designs.\n\n**Note:** This property is web-only and requires modern browser support.\n\n<a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter">MDN Docs for backdrop-filter</a><br/><br/>',
+    },
   };
 };
 

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -157,6 +157,7 @@ type CommonBoxVisualProps = MakeObjectResponsive<
     | 'borderBottomStyle'
     | 'borderLeftStyle'
     | 'borderRightStyle'
+    | 'backdropFilter'
   > & {
       /**
        * Sets the elevation for Box

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -164,6 +164,9 @@ const makeBoxProps = (
     transformOrigin: props.transformOrigin,
     clipPath: props.clipPath,
 
+    // Backdrop Filter
+    backdropFilter: props.backdropFilter,
+
     // callbacks
     onMouseEnter: props.onMouseEnter,
     onMouseLeave: props.onMouseLeave,


### PR DESCRIPTION
## Description

Backdrop blur option for the Blade Box component.

## Changes

- Added a backdrop blur property for the Blade Box component.

## Additional Information

- This was needed for multiple components while developing Points Pay and Contextual for our [Frontend Loyalty Stack](https://github.com/razorpay/frontend-loyalty-stack). 
- So far, we've been using a styled div for this instead.

## Component Checklist
- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset

[Design Link for reference](https://www.figma.com/design/RK15hTOMANOTQVLdgIHsB9/Templatised-Contextual-Campaigns?node-id=0-1&p=f&m=dev)