### PR TITLE
feat: phone number input validation on input and paste events

### DIFF
--- a/.changeset/thirty-snails-speak.md
+++ b/.changeset/thirty-snails-speak.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': minor
+---
+
+feat: add numeric validation for input and paste events on PhoneNumberInput

--- a/packages/blade/src/components/Form/FormTypes.ts
+++ b/packages/blade/src/components/Form/FormTypes.ts
@@ -39,6 +39,13 @@ export type FormInputOnClickEvent = {
 
 export type FormInputHandleOnClickEvent = ({ name, value }: FormInputOnClickEvent) => void;
 
+export type FormInputHandleOnPasteEvent = ({ name, value }: FormInputOnPasteEvent) => void;
+
+export type FormInputOnPasteEvent = {
+  name?: string;
+  value?: React.ClipboardEvent<HTMLInputElement>;
+};
+
 export type FormInputValidationProps = {
   /**
    * Help text for the input

--- a/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
+++ b/packages/blade/src/components/Input/BaseInput/BaseInput.tsx
@@ -37,6 +37,7 @@ import type { ActionStates } from '~utils/useInteraction';
 import type {
   FormInputHandleOnClickEvent,
   FormInputHandleOnKeyDownEvent,
+  FormInputHandleOnPasteEvent,
 } from '~components/Form/FormTypes';
 import type {
   BladeElementRef,
@@ -135,6 +136,10 @@ type BaseInputCommonProps = FormInputLabelProps &
      * For React Native this will call `onEndEditing` event since we want to get the last value of the input field
      */
     onBlur?: FormInputOnEvent;
+    /**
+     * The callback function to be invoked when value is pasted into the input field
+     */
+    onPaste?: FormInputHandleOnPasteEvent;
     /**
      * Ignores the blur event animation (Used in Select to ignore blur animation when item in option is clicked)
      */
@@ -526,6 +531,7 @@ const useInput = ({
   onSubmit,
   onInput,
   onKeyDown,
+  onPaste,
   onInputKeydownTagHandler,
 }: Pick<
   BaseInputProps,
@@ -538,6 +544,7 @@ const useInput = ({
   | 'onKeyDown'
   | 'onClick'
   | 'onSubmit'
+  | 'onPaste'
 > & {
   onInputKeydownTagHandler: OnInputKeydownTagHandlerType;
 }): {
@@ -548,6 +555,7 @@ const useInput = ({
   handleOnSubmit: FormInputHandleOnEvent;
   handleOnInput: FormInputHandleOnEvent;
   handleOnKeyDown: FormInputHandleOnKeyDownEvent;
+  handleOnPaste: FormInputHandleOnPasteEvent;
   inputValue?: string;
 } => {
   if (__DEV__) {
@@ -639,6 +647,16 @@ const useInput = ({
     [onBlur],
   );
 
+  const handleOnPaste: FormInputHandleOnPasteEvent = React.useCallback(
+    ({ name, value }) => {
+      onPaste?.({
+        name,
+        value,
+      });
+    },
+    [onPaste],
+  );
+
   const handleOnChange: FormInputHandleOnEvent = React.useCallback(
     ({ name, value }) => {
       let _value = '';
@@ -699,6 +717,7 @@ const useInput = ({
     handleOnSubmit,
     handleOnInput,
     handleOnKeyDown,
+    handleOnPaste,
     inputValue,
   };
 };
@@ -811,6 +830,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
     onSubmit,
     onClick,
     onKeyDown,
+    onPaste,
     isDisabled,
     necessityIndicator,
     validationState,
@@ -902,6 +922,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
     handleOnSubmit,
     handleOnInput,
     handleOnKeyDown,
+    handleOnPaste,
     inputValue,
   } = useInput({
     defaultValue,
@@ -913,6 +934,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
     onSubmit,
     onInput,
     onKeyDown,
+    onPaste,
     onInputKeydownTagHandler,
   });
   const { inputId, helpTextId, errorTextId, successTextId } = useFormId(id);
@@ -1082,6 +1104,7 @@ const _BaseInput: React.ForwardRefRenderFunction<BladeElementRef, BaseInputProps
                 handleOnInput={handleOnInput}
                 handleOnKeyDown={handleOnKeyDown}
                 handleOnClick={handleOnClick}
+                handleOnPaste={handleOnPaste}
                 leadingIcon={leadingIcon}
                 prefix={prefix}
                 trailingInteractionElement={trailingInteractionElement}

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.web.tsx
@@ -95,6 +95,7 @@ const _StyledBaseInput: React.ForwardRefRenderFunction<
     handleOnInput,
     handleOnKeyDown,
     handleOnClick,
+    handleOnPaste,
     keyboardType,
     keyboardReturnKeyType,
     autoCompleteSuggestionType,
@@ -127,6 +128,9 @@ const _StyledBaseInput: React.ForwardRefRenderFunction<
     },
     onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
       handleOnKeyDown?.({ name, key: event.key, code: event.code, event });
+    },
+    onPaste: (event: React.ClipboardEvent<HTMLInputElement>): void => {
+      handleOnPaste?.({ name, value: event });
     },
     disabled: isDisabled,
     enterKeyHint: keyboardReturnKeyType === 'default' ? 'enter' : keyboardReturnKeyType,

--- a/packages/blade/src/components/Input/BaseInput/types.ts
+++ b/packages/blade/src/components/Input/BaseInput/types.ts
@@ -5,6 +5,7 @@ import type { FormInputHandleOnEvent } from '~components/Form';
 import type {
   FormInputHandleOnClickEvent,
   FormInputHandleOnKeyDownEvent,
+  FormInputHandleOnPasteEvent,
   FormInputOnClickEvent,
 } from '~components/Form/FormTypes';
 import type { ContainerElementType } from '~utils/types';
@@ -56,6 +57,7 @@ export type StyledBaseInputProps = {
   handleOnKeyDown?: FormInputHandleOnKeyDownEvent;
   handleOnInput?: FormInputHandleOnEvent;
   handleOnClick?: FormInputHandleOnClickEvent;
+  handleOnPaste?: FormInputHandleOnPasteEvent;
   hasLeadingIcon?: boolean;
   hasTrailingIcon?: boolean;
   accessibilityProps: Record<string, unknown>;

--- a/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.web.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.web.tsx
@@ -18,6 +18,29 @@ import type { BladeElementRef } from '~utils/types';
 import { CloseIcon } from '~components/Icons';
 import { MetaConstants } from '~utils/metaAttribute';
 import { useControllableState } from '~utils/useControllable';
+import type { FormInputOnKeyDownEvent, FormInputOnPasteEvent } from '~components/Form/FormTypes';
+
+const NUMBERS_ONLY_REGEX = /^\d+$/;
+
+export const isNumericInput = (input: string): boolean => {
+  return NUMBERS_ONLY_REGEX.test(input);
+};
+
+export function validateNumericInput(event: FormInputOnKeyDownEvent['event']): void {
+  const { key, ctrlKey, metaKey } = event;
+
+  // Check if the entered key is a number; if not, prevent the default action
+  const isCharacterKey = key.length === 1;
+
+  // return for non-character keys
+  if (ctrlKey || metaKey || !isCharacterKey) {
+    return;
+  }
+
+  if (!isNumericInput(key)) {
+    event.preventDefault();
+  }
+}
 
 const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNumberInputProps> = (
   {
@@ -121,6 +144,19 @@ const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNu
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [allowedCountries, flags]);
 
+  const handleKeyDown = (keyboardEvent: FormInputOnKeyDownEvent): void => {
+    validateNumericInput(keyboardEvent.event);
+  };
+
+  const handlePaste = (pasteEvent: FormInputOnPasteEvent): void => {
+    const pastedText = pasteEvent.value?.clipboardData?.getData('text') ?? '';
+
+    // Only allow pastedText if it only has numeric characters
+    if (!NUMBERS_ONLY_REGEX.test(pastedText)) {
+      pasteEvent?.value?.preventDefault();
+    }
+  };
+
   const handleOnChange = ({
     name,
     value,
@@ -195,6 +231,8 @@ const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNu
         }
         handleOnChange({ name, value, selectedCountry });
       }}
+      onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/packages/blade/src/components/Input/PhoneNumberInput/__tests__/PhoneNumberInput.web.test.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/__tests__/PhoneNumberInput.web.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { useRef } from 'react';
-import { PhoneNumberInput } from '..';
+import { fireEvent } from '@testing-library/react';
+import { PhoneNumberInput, isNumericInput, validateNumericInput } from '..';
 import renderWithTheme from '~utils/testing/renderWithTheme.web';
 import assertAccessible from '~utils/testing/assertAccessible.web';
 import { Button } from '~components/Button';
@@ -142,6 +143,296 @@ describe('<PhoneNumberInput />', () => {
         data-analytics-value="phone-input-value"
       />,
     );
+
     expect(container).toMatchSnapshot();
+  });
+
+  // Tests for new numeric input validation functionality
+  describe('Phone Number Input Validation', () => {
+    describe('isNumericInput utility function', () => {
+      it('should return true for numeric strings', () => {
+        expect(isNumericInput('123')).toBe(true);
+        expect(isNumericInput('0')).toBe(true);
+        expect(isNumericInput('9876543210')).toBe(true);
+      });
+
+      it('should return false for non-numeric strings', () => {
+        expect(isNumericInput('abc')).toBe(false);
+        expect(isNumericInput('123a')).toBe(false);
+        expect(isNumericInput('a123')).toBe(false);
+        expect(isNumericInput('12.3')).toBe(false);
+        expect(isNumericInput('12-3')).toBe(false);
+        expect(isNumericInput('')).toBe(false);
+      });
+
+      it('should return false for strings with spaces', () => {
+        expect(isNumericInput('123 456')).toBe(false);
+        expect(isNumericInput(' 123')).toBe(false);
+        expect(isNumericInput('123 ')).toBe(false);
+      });
+
+      it('should return false for special characters', () => {
+        expect(isNumericInput('123+')).toBe(false);
+        expect(isNumericInput('+123')).toBe(false);
+        expect(isNumericInput('123-456')).toBe(false);
+        expect(isNumericInput('(123) 456')).toBe(false);
+      });
+    });
+
+    describe('validateNumericInput utility function', () => {
+      it('should prevent default for non-numeric character keys', () => {
+        const mockEvent = ({
+          key: 'a',
+          ctrlKey: false,
+          metaKey: false,
+          preventDefault: jest.fn(),
+        } as Partial<
+          React.KeyboardEvent<HTMLInputElement>
+        >) as React.KeyboardEvent<HTMLInputElement>;
+
+        validateNumericInput(mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not prevent default for numeric character keys', () => {
+        const mockEvent = ({
+          key: '5',
+          ctrlKey: false,
+          metaKey: false,
+          preventDefault: jest.fn(),
+        } as Partial<
+          React.KeyboardEvent<HTMLInputElement>
+        >) as React.KeyboardEvent<HTMLInputElement>;
+
+        validateNumericInput(mockEvent);
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      });
+
+      it('should allow control keys (Backspace, Delete, Tab, etc.)', () => {
+        const controlKeys = [
+          'Backspace',
+          'Delete',
+          'Tab',
+          'Escape',
+          'Enter',
+          'Home',
+          'End',
+          'ArrowLeft',
+          'ArrowRight',
+          'ArrowUp',
+          'ArrowDown',
+        ];
+
+        controlKeys.forEach((key) => {
+          const mockEvent = ({
+            key,
+            ctrlKey: false,
+            metaKey: false,
+            preventDefault: jest.fn(),
+          } as Partial<
+            React.KeyboardEvent<HTMLInputElement>
+          >) as React.KeyboardEvent<HTMLInputElement>;
+
+          validateNumericInput(mockEvent);
+
+          expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        });
+      });
+
+      it('should allow Ctrl+key combinations', () => {
+        const mockEvent = ({
+          key: 'a',
+          ctrlKey: true,
+          metaKey: false,
+          preventDefault: jest.fn(),
+        } as Partial<
+          React.KeyboardEvent<HTMLInputElement>
+        >) as React.KeyboardEvent<HTMLInputElement>;
+
+        validateNumericInput(mockEvent);
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      });
+
+      it('should allow Cmd+key combinations (macOS)', () => {
+        const mockEvent = ({
+          key: 'a',
+          ctrlKey: false,
+          metaKey: true,
+          preventDefault: jest.fn(),
+        } as Partial<
+          React.KeyboardEvent<HTMLInputElement>
+        >) as React.KeyboardEvent<HTMLInputElement>;
+
+        validateNumericInput(mockEvent);
+
+        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('keyboard input validation', () => {
+      it('should prevent typing non-numeric characters', async () => {
+        const user = userEvent.setup();
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Try typing non-numeric characters
+        await user.type(input, 'abc');
+
+        // Input should remain empty since non-numeric chars are prevented
+        expect(input).toHaveValue('');
+      });
+
+      it('should allow typing numeric characters', async () => {
+        const user = userEvent.setup();
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Type numeric characters - since validation happens before formatting,
+        // we expect the raw numeric input without formatting in this specific test
+        await user.type(input, '123456');
+
+        // The validation allows numeric input but formatting may not apply in this test context
+        expect(input).toHaveValue('123456');
+      });
+
+      it('should allow control keys like Backspace and Delete', async () => {
+        const user = userEvent.setup();
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(
+          <PhoneNumberInput label={label} defaultValue="+91 12 345" />,
+        );
+
+        const input = getByLabelText(label);
+
+        // Should allow backspace
+        await user.type(input, '{backspace}');
+
+        expect(input).toHaveValue('+91 12 34');
+      });
+    });
+
+    describe('paste validation', () => {
+      it('should prevent pasting non-numeric content', () => {
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Try pasting non-numeric content
+        fireEvent.paste(input, {
+          clipboardData: {
+            getData: () => 'abc123def',
+          },
+        });
+
+        // Should prevent the paste
+        expect(input).toHaveValue('');
+      });
+
+      it('should allow pasting numeric content', () => {
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Paste numeric content - validation should allow it
+        fireEvent.paste(input, {
+          clipboardData: {
+            getData: () => '1234567890',
+          },
+        });
+
+        // Since validation allows numeric paste, it should not be prevented
+        // Note: The actual formatting behavior may vary in test environment
+        expect(() => fireEvent.paste(input)).not.toThrow();
+      });
+
+      it('should prevent pasting mixed alphanumeric content', () => {
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Try pasting mixed content
+        fireEvent.paste(input, {
+          clipboardData: {
+            getData: () => '123abc456',
+          },
+        });
+
+        // Should prevent the paste
+        expect(input).toHaveValue('');
+      });
+
+      it('should handle paste events with empty clipboard', () => {
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Paste with empty clipboard
+        fireEvent.paste(input, {
+          clipboardData: {
+            getData: () => '',
+          },
+        });
+
+        // Should handle gracefully
+        expect(input).toHaveValue('');
+      });
+
+      it('should handle paste events without clipboard data', () => {
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Paste without clipboardData
+        expect(() => fireEvent.paste(input)).not.toThrow();
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle rapid typing of mixed characters', async () => {
+        const user = userEvent.setup();
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Rapidly type mixed characters - validation should allow only numeric ones
+        await user.type(input, '1a2b3c4d5');
+
+        // Only numeric characters should be entered (without formatting in this test context)
+        expect(input).toHaveValue('12345');
+      });
+
+      it('should work with different input types', () => {
+        const label = 'Enter phone number';
+
+        const { getByLabelText } = renderWithTheme(<PhoneNumberInput label={label} />);
+
+        const input = getByLabelText(label);
+
+        // Verify the input type is set correctly for phone numbers
+        expect(input).toHaveAttribute('type', 'tel');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

This PR adds validation to disallow non-numeric inputs in `PhoneNumberInput` component.
It also ensures that the same is handled when any text is pasted into the input.

## Changes
- Adds `onPaste` event support for `BaseInput` component for web via `handleOnPaste` handler
- Validates the character pressed using `onKeyDown` event and ensures that only `numeric` characters are allowed
- Validates the text pasted using `onPaste` event and ensures that text only contains `numbers`


## Additional Information

- Future scope - If number is pasted with dialling code, the event dispatched can be about updating `diallingCode` and `number`. This is not covered within the scope of this PR

## Component Checklist

- [x] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [x] Add KitchenSink Story
- [x] Add Interaction Tests (if applicable)
- [x] Add changeset
