### PR TITLE
adding element timing attr

### DIFF
--- a/packages/blade/src/components/Accordion/types.ts
+++ b/packages/blade/src/components/Accordion/types.ts
@@ -2,7 +2,7 @@ import type React from 'react';
 import type { BoxProps } from '~components/Box';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import type { IconComponent } from '~components/Icons';
-import type { DataAnalyticsAttribute, TestID } from '~utils/types';
+import type { DataAnalyticsAttribute, TestID, ElementTiming } from '~utils/types';
 
 type AccordionVariantType = 'filled' | 'transparent';
 
@@ -68,6 +68,7 @@ type AccordionProps = {
    */
   children: React.ReactElement | React.ReactElement[];
 } & TestID &
+  ElementTiming &
   StyledPropsBlade;
 
 export type {

--- a/packages/blade/src/components/BaseHeaderFooter/BaseHeader.tsx
+++ b/packages/blade/src/components/BaseHeaderFooter/BaseHeader.tsx
@@ -7,7 +7,7 @@ import BaseBox from '~components/Box/BaseBox';
 import { Heading, Text } from '~components/Typography';
 import { IconButton } from '~components/Button/IconButton';
 import { ChevronLeftIcon, CloseIcon } from '~components/Icons';
-import type { DataAnalyticsAttribute, TestID } from '~utils/types';
+import type { DataAnalyticsAttribute, TestID, ElementTiming } from '~utils/types';
 import type { BoxProps } from '~components/Box';
 import { Box } from '~components/Box';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
@@ -108,6 +108,7 @@ type BaseHeaderProps = {
   | 'onPointerUp'
 > &
   TestID &
+  ElementTiming &
   DataAnalyticsAttribute;
 
 type TrailingComponents = 'Button' | 'Badge' | 'Link' | 'Text' | 'Amount';

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -4,7 +4,12 @@ import type { MarginProps, PaddingProps, SpacingValueType } from './spacingTypes
 import type { MakeObjectResponsive } from './responsiveTypes';
 import type { Theme } from '~components/BladeProvider';
 import type { Border, Elevation } from '~tokens/global';
-import type { DataAnalyticsAttribute, PickCSSByPlatform, TestID } from '~utils/types';
+import type {
+  DataAnalyticsAttribute,
+  PickCSSByPlatform,
+  TestID,
+  ElementTiming,
+} from '~utils/types';
 import type { Platform } from '~utils';
 import type { BladeCommonEvents } from '~components/types';
 import type { DotNotationToken } from '~utils/lodashButBetter/get';
@@ -313,6 +318,7 @@ type BoxProps = Partial<
       tabIndex?: number;
       id?: string;
     } & TestID &
+    ElementTiming &
     DataAnalyticsAttribute
 >;
 
@@ -326,7 +332,7 @@ type BaseBoxProps = Omit<BoxProps, keyof BoxVisualProps> &
         className?: string;
         id?: string;
         tabIndex?: number;
-      }
+      } & ElementTiming
   > &
   BladeCommonEvents;
 

--- a/packages/blade/src/components/Box/Box.tsx
+++ b/packages/blade/src/components/Box/Box.tsx
@@ -49,7 +49,7 @@ const validateBackgroundProp = (
  */
 const makeBoxProps = (
   props: BoxProps,
-): KeysRequired<Omit<BoxProps, 'testID' | 'id' | '__brand__'>> => {
+): KeysRequired<Omit<BoxProps, 'testID' | 'id' | '__brand__' | 'elementtiming'>> => {
   return {
     // Layout
     display: props.display,

--- a/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.web.tsx
@@ -8,6 +8,7 @@ import { getStyledProps, useStyledProps } from '~components/Box/styledProps';
 import { makeAccessible } from '~utils/makeAccessible';
 import { omitPropsFromHTML } from '~utils/omitPropsFromHTML';
 import type { BladeElementRef } from '~utils/types';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
 const StyledBaseText = styled.div.withConfig({
   shouldForwardProp: omitPropsFromHTML,
@@ -102,6 +103,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
       textTransform={textTransform}
       {...makeAccessible(accessibilityProps)}
       {...metaAttribute({ name: componentName, testID })}
+      {...makeAnalyticsAttribute(styledProps)}
     >
       {children}
     </StyledBaseText>

--- a/packages/blade/src/components/Typography/BaseText/types.ts
+++ b/packages/blade/src/components/Typography/BaseText/types.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 import type { Theme } from '~components/BladeProvider';
 import type { AccessibilityProps } from '~utils/makeAccessible/types';
-import type { DataAnalyticsAttribute, TestID } from '~utils/types';
+import type { DataAnalyticsAttribute, TestID, ElementTiming } from '~utils/types';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import type { DotNotationToken } from '~utils/lodashButBetter/get';
 
@@ -59,6 +59,7 @@ export type BaseTextProps = {
   numberOfLines?: number;
   componentName?: 'base-text' | 'text' | 'title' | 'heading' | 'code' | 'display';
 } & TestID &
+  ElementTiming &
   DataAnalyticsAttribute &
   StyledPropsBlade;
 

--- a/packages/blade/src/components/Typography/Display/Display.tsx
+++ b/packages/blade/src/components/Typography/Display/Display.tsx
@@ -5,8 +5,9 @@ import type { BaseTextProps, BaseTextSizes } from '../BaseText/types';
 import { useValidateAsProp } from '../utils';
 import { getStyledProps } from '~components/Box/styledProps';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
-import type { BladeElementRef, TestID } from '~utils/types';
+import type { BladeElementRef, TestID, ElementTiming } from '~utils/types';
 import { getPlatformType } from '~utils';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
 const validAsValues = ['span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 export type DisplayProps = {
@@ -24,6 +25,7 @@ export type DisplayProps = {
   textDecorationLine?: BaseTextProps['textDecorationLine'];
   textTransform?: BaseTextProps['textTransform'];
 } & TestID &
+  ElementTiming &
   StyledPropsBlade;
 
 const getProps = ({
@@ -98,6 +100,7 @@ const _Display = (
       textDecorationLine={textDecorationLine}
       textTransform={textTransform}
       {...getStyledProps(styledProps)}
+      {...makeAnalyticsAttribute(styledProps)}
     >
       {children}
     </BaseText>

--- a/packages/blade/src/components/Typography/Heading/Heading.tsx
+++ b/packages/blade/src/components/Typography/Heading/Heading.tsx
@@ -7,7 +7,8 @@ import { useValidateAsProp } from '../utils';
 import { getStyledProps } from '~components/Box/styledProps';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import { isReactNative } from '~utils';
-import type { BladeElementRef, TestID } from '~utils/types';
+import type { BladeElementRef, TestID, ElementTiming } from '~utils/types';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
 const validAsValues = ['span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 export type HeadingProps = {
@@ -26,6 +27,7 @@ export type HeadingProps = {
   textTransform?: BaseTextProps['textTransform'];
   wordBreak?: BaseTextProps['wordBreak'];
 } & TestID &
+  ElementTiming &
   StyledPropsBlade;
 
 export const getHeadingProps = ({
@@ -106,6 +108,7 @@ const _Heading = (
       textTransform={textTransform}
       wordBreak={wordBreak}
       {...getStyledProps(styledProps)}
+      {...makeAnalyticsAttribute(styledProps)}
     >
       {children}
     </BaseText>

--- a/packages/blade/src/components/Typography/Text/Text.tsx
+++ b/packages/blade/src/components/Typography/Text/Text.tsx
@@ -6,7 +6,7 @@ import type { BaseTextProps, BaseTextSizes } from '../BaseText/types';
 import { useValidateAsProp } from '../utils';
 import { getStyledProps } from '~components/Box/styledProps';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
-import type { BladeElementRef, TestID } from '~utils/types';
+import type { BladeElementRef, TestID, ElementTiming } from '~utils/types';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { throwBladeError } from '~utils/logger';
 
@@ -27,6 +27,7 @@ type TextCommonProps = {
   textDecorationLine?: BaseTextProps['textDecorationLine'];
   wordBreak?: BaseTextProps['wordBreak'];
 } & TestID &
+  ElementTiming &
   StyledPropsBlade;
 
 export type TextVariant = 'body' | 'caption';
@@ -148,6 +149,7 @@ const _Text = <T extends { variant: TextVariant }>(
     textDecorationLine,
     wordBreak,
     textTransform,
+    elementtiming,
     ...styledProps
   }: TextProps<T>,
   ref: React.Ref<BladeElementRef>,
@@ -157,6 +159,7 @@ const _Text = <T extends { variant: TextVariant }>(
     truncateAfterLines,
     wordBreak,
     textTransform,
+    elementtiming,
     ...getTextProps({
       variant,
       weight,

--- a/packages/blade/src/utils/makeAnalyticsAttribute/makeAnalyticsAttribute.tsx
+++ b/packages/blade/src/utils/makeAnalyticsAttribute/makeAnalyticsAttribute.tsx
@@ -2,7 +2,7 @@ import type { DataAnalyticsAttribute } from '~utils/types';
 
 const makeAnalyticsAttribute = (props: Record<string, unknown>): DataAnalyticsAttribute => {
   return Object.entries(props)
-    .filter(([key]) => key.startsWith('data-analytics'))
+    .filter(([key]) => key.startsWith('data-analytics') || key.startsWith('elementtiming'))
     .reduce<DataAnalyticsAttribute>(
       (acc, [key, value]) => ({
         ...acc,

--- a/packages/blade/src/utils/omitPropsFromHTML/index.ts
+++ b/packages/blade/src/utils/omitPropsFromHTML/index.ts
@@ -27,6 +27,14 @@ type shouldForwardProp = <O extends object>(
 ) => boolean;
 
 const omitPropsFromHTML: shouldForwardProp = (prop, defaultValidatorFn): boolean => {
+  /**
+   * Element timing is a valid HTML attribute
+   * Checkout https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/elementtiming
+   */
+  if ((prop as string) === 'elementtiming') {
+    return true;
+  }
+
   return !filterProps.includes(prop as string) && defaultValidatorFn(prop);
 };
 

--- a/packages/blade/src/utils/types.ts
+++ b/packages/blade/src/utils/types.ts
@@ -94,6 +94,15 @@ type TestID = {
   testID?: string;
 };
 
+type ElementTiming = {
+  /**
+   * Element timing that can be used to track the performance of the component
+   *
+   * Checkout https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/elementtiming
+   */
+  elementtiming?: string;
+};
+
 /**
  * Similar to `Pick` except this returns `never` when value doesn't exist (native `Pick` returns `unknown`).
  *
@@ -160,6 +169,7 @@ export type {
   StringChildrenType,
   StringWithAutocomplete,
   TestID,
+  ElementTiming,
   PickIfExist,
   PickCSSByPlatform,
   BladeElementRef,


### PR DESCRIPTION
## Description

<!-- Briefly explain the purpose of your PR -->
- JIRA: https://app.devrev.ai/razorpay/works/ISS-1017333
- We need to use the elementtiming attribute to track performance metrics

## Changes
- Adding elementtiming prop in makeAnalyticsAttribute

<!-- List the specific changes made, consider adding screenshots if relevant -->
<img width="1499" height="422" alt="Screenshot 2025-09-30 at 9 41 40 PM" src="https://github.com/user-attachments/assets/a83380c8-64c2-4841-9653-7547afa907a6" />

## Additional Information
- Slack thread: https://razorpay.slack.com/archives/C01H13RTF8V/p1757673526983189


## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
