### PR TITLE
fix(docs): correct installation steps count from 3 to 4

### DIFF
--- a/.changeset/solid-jars-kiss.md
+++ b/.changeset/solid-jars-kiss.md
@@ -1,5 +1,0 @@
----
-'@razorpay/blade': patch
----
-
-fix docs: correct installation steps count from 3 to 4

--- a/.changeset/solid-jars-kiss.md
+++ b/.changeset/solid-jars-kiss.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix docs: correct installation steps count from 3 to 4

--- a/packages/blade/docs/guides/Installation.stories.mdx
+++ b/packages/blade/docs/guides/Installation.stories.mdx
@@ -72,7 +72,7 @@ Before you install the package, make sure that you have performed the following 
 
 <br />
 
-<Text marginY="spacing.4">Follow these 3 steps to get started!</Text>
+<Text marginY="spacing.4">Follow these 4 steps to get started!</Text>
 
 <Tabs marginTop="spacing.8" variant="bordered" orientation="horizontal">
   <Box position="sticky" top="0px" zIndex={1} backgroundColor="surface.background.gray.intense">


### PR DESCRIPTION
Fixes #3077

Corrected the installation steps count in the documentation from 3 to 4 to match the actual steps listed.

This resolves the mismatch between header and content.