### PR TITLE
fix(ChatInput): wire onDismiss so close button works on uploading files

### DIFF
--- a/.changeset/olive-shoes-listen.md
+++ b/.changeset/olive-shoes-listen.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+fix(ChatInput): wire onDismiss so close button works on uploading files

--- a/packages/blade/src/components/ChatInput/ChatInput.web.tsx
+++ b/packages/blade/src/components/ChatInput/ChatInput.web.tsx
@@ -160,6 +160,7 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
                 key={file.id ?? file.name}
                 file={file}
                 onRemove={() => handleFileRemove(file)}
+                onDismiss={() => handleFileRemove(file)}
                 onReupload={onFileReupload ? () => onFileReupload({ file }) : undefined}
               />
             ))}

--- a/packages/blade/src/components/ChatInput/ChatInput.web.tsx
+++ b/packages/blade/src/components/ChatInput/ChatInput.web.tsx
@@ -43,6 +43,7 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
     fileList,
     onFileChange,
     onFileRemove,
+    onFileDismiss,
     onFileReupload,
     accept,
     suggestions,
@@ -73,6 +74,7 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
     handleUploadClick,
     handleFileInputChange,
     handleFileRemove,
+    handleFileDismiss,
     handlePaste,
     handleInnerMouseDownCapture,
   } = useChatInput(
@@ -87,6 +89,7 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
       fileList,
       onFileChange,
       onFileRemove,
+      onFileDismiss,
       accept,
       suggestions,
       onSuggestionAccept,
@@ -160,7 +163,7 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
                 key={file.id ?? file.name}
                 file={file}
                 onRemove={() => handleFileRemove(file)}
-                onDismiss={() => handleFileRemove(file)}
+                onDismiss={() => handleFileDismiss(file)}
                 onReupload={onFileReupload ? () => onFileReupload({ file }) : undefined}
               />
             ))}

--- a/packages/blade/src/components/ChatInput/docs/ChatInput.stories.tsx
+++ b/packages/blade/src/components/ChatInput/docs/ChatInput.stories.tsx
@@ -709,6 +709,50 @@ export const ProductUsecaseChatExperience: StoryFn<typeof ChatInput> = () => {
 };
 ProductUsecaseChatExperience.storyName = 'Product Usecase: Chat Experience';
 
+export const WithFileDismissDuringUpload: StoryFn<typeof ChatInput> = () => {
+  const [files, setFiles] = React.useState<BladeFileList>([
+    {
+      name: 'report.pdf',
+      size: 204800,
+      status: 'uploading',
+      uploadPercent: 45,
+      id: 'file-uploading-1',
+    } as BladeFileList[0],
+    {
+      name: 'screenshot.png',
+      size: 76160,
+      status: 'success',
+      id: 'file-success-1',
+    } as BladeFileList[0],
+  ]);
+
+  return (
+    <Box maxWidth="600px" display="flex" flexDirection="column" gap="spacing.5">
+      <ChatInput
+        placeholder="Ask a question..."
+        fileList={files}
+        onFileChange={({ fileList }) => setFiles(fileList)}
+        onFileRemove={({ file }) => {
+          console.log('File removed/dismissed:', file.name);
+          setFiles((prev) => prev.filter((f) => f.id !== file.id));
+        }}
+        onSubmit={({ value, fileList }) => {
+          console.log('Submitted:', value, 'Files:', fileList);
+          setFiles([]);
+        }}
+      />
+      <Text size="small" color="surface.text.gray.muted">
+        Click the ✕ on the uploading file to dismiss it. The{' '}
+        <Text as="span" size="small" weight="semibold">
+          onFileRemove
+        </Text>{' '}
+        callback fires for both trash (success) and dismiss (uploading) actions.
+      </Text>
+    </Box>
+  );
+};
+WithFileDismissDuringUpload.storyName = 'With File Dismiss During Upload';
+
 export const WithFileReupload: StoryFn<typeof ChatInput> = () => {
   const [files, setFiles] = React.useState<BladeFileList>([
     {

--- a/packages/blade/src/components/ChatInput/docs/ChatInput.stories.tsx
+++ b/packages/blade/src/components/ChatInput/docs/ChatInput.stories.tsx
@@ -733,7 +733,12 @@ export const WithFileDismissDuringUpload: StoryFn<typeof ChatInput> = () => {
         fileList={files}
         onFileChange={({ fileList }) => setFiles(fileList)}
         onFileRemove={({ file }) => {
-          console.log('File removed/dismissed:', file.name);
+          console.log('onFileRemove (trash icon):', file.name);
+          setFiles((prev) => prev.filter((f) => f.id !== file.id));
+        }}
+        onFileDismiss={({ file }) => {
+          console.log('onFileDismiss (✕ on uploading file):', file.name);
+          // Cancel your in-flight upload here, e.g. abortController.abort()
           setFiles((prev) => prev.filter((f) => f.id !== file.id));
         }}
         onSubmit={({ value, fileList }) => {
@@ -742,11 +747,15 @@ export const WithFileDismissDuringUpload: StoryFn<typeof ChatInput> = () => {
         }}
       />
       <Text size="small" color="surface.text.gray.muted">
-        Click the ✕ on the uploading file to dismiss it. The{' '}
+        ✕ on the uploading file fires{' '}
+        <Text as="span" size="small" weight="semibold">
+          onFileDismiss
+        </Text>
+        . Trash on the success file fires{' '}
         <Text as="span" size="small" weight="semibold">
           onFileRemove
-        </Text>{' '}
-        callback fires for both trash (success) and dismiss (uploading) actions.
+        </Text>
+        . Check the console.
       </Text>
     </Box>
   );

--- a/packages/blade/src/components/ChatInput/types.ts
+++ b/packages/blade/src/components/ChatInput/types.ts
@@ -71,9 +71,15 @@ type ChatInputProps = {
   onFileChange?: ({ fileList }: { fileList: BladeFileList }) => void;
 
   /**
-   * Callback fired when a file is removed from the attachment previews
+   * Callback fired when a file is removed (trash icon on a success-status file)
    */
   onFileRemove?: ({ file }: { file: BladeFile }) => void;
+
+  /**
+   * Callback fired when the dismiss (✕) button is clicked on an uploading-status file.
+   * Use this to cancel an in-flight upload request.
+   */
+  onFileDismiss?: ({ file }: { file: BladeFile }) => void;
 
   /**
    * Callback fired when the re-upload button is clicked on a file with error status

--- a/packages/blade/src/components/ChatInput/useChatInput.ts
+++ b/packages/blade/src/components/ChatInput/useChatInput.ts
@@ -20,6 +20,7 @@ type UseChatInputProps = Pick<
   | 'fileList'
   | 'onFileChange'
   | 'onFileRemove'
+  | 'onFileDismiss'
   | 'accept'
   | 'suggestions'
   | 'onSuggestionAccept'
@@ -34,6 +35,7 @@ const useChatInput = (
     fileList: controlledFileList,
     onFileChange,
     onFileRemove,
+    onFileDismiss,
     accept,
     suggestions,
     onSuggestionAccept,
@@ -61,6 +63,7 @@ const useChatInput = (
   handleUploadClick: () => void;
   handleFileInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleFileRemove: (file: BladeFile) => void;
+  handleFileDismiss: (file: BladeFile) => void;
   handlePaste: (event: React.ClipboardEvent<HTMLInputElement>) => void;
   handleInnerMouseDownCapture: (event: React.MouseEvent) => void;
 } => {
@@ -187,6 +190,15 @@ const useChatInput = (
     [files, setFiles, onFileRemove],
   );
 
+  const handleFileDismiss = React.useCallback(
+    (file: BladeFile) => {
+      const newFileList = files.filter((f) => f.id !== file.id);
+      setFiles(() => newFileList);
+      onFileDismiss?.({ file });
+    },
+    [files, setFiles, onFileDismiss],
+  );
+
   const handlePaste = React.useCallback(
     (event: React.ClipboardEvent<HTMLInputElement>) => {
       const clipboardFiles = Array.from(event.clipboardData?.files ?? []);
@@ -237,6 +249,7 @@ const useChatInput = (
     handleUploadClick,
     handleFileInputChange,
     handleFileRemove,
+    handleFileDismiss,
     handlePaste,
     handleInnerMouseDownCapture,
   };


### PR DESCRIPTION
## Problem

`FileUploadItem` renders a close/dismiss (✕) button when a file has \`status: 'uploading'\`, which calls its \`onDismiss\` prop internally. ChatInput never passed \`onDismiss\`, making the button a no-op for consumers.

## Fix

- Added a dedicated **`onFileDismiss`** prop to `ChatInputProps` — fired when the ✕ is clicked on an uploading-status file (separate from `onFileRemove` which fires on the trash icon for success-status files)
- Added `handleFileDismiss` in `useChatInput` that removes the file from internal state and calls `onFileDismiss`
- `FileUploadItem` now receives `onDismiss` → `handleFileDismiss` and `onRemove` → `handleFileRemove` independently

This separation matters: consumers typically need to cancel an in-flight upload request (e.g. `abortController.abort()`) in `onFileDismiss`, which is a different action from simply removing an already-uploaded file in `onFileRemove`.

## Story

Added **"With File Dismiss During Upload"** story that pre-seeds one `uploading` and one `success` file, demonstrating that ✕ fires `onFileDismiss` and trash fires `onFileRemove` independently (check the console).

## Test plan

- [ ] Open the new **"With File Dismiss During Upload"** story in Storybook
- [ ] Click ✕ on `report.pdf` (uploading) → `onFileDismiss` logs in console, file removed
- [ ] Click trash on `screenshot.png` (success) → `onFileRemove` logs in console, file removed
- [ ] Verify the **"With File Reupload"** story: after re-upload sets status to `uploading`, the ✕ now fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)