### PR TITLE
fix(styled-props): forward flex props to components (closes #1543)

### DIFF
--- a/.changeset/styled-props-flex-support.md
+++ b/.changeset/styled-props-flex-support.md
@@ -1,0 +1,9 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: add `flex`, `flexGrow`, `flexShrink`, `flexBasis` to styled props allowlist so they work on Blade components like `Button`, `TextInput`, etc.
+
+Before this fix, passing `flex="1"` to `Button` / `TextInput` inside a flex `Box` container was silently dropped, causing children not to split width equally. Now styled-props correctly forward these flex properties.
+
+Closes #1543

--- a/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
+++ b/packages/blade/src/components/Box/BaseBox/types/propsTypes.ts
@@ -226,7 +226,18 @@ type BoxVisualProps = MakeObjectResponsive<{
 type StyledPropsBlade = Partial<
   Omit<
     MarginProps &
-      Pick<FlexboxProps, 'alignSelf' | 'justifySelf' | 'placeSelf' | 'order' | 'flexWrap'> &
+      Pick<
+        FlexboxProps,
+        | 'alignSelf'
+        | 'justifySelf'
+        | 'placeSelf'
+        | 'order'
+        | 'flexWrap'
+        | 'flex'
+        | 'flexGrow'
+        | 'flexShrink'
+        | 'flexBasis'
+      > &
       PositionProps &
       Pick<
         GridProps,

--- a/packages/blade/src/components/Box/styledProps/getStyledProps.ts
+++ b/packages/blade/src/components/Box/styledProps/getStyledProps.ts
@@ -77,6 +77,10 @@ const makeStyledProps = (props: StyledPropsInputType): KeysRequired<StyledPropsB
     left: props.left,
     visibility: props.visibility,
     flexWrap: props.flexWrap,
+    flex: props.flex,
+    flexGrow: props.flexGrow,
+    flexShrink: props.flexShrink,
+    flexBasis: props.flexBasis,
   };
 };
 


### PR DESCRIPTION
## Context / Motivation

Fixes #1543.

Before this change, passing `flex` / `flexGrow` / `flexShrink` / `flexBasis` to Blade components like `Button` or `TextInput` inside a flex container had no effect:

```tsx
<Box display="flex" gap="spacing.3">
  <TextInput label="Email" flex="1" />
  <Button flex="1">Submit</Button>
</Box>
// TextInput and Button do NOT split the width equally
```

Root cause: `StyledPropsBlade` (`packages/blade/src/components/Box/BaseBox/types/propsTypes.ts`) picked only `'alignSelf' | 'justifySelf' | 'placeSelf' | 'order' | 'flexWrap'` from `FlexboxProps`, and the `makeStyledProps` allowlist (`packages/blade/src/components/Box/styledProps/getStyledProps.ts`) didn't include the flex item properties either. So `getStyledProps(rest)` silently dropped `flex`, `flexGrow`, etc. before they reached the component's outer wrapper.

## Changes

- Added `flex`, `flexGrow`, `flexShrink`, `flexBasis` to the `StyledPropsBlade` type.
- Added the same four properties to `makeStyledProps` so they flow through `getStyledProps` / `useStyledProps`.

Scope kept minimal on purpose:
- Did **not** add `width` / `height` / `minWidth` / `maxWidth` / `minHeight` / `maxHeight` to styled props. `BaseButton` computes its own internal `width` / `height` for icon-only buttons (via `getProps`) and passes them to `StyledBaseButton`; adding these to styled props now would require carefully ordering the spread on every component and is best done as a follow-up.
- No runtime behaviour change for any existing prop — only net-new props are forwarded.
- The existing `defaultStyledPropsObject = makeStyledProps({})` in `storybookArgTypes.ts` auto-picks up the new props for Storybook docs.

## Test plan

- [ ] `yarn workspace @razorpay/blade build` passes (type check includes the new properties)
- [ ] Open the "Styled Props" story — the new `flex`, `flexGrow`, `flexShrink`, `flexBasis` controls appear and applying `flex="1"` to the example `Button` makes it stretch inside a flex `Box`.
- [ ] Reproduce the example from the issue:
  ```tsx
  <Box display="flex" gap="spacing.3">
    <TextInput label="Email" flex="1" />
    <Button flex="1">Submit</Button>
  </Box>
  ```
  Both children should now each occupy ~50% of the container width (minus gap).

## Checklist
- [x] Add changeset (`.changeset/styled-props-flex-support.md`, `patch`)
- [x] TypeScript `StyledPropsBlade` updated
- [x] `makeStyledProps` allowlist updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)