### PR TITLE
fix(Table): show row hover gradient when only hoverActions is passed (closes #3281)

### DIFF
--- a/.changeset/table-hover-actions-gradient.md
+++ b/.changeset/table-hover-actions-gradient.md
@@ -1,0 +1,16 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(Table): show row hover gradient when only `hoverActions` is passed
+
+Previously a `TableRow` only rendered the hover gradient / background when
+`onHover` or `onClick` was provided. Rows that showed `hoverActions`
+without either callback had the actions reveal on hover but no row
+highlight underneath, which was visually inconsistent.
+
+`hoverActions` now participates in the hoverable check alongside
+`onHover` and `onClick`, so the row gradient shows whenever any
+hover-driven UI is attached.
+
+Closes #3281

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -391,7 +391,9 @@ const _TableRow = <Item,>({
     <StyledRow
       disabled={isDisabled}
       $isSelectable={isDisabled ? false : isSelectable}
-      $isHoverable={isDisabled ? false : Boolean(onHover) || Boolean(onClick)}
+      $isHoverable={
+        isDisabled ? false : Boolean(onHover) || Boolean(onClick) || Boolean(hoverActions)
+      }
       $showBorderedCells={showBorderedCells}
       item={item}
       className={isDisabled ? 'disabled-row' : ''}


### PR DESCRIPTION
## Context

Closes #3281 — reported by @anuraghazra.

The row hover gradient on \`TableRow\` was gated behind \`Boolean(onHover) || Boolean(onClick)\` only. Tables that used hover-revealed actions without a click or hover handler (\`hoverActions\` alone) saw the actions appear on hover but **no underlying row highlight** — the row looked static while the actions popped in, which is visually inconsistent with how hoverable rows normally read.

## Root cause

\`packages/blade/src/components/Table/TableBody.web.tsx\` line 394 (before):

\`\`\`tsx
\$isHoverable={isDisabled ? false : Boolean(onHover) || Boolean(onClick)}
\`\`\`

The hover-state CSS block at line 283-293 only applies when \`\$isHoverable || \$isSelectable\` is true. A row with \`hoverActions\` but no \`onHover\`/\`onClick\` and no selection → neither condition fires → no gradient.

## Fix

Include \`hoverActions\` in the \`\$isHoverable\` computation:

\`\`\`tsx
\$isHoverable={
  isDisabled ? false : Boolean(onHover) || Boolean(onClick) || Boolean(hoverActions)
}
\`\`\`

One-line change. Hoverable disabled rows stay non-hoverable (the \`isDisabled\` short-circuit is preserved).

## Scope

- ✅ Primary bug — hoverAction now triggers the row gradient.
- ⏭️ **Not in this PR — disabled-row hover** (also called out by @anuraghazra in the issue comment): the current \`&:hover:not(.disabled-row)\` selector intentionally excludes disabled rows so they don't appear interactive. Before we punch a hole in that, it'd be good to confirm the intended UX — should a disabled row that has hoverActions show a *different* (muted) hover background, or stay flat? Happy to follow up in a separate PR once the direction is decided.

## Test plan

- [ ] Open \`Table\` Storybook docs (\`TableHoverActions.stories.tsx\`) — rows already pass \`hoverActions\`. Confirm the gradient now appears on hover without adding \`onHover\`/\`onClick\`.
- [ ] Existing \`onHover\` / \`onClick\` stories unchanged — rows still hover as before.
- [ ] Disabled rows with \`hoverActions\` remain non-hoverable (to be revisited per scope note above).
- [ ] No existing tests break (hover-related tests in \`Table.web.test.tsx\` continue to pass; snapshots unaffected because the condition only changes when \`hoverActions\` is present without \`onHover\`/\`onClick\`).

## Checklist
- [x] Add changeset (\`patch\`)
- [x] Single-line scope, no behavioural change for existing prop combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)