### PR TITLE
fix(Table): show row hover gradient when only hoverActions is passed

### DIFF
--- a/.changeset/fix-table-hover-actions.md
+++ b/.changeset/fix-table-hover-actions.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(Table): show row hover gradient when only hoverActions is passed

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -266,13 +266,13 @@ const StyledRow = styled(Row)<{
                 '& > div:first-child': {
                   overflow: 'visible',
                 },
-              },
-              '& td:last-child:focus-within': {
-                opacity: 1,
                 ...getTableActionsHoverStyles({
                   theme,
                   hoverColor: tableRow.nonStripe.backgroundColor,
                 }),
+              },
+              '& td:last-child:focus-within': {
+                opacity: 1,
               },
               '&:hover td:last-child': {
                 opacity: 1,


### PR DESCRIPTION
Fixes #3281. This PR ensures that the hover actions linear gradient is visible even when onHover is not provided or when the row is disabled. This is done by applying the base gradient styles directly to the last cell when hover actions are present.