### PR TITLE
fix(docs): add overflow behaviour for properties table in mobile view

### DIFF
--- a/.changeset/fix-docs-props-overflow.md
+++ b/.changeset/fix-docs-props-overflow.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(docs): add overflow behaviour for properties table in mobile view

--- a/.changeset/fix-docs-steps-count.md
+++ b/.changeset/fix-docs-steps-count.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(docs): correct installation steps count from 3 to 4

--- a/.changeset/fix-table-hover-actions.md
+++ b/.changeset/fix-table-hover-actions.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(Table): show row hover gradient when only hoverActions is passed

--- a/packages/blade/docs/guides/Installation.mdx
+++ b/packages/blade/docs/guides/Installation.mdx
@@ -72,7 +72,7 @@ Before you install the package, make sure that you have performed the following 
 
 <br />
 
-<Text marginY="spacing.4">Follow these 3 steps to get started!</Text>
+<Text marginY="spacing.4">Follow these 4 steps to get started!</Text>
 
 <Tabs marginTop="spacing.8" variant="bordered" orientation="horizontal">
   <Box position="sticky" top="0px" zIndex={1} backgroundColor="surface.background.gray.intense">

--- a/packages/blade/src/components/Table/TableBody.web.tsx
+++ b/packages/blade/src/components/Table/TableBody.web.tsx
@@ -266,13 +266,13 @@ const StyledRow = styled(Row)<{
                 '& > div:first-child': {
                   overflow: 'visible',
                 },
-              },
-              '& td:last-child:focus-within': {
-                opacity: 1,
                 ...getTableActionsHoverStyles({
                   theme,
                   hoverColor: tableRow.nonStripe.backgroundColor,
                 }),
+              },
+              '& td:last-child:focus-within': {
+                opacity: 1,
               },
               '&:hover td:last-child': {
                 opacity: 1,

--- a/packages/blade/src/utils/storybook/StoryPageWrapper.tsx
+++ b/packages/blade/src/utils/storybook/StoryPageWrapper.tsx
@@ -179,7 +179,9 @@ const StoryPageWrapper = (props: StoryPageWrapperTypes): React.ReactElement => {
                     </Box>
                   ) : null}
                 </BaseBox>
-                {props.argTableComponent ? <Controls of={props.argTableComponent} /> : <Controls />}
+                <Box overflow="auto">
+                  {props.argTableComponent ? <Controls of={props.argTableComponent} /> : <Controls />}
+                </Box>
               </>
             ) : null}
 


### PR DESCRIPTION
Fixes #2974. Added overflow auto to the properties table container in Storybook documentation to allow horizontal scrolling on mobile devices.