### PR TITLE
feat(tokens): add zIndex as a global design token

### DIFF
--- a/.changeset/swift-tokens-rise.md
+++ b/.changeset/swift-tokens-rise.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+feat(tokens): add zIndex as a design token and move componentZIndices to reference token values

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -129,7 +129,6 @@ const Popover = ({
           side={computedSide}
           style={{
             ...floatingStyles,
-            // TODO: Tokenize zIndex values
             zIndex,
           }}
           arrow={

--- a/packages/blade/src/components/Popover/Popover.web.tsx
+++ b/packages/blade/src/components/Popover/Popover.web.tsx
@@ -160,7 +160,6 @@ const _Popover = ({
                 <BaseBox
                   ref={refs.setFloating}
                   style={floatingStyles}
-                  // TODO: Tokenize zIndex values
                   zIndex={zIndex}
                   {...getFloatingProps()}
                   {...metaAttribute({ name: MetaConstants.Popover })}

--- a/packages/blade/src/components/SpotlightPopoverTour/TourPopover.web.tsx
+++ b/packages/blade/src/components/SpotlightPopoverTour/TourPopover.web.tsx
@@ -145,7 +145,6 @@ const TourPopover = ({
             <BaseBox
               ref={refs.setFloating}
               style={{ ...floatingStyles, pointerEvents: isMounted ? 'auto' : 'none' }}
-              // TODO: Tokenize zIndex values
               zIndex={zIndex}
               {...getFloatingProps()}
               {...metaAttribute({ name: MetaConstants.TourPopover })}

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -105,7 +105,6 @@ const Tooltip = ({
               // this happens because measure is async and it takes few miliseconds to calculate the positions.
               left: floatingStyles.left || -200,
               top: floatingStyles.top || -200,
-              // TODO: Tokenize zIndex values
               zIndex,
             }}
             arrow={

--- a/packages/blade/src/tokens/global/index.ts
+++ b/packages/blade/src/tokens/global/index.ts
@@ -24,3 +24,5 @@ export type { Size } from './size';
 export { size } from './size';
 export type { Elevation, ElevationWithColorModes } from './elevation';
 export { elevation } from './elevation';
+export type { ZIndex } from './zIndex';
+export { zIndex } from './zIndex';

--- a/packages/blade/src/tokens/global/zIndex.ts
+++ b/packages/blade/src/tokens/global/zIndex.ts
@@ -1,0 +1,26 @@
+export type ZIndex = Readonly<{
+  /** -1: Hides element behind all other content */
+  hide: -1;
+  /** 0: Default document flow, no stacking */
+  base: 0;
+  /** 100: Sticky UI chrome — top nav, bottom nav, bottom sheet handles */
+  sticky: 100;
+  /** 1000: Full-screen blocking overlays — modal backdrops */
+  overlay: 1000;
+  /** 1001: Slide-in side panels — drawers */
+  drawer: 1001;
+  /** 1002: Inline dropdown and select overlays */
+  dropdown: 1002;
+  /** 1100: Floating contextual UI — popovers, tooltips, tour masks, preview panels */
+  popover: 1100;
+}>;
+
+export const zIndex: ZIndex = {
+  hide: -1,
+  base: 0,
+  sticky: 100,
+  overlay: 1000,
+  drawer: 1001,
+  dropdown: 1002,
+  popover: 1100,
+};

--- a/packages/blade/src/tokens/theme/bladeTheme.ts
+++ b/packages/blade/src/tokens/theme/bladeTheme.ts
@@ -9,6 +9,7 @@ import {
   typography,
   elevation,
   opacity,
+  zIndex,
 } from '~tokens/global';
 
 const colors: ColorsWithModes = {
@@ -1400,6 +1401,7 @@ const bladeTheme: ThemeTokens = {
   spacing,
   elevation,
   typography,
+  zIndex,
 };
 
 export default bladeTheme;

--- a/packages/blade/src/tokens/theme/theme.ts
+++ b/packages/blade/src/tokens/theme/theme.ts
@@ -7,6 +7,7 @@ import type {
   Spacing,
   TypographyWithPlatforms,
   ElevationWithColorModes,
+  ZIndex,
 } from '~tokens/global';
 import type { ColorChromaticScale, ColorNeutralGrayScale } from '~tokens/global/colors';
 
@@ -174,6 +175,7 @@ export type ThemeTokens = {
   elevation: ElevationWithColorModes;
   spacing: Spacing;
   typography: TypographyWithPlatforms;
+  zIndex: ZIndex;
 };
 
 export type SpacingValues = `${Spacing[keyof Spacing]}px`;

--- a/packages/blade/src/utils/componentZIndices.ts
+++ b/packages/blade/src/utils/componentZIndices.ts
@@ -1,13 +1,14 @@
-// TODO: Move these properly to tokens at some point
+import { zIndex } from '~tokens/global';
+
 export const componentZIndices = {
-  bottomSheet: 100,
-  bottomNav: 100, // should be behind drawer since sidenav opens in drawer in mobile
-  modal: 1000,
-  drawer: 1001,
-  dropdownOverlay: 1002,
-  tourMask: 1100,
-  popover: 1100,
-  tooltip: 1100,
-  topnav: 100,
-  previewPanel: 1100,
+  bottomSheet: zIndex.sticky,
+  bottomNav: zIndex.sticky, // should be behind drawer since sidenav opens in drawer in mobile
+  modal: zIndex.overlay,
+  drawer: zIndex.drawer,
+  dropdownOverlay: zIndex.dropdown,
+  tourMask: zIndex.popover,
+  popover: zIndex.popover,
+  tooltip: zIndex.popover,
+  topnav: zIndex.sticky,
+  previewPanel: zIndex.popover,
 };


### PR DESCRIPTION
## Description

Adds `zIndex` as a first-class global design token in the Blade token system, resolving TODOs that have been present across Popover, Tooltip, and SpotlightPopoverTour components.

Previously, z-index values lived as hardcoded numbers in `utils/componentZIndices.ts` with a top-level comment `// TODO: Move these properly to tokens at some point`. Four component files each had their own `// TODO: Tokenize zIndex values` comment. This PR resolves all of them.

## Changes

- **New:** `packages/blade/src/tokens/global/zIndex.ts` â€” defines semantic z-index layers (`hide`, `base`, `sticky`, `overlay`, `drawer`, `dropdown`, `popover`) with JSDoc comments, following the same pattern as `spacing.ts` and `motion.ts`
- **Updated:** `tokens/global/index.ts` â€” exports the new `ZIndex` type and `zIndex` constant alongside all other global tokens
- **Updated:** `tokens/theme/theme.ts` â€” adds `zIndex: ZIndex` to `ThemeTokens`, making it overridable via `createTheme()`
- **Updated:** `tokens/theme/bladeTheme.ts` â€” includes `zIndex` in the default Blade theme object
- **Updated:** `utils/componentZIndices.ts` â€” removes hardcoded numbers, now reads from the `zIndex` token (fully backward-compatible; no existing imports need to change)
- Removed 4 resolved `// TODO: Tokenize zIndex values` comments from `Popover.web.tsx`, `Popover.native.tsx`, `TourPopover.web.tsx`, `Tooltip.native.tsx`

## Additional Information

The values are completely unchanged â€” this is a pure architectural refactor. All existing component imports of `componentZIndices` continue to work without any modification.

After this change, consumers who need custom z-index layering (e.g. white-label integrations) can override via `createTheme({ zIndex: { popover: 2000 } })`.

## Component Checklist

- [ ] Update Component Status Page â€” N/A (token-only change, no new component)
- [ ] Perform Manual Testing in Other Browsers â€” N/A (no visual change, values are identical)
- [ ] Add KitchenSink Story â€” N/A
- [ ] Add Interaction Tests â€” N/A
- [x] Add changeset
