### PR TITLE
fix(FormLabel): hide visual necessity indicator from screen readers to prevent double announcement

### DIFF
--- a/.changeset/calm-labels-speak.md
+++ b/.changeset/calm-labels-speak.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(FormLabel): hide visual necessity indicator from screen readers to prevent double announcement

--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -10,6 +10,7 @@ import { VisuallyHidden } from '~components/VisuallyHidden';
 import { Text } from '~components/Typography';
 import { getPlatformType, makeSize, useBreakpoint } from '~utils';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
 import BaseBox from '~components/Box/BaseBox';
 import { useTheme } from '~components/BladeProvider';
 import { makeSpace } from '~utils/makeSpace';
@@ -152,8 +153,9 @@ const FormLabel = ({
         {children}
       </Text>
       {computedAccessibilityNode}
-      {/* TODO: Hide from screen readers to prevent double announcement */}
-      {necessityLabel}
+      {necessityLabel ? (
+        <BaseBox {...makeAccessible({ hidden: true })}>{necessityLabel}</BaseBox>
+      ) : null}
     </BaseBox>
   );
 


### PR DESCRIPTION
## Summary

`FormLabel` renders two things when `necessityIndicator` is `required` or `optional`:

1. A **`VisuallyHidden` node** — invisible to sighted users, read aloud by screen readers (e.g. "required" or "optional")
2. A **visible indicator** — `*` for required, `(optional)` for optional — which is also read by screen readers

The result is a double announcement. For example, NVDA/VoiceOver reads **"Email required asterisk"** instead of **"Email required"**. The `(optional)` case announces **"Email optional open paren optional close paren"**.

The TODO comment at [FormLabel.tsx:155](packages/blade/src/components/Form/FormLabel.tsx) acknowledged this:
```tsx
{/* TODO: Hide from screen readers to prevent double announcement */}
{necessityLabel}
```

## Fix

Wrap the visible `necessityLabel` in `makeAccessible({ hidden: true })`. This emits:
- **Web:** `aria-hidden="true"` on the wrapper element
- **React Native:** `accessibilityElementsHidden={true}` + `importantForAccessibility="no-hide-descendants"`

`makeAccessible` is already used by other Form components (`SelectorGroupField`, `SelectorInput`) — this follows the same pattern.

```tsx
// Before
{/* TODO: Hide from screen readers to prevent double announcement */}
{necessityLabel}

// After
{necessityLabel ? (
  <BaseBox {...makeAccessible({ hidden: true })}>{necessityLabel}</BaseBox>
) : null}
```

No visual change. The `*` and `(optional)` text continue to render as before — they are now just skipped by assistive technology since the `VisuallyHidden` node already announces the information semantically.

## Testing

- Required field: screen reader announces **"[label] required"** (not "required asterisk")
- Optional field: screen reader announces **"[label] optional"** (not "optional open paren optional close paren")
- `necessityIndicator="none"` (default): no change — `necessityLabel` is null so the wrapper is not rendered