### PR TITLE
feat(Accordion): add headingLevel prop so consumers can set the correct aria-level for item headings

### DIFF
--- a/.changeset/wise-heading-flows.md
+++ b/.changeset/wise-heading-flows.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': minor
+---
+
+feat(Accordion): add headingLevel prop to allow consumers to set the correct aria-level for accordion item headings

--- a/packages/blade/src/components/Accordion/Accordion.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.tsx
@@ -72,6 +72,7 @@ const _Accordion = (
     children,
     variant = 'transparent',
     size = 'large',
+    headingLevel = 3,
     maxWidth,
     minWidth,
     testID,
@@ -108,6 +109,7 @@ const _Accordion = (
       variant,
       numberOfItems,
       size,
+      headingLevel,
     }),
     [
       expandedAccordionItemIndex,
@@ -118,6 +120,7 @@ const _Accordion = (
       variant,
       numberOfItems,
       size,
+      headingLevel,
     ],
   );
 

--- a/packages/blade/src/components/Accordion/AccordionButton.web.tsx
+++ b/packages/blade/src/components/Accordion/AccordionButton.web.tsx
@@ -21,7 +21,7 @@ const _AccordionButton = ({
   isDisabled,
 }: AccordionButtonProps): ReactElement => {
   const { onExpandChange, isExpanded, collapsibleBodyId } = useCollapsible();
-  const { showNumberPrefix, expandedIndex, size, variant, numberOfItems } = useAccordion();
+  const { showNumberPrefix, expandedIndex, size, variant, numberOfItems, headingLevel } = useAccordion();
 
   const toggleCollapse = (): void => onExpandChange(!isExpanded);
   const onClick = (): void => toggleCollapse();
@@ -49,8 +49,7 @@ const _AccordionButton = ({
 
   return (
     <BaseBox
-      // a11y guidelines suggest having an apt heading surround a button but heading level is hardcoded here
-      {...makeAccessible({ role: 'heading', level: 3 })}
+      {...makeAccessible({ role: 'heading', level: headingLevel })}
       width="100%"
     >
       <StyledAccordionButton

--- a/packages/blade/src/components/Accordion/AccordionContext.tsx
+++ b/packages/blade/src/components/Accordion/AccordionContext.tsx
@@ -10,6 +10,7 @@ type AccordionContextState = {
   variant: AccordionProps['variant'];
   numberOfItems: number;
   size: NonNullable<AccordionProps['size']>;
+  headingLevel: NonNullable<AccordionProps['headingLevel']>;
 };
 
 type AccordionItemContextState = {

--- a/packages/blade/src/components/Accordion/types.ts
+++ b/packages/blade/src/components/Accordion/types.ts
@@ -61,6 +61,15 @@ type AccordionProps = {
   size?: 'large' | 'medium';
 
   /**
+   * Sets the heading level (`aria-level`) for each accordion item's trigger.
+   * Match this to the surrounding document hierarchy so screen readers announce
+   * the correct heading depth (e.g. use `2` when the accordion lives inside an `<h2>` section).
+   *
+   * @default 3
+   */
+  headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+
+  /**
    * maxWidth prop of Accordion
    *
    */


### PR DESCRIPTION
## Summary

Every `AccordionItem` trigger renders inside a heading wrapper. The heading level was hardcoded to `3`:

```tsx
// AccordionButton.web.tsx (before)
<BaseBox
  // a11y guidelines suggest having an apt heading surround a button but heading level is hardcoded here
  {...makeAccessible({ role: 'heading', level: 3 })}
  width="100%"
>
```

This means every accordion — regardless of where it sits in the page — always announces as an `<h3>`. If an accordion lives inside an `<h1>` section, screen readers encounter heading levels that jump from 1 → 3 (skipping 2), which breaks document outline navigation. If it lives inside an `<h4>` section, the `<h3>` is actually *higher* in the hierarchy than its parent.

The comment in the code acknowledged this: `// a11y guidelines suggest having an apt heading surround a button but heading level is hardcoded here`.

## Fix

Added `headingLevel?: 1 | 2 | 3 | 4 | 5 | 6` to `AccordionProps` (defaults to `3`). The value flows through `AccordionContext` to `AccordionButton.web.tsx`.

```tsx
// Usage
<Accordion headingLevel={2}>
  <AccordionItem>...</AccordionItem>
</Accordion>
```

```tsx
// AccordionButton.web.tsx (after)
<BaseBox
  {...makeAccessible({ role: 'heading', level: headingLevel })}
  width="100%"
>
```

The default value is `3`, so existing consumers are completely unaffected.

## Changes

- `types.ts` — add `headingLevel?: 1 | 2 | 3 | 4 | 5 | 6` to `AccordionProps` with JSDoc
- `AccordionContext.tsx` — add `headingLevel` to `AccordionContextState`
- `Accordion.tsx` — destructure `headingLevel = 3`, include in context value and `useMemo` deps
- `AccordionButton.web.tsx` — read `headingLevel` from context, replace hardcoded `3`, remove stale comment

## Testing

- Default: accordion without `headingLevel` prop still renders `aria-level="3"` (unchanged)
- Custom: `<Accordion headingLevel={2}>` renders `aria-level="2"` on each item's heading wrapper
- Screen reader (NVDA/VoiceOver): document outline navigation follows the specified heading level correctly