### PR TITLE
feat(a11y): respect prefers-reduced-motion — wire MotionConfig into BladeProvider and add useReducedMotion hook

### DIFF
--- a/.changeset/motion-honors-user.md
+++ b/.changeset/motion-honors-user.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': minor
+---
+
+feat(a11y): respect prefers-reduced-motion OS setting — add MotionConfig to BladeProvider and export useReducedMotion hook

--- a/packages/blade/src/components/BladeProvider/BladeProvider.web.tsx
+++ b/packages/blade/src/components/BladeProvider/BladeProvider.web.tsx
@@ -4,6 +4,7 @@ import {
   StyleSheetManager,
 } from 'styled-components';
 import { FloatingDelayGroup } from '@floating-ui/react';
+import { MotionConfig } from 'framer-motion';
 import stylisCSSHigherSpecificity from './stylisCSSHigherSpecificity';
 import { ThemeContext } from './useTheme';
 import { useBladeProvider } from './useBladeProvider';
@@ -30,9 +31,14 @@ const BladeProvider = ({
               You can move DrawerStackProvider to common utils and rename to GlobalStackProvider
               and reuse it for your component.
             */}
-            <DrawerStackProvider>
-              <BottomSheetStackProvider>{children}</BottomSheetStackProvider>
-            </DrawerStackProvider>
+            {/* reducedMotion="user" reads the OS-level "Reduce Motion" preference
+                and sets all framer-motion animation durations to 0 when enabled.
+                This covers BaseMotion, Scale, Stagger, AnimateInteractions, etc. */}
+            <MotionConfig reducedMotion="user">
+              <DrawerStackProvider>
+                <BottomSheetStackProvider>{children}</BottomSheetStackProvider>
+              </DrawerStackProvider>
+            </MotionConfig>
           </StyleSheetManager>
         </StyledComponentThemeProvider>
       </FloatingDelayGroup>

--- a/packages/blade/src/utils/index.ts
+++ b/packages/blade/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './getPlatformType';
 export * from './useBreakpoint';
 export * from './useColorScheme';
 export * from './useInterval';
+export * from './useReducedMotion';
 export * from './platform';
 
 // https://github.com/razorpay/blade/pull/1193#discussion_r1212616031

--- a/packages/blade/src/utils/useReducedMotion.ts
+++ b/packages/blade/src/utils/useReducedMotion.ts
@@ -1,0 +1,47 @@
+import React from 'react';
+
+/**
+ * Returns `true` when the user has requested that the system minimize the amount
+ * of non-essential motion (OS-level "Reduce Motion" setting or
+ * `prefers-reduced-motion: reduce` browser preference).
+ *
+ * For components built with BaseMotion / framer-motion (Scale, Stagger,
+ * AnimateInteractions, etc.), reduced motion is handled automatically by
+ * BladeProvider — no manual check is required.
+ *
+ * Use this hook when you need to conditionally control CSS transitions,
+ * canvas animations, or any custom animation logic:
+ *
+ * ```tsx
+ * const prefersReducedMotion = useReducedMotion();
+ *
+ * <Box
+ *   transitionDuration={prefersReducedMotion ? 'duration.2xquick' : 'duration.moderate'}
+ * />
+ * ```
+ *
+ * The hook subscribes to OS-level changes, so the component re-renders if the
+ * user toggles the setting without a page reload.
+ */
+const useReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = ({ matches }: MediaQueryListEvent): void => {
+      setPrefersReducedMotion(matches);
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return (): void => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+export { useReducedMotion };


### PR DESCRIPTION
## Problem

Blade had **zero support** for `prefers-reduced-motion`. Users with vestibular disorders, epilepsy, or general motion sensitivity can set "Reduce Motion" in their OS — macOS, iOS, Windows, and Android all expose this setting. When set, the browser emits `prefers-reduced-motion: reduce`, and applications are expected to minimize or eliminate non-essential animation.

Every Blade animation — entrance/exit transitions, scale effects, stagger sequences, interactive hover animations — played at full speed regardless of this OS preference. This is a WCAG 2.1 SC 2.3.3 (Animation from Interactions) violation and affects real users.

A search across the entire codebase returned exactly **one result** for `prefers-reduced-motion` — a JSDoc comment in `BaseMotion.tsx` that claimed the component "handles reduced motion" but contained no implementation.

## Solution

**Part 1 — `BladeProvider.web.tsx`**

framer-motion ships a `<MotionConfig reducedMotion="user">` provider that reads the OS preference and sets all animation durations/delays to `0` for every framer-motion component inside it. Adding this to `BladeProvider` — where all other system-wide providers already live — covers every component that uses `BaseMotion`, `BaseMotionEntryExit`, `Scale`, `Stagger`, `AnimateInteractions`, or any other framer-motion-powered animation. Zero changes to individual components required.

```tsx
// BladeProvider.web.tsx — the entire fix for framer-motion animations
<MotionConfig reducedMotion="user">
  <DrawerStackProvider>
    <BottomSheetStackProvider>{children}</BottomSheetStackProvider>
  </DrawerStackProvider>
</MotionConfig>
```

`reducedMotion="user"` is dynamic — if the user toggles the OS setting while the app is running, framer-motion reacts without a page reload.

**Part 2 — `useReducedMotion` hook**

Not all Blade animations use framer-motion. CSS `transition` and `animation` properties in styled-components (Toast entrance/exit, Modal backdrop fade, etc.) are not controlled by `MotionConfig`. Blade consumers building custom components on top of Blade also need a way to synchronize with the OS preference.

The new `useReducedMotion()` hook reads `window.matchMedia('(prefers-reduced-motion: reduce)')` directly, subscribes to OS-level changes, and returns a stable `boolean`. Exported from `~utils` as part of the public API.

```tsx
import { useReducedMotion } from '@razorpay/blade/utils';

const prefersReducedMotion = useReducedMotion();

<Box
  transitionDuration={prefersReducedMotion ? 'duration.2xquick' : 'duration.moderate'}
/>
```

## Files Changed

- `packages/blade/src/components/BladeProvider/BladeProvider.web.tsx` — import `MotionConfig`, wrap children
- `packages/blade/src/utils/useReducedMotion.ts` — new hook with JSDoc and OS change subscription
- `packages/blade/src/utils/index.ts` — export `useReducedMotion` from public API
- `.changeset/motion-honors-user.md` — `minor` bump (new exported hook)

## Testing

**To verify MotionConfig coverage:**
1. macOS: System Settings → Accessibility → Display → Reduce Motion ✓
2. iOS: Settings → Accessibility → Motion → Reduce Motion ✓
3. Windows: Settings → Ease of Access → Display → Show animations ✓
4. Or use Chrome DevTools: Rendering → Emulate CSS media → `prefers-reduced-motion: reduce`

With the setting on, all BaseMotion, Scale, Stagger, and AnimateInteractions animations should complete instantly (no visible transition). With it off, animations play normally.

**To verify useReducedMotion:**
```tsx
const prefersReducedMotion = useReducedMotion();
console.log(prefersReducedMotion); // true when OS reduce motion is on
```
Toggle the OS setting — the value updates without a page reload.

## Scope Note

CSS-based animations in styled-components (Toast entrance, certain Modal transitions) are outside the scope of `MotionConfig`. Those can be addressed in a follow-up using `useReducedMotion` within the relevant styled-components, following the same pattern established here.