### PR TITLE
fix(build): disable tree-shaking in native rollup config

### DIFF
--- a/.changeset/fix-native-rollup-treeshake.md
+++ b/.changeset/fix-native-rollup-treeshake.md
@@ -1,0 +1,9 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(build): disable tree-shaking in native rollup config
+
+The native build's `getNativeConfig` was tree-shaking aggressively, dropping bindings whose usage rollup couldn't see across the separately-bundled entries (components, tokens, utils). This silently broke multi-statement modules — for example `tokens/global/motion.ts` shipped with only the `easing` object literal as a discarded expression, with `delay`, `duration`, and the `motion` wrapper (and its export) stripped entirely. Same pattern affected `tokens/global/typography.ts`, `utils/logger/logger.ts`, and ~24 other native files. Result: `import { motion }` / `import { logger }` / etc. resolved to `undefined` at runtime in the published `@razorpay/blade@12.101.1` native bundle, which made every component depending on `theme.motion`, the BladeProvider, the Toast, and the React-Native splash flow crash.
+
+Mirrors the existing `treeshake: false` setting (and rationale comment) on `getWebConfig`. Consumers (the React Native app's Metro bundler) tree-shake their own bundle, so disabling rollup-level tree-shaking on the published native artifact is the correct call.

--- a/packages/blade/rollup.config.mjs
+++ b/packages/blade/rollup.config.mjs
@@ -182,6 +182,16 @@ const getNativeConfig = (inputs) => {
 
   return {
     input: inputs,
+    // Mirror getWebConfig: each export category (components, tokens, utils) is
+    // bundled as its own rollup entry, so cross-category usages (e.g. a token
+    // referenced by a component) are invisible to rollup's tree-shaker. With
+    // tree-shaking on, rollup drops bindings whose usage it can't see, leaving
+    // only side-effect-bearing expressions behind — which silently breaks
+    // multi-statement modules like `tokens/global/motion.ts` (delay, duration,
+    // and the motion wrapper get stripped, only the easing object literal
+    // survives as a discarded expression). Disable tree-shaking; the consumer
+    // will tree-shake instead.
+    treeshake: false,
     output: [
       {
         dir: `${outputRootDirectory}/${libDirectory}/${platform}`,


### PR DESCRIPTION
## Description

Fixes a build regression in the React Native bundle where rollup was tree-shaking aggressively and silently dropping multi-statement modules' bindings + exports — leaving only side-effect-bearing expressions behind.

The published `@razorpay/blade@12.101.1` ships with **24 broken native files** as a result. Examples:

- `tokens/global/motion.ts` → built file has only the `easing` object literal as a discarded expression. `delay`, `duration`, the `motion` wrapper, and the `export { motion }` are all stripped. `import { motion }` resolves to `undefined` at runtime.
- `tokens/global/typography.ts` → same: `var typography = …` and its export are gone. Only the inner object literal floats as `({...})`.
- `utils/logger/logger.ts` → exports both `throwBladeError` and `logger` in source. Built file only exports `throwBladeError`. `getCommonLogger` and `logger` are entirely dropped.

This breaks every native consumer that touches `theme.motion`, the `BladeProvider`, the `Toast`, the splash flow — including the `frontend-mobile-app` Blade v12 spike.

## Changes

Add `treeshake: false` to `getNativeConfig` in `packages/blade/rollup.config.mjs`, mirroring the existing setting on `getWebConfig`. The web config's own comment already explains the reasoning verbatim:

> Since we individually bundle each export category (components, tokens, utils) it is possible that some function of `utils` is used in `components` but rollup will have no idea about it and tree shake it away. So we disable tree shaking, this should not cause any issues since consumers will do their own tree shaking.

The same situation applies to native — the fix is just to set `treeshake: false` there too. Consumers (Metro for the mobile app, etc.) will tree-shake their own bundles.

## Verification

Rebuilt locally with `FRAMEWORK=REACT_NATIVE rollup -c` and confirmed all 24 originally-broken files now produce proper `var X = …` declarations and `export { X }` statements.

Bug-reproduction script (Node, run from a `node_modules/@razorpay/blade@12.101.1` install):

```js
const fs = require("fs"), path = require("path");
const root = "node_modules/@razorpay/blade/build/lib/native";
for (const [rel, name] of [
  ["tokens/global/motion.js", "motion"],
  ["tokens/global/typography.js", "typography"],
  ["utils/logger/logger.js", "logger"],
]) {
  const src = fs.readFileSync(path.join(root, rel), "utf8");
  const hasVar = new RegExp(`(?:var|const|let)\\s+${name}\\s*=`).test(src);
  const hasExport = new RegExp(`export\\s*\\{[^}]*\\b${name}\\b`).test(src);
  console.log(rel, "var:", hasVar, "export:", hasExport);
}
```

Pre-fix output:
```
tokens/global/motion.js      var: false  export: false
tokens/global/typography.js  var: false  export: false
utils/logger/logger.js       var: false  export: false
```

Post-fix output (after rebuilding from source with this PR applied):
```
tokens/global/motion.js      var: true   export: true
tokens/global/typography.js  var: true   export: true
utils/logger/logger.js       var: true   export: true
```

## Additional Information

- Web build (`build:react-prod` / `build:react-dev`) is unaffected — it already has `treeshake: false`.
- This regression has been live in published native bundles for some time; it just hadn't been caught because mobile is the first heavy consumer of v12 native to hit it (currently doing the Blade v12 migration spike).
- Asking for a `12.101.2` (or next patch) publish once this lands so the mobile app can drop its temporary `patch-package` workarounds.

## Component Checklist

- [ ] Update Component Status Page (n/a — build-config fix)
- [ ] Perform Manual Testing in Other Browsers (n/a — affects native artifact only; web bundle unchanged)
- [ ] Add KitchenSink Story (n/a)
- [ ] Add Interaction Tests (if applicable) (n/a — would catch this with a "broken-export integration test", happy to add as follow-up)
- [x] Add changeset