### PR TITLE
docs: document global.navigator.product jest configuration for React Native

### DIFF
--- a/.changeset/silent-falcons-knock.md
+++ b/.changeset/silent-falcons-knock.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+docs: document global.navigator.product jest configuration for React Native

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,19 @@ yarn test:react # web tests
 yarn test:react-native # native tests
 ```
 
+#### Configuring Jest for React Native Consumers
+
+If you use Blade in a React Native project and run tests with Jest, you may need to configure `global.navigator.product` in your Jest setup file. Blade internally uses this to detect the React Native platform at runtime, but Jest does not set it by default:
+
+```js
+// jest-setup.js (or your Jest setup file)
+global.navigator = {
+  product: 'ReactNative',
+};
+```
+
+Without this configuration, tests that import Blade components may fail because the platform detection logic cannot determine the target environment.
+
 ### Visual Tests
 
 We also have visual tests that run on every PR. So if your PR changes / breaks a certain component, the diff will show up on chromatic checks of PR


### PR DESCRIPTION
## Summary
Fixes #1220 — adds documentation for configuring `global.navigator.product` in Jest setup files for React Native consumers.

## Problem
Blade internally uses `global.navigator.product` to detect the React Native platform at runtime. While this works in production, Jest does not set this global by default, causing tests that import Blade components to fail.

## Change
Added a "Configuring Jest for React Native Consumers" subsection under the Unit Tests section in CONTRIBUTING.md with a code snippet showing how to configure the global in a Jest setup file.

## Type of Change
- [x] Documentation