### PR TITLE
fix(native): blade React Native component fixes and stubs

### DIFF
--- a/.changeset/bright-cooks-jog.md
+++ b/.changeset/bright-cooks-jog.md
@@ -1,0 +1,14 @@
+---
+"@razorpay/blade": minor
+---
+
+Fixed styled-components v6 error in BaseBox.native.tsx
+Fixed makeBorderSize string issue with a native-only implementation
+Fixed reanimated crash in Popover and Tooltip content wrappers
+Fixed badge spacing, chips styling, switch AnimatedThumb, and TextInput label on native
+Fixed Tooltip native implementation
+Fixed Popover on iOS, Android, and crash on re-render
+Added Avatar, AvatarGroup, and EmptyState native implementations
+Added Spark native stubs (FluidGradient, RzpGlass)
+Added native stubs for web-only components (MotionDashboard, StepperRouter, Rotate, Calendar, CustomMenu, SpinWheel)
+Added StyledDropdownOverlay native stub

--- a/packages/blade/src/components/Avatar/Avatar.native.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.native.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { Image, Pressable, Linking } from 'react-native';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { throwBladeError } from '~utils/logger';
+import type { BladeElementRef } from '~utils/types';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import getIn from '~utils/lodashButBetter/get';
 import type { AvatarProps } from './types';
 import {
   avatarSizeTokens,
@@ -11,23 +17,17 @@ import {
   avatarTextSizeMapping,
 } from './avatarTokens';
 import { useAvatarGroupContext } from './AvatarGroupContext';
+import { getInitials } from './avatarUtils';
 import { getStyledProps } from '~components/Box/styledProps';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
-import { throwBladeError } from '~utils/logger';
 import { UserIcon } from '~components/Icons';
-import type { BladeElementRef } from '~utils/types';
 import BaseBox from '~components/Box/BaseBox';
 import { getComponentId } from '~utils/isValidAllowedChildren';
-import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 import { useTheme } from '~components/BladeProvider';
 import { Heading, Text } from '~components/Typography';
 import { getTextColorToken } from '~components/Button/BaseButton/BaseButton';
 import type { IconColor } from '~components/Button/BaseButton/types';
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
-import { makeAccessible } from '~utils/makeAccessible';
-import getIn from '~utils/lodashButBetter/get';
-import { getInitials } from './avatarUtils';
 
 // Approximate native line-height for Indicator's internal Text.
 // On native an empty <Text> reserves line-height even with no content, pushing

--- a/packages/blade/src/components/Avatar/Avatar.native.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.native.tsx
@@ -1,14 +1,241 @@
+import React from 'react';
+import { Image, Pressable, Linking } from 'react-native';
 import type { AvatarProps } from './types';
+import {
+  avatarSizeTokens,
+  avatarBorderRadiusTokens,
+  avatarToBottomAddonSize,
+  avatarToIndicatorSize,
+  avatarTopAddonOffsets,
+  avatarIconSizeTokens,
+  avatarTextSizeMapping,
+} from './avatarTokens';
+import { useAvatarGroupContext } from './AvatarGroupContext';
+import { getStyledProps } from '~components/Box/styledProps';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { throwBladeError } from '~utils/logger';
+import { UserIcon } from '~components/Icons';
+import type { BladeElementRef } from '~utils/types';
+import BaseBox from '~components/Box/BaseBox';
+import { getComponentId } from '~utils/isValidAllowedChildren';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { useTheme } from '~components/BladeProvider';
+import { Heading, Text } from '~components/Typography';
+import { getTextColorToken } from '~components/Button/BaseButton/BaseButton';
+import type { IconColor } from '~components/Button/BaseButton/types';
+import type { BaseTextProps } from '~components/Typography/BaseText/types';
+import { makeAccessible } from '~utils/makeAccessible';
+import getIn from '~utils/lodashButBetter/get';
 
-const Avatar = (_props: AvatarProps): React.ReactElement => {
-  throwBladeError({
-    message: 'Avatar is not yet implemented for React Native',
-    moduleName: 'Avatar',
-  });
+// Approximate native line-height for Indicator's internal Text.
+// On native an empty <Text> reserves line-height even with no content, pushing
+// the SVG dot down when it is vertically centred inside the flex row.
+// Subtracting (lineHeight - svgSize) / 2 from the web top-offset compensates.
+const INDICATOR_TEXT_LINE_HEIGHT = 20;
 
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <></>;
+// Subtle-emphasis dot sizes (px) per indicator size — from indicatorDotSizes.
+const indicatorSubtleSvgSize: Record<'small' | 'medium' | 'large', number> = {
+  small: 6,
+  medium: 8,
+  large: 10,
 };
 
+function nativeTopOffset(webTop: string, indicatorSize: 'small' | 'medium' | 'large'): number {
+  const px = parseInt(webTop, 10); // e.g. '2px' → 2
+  const svgSize = indicatorSubtleSvgSize[indicatorSize];
+  const centeringOffset = Math.max(0, (INDICATOR_TEXT_LINE_HEIGHT - svgSize) / 2);
+  return px - centeringOffset;
+}
+
+const getInitials = (name: string): string => {
+  const names = name.trim().toUpperCase().split(' ');
+  if (names.length === 1) return names[0].substring(0, 2);
+  return names[0][0] + names[names.length - 1][0];
+};
+
+const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
+  {
+    name,
+    color = 'neutral',
+    size = 'medium',
+    variant = 'circle',
+    icon,
+    href,
+    isSelected,
+    bottomAddon: BottomAddon,
+    topAddon,
+    src,
+    alt,
+    testID,
+    onClick,
+    ...rest
+  },
+  ref,
+) => {
+  if (__DEV__) {
+    if (src && !alt && !name) {
+      throwBladeError({
+        moduleName: 'Avatar',
+        message: '"alt" or "name" prop is required when the "src" prop is provided.',
+      });
+    }
+    if (topAddon && getComponentId(topAddon) !== 'Indicator') {
+      throwBladeError({
+        moduleName: 'Avatar',
+        message: 'TopAddon only accepts `Indicator` component.',
+      });
+    }
+  }
+
+  const groupProps = useAvatarGroupContext();
+  const { theme } = useTheme();
+  const avatarSize = groupProps?.size ?? size;
+  const isInteractive = Boolean(onClick || href);
+  const dimension = avatarSizeTokens[avatarSize];
+  const borderRadius =
+    theme.border.radius[
+      variant === 'circle'
+        ? avatarBorderRadiusTokens.circle
+        : avatarBorderRadiusTokens.square[avatarSize]
+    ];
+  const bgColor = getIn(theme.colors, `interactive.background.${color}.faded`, '') as string;
+
+  const iconColor = getTextColorToken({
+    property: 'icon',
+    variant: 'secondary',
+    color,
+    state: 'default',
+  }) as IconColor;
+
+  const textColor = getTextColorToken({
+    property: 'text',
+    variant: 'secondary',
+    color,
+    state: 'default',
+  }) as BaseTextProps['color'];
+
+  const [imgError, setImgError] = React.useState(false);
+  const Icon = icon ?? UserIcon;
+  const isSquare = variant === 'square';
+  const hasAddons = Boolean(topAddon || BottomAddon);
+
+  const renderContent = (): React.ReactElement => {
+    if (src && !imgError) {
+      return (
+        <Image
+          source={{ uri: src }}
+          style={{ width: dimension, height: dimension, borderRadius }}
+          resizeMode="cover"
+          onError={() => setImgError(true)}
+          accessibilityLabel={alt ?? name}
+        />
+      );
+    }
+
+    if (name && (!src || imgError)) {
+      return avatarSize === 'xlarge' ? (
+        <Heading size={avatarTextSizeMapping[avatarSize]} weight="semibold" color={textColor}>
+          {getInitials(name)}
+        </Heading>
+      ) : (
+        <Text size={avatarTextSizeMapping[avatarSize]} weight="semibold" color={textColor}>
+          {getInitials(name)}
+        </Text>
+      );
+    }
+
+    return <Icon size={avatarIconSizeTokens[avatarSize]} color={iconColor} />;
+  };
+
+  const handlePress = (): void => {
+    if (href) Linking.openURL(href);
+    // onClick is typed for web (MouseEvent); on native we call it without an event arg
+    onClick?.(undefined as never);
+  };
+
+  const indicatorSize = avatarToIndicatorSize[avatarSize];
+  const topOffset = avatarTopAddonOffsets[variant][avatarSize];
+
+  const avatarBody = (
+    <BaseBox
+      {...metaAttribute({ name: MetaConstants.Avatar, testID })}
+      {...getStyledProps(rest)}
+      {...makeAnalyticsAttribute(rest)}
+      style={{
+        width: dimension,
+        height: dimension,
+        borderRadius,
+        borderWidth: isSelected ? theme.border.width.thicker : theme.border.width.thinner,
+        borderColor: isSelected
+          ? theme.colors.surface.border.primary.normal
+          : theme.colors.surface.border.gray.subtle,
+        backgroundColor: bgColor,
+        overflow: 'hidden',
+      }}
+    >
+      <BaseBox display="flex" alignItems="center" justifyContent="center" height="100%">
+        {renderContent()}
+      </BaseBox>
+    </BaseBox>
+  );
+
+  // Addons are placed OUTSIDE the overflow:hidden avatar body so they are never
+  // clipped — unlike the web where CSS overflow:hidden doesn't clip
+  // absolutely-positioned children by default.
+  const avatarWithAddons = hasAddons ? (
+    <BaseBox style={{ width: dimension, height: dimension }}>
+      {avatarBody}
+      {topAddon ? (
+        <BaseBox
+          position="absolute"
+          // Native fix: subtract the centering offset caused by the empty <Text>
+          // inside Indicator that adds line-height even with no content.
+          style={{
+            top: nativeTopOffset(topOffset.top, indicatorSize),
+            right: parseInt(topOffset.right, 10),
+          }}
+          zIndex={2}
+        >
+          {React.cloneElement(topAddon, { size: indicatorSize })}
+        </BaseBox>
+      ) : null}
+      {BottomAddon ? (
+        <BaseBox
+          position="absolute"
+          style={{
+            bottom: isSquare ? Math.round(dimension * -0.1) : 0,
+            right: isSquare ? Math.round(dimension * -0.1) : 0,
+          }}
+          zIndex={2}
+        >
+          <BottomAddon size={avatarToBottomAddonSize[avatarSize]} color={iconColor} />
+        </BaseBox>
+      ) : null}
+    </BaseBox>
+  ) : (
+    avatarBody
+  );
+
+  if (isInteractive) {
+    return (
+      <Pressable
+        ref={ref as never}
+        onPress={handlePress}
+        {...makeAccessible({ role: href ? 'link' : 'button' })}
+      >
+        {avatarWithAddons}
+      </Pressable>
+    );
+  }
+
+  return avatarWithAddons;
+};
+
+const Avatar = assignWithoutSideEffects(React.forwardRef(_Avatar), {
+  displayName: 'Avatar',
+  componentId: 'Avatar',
+});
+
 export { Avatar };
+export type { AvatarProps };

--- a/packages/blade/src/components/Avatar/Avatar.native.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.native.tsx
@@ -129,6 +129,7 @@ const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
           resizeMode="cover"
           onError={() => setImgError(true)}
           accessibilityLabel={alt ?? name}
+          accessibilityIgnoresInvertColors
         />
       );
     }
@@ -149,7 +150,7 @@ const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
   };
 
   const handlePress = (): void => {
-    if (href) Linking.openURL(href);
+    if (href) void Linking.openURL(href);
     // onClick is typed for web (MouseEvent); on native we call it without an event arg
     onClick?.(undefined as never);
   };

--- a/packages/blade/src/components/Avatar/Avatar.native.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.native.tsx
@@ -27,14 +27,17 @@ import type { IconColor } from '~components/Button/BaseButton/types';
 import type { BaseTextProps } from '~components/Typography/BaseText/types';
 import { makeAccessible } from '~utils/makeAccessible';
 import getIn from '~utils/lodashButBetter/get';
+import { getInitials } from './avatarUtils';
 
 // Approximate native line-height for Indicator's internal Text.
 // On native an empty <Text> reserves line-height even with no content, pushing
 // the SVG dot down when it is vertically centred inside the flex row.
 // Subtracting (lineHeight - svgSize) / 2 from the web top-offset compensates.
+// Value sourced from Indicator component's internal text line-height on native.
 const INDICATOR_TEXT_LINE_HEIGHT = 20;
 
-// Subtle-emphasis dot sizes (px) per indicator size — from indicatorDotSizes.
+// Subtle-emphasis dot sizes (px) per indicator size.
+// Sourced from indicatorDotSizes in indicatorTokens — keep in sync if those change.
 const indicatorSubtleSvgSize: Record<'small' | 'medium' | 'large', number> = {
   small: 6,
   medium: 8,
@@ -47,12 +50,6 @@ function nativeTopOffset(webTop: string, indicatorSize: 'small' | 'medium' | 'la
   const centeringOffset = Math.max(0, (INDICATOR_TEXT_LINE_HEIGHT - svgSize) / 2);
   return px - centeringOffset;
 }
-
-const getInitials = (name: string): string => {
-  const names = name.trim().toUpperCase().split(' ');
-  if (names.length === 1) return names[0].substring(0, 2);
-  return names[0][0] + names[names.length - 1][0];
-};
 
 const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
   {
@@ -151,8 +148,8 @@ const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
 
   const handlePress = (): void => {
     if (href) void Linking.openURL(href);
-    // onClick is typed for web (MouseEvent); on native we call it without an event arg
-    onClick?.(undefined as never);
+    // onClick is web-only (MouseEvent); on native the Pressable's onPress already handles
+    // the interaction — do not call onClick to avoid passing undefined as a MouseEvent.
   };
 
   const indicatorSize = avatarToIndicatorSize[avatarSize];

--- a/packages/blade/src/components/Avatar/Avatar.native.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.native.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
 import { Image, Pressable, Linking } from 'react-native';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
-import { throwBladeError } from '~utils/logger';
-import type { BladeElementRef } from '~utils/types';
-import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
-import { makeAccessible } from '~utils/makeAccessible';
-import getIn from '~utils/lodashButBetter/get';
 import type { AvatarProps } from './types';
 import {
   avatarSizeTokens,
@@ -18,12 +12,18 @@ import {
 } from './avatarTokens';
 import { useAvatarGroupContext } from './AvatarGroupContext';
 import { getInitials } from './avatarUtils';
-import { getStyledProps } from '~components/Box/styledProps';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { throwBladeError } from '~utils/logger';
+import type { BladeElementRef } from '~utils/types';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import getIn from '~utils/lodashButBetter/get';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
-import { UserIcon } from '~components/Icons';
-import BaseBox from '~components/Box/BaseBox';
 import { getComponentId } from '~utils/isValidAllowedChildren';
+import { UserIcon } from '~components/Icons';
 import { useTheme } from '~components/BladeProvider';
+import { getStyledProps } from '~components/Box/styledProps';
+import BaseBox from '~components/Box/BaseBox';
 import { Heading, Text } from '~components/Typography';
 import { getTextColorToken } from '~components/Button/BaseButton/BaseButton';
 import type { IconColor } from '~components/Button/BaseButton/types';

--- a/packages/blade/src/components/Avatar/Avatar.web.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.web.tsx
@@ -18,15 +18,7 @@ import BaseBox from '~components/Box/BaseBox';
 import { getComponentId } from '~utils/isValidAllowedChildren';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
-const getInitials = (name: string): string => {
-  // Combine first and last name initials
-  const names = name.trim().toUpperCase().split(' ');
-
-  if (names.length === 1) {
-    return names[0].substring(0, 2);
-  }
-  return names[0][0] + names[names.length - 1][0];
-};
+import { getInitials } from './avatarUtils';
 
 const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
   {

--- a/packages/blade/src/components/Avatar/Avatar.web.tsx
+++ b/packages/blade/src/components/Avatar/Avatar.web.tsx
@@ -18,7 +18,15 @@ import BaseBox from '~components/Box/BaseBox';
 import { getComponentId } from '~utils/isValidAllowedChildren';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
-import { getInitials } from './avatarUtils';
+const getInitials = (name: string): string => {
+  // Combine first and last name initials
+  const names = name.trim().toUpperCase().split(' ');
+
+  if (names.length === 1) {
+    return names[0].substring(0, 2);
+  }
+  return names[0][0] + names[names.length - 1][0];
+};
 
 const _Avatar: React.ForwardRefRenderFunction<BladeElementRef, AvatarProps> = (
   {

--- a/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
+++ b/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
@@ -1,14 +1,124 @@
+import React from 'react';
+import { View } from 'react-native';
 import type { AvatarGroupProps } from './types';
-import { throwBladeError } from '~utils/logger';
+import { avatarSizeTokens, avatarTextSizeMapping } from './avatarTokens';
+import { AvatarGroupProvider } from './AvatarGroupContext';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { useTheme } from '~components/BladeProvider';
+import { Text } from '~components/Typography';
 
-const AvatarGroup = (_props: AvatarGroupProps): React.ReactElement => {
-  throwBladeError({
-    message: 'AvatarGroup is not yet implemented for React Native',
-    moduleName: 'AvatarGroup',
-  });
+const _AvatarGroup = ({
+  children,
+  size = 'medium',
+  maxCount,
+  testID,
+}: AvatarGroupProps): React.ReactElement => {
+  const { theme } = useTheme();
+  const all = React.Children.toArray(children);
+  const totalCount = all.length;
+  const dimension = avatarSizeTokens[size];
 
-  // eslint-disable-next-line react/jsx-no-useless-fragment
-  return <></>;
+  // Web uses dimension / 2 overlap: `marginLeft: -avatarSizeTokens[size] / 2`
+  const overlap = dimension / 2;
+
+  // 2px opaque ring — mirrors StyledAvatar's backgroundColor="surface.background.gray.intense".
+  // Without it, semi-transparent faded avatar colours blend at the overlap (Venn-diagram effect).
+  const RING = 2;
+  const wrapperSize = dimension + RING * 2;
+  const wrapperRadius = wrapperSize / 2;
+  const ringColor = theme.colors.surface.background.gray.intense;
+
+  // Adjusted so avatar bodies (not wrappers) overlap by exactly dimension / 2.
+  // derivation: marginLeft = -(overlap + 2*RING) → body-to-body overlap = dimension/2.
+  const itemMarginLeft = -(overlap + RING * 2);
+
+  const visible = maxCount ? all.slice(0, maxCount) : all;
+  const overflowCount = maxCount ? Math.max(0, totalCount - maxCount) : 0;
+
+  return (
+    <AvatarGroupProvider value={{ size }}>
+      <View
+        style={{ flexDirection: 'row', alignItems: 'center' }}
+        {...metaAttribute({ name: MetaConstants.AvatarGroup, testID })}
+      >
+        {visible.map((child, i) => (
+          // Each wrapper is RING px larger on every side, filled with opaque intense-gray.
+          // The avatar body sits inside the padding exposing the gray ring as a separator.
+          // Ascending zIndex mirrors web's DOM-order stacking so each later avatar is on top.
+          <View
+            key={i}
+            style={{
+              padding: RING,
+              width: wrapperSize,
+              height: wrapperSize,
+              borderRadius: wrapperRadius,
+              backgroundColor: ringColor,
+              marginLeft: i === 0 ? 0 : itemMarginLeft,
+              zIndex: i + 1,
+            }}
+          >
+            {child}
+          </View>
+        ))}
+
+        {overflowCount > 0 ? (
+          <View
+            style={{
+              padding: RING,
+              width: wrapperSize,
+              height: wrapperSize,
+              borderRadius: wrapperRadius,
+              backgroundColor: ringColor,
+              marginLeft: itemMarginLeft,
+              zIndex: visible.length + 1,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <View
+              style={{
+                width: dimension,
+                height: dimension,
+                borderRadius: dimension / 2,
+                backgroundColor: theme.colors.interactive.background.neutral.faded,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Text size={avatarTextSizeMapping[size]} weight="semibold">
+                {`+${overflowCount}`}
+              </Text>
+            </View>
+          </View>
+        ) : null}
+      </View>
+    </AvatarGroupProvider>
+  );
 };
+
+/**
+ * ### AvatarGroup Component
+ *
+ * Groups multiple Avatar components with overlapping stacking and optional overflow count.
+ *
+ * ---
+ *
+ * #### Usage
+ *
+ * ```jsx
+ * <AvatarGroup size="medium" maxCount={3}>
+ *   <Avatar name="Nitin Kumar" color="primary" />
+ *   <Avatar name="Priya Sharma" color="positive" />
+ *   <Avatar name="Raj Patel" color="notice" />
+ * </AvatarGroup>
+ * ```
+ *
+ * Checkout {@link https://blade.razorpay.com/?path=/docs/components-avatar-avatargroup AvatarGroup Documentation}
+ */
+const AvatarGroup = assignWithoutSideEffects(_AvatarGroup, {
+  displayName: 'AvatarGroup',
+  componentId: 'AvatarGroup',
+});
 
 export { AvatarGroup };

--- a/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
+++ b/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
@@ -42,25 +42,28 @@ const _AvatarGroup = ({
         style={{ flexDirection: 'row', alignItems: 'center' }}
         {...metaAttribute({ name: MetaConstants.AvatarGroup, testID })}
       >
-        {visible.map((child, i) => (
+        {visible.map((child, i) => {
+          const key = React.isValidElement(child) ? (child.key ?? i) : i;
+          return (
           // Each wrapper is RING px larger on every side, filled with opaque intense-gray.
           // The avatar body sits inside the padding exposing the gray ring as a separator.
           // Ascending zIndex mirrors web's DOM-order stacking so each later avatar is on top.
-          <View
-            key={i}
-            style={{
-              padding: RING,
-              width: wrapperSize,
-              height: wrapperSize,
-              borderRadius: wrapperRadius,
-              backgroundColor: ringColor,
-              marginLeft: i === 0 ? 0 : itemMarginLeft,
-              zIndex: i + 1,
-            }}
-          >
-            {child}
-          </View>
-        ))}
+            <View
+              key={key}
+              style={{
+                padding: RING,
+                width: wrapperSize,
+                height: wrapperSize,
+                borderRadius: wrapperRadius,
+                backgroundColor: ringColor,
+                marginLeft: i === 0 ? 0 : itemMarginLeft,
+                zIndex: i + 1,
+              }}
+            >
+              {child}
+            </View>
+          );
+        })}
 
         {overflowCount > 0 ? (
           <View

--- a/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
+++ b/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { View } from 'react-native';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import type { AvatarGroupProps } from './types';
 import { avatarSizeTokens, avatarTextSizeMapping } from './avatarTokens';
 import { AvatarGroupProvider } from './AvatarGroupContext';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { useTheme } from '~components/BladeProvider';
 import { Text } from '~components/Typography';

--- a/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
+++ b/packages/blade/src/components/Avatar/AvatarGroup.native.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { View } from 'react-native';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import type { AvatarGroupProps } from './types';
 import { avatarSizeTokens, avatarTextSizeMapping } from './avatarTokens';
 import { AvatarGroupProvider } from './AvatarGroupContext';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { useTheme } from '~components/BladeProvider';
 import { Text } from '~components/Typography';
 
@@ -43,11 +43,11 @@ const _AvatarGroup = ({
         {...metaAttribute({ name: MetaConstants.AvatarGroup, testID })}
       >
         {visible.map((child, i) => {
-          const key = React.isValidElement(child) ? (child.key ?? i) : i;
+          const key = React.isValidElement(child) ? child.key ?? i : i;
           return (
-          // Each wrapper is RING px larger on every side, filled with opaque intense-gray.
-          // The avatar body sits inside the padding exposing the gray ring as a separator.
-          // Ascending zIndex mirrors web's DOM-order stacking so each later avatar is on top.
+            // Each wrapper is RING px larger on every side, filled with opaque intense-gray.
+            // The avatar body sits inside the padding exposing the gray ring as a separator.
+            // Ascending zIndex mirrors web's DOM-order stacking so each later avatar is on top.
             <View
               key={key}
               style={{

--- a/packages/blade/src/components/Avatar/TrustedBadgeIcon.native.tsx
+++ b/packages/blade/src/components/Avatar/TrustedBadgeIcon.native.tsx
@@ -1,4 +1,5 @@
 import { throwBladeError } from '~utils/logger';
+import { Text } from '~components/Typography';
 
 import type { IconComponent } from '~components/Icons';
 
@@ -8,7 +9,7 @@ const TrustedBadgeIcon: IconComponent = () => {
     moduleName: 'TrustedBadgeIcon',
   });
 
-  return <></>;
+  return <Text>TrustedBadgeIcon is not available for Native mobile apps.</Text>;
 };
 
 export { TrustedBadgeIcon };

--- a/packages/blade/src/components/Avatar/avatarUtils.ts
+++ b/packages/blade/src/components/Avatar/avatarUtils.ts
@@ -1,0 +1,7 @@
+const getInitials = (name: string): string => {
+  const names = name.trim().toUpperCase().split(' ');
+  if (names.length === 1) return names[0].substring(0, 2);
+  return names[0][0] + names[names.length - 1][0];
+};
+
+export { getInitials };

--- a/packages/blade/src/components/Badge/StyledBadge.native.tsx
+++ b/packages/blade/src/components/Badge/StyledBadge.native.tsx
@@ -6,6 +6,10 @@ import BaseBox from '~components/Box/BaseBox';
 const StyledBadge = styled(BaseBox)<StyledBadgeProps>((props) => ({
   ...getStyledBadgeStyles(props),
   alignSelf: 'center',
+  justifyContent: 'center',
+  // iOS adds extra lineHeight space above glyphs; paddingBottom shifts the flex-center
+  // reference upward by 0.5px to compensate, centering the visual text in the badge
+  paddingBottom: 0.5,
 }));
 
 export { StyledBadge };

--- a/packages/blade/src/components/Badge/__tests__/__snapshots__/Badge.native.test.tsx.snap
+++ b/packages/blade/src/components/Badge/__tests__/__snapshots__/Badge.native.test.tsx.snap
@@ -37,6 +37,8 @@ exports[`<Badge /> should render Badge with Icon 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -242,6 +244,8 @@ exports[`<Badge /> should render Badge with default props 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -347,6 +351,8 @@ exports[`<Badge /> should render intense emphasis information color Badge 1`] = 
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -452,6 +458,8 @@ exports[`<Badge /> should render intense emphasis information color Badge 2`] = 
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -557,6 +565,8 @@ exports[`<Badge /> should render intense emphasis negative color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -662,6 +672,8 @@ exports[`<Badge /> should render intense emphasis negative color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -767,6 +779,8 @@ exports[`<Badge /> should render intense emphasis neutral color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -872,6 +886,8 @@ exports[`<Badge /> should render intense emphasis neutral color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -977,6 +993,8 @@ exports[`<Badge /> should render intense emphasis notice color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1082,6 +1100,8 @@ exports[`<Badge /> should render intense emphasis notice color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1187,6 +1207,8 @@ exports[`<Badge /> should render intense emphasis positive color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1292,6 +1314,8 @@ exports[`<Badge /> should render intense emphasis positive color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1397,6 +1421,8 @@ exports[`<Badge /> should render intense emphasis primary color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1502,6 +1528,8 @@ exports[`<Badge /> should render intense emphasis primary color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1607,6 +1635,8 @@ exports[`<Badge /> should render large size Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1712,6 +1742,8 @@ exports[`<Badge /> should render medium size Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1817,6 +1849,8 @@ exports[`<Badge /> should render small size Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -1922,6 +1956,8 @@ exports[`<Badge /> should render subtle emphasis information color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2027,6 +2063,8 @@ exports[`<Badge /> should render subtle emphasis information color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2132,6 +2170,8 @@ exports[`<Badge /> should render subtle emphasis negative color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2237,6 +2277,8 @@ exports[`<Badge /> should render subtle emphasis negative color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2342,6 +2384,8 @@ exports[`<Badge /> should render subtle emphasis neutral color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2447,6 +2491,8 @@ exports[`<Badge /> should render subtle emphasis neutral color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2552,6 +2598,8 @@ exports[`<Badge /> should render subtle emphasis notice color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2657,6 +2705,8 @@ exports[`<Badge /> should render subtle emphasis notice color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2762,6 +2812,8 @@ exports[`<Badge /> should render subtle emphasis positive color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2867,6 +2919,8 @@ exports[`<Badge /> should render subtle emphasis positive color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -2972,6 +3026,8 @@ exports[`<Badge /> should render subtle emphasis primary color Badge 1`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }
@@ -3077,6 +3133,8 @@ exports[`<Badge /> should render subtle emphasis primary color Badge 2`] = `
             "borderRadius": 9999,
             "display": "flex",
             "flexWrap": "nowrap",
+            "justifyContent": "center",
+            "paddingBottom": 0.5,
           },
         ]
       }

--- a/packages/blade/src/components/BaseMotion/docs/MotionDashboardComponents.native.tsx
+++ b/packages/blade/src/components/BaseMotion/docs/MotionDashboardComponents.native.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+export const DashboardWithRoutingExample = (): React.ReactElement => (
+  <Text>DashboardWithRoutingExample is not available on native</Text>
+);

--- a/packages/blade/src/components/BaseMotion/docs/StepperRouterExample.native.tsx
+++ b/packages/blade/src/components/BaseMotion/docs/StepperRouterExample.native.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+const StepperRouterExample = (_props: Record<string, unknown>): React.ReactElement => (
+  <Text>StepperRouterExample is not available on native</Text>
+);
+
+export { StepperRouterExample };

--- a/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
+++ b/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                       }
                     }
                     accessible={true}
-                    borderRadius="8px"
+                    borderRadius={8}
                     buttonPaddingBottom="0px"
                     buttonPaddingLeft="12px"
                     buttonPaddingRight="12px"
@@ -847,6 +847,8 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                                 "borderRadius": 9999,
                                 "display": "flex",
                                 "flexWrap": "nowrap",
+                                "justifyContent": "center",
+                                "paddingBottom": 0.5,
                               },
                             ]
                           }
@@ -1348,7 +1350,7 @@ exports[`<BottomSheet /> should render empty header 1`] = `
                       }
                     }
                     accessible={true}
-                    borderRadius="8px"
+                    borderRadius={8}
                     buttonPaddingBottom="0px"
                     buttonPaddingLeft="12px"
                     buttonPaddingRight="12px"

--- a/packages/blade/src/components/Box/BaseBox/BaseBox.native.tsx
+++ b/packages/blade/src/components/Box/BaseBox/BaseBox.native.tsx
@@ -30,7 +30,7 @@ const StyledBaseBox = styled(View)
   .withConfig({
     shouldForwardProp: (prop, defaultValidator) =>
       isSupportedOnReactNativeElement(prop) &&
-      (typeof defaultValidator === 'function' ? defaultValidator(prop) : true),
+      (typeof defaultValidator === 'function' ? defaultValidator(prop) : false),
   })<BaseBoxProps>((props) => {
   const cssObject = getBaseBoxStyles(props);
   return cssObject;

--- a/packages/blade/src/components/Box/BaseBox/BaseBox.native.tsx
+++ b/packages/blade/src/components/Box/BaseBox/BaseBox.native.tsx
@@ -30,7 +30,7 @@ const StyledBaseBox = styled(View)
   .withConfig({
     shouldForwardProp: (prop, defaultValidator) =>
       isSupportedOnReactNativeElement(prop) &&
-      (typeof defaultValidator === 'function' ? defaultValidator(prop) : false),
+      (typeof defaultValidator === 'function' ? defaultValidator(prop) : true),
   })<BaseBoxProps>((props) => {
   const cssObject = getBaseBoxStyles(props);
   return cssObject;

--- a/packages/blade/src/components/Box/BaseBox/BaseBox.native.tsx
+++ b/packages/blade/src/components/Box/BaseBox/BaseBox.native.tsx
@@ -29,7 +29,8 @@ const StyledBaseBox = styled(View)
   })
   .withConfig({
     shouldForwardProp: (prop, defaultValidator) =>
-      isSupportedOnReactNativeElement(prop) && defaultValidator(prop),
+      isSupportedOnReactNativeElement(prop) &&
+      (typeof defaultValidator === 'function' ? defaultValidator(prop) : true),
   })<BaseBoxProps>((props) => {
   const cssObject = getBaseBoxStyles(props);
   return cssObject;

--- a/packages/blade/src/components/Box/BaseBox/baseBoxStyles.ts
+++ b/packages/blade/src/components/Box/BaseBox/baseBoxStyles.ts
@@ -74,7 +74,7 @@ const getBorderRadiusValue = (
   borderRadius: BaseBoxProps['borderRadius'],
   theme: Theme,
   breakpoint?: keyof Breakpoints,
-): string | undefined => {
+): string | number | undefined => {
   const responsiveBorderRadiusValue = getResponsiveValue(borderRadius, breakpoint);
   return isEmpty(responsiveBorderRadiusValue)
     ? undefined
@@ -86,7 +86,7 @@ const getBorderWidthValue = (
   borderWidth: BaseBoxProps['borderWidth'],
   theme: Theme,
   breakpoint?: keyof Breakpoints,
-): string | undefined => {
+): string | number | undefined => {
   const responsiveBorderWidthValue = getResponsiveValue(borderWidth, breakpoint);
   return isEmpty(responsiveBorderWidthValue)
     ? undefined

--- a/packages/blade/src/components/Box/__tests__/baseBoxStyles.test.ts
+++ b/packages/blade/src/components/Box/__tests__/baseBoxStyles.test.ts
@@ -5,6 +5,7 @@ import {
   getBorderRadiusValue,
 } from '../BaseBox/baseBoxStyles';
 import bladeLightTheme from '~components/BladeProvider/__tests__/bladeLightTheme';
+import { isReactNative } from '~utils';
 
 export const removeUndefinedValues = (props: Record<string, unknown>): Record<string, unknown> =>
   JSON.parse(JSON.stringify(props));
@@ -22,10 +23,13 @@ describe('getColorValue', () => {
 
 describe('getBorderRadiusValue', () => {
   it('should return correct border-radius value', () => {
-    expect(getBorderRadiusValue('max', bladeLightTheme, 'base')).toBe('9999px');
-    expect(getBorderRadiusValue('small', bladeLightTheme, 'base')).toBe('8px');
+    const native = isReactNative();
+    expect(getBorderRadiusValue('max', bladeLightTheme, 'base')).toBe(native ? 9999 : '9999px');
+    expect(getBorderRadiusValue('small', bladeLightTheme, 'base')).toBe(native ? 8 : '8px');
     expect(getBorderRadiusValue(undefined, bladeLightTheme, 'm')).toBe(undefined);
-    expect(getBorderRadiusValue({ base: 'medium', s: 'max' }, bladeLightTheme, 's')).toBe('9999px');
+    expect(getBorderRadiusValue({ base: 'medium', s: 'max' }, bladeLightTheme, 's')).toBe(
+      native ? 9999 : '9999px',
+    );
   });
 });
 

--- a/packages/blade/src/components/Button/BaseButton/__tests__/__snapshots__/BaseButton.native.test.tsx.snap
+++ b/packages/blade/src/components/Button/BaseButton/__tests__/__snapshots__/BaseButton.native.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<BaseButton /> should render button with default properties 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -206,7 +206,7 @@ exports[`<BaseButton /> should render button with full width 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -384,7 +384,7 @@ exports[`<BaseButton /> should render button with icon with default iconPosition
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -666,7 +666,7 @@ exports[`<BaseButton /> should render button with icon with left iconPosition 1`
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -948,7 +948,7 @@ exports[`<BaseButton /> should render button with icon with right iconPosition 1
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1230,7 +1230,7 @@ exports[`<BaseButton /> should render button with icon without text 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="0px"
     buttonPaddingRight="0px"
@@ -1480,7 +1480,7 @@ exports[`<BaseButton /> should render disabled button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1655,7 +1655,7 @@ exports[`<BaseButton /> should render disabled information color primary button 
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1830,7 +1830,7 @@ exports[`<BaseButton /> should render disabled information color secondary butto
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2008,7 +2008,7 @@ exports[`<BaseButton /> should render disabled negative color primary button 1`]
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2183,7 +2183,7 @@ exports[`<BaseButton /> should render disabled negative color secondary button 1
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2361,7 +2361,7 @@ exports[`<BaseButton /> should render disabled neutral color primary button 1`] 
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2536,7 +2536,7 @@ exports[`<BaseButton /> should render disabled neutral color secondary button 1`
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2714,7 +2714,7 @@ exports[`<BaseButton /> should render disabled notice color primary button 1`] =
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2889,7 +2889,7 @@ exports[`<BaseButton /> should render disabled notice color secondary button 1`]
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3067,7 +3067,7 @@ exports[`<BaseButton /> should render disabled positive color primary button 1`]
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3242,7 +3242,7 @@ exports[`<BaseButton /> should render disabled positive color secondary button 1
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3420,7 +3420,7 @@ exports[`<BaseButton /> should render disabled primary color primary button 1`] 
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3595,7 +3595,7 @@ exports[`<BaseButton /> should render disabled primary color secondary button 1`
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3773,7 +3773,7 @@ exports[`<BaseButton /> should render disabled primary color tertiary button 1`]
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3951,7 +3951,7 @@ exports[`<BaseButton /> should render disabled white color primary button 1`] = 
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4126,7 +4126,7 @@ exports[`<BaseButton /> should render disabled white color secondary button 1`] 
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4304,7 +4304,7 @@ exports[`<BaseButton /> should render disabled white color tertiary button 1`] =
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4482,7 +4482,7 @@ exports[`<BaseButton /> should render information color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4660,7 +4660,7 @@ exports[`<BaseButton /> should render information color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4838,7 +4838,7 @@ exports[`<BaseButton /> should render large size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="12px"
+    borderRadius={12}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="16px"
     buttonPaddingRight="16px"
@@ -5016,7 +5016,7 @@ exports[`<BaseButton /> should render loading button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -5358,7 +5358,7 @@ exports[`<BaseButton /> should render medium size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -5536,7 +5536,7 @@ exports[`<BaseButton /> should render negative color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -5714,7 +5714,7 @@ exports[`<BaseButton /> should render negative color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -5892,7 +5892,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -6070,7 +6070,7 @@ exports[`<BaseButton /> should render neutral color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -6248,7 +6248,7 @@ exports[`<BaseButton /> should render notice color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -6426,7 +6426,7 @@ exports[`<BaseButton /> should render notice color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -6604,7 +6604,7 @@ exports[`<BaseButton /> should render positive color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -6782,7 +6782,7 @@ exports[`<BaseButton /> should render positive color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -6960,7 +6960,7 @@ exports[`<BaseButton /> should render primary color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -7138,7 +7138,7 @@ exports[`<BaseButton /> should render primary color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -7316,7 +7316,7 @@ exports[`<BaseButton /> should render primary color tertiary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -7494,7 +7494,7 @@ exports[`<BaseButton /> should render small size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="8px"
     buttonPaddingRight="8px"
@@ -7672,7 +7672,7 @@ exports[`<BaseButton /> should render white color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -7850,7 +7850,7 @@ exports[`<BaseButton /> should render white color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -8028,7 +8028,7 @@ exports[`<BaseButton /> should render white color tertiary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -8206,7 +8206,7 @@ exports[`<BaseButton /> should render xsmall size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="8px"
     buttonPaddingRight="8px"

--- a/packages/blade/src/components/Button/BaseButton/types.ts
+++ b/packages/blade/src/components/Button/BaseButton/types.ts
@@ -41,7 +41,7 @@ export type BaseButtonStyleProps = {
   focusRingColor: string;
   motionDuration: DurationString;
   motionEasing: EasingString;
-  borderRadius: BorderRadiusValues;
+  borderRadius: BorderRadiusValues | number;
   height?: string;
   width?: string;
 };
@@ -73,7 +73,7 @@ export type StyledBaseButtonProps = Omit<
   isFullWidth: boolean;
   motionDuration: DurationString;
   motionEasing: EasingString;
-  borderRadius: BorderRadiusValues;
+  borderRadius: BorderRadiusValues | number;
   borderWidth?: string;
   accessibilityProps: Record<string, unknown>;
   isPressed: boolean;

--- a/packages/blade/src/components/Button/Button/__tests__/__snapshots__/Button.native.test.tsx.snap
+++ b/packages/blade/src/components/Button/Button/__tests__/__snapshots__/Button.native.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<Button /> should render button with default properties 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -206,7 +206,7 @@ exports[`<Button /> should render button with full width 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -384,7 +384,7 @@ exports[`<Button /> should render button with icon with default iconPosition 1`]
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -666,7 +666,7 @@ exports[`<Button /> should render button with icon with right iconPosition 1`] =
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -948,7 +948,7 @@ exports[`<Button /> should render disabled button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1123,7 +1123,7 @@ exports[`<Button /> should render disabled negative color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1298,7 +1298,7 @@ exports[`<Button /> should render disabled negative color secondary button 1`] =
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1476,7 +1476,7 @@ exports[`<Button /> should render disabled positive color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1651,7 +1651,7 @@ exports[`<Button /> should render disabled positive color secondary button 1`] =
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1829,7 +1829,7 @@ exports[`<Button /> should render disabled primary color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2004,7 +2004,7 @@ exports[`<Button /> should render disabled primary color secondary button 1`] = 
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2182,7 +2182,7 @@ exports[`<Button /> should render disabled primary color tertiary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2360,7 +2360,7 @@ exports[`<Button /> should render disabled white color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2535,7 +2535,7 @@ exports[`<Button /> should render disabled white color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2713,7 +2713,7 @@ exports[`<Button /> should render disabled white color tertiary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -2891,7 +2891,7 @@ exports[`<Button /> should render large size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="12px"
+    borderRadius={12}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="16px"
     buttonPaddingRight="16px"
@@ -3069,7 +3069,7 @@ exports[`<Button /> should render medium size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3247,7 +3247,7 @@ exports[`<Button /> should render negative color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3425,7 +3425,7 @@ exports[`<Button /> should render negative color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3603,7 +3603,7 @@ exports[`<Button /> should render positive color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3781,7 +3781,7 @@ exports[`<Button /> should render positive color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3959,7 +3959,7 @@ exports[`<Button /> should render primary color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4137,7 +4137,7 @@ exports[`<Button /> should render primary color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4315,7 +4315,7 @@ exports[`<Button /> should render primary color tertiary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4493,7 +4493,7 @@ exports[`<Button /> should render small size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="8px"
     buttonPaddingRight="8px"
@@ -4671,7 +4671,7 @@ exports[`<Button /> should render white color primary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -4849,7 +4849,7 @@ exports[`<Button /> should render white color secondary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -5027,7 +5027,7 @@ exports[`<Button /> should render white color tertiary button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -5205,7 +5205,7 @@ exports[`<Button /> should render xsmall size button 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="8px"
     buttonPaddingRight="8px"

--- a/packages/blade/src/components/Card/__tests__/__snapshots__/Card.native.test.tsx.snap
+++ b/packages/blade/src/components/Card/__tests__/__snapshots__/Card.native.test.tsx.snap
@@ -289,7 +289,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
                   }
                 }
                 accessible={true}
-                borderRadius="8px"
+                borderRadius={8}
                 buttonPaddingBottom="0px"
                 buttonPaddingLeft="12px"
                 buttonPaddingRight="12px"
@@ -479,7 +479,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
                   }
                 }
                 accessible={true}
-                borderRadius="8px"
+                borderRadius={8}
                 buttonPaddingBottom="0px"
                 buttonPaddingLeft="12px"
                 buttonPaddingRight="12px"
@@ -1119,6 +1119,8 @@ exports[`<Card /> should render a Card with Header 1`] = `
                       "borderRadius": 9999,
                       "display": "flex",
                       "flexWrap": "nowrap",
+                      "justifyContent": "center",
+                      "paddingBottom": 0.5,
                     },
                   ]
                 }

--- a/packages/blade/src/components/ChatMessage/Rotate.native.tsx
+++ b/packages/blade/src/components/ChatMessage/Rotate.native.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { View } from 'react-native';
+
+const Rotate = ({ children }: { children: React.ReactNode }): React.ReactElement => (
+  <View>{children}</View>
+);
+
+export default Rotate;

--- a/packages/blade/src/components/Checkbox/__tests__/__snapshots__/CheckboxGroup.native.test.tsx.snap
+++ b/packages/blade/src/components/Checkbox/__tests__/__snapshots__/CheckboxGroup.native.test.tsx.snap
@@ -1393,12 +1393,14 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
             data-blade-component="base-box"
             display="flex"
             flexDirection="row"
+            gap="spacing.2"
             style={
               [
                 {
                   "alignItems": "center",
                   "display": "flex",
                   "flexDirection": "row",
+                  "gap": 4,
                 },
               ]
             }

--- a/packages/blade/src/components/Chip/AnimatedChip.native.tsx
+++ b/packages/blade/src/components/Chip/AnimatedChip.native.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import getIn from '~utils/lodashButBetter/get';
 import { getAnimatedChipStyles } from './getAnimatedChipStyles';
 import type { AnimatedChipProps } from './types';
 import { chipMotionTokens } from './chipTokens';
-import getIn from '~utils/lodashButBetter/get';
 import { useTheme } from '~components/BladeProvider';
 
-const StyledAnimatedChip = styled(Animated.View)<AnimatedChipProps>((props) => {
-  return {
-    ...getAnimatedChipStyles(props),
-    alignSelf: 'center',
-  };
-});
+const StyledAnimatedChip = styled(Animated.View)<AnimatedChipProps>(
+  ({ theme, backgroundColor, ...props }) => {
+    return {
+      ...getAnimatedChipStyles({ theme, ...props }),
+      alignSelf: 'center',
+      overflow: 'hidden',
+      backgroundColor: backgroundColor ? getIn(theme.colors, backgroundColor) : 'transparent',
+    };
+  },
+);
 
 const AnimatedChip = ({
   borderColor,
+  backgroundColor,
   children,
   isPressed,
   isDisabled,
@@ -39,7 +44,12 @@ const AnimatedChip = ({
   }, [isPressed]);
 
   return (
-    <StyledAnimatedChip borderColor={borderColor} isDisabled={isDisabled} style={chipAnimation}>
+    <StyledAnimatedChip
+      borderColor={borderColor}
+      backgroundColor={backgroundColor}
+      isDisabled={isDisabled}
+      style={chipAnimation}
+    >
       {children}
     </StyledAnimatedChip>
   );

--- a/packages/blade/src/components/Chip/AnimatedChip.native.tsx
+++ b/packages/blade/src/components/Chip/AnimatedChip.native.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components/native';
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
-import getIn from '~utils/lodashButBetter/get';
 import { getAnimatedChipStyles } from './getAnimatedChipStyles';
 import type { AnimatedChipProps } from './types';
 import { chipMotionTokens } from './chipTokens';
+import getIn from '~utils/lodashButBetter/get';
 import { useTheme } from '~components/BladeProvider';
 
 const StyledAnimatedChip = styled(Animated.View)<AnimatedChipProps>(

--- a/packages/blade/src/components/Chip/Chip.tsx
+++ b/packages/blade/src/components/Chip/Chip.tsx
@@ -156,6 +156,7 @@ const _Chip: React.ForwardRefRenderFunction<BladeElementRef, ChipProps> = (
       {...metaAttribute({ name: MetaConstants.Chip, testID })}
       {...getStyledProps(rest)}
       display={(isReactNative() ? 'flex' : 'inline-flex') as never}
+      alignSelf={isReactNative() ? 'flex-start' : undefined}
       ref={getOuterMotionRef({ _motionMeta, ref })}
       width={width}
       maxWidth={maxWidth}
@@ -173,10 +174,10 @@ const _Chip: React.ForwardRefRenderFunction<BladeElementRef, ChipProps> = (
         inputProps={isReactNative() ? inputProps : {}}
         style={{
           cursor: _isDisabled ? 'not-allowed' : 'pointer',
-          width: '100%',
+          ...(!isReactNative() && { width: '100%' }),
         }}
       >
-        <BaseBox display="flex" flexDirection="column" width="100%">
+        <BaseBox display="flex" flexDirection="column" {...(!isReactNative() && { width: '100%' })}>
           <BaseBox display="flex" alignItems="center" flexDirection="row">
             <SelectorInput
               hoverTokens={getChipInputHoverTokens(chipColor)}
@@ -189,6 +190,7 @@ const _Chip: React.ForwardRefRenderFunction<BladeElementRef, ChipProps> = (
             />
             <AnimatedChip
               borderColor={chipBorderColor}
+              backgroundColor={chipBackgroundColor}
               isDisabled={_isDisabled}
               isPressed={isPressed}
               isDesktop={matchedDeviceType === 'desktop'}
@@ -218,7 +220,7 @@ const _Chip: React.ForwardRefRenderFunction<BladeElementRef, ChipProps> = (
                   ]
                 }
                 height={makeSize(chipHeightTokens[_size])}
-                width="100%"
+                width={isReactNative() ? undefined : '100%'}
               >
                 {Icon ? (
                   <BaseBox display="flex">

--- a/packages/blade/src/components/Chip/Chip.tsx
+++ b/packages/blade/src/components/Chip/Chip.tsx
@@ -190,7 +190,7 @@ const _Chip: React.ForwardRefRenderFunction<BladeElementRef, ChipProps> = (
             />
             <AnimatedChip
               borderColor={chipBorderColor}
-              backgroundColor={chipBackgroundColor}
+              {...(isReactNative() && { backgroundColor: chipBackgroundColor })}
               isDisabled={_isDisabled}
               isPressed={isPressed}
               isDesktop={matchedDeviceType === 'desktop'}

--- a/packages/blade/src/components/Chip/StyledChipWrapper.native.tsx
+++ b/packages/blade/src/components/Chip/StyledChipWrapper.native.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components/native';
-import getIn from '~utils/lodashButBetter/get';
-import { makeBorderSize } from '~utils/makeBorderSize';
 import type { StyledChipWrapperProps } from './types';
 import { chipBorderRadiusTokens } from './chipTokens';
+import getIn from '~utils/lodashButBetter/get';
+import { makeBorderSize } from '~utils/makeBorderSize';
 import BaseBox from '~components/Box/BaseBox';
 
 const StyledChipWrapper = styled(BaseBox)<StyledChipWrapperProps>(

--- a/packages/blade/src/components/Chip/StyledChipWrapper.native.tsx
+++ b/packages/blade/src/components/Chip/StyledChipWrapper.native.tsx
@@ -1,13 +1,21 @@
 import styled from 'styled-components/native';
-import type { StyledChipWrapperProps } from './types';
 import getIn from '~utils/lodashButBetter/get';
+import { makeBorderSize } from '~utils/makeBorderSize';
+import type { StyledChipWrapperProps } from './types';
+import { chipBorderRadiusTokens } from './chipTokens';
 import BaseBox from '~components/Box/BaseBox';
 
 const StyledChipWrapper = styled(BaseBox)<StyledChipWrapperProps>(
-  ({ theme, borderColor, isChecked }) => {
+  ({ theme, borderColor, isChecked, size = 'small' }) => {
+    const borderRadius = chipBorderRadiusTokens[size];
+    const outerRadius = theme.border.radius[borderRadius];
+    const outerBorderWidth = getIn(theme, 'border.width.thin') as number;
     return {
       display: 'flex',
       borderColor: isChecked ? getIn(theme.colors, borderColor) : 'transparent',
+      borderRadius: makeBorderSize(outerRadius - outerBorderWidth),
+      // Clipping is handled by AnimatedChip's overflow:hidden; avoid double-clip artifact.
+      overflow: 'visible',
     };
   },
 );

--- a/packages/blade/src/components/Chip/__tests__/__snapshots__/Chip.native.test.tsx.snap
+++ b/packages/blade/src/components/Chip/__tests__/__snapshots__/Chip.native.test.tsx.snap
@@ -125,11 +125,13 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
           }
         >
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -190,11 +192,9 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -212,6 +212,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                   }
                 >
                   <View
+                    backgroundColor="transparent"
                     borderColor="interactive.border.gray.disabled"
                     isDisabled={true}
                     style={
@@ -219,7 +220,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 0)",
                           "borderColor": "hsla(204, 8%, 88%, 1)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -228,6 +229,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -271,15 +273,15 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -335,11 +337,13 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -400,11 +404,9 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -422,6 +424,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -429,7 +432,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -438,6 +441,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -481,15 +485,15 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -676,11 +680,13 @@ exports[`<Chip /> should render chip 1`] = `
           }
         >
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -741,11 +747,9 @@ exports[`<Chip /> should render chip 1`] = `
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -763,6 +767,7 @@ exports[`<Chip /> should render chip 1`] = `
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -770,7 +775,7 @@ exports[`<Chip /> should render chip 1`] = `
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -779,6 +784,7 @@ exports[`<Chip /> should render chip 1`] = `
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -822,15 +828,15 @@ exports[`<Chip /> should render chip 1`] = `
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -886,11 +892,13 @@ exports[`<Chip /> should render chip 1`] = `
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -951,11 +959,9 @@ exports[`<Chip /> should render chip 1`] = `
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -973,6 +979,7 @@ exports[`<Chip /> should render chip 1`] = `
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -980,7 +987,7 @@ exports[`<Chip /> should render chip 1`] = `
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -989,6 +996,7 @@ exports[`<Chip /> should render chip 1`] = `
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -1032,15 +1040,15 @@ exports[`<Chip /> should render chip 1`] = `
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -1227,11 +1235,13 @@ exports[`<Chip /> should render chip with icon 1`] = `
           }
         >
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -1292,11 +1302,9 @@ exports[`<Chip /> should render chip with icon 1`] = `
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -1314,6 +1322,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -1321,7 +1330,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -1330,6 +1339,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -1373,15 +1383,15 @@ exports[`<Chip /> should render chip with icon 1`] = `
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -1537,11 +1547,13 @@ exports[`<Chip /> should render chip with icon 1`] = `
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -1602,11 +1614,9 @@ exports[`<Chip /> should render chip with icon 1`] = `
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -1624,6 +1634,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -1631,7 +1642,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -1640,6 +1651,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -1683,15 +1695,15 @@ exports[`<Chip /> should render chip with icon 1`] = `
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -1978,11 +1990,13 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
           }
         >
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -2043,11 +2057,9 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -2065,6 +2077,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                   }
                 >
                   <View
+                    backgroundColor="transparent"
                     borderColor="interactive.border.gray.disabled"
                     isDisabled={true}
                     style={
@@ -2072,7 +2085,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 0)",
                           "borderColor": "hsla(204, 8%, 88%, 1)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -2081,6 +2094,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -2124,15 +2138,15 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -2188,11 +2202,13 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -2253,11 +2269,9 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -2275,6 +2289,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -2282,7 +2297,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -2291,6 +2306,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -2334,15 +2350,15 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"

--- a/packages/blade/src/components/Chip/__tests__/__snapshots__/ChipGroup.native.test.tsx.snap
+++ b/packages/blade/src/components/Chip/__tests__/__snapshots__/ChipGroup.native.test.tsx.snap
@@ -251,11 +251,13 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
           }
         >
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -315,11 +317,9 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -337,6 +337,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -344,7 +345,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -353,6 +354,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -396,15 +398,15 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -460,11 +462,13 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -524,11 +528,9 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -546,6 +548,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -553,7 +556,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -562,6 +565,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -605,15 +609,15 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -669,11 +673,13 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -733,11 +739,9 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -755,6 +759,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -762,7 +767,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -771,6 +776,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -814,15 +820,15 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -1136,11 +1142,13 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
           }
         >
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -1201,11 +1209,9 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -1223,6 +1229,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -1230,7 +1237,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -1239,6 +1246,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -1282,15 +1290,15 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -1346,11 +1354,13 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -1411,11 +1421,9 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -1433,6 +1441,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -1440,7 +1449,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -1449,6 +1458,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -1492,15 +1502,15 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"
@@ -1556,11 +1566,13 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
             </View>
           </View>
           <View
+            alignSelf="flex-start"
             data-blade-component="chip"
             display="flex"
             style={
               [
                 {
+                  "alignSelf": "flex-start",
                   "display": "flex",
                 },
               ]
@@ -1621,11 +1633,9 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                     {
                       "display": "flex",
                       "flexDirection": "column",
-                      "width": "100%",
                     },
                   ]
                 }
-                width="100%"
               >
                 <View
                   alignItems="center"
@@ -1643,6 +1653,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                   }
                 >
                   <View
+                    backgroundColor="surface.background.gray.intense"
                     borderColor="interactive.border.gray.faded"
                     isDisabled={false}
                     style={
@@ -1650,7 +1661,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                         {
                           "alignItems": "center",
                           "alignSelf": "center",
-                          "backgroundColor": "transparent",
+                          "backgroundColor": "hsla(0, 0%, 100%, 1)",
                           "borderColor": "hsla(206, 10%, 29%, 0.18)",
                           "borderRadius": 8,
                           "borderWidth": 1,
@@ -1659,6 +1670,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                           "flexWrap": "nowrap",
                           "justifyContent": "center",
                           "maxWidth": 280,
+                          "overflow": "hidden",
                           "textAlign": "left",
                           "textOverflow": "ellipsis",
                         },
@@ -1702,15 +1714,15 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                             "overflow": "hidden",
                             "paddingLeft": 8,
                             "paddingRight": 8,
-                            "width": "100%",
                           },
                           {
                             "borderColor": "transparent",
+                            "borderRadius": 7,
                             "display": "flex",
+                            "overflow": "visible",
                           },
                         ]
                       }
-                      width="100%"
                     >
                       <View
                         data-blade-component="base-box"

--- a/packages/blade/src/components/Chip/types.ts
+++ b/packages/blade/src/components/Chip/types.ts
@@ -234,6 +234,7 @@ type ChipBorderColors =
 
 type AnimatedChipProps = {
   borderColor: ChipBorderColors;
+  backgroundColor?: ChipBackgroundColors;
   isPressed?: boolean;
   isDisabled?: boolean;
   isDesktop?: boolean;

--- a/packages/blade/src/components/Collapsible/__tests__/__snapshots__/Collapsible.native.test.tsx.snap
+++ b/packages/blade/src/components/Collapsible/__tests__/__snapshots__/Collapsible.native.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`<Collapsible /> should render with CollapsibleButton 1`] = `
         }
         accessible={true}
         alignSelf="flex-start"
-        borderRadius="8px"
+        borderRadius={8}
         buttonPaddingBottom="0px"
         buttonPaddingLeft="12px"
         buttonPaddingRight="12px"

--- a/packages/blade/src/components/DatePicker/Calendar.native.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.native.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+const Calendar = (_props: Record<string, unknown>): React.ReactElement => (
+  <Text>Calendar is not available on native</Text>
+);
+
+export { Calendar };

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.test.stories.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.test.stories.tsx
@@ -1085,12 +1085,12 @@ DatePickerPresetOnApplyCurrentValues.play = async () => {
   await expect(handleApply).toHaveBeenCalledTimes(2);
 
   // Check first call (7 days)
-  const firstAppliedValue = handleApply!.mock.calls[0][0] as [Date, Date];
+  const firstAppliedValue = handleApply.mock.calls[0][0] as [Date, Date];
   const firstDaysDiff = dayjs(firstAppliedValue[1]).diff(dayjs(firstAppliedValue[0]), 'days');
   await expect(firstDaysDiff).toBe(7);
 
   // Check second call (30 days) - this should NOT be stale
-  const secondAppliedValue = handleApply!.mock.calls[1][0] as [Date, Date];
+  const secondAppliedValue = handleApply.mock.calls[1][0] as [Date, Date];
   const secondDaysDiff = dayjs(secondAppliedValue[1]).diff(dayjs(secondAppliedValue[0]), 'days');
   await expect(secondDaysDiff).toBe(30);
 
@@ -1112,7 +1112,7 @@ export const DatePickerPresetFormSubmissionPrevention: StoryFn<
     <form
       onSubmit={(e) => {
         e.preventDefault();
-        handleFormSubmit!(e);
+        handleFormSubmit(e);
       }}
     >
       <DatePickerComponent
@@ -1160,7 +1160,7 @@ DatePickerPresetFormSubmissionPrevention.play = async () => {
   await expect(handleApplyForm).toHaveBeenCalledTimes(1);
 
   // Verify the preset value was applied correctly
-  const appliedValue = handleApplyForm!.mock.calls[0][0] as [Date, Date];
+  const appliedValue = handleApplyForm.mock.calls[0][0] as [Date, Date];
   const daysDiff = dayjs(appliedValue[1]).diff(dayjs(appliedValue[0]), 'days');
   await expect(daysDiff).toBe(7);
 };

--- a/packages/blade/src/components/Dropdown/StyledDropdownOverlay.native.tsx
+++ b/packages/blade/src/components/Dropdown/StyledDropdownOverlay.native.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components/native';
+import BaseBox from '~components/Box/BaseBox';
+import { makeSize } from '~utils';
+import type { ColorSchemeNames } from '~tokens/theme';
+
+// Web-only CSS properties (borderWidth:'none', backdropFilter, borderTopStyle) are intentionally
+// excluded here — they are invalid in React Native and crash Fabric/New Architecture.
+const StyledDropdownOverlay = styled(BaseBox)<{
+  isInBottomSheet?: boolean;
+  colorScheme: ColorSchemeNames;
+}>((props) => {
+  const { theme } = props;
+  return {
+    backgroundColor: theme.colors.popup.background.gray.moderate,
+    borderRadius: makeSize(theme.border.radius.medium),
+  };
+});
+
+export { StyledDropdownOverlay };

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
@@ -832,10 +832,8 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                 },
                 [
                   {
-                    "backdropFilter": "blur(8px)",
                     "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
                     "borderRadius": 12,
-                    "borderWidth": "none",
                     "transform": [
                       {
                         "translateY": 8,

--- a/packages/blade/src/components/EmptyState/EmptyState.native.tsx
+++ b/packages/blade/src/components/EmptyState/EmptyState.native.tsx
@@ -33,7 +33,7 @@ const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStatePro
         </BaseBox>
       ) : null}
 
-      <BaseBox display="flex" flexDirection="column" gap="spacing.1" alignItems="center">
+      <BaseBox display="flex" flexDirection="column" gap={tokens.gapInsideContentSection} alignItems="center">
         {title ? (
           <Heading
             textAlign="center"

--- a/packages/blade/src/components/EmptyState/EmptyState.native.tsx
+++ b/packages/blade/src/components/EmptyState/EmptyState.native.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
+import type { BladeElementRef } from '~utils/types';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 import { emptyStateSizeTokens } from './emptyStateTokens';
 import type { EmptyStateProps } from './types';
-import type { BladeElementRef } from '~utils/types';
 import BaseBox from '~components/Box/BaseBox';
 import { Heading, Text } from '~components/Typography';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { getStyledProps } from '~components/Box/styledProps';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
-import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
 const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStateProps> = (
   { asset, title, description, children, size = 'medium', testID, ...props },
@@ -33,7 +33,12 @@ const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStatePro
         </BaseBox>
       ) : null}
 
-      <BaseBox display="flex" flexDirection="column" gap={tokens.gapInsideContentSection} alignItems="center">
+      <BaseBox
+        display="flex"
+        flexDirection="column"
+        gap={tokens.gapInsideContentSection}
+        alignItems="center"
+      >
         {title ? (
           <Heading
             textAlign="center"

--- a/packages/blade/src/components/EmptyState/EmptyState.native.tsx
+++ b/packages/blade/src/components/EmptyState/EmptyState.native.tsx
@@ -1,16 +1,92 @@
 import React from 'react';
-/* eslint-disable react/jsx-no-useless-fragment */
+import { emptyStateSizeTokens } from './emptyStateTokens';
 import type { EmptyStateProps } from './types';
-import { Text } from '~components/Typography';
-import { throwBladeError } from '~utils/logger';
+import type { BladeElementRef } from '~utils/types';
+import BaseBox from '~components/Box/BaseBox';
+import { Heading, Text } from '~components/Typography';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { getStyledProps } from '~components/Box/styledProps';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 
-const EmptyState = (_props: EmptyStateProps): React.ReactElement => {
-  throwBladeError({
-    message: 'EmptyState is not yet implemented for native',
-    moduleName: 'EmptyState',
-  });
+const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStateProps> = (
+  { asset, title, description, children, size = 'medium', testID, ...props },
+  ref,
+) => {
+  const tokens = emptyStateSizeTokens[size];
 
-  return <Text>EmptyState Component is not available for Native mobile apps.</Text>;
+  return (
+    <BaseBox
+      ref={ref as never}
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      gap={tokens.gapBetweenSections}
+      {...metaAttribute({ name: MetaConstants.EmptyState, testID })}
+      {...getStyledProps(props)}
+      {...makeAnalyticsAttribute(props)}
+    >
+      {asset ? (
+        <BaseBox alignItems="center" justifyContent="center">
+          {asset}
+        </BaseBox>
+      ) : null}
+
+      <BaseBox display="flex" flexDirection="column" gap="spacing.1" alignItems="center">
+        {title ? (
+          <Heading
+            textAlign="center"
+            size={tokens.titleSize}
+            weight="semibold"
+            color="surface.text.gray.subtle"
+          >
+            {title}
+          </Heading>
+        ) : null}
+
+        {description ? (
+          <Text
+            textAlign="center"
+            size={tokens.descriptionSize}
+            color="surface.text.gray.muted"
+            weight="regular"
+            variant="body"
+          >
+            {description}
+          </Text>
+        ) : null}
+      </BaseBox>
+
+      {children}
+    </BaseBox>
+  );
 };
+
+/**
+ * ### EmptyState Component
+ *
+ * Displays an empty state with an optional asset, title, description and action slot.
+ *
+ * ---
+ *
+ * #### Usage
+ *
+ * ```jsx
+ * <EmptyState
+ *   asset={<Image source={require('./empty.png')} />}
+ *   title="No transactions yet"
+ *   description="Once you start accepting payments your transactions will appear here."
+ * >
+ *   <Button>Create Payment Link</Button>
+ * </EmptyState>
+ * ```
+ *
+ * Checkout {@link https://blade.razorpay.com/?path=/docs/components-emptystate EmptyState Documentation}
+ */
+const EmptyState = assignWithoutSideEffects(React.forwardRef(_EmptyState), {
+  displayName: 'EmptyState',
+  componentId: 'EmptyState',
+});
 
 export { EmptyState };

--- a/packages/blade/src/components/EmptyState/EmptyState.native.tsx
+++ b/packages/blade/src/components/EmptyState/EmptyState.native.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
+import { emptyStateSizeTokens } from './emptyStateTokens';
+import type { EmptyStateProps } from './types';
 import type { BladeElementRef } from '~utils/types';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
-import { emptyStateSizeTokens } from './emptyStateTokens';
-import type { EmptyStateProps } from './types';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import BaseBox from '~components/Box/BaseBox';
 import { Heading, Text } from '~components/Typography';
 import { getStyledProps } from '~components/Box/styledProps';
-import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 
 const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStateProps> = (
   { asset, title, description, children, size = 'medium', testID, ...props },

--- a/packages/blade/src/components/EmptyState/EmptyState.web.tsx
+++ b/packages/blade/src/components/EmptyState/EmptyState.web.tsx
@@ -32,7 +32,7 @@ const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStatePro
           {asset}
         </BaseBox>
       ) : null}
-      <BaseBox display="flex" flexDirection="column" gap="spacing.1" alignItems="center">
+      <BaseBox display="flex" flexDirection="column" gap={tokens.gapInsideContentSection} alignItems="center">
         {title ? (
           <Heading
             textAlign="center"

--- a/packages/blade/src/components/EmptyState/EmptyState.web.tsx
+++ b/packages/blade/src/components/EmptyState/EmptyState.web.tsx
@@ -32,7 +32,7 @@ const _EmptyState: React.ForwardRefRenderFunction<BladeElementRef, EmptyStatePro
           {asset}
         </BaseBox>
       ) : null}
-      <BaseBox display="flex" flexDirection="column" gap={tokens.gapInsideContentSection} alignItems="center">
+      <BaseBox display="flex" flexDirection="column" gap="spacing.1" alignItems="center">
         {title ? (
           <Heading
             textAlign="center"

--- a/packages/blade/src/components/EmptyState/emptyStateTokens.ts
+++ b/packages/blade/src/components/EmptyState/emptyStateTokens.ts
@@ -10,6 +10,7 @@ export type EmptyStateSizeTokens = {
   titleSize: Extract<HeadingProps['size'], 'small' | 'medium' | 'xlarge'>;
   descriptionSize: Extract<BaseTextSizes, 'xsmall' | 'small' | 'medium' | 'large'>;
   gapBetweenSections: DotNotationSpacingStringToken;
+  gapInsideContentSection: DotNotationSpacingStringToken;
 };
 
 export const emptyStateSizeTokens: Record<EmptyStateSize, EmptyStateSizeTokens> = {
@@ -19,6 +20,7 @@ export const emptyStateSizeTokens: Record<EmptyStateSize, EmptyStateSizeTokens> 
     titleSize: 'small',
     descriptionSize: 'xsmall',
     gapBetweenSections: 'spacing.5',
+    gapInsideContentSection: 'spacing.1',
   },
   medium: {
     assetMaxWidth: '90px',
@@ -26,6 +28,7 @@ export const emptyStateSizeTokens: Record<EmptyStateSize, EmptyStateSizeTokens> 
     titleSize: 'small',
     descriptionSize: 'small',
     gapBetweenSections: 'spacing.6',
+    gapInsideContentSection: 'spacing.1',
   },
   large: {
     assetMaxWidth: '120px',
@@ -33,6 +36,7 @@ export const emptyStateSizeTokens: Record<EmptyStateSize, EmptyStateSizeTokens> 
     titleSize: 'medium',
     descriptionSize: 'medium',
     gapBetweenSections: 'spacing.7',
+    gapInsideContentSection: 'spacing.1',
   },
   xlarge: {
     assetMaxWidth: '160px',
@@ -40,5 +44,6 @@ export const emptyStateSizeTokens: Record<EmptyStateSize, EmptyStateSizeTokens> 
     titleSize: 'xlarge',
     descriptionSize: 'large',
     gapBetweenSections: 'spacing.8',
+    gapInsideContentSection: 'spacing.1',
   },
 };

--- a/packages/blade/src/components/Form/FormHint.tsx
+++ b/packages/blade/src/components/Form/FormHint.tsx
@@ -26,8 +26,8 @@ const HintText = ({ icon: Icon, children, id, color, size }: HintTextProps): Rea
     <BaseBox marginTop={hintMarginTop[size]} id={id}>
       <FormHintWrapper>
         {Icon ? (
-          // offset block element 2px down to align with text
-          <Box flexShrink={0} marginTop="spacing.1">
+          // offset block element 2px down to align with text baseline on web only
+          <Box flexShrink={0} marginTop={isReactNative ? 'spacing.0' : 'spacing.1'}>
             <Icon />
           </Box>
         ) : null}
@@ -37,7 +37,7 @@ const HintText = ({ icon: Icon, children, id, color, size }: HintTextProps): Rea
           size={hintTextSize[size]}
           variant="caption"
           wordBreak="break-word"
-          marginTop={size === 'large' && Icon ? 'spacing.1' : 'spacing.0'}
+          marginTop={!isReactNative && size === 'large' && Icon ? 'spacing.1' : 'spacing.0'}
         >
           {children}
         </Text>

--- a/packages/blade/src/components/Form/FormHintWrapper.native.tsx
+++ b/packages/blade/src/components/Form/FormHintWrapper.native.tsx
@@ -3,7 +3,7 @@ import BaseBox from '~components/Box/BaseBox';
 
 const FormHintWrapper = ({ children }: { children: React.ReactNode }): React.ReactElement => {
   return (
-    <BaseBox display="flex" flexDirection="row" alignItems="center">
+    <BaseBox display="flex" flexDirection="row" alignItems="center" gap="spacing.2">
       {children}
     </BaseBox>
   );

--- a/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.native.test.tsx.snap
@@ -979,12 +979,14 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
             data-blade-component="base-box"
             display="flex"
             flexDirection="row"
+            gap="spacing.2"
             style={
               [
                 {
                   "alignItems": "center",
                   "display": "flex",
                   "flexDirection": "row",
+                  "gap": 4,
                 },
               ]
             }
@@ -996,7 +998,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
                 [
                   {
                     "flexShrink": 0,
-                    "marginTop": 2,
+                    "marginTop": 0,
                   },
                 ]
               }
@@ -1472,12 +1474,14 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
             data-blade-component="base-box"
             display="flex"
             flexDirection="row"
+            gap="spacing.2"
             style={
               [
                 {
                   "alignItems": "center",
                   "display": "flex",
                   "flexDirection": "row",
+                  "gap": 4,
                 },
               ]
             }
@@ -1489,7 +1493,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
                 [
                   {
                     "flexShrink": 0,
-                    "marginTop": 2,
+                    "marginTop": 0,
                   },
                 ]
               }
@@ -2635,13 +2639,6 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                   </RNSVGGroup>
                 </RNSVGSvgView>
               </View>
-              <Modal
-                accessibilityLabel="Success"
-                collapsable={false}
-                hardwareAccelerated={false}
-                transparent={true}
-                visible={false}
-              />
             </View>
           </View>
         </View>
@@ -2688,12 +2685,14 @@ exports[`<BaseInput /> should render with large size input 1`] = `
             data-blade-component="base-box"
             display="flex"
             flexDirection="row"
+            gap="spacing.2"
             style={
               [
                 {
                   "alignItems": "center",
                   "display": "flex",
                   "flexDirection": "row",
+                  "gap": 4,
                 },
               ]
             }
@@ -2705,7 +2704,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                 [
                   {
                     "flexShrink": 0,
-                    "marginTop": 2,
+                    "marginTop": 0,
                   },
                 ]
               }
@@ -2783,7 +2782,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
               fontStyle="normal"
               fontWeight="regular"
               lineHeight={50}
-              marginTop="spacing.1"
+              marginTop="spacing.0"
               style={
                 [
                   {
@@ -2797,7 +2796,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                     "marginBottom": 0,
                     "marginLeft": 0,
                     "marginRight": 0,
-                    "marginTop": 2,
+                    "marginTop": 0,
                     "paddingBottom": 0,
                     "paddingLeft": 0,
                     "paddingRight": 0,

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
@@ -796,10 +796,8 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                 },
                 [
                   {
-                    "backdropFilter": "blur(8px)",
                     "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
                     "borderRadius": 12,
-                    "borderWidth": "none",
                     "transform": [
                       {
                         "translateY": 8,
@@ -1867,7 +1865,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                     }
                   }
                   accessible={true}
-                  borderRadius="8px"
+                  borderRadius={8}
                   buttonPaddingBottom="0px"
                   buttonPaddingLeft="12px"
                   buttonPaddingRight="12px"

--- a/packages/blade/src/components/Menu/docs/CustomMenu.native.tsx
+++ b/packages/blade/src/components/Menu/docs/CustomMenu.native.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+const MenuTrigger = (_props: Record<string, unknown>): React.ReactElement => (
+  <Text>MenuTrigger is not available on native</Text>
+);
+
+const navMenuItems: never[] = [];
+
+const CustomMenuItem = (_props: Record<string, unknown>): React.ReactElement => (
+  <Text>CustomMenuItem is not available on native</Text>
+);
+
+const CustomMenuTrigger = (_props: Record<string, unknown>): React.ReactElement => (
+  <Text>CustomMenuTrigger is not available on native</Text>
+);
+
+export { MenuTrigger, navMenuItems, CustomMenuItem, CustomMenuTrigger };

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -14,6 +14,7 @@ import { useControllableState } from '~utils/useControllable';
 import { PopupArrow } from '~components/PopupArrow';
 import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { componentZIndices } from '~utils/componentZIndices';
+import { useFloatingPortal } from './useFloatingPortal.native';
 
 const IOS_OFFSET_CORRECTION = 10;
 
@@ -41,8 +42,6 @@ const Popover = ({
   const [side] = getFloatingPlacementParts(placement);
   const isHorizontal = side === 'left' || side === 'right';
   const arrowRef = React.useRef();
-  const backdropRef = React.useRef<TouchableOpacity>(null);
-  const [backdropOffset, setBackdropOffset] = React.useState({ x: 0, y: 0 });
 
   const context = useFloating({
     sameScrollView: false,
@@ -61,17 +60,8 @@ const Popover = ({
   const { refs, floatingStyles, update } = context;
   const [computedSide] = getFloatingPlacementParts(context.placement);
 
-  // Measure the Portal backdrop's window position to correct coordinate mismatch
-  // between measureInWindow (used by floating-ui) and the Portal container's coordinate space
-  const onBackdropLayout = React.useCallback(() => {
-    if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
-      ((backdropRef.current as unknown) as {
-        measureInWindow: (cb: (x: number, y: number, w: number, h: number) => void) => void;
-      }).measureInWindow((bx: number, by: number) => {
-        setBackdropOffset({ x: bx || 0, y: by || 0 });
-      });
-    }
-  }, []);
+  const [isVisible, setIsVisible] = React.useState(() => controllableIsOpen);
+  const { backdropRef, backdropOffset, onBackdropLayout } = useFloatingPortal(update, isVisible);
 
   const handleOpen = React.useCallback(() => {
     controllableSetIsOpen(() => true);
@@ -84,7 +74,6 @@ const Popover = ({
   }, [controllableSetIsOpen, onOpenChange]);
 
   // wait for animation to finish before unmounting
-  const [isVisible, setIsVisible] = React.useState(() => controllableIsOpen);
   React.useEffect(() => {
     const id = setTimeout(() => {
       if (!controllableIsOpen) {
@@ -97,17 +86,6 @@ const Popover = ({
     }
     return () => clearTimeout(id);
   }, [controllableIsOpen]);
-
-  // Re-run floating position computation after backdrop offset is measured
-  React.useEffect(() => {
-    if (isVisible && (backdropOffset.x !== 0 || backdropOffset.y !== 0)) {
-      const id = setTimeout(() => {
-        update();
-      }, 50);
-      return () => clearTimeout(id);
-    }
-    return undefined;
-  }, [backdropOffset, isVisible, update]);
 
   const contextValue = React.useMemo(() => {
     return {

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -132,45 +132,47 @@ const Popover = ({
       })}
       {isVisible && (
         <Portal hostName="BladeBottomSheetPortal">
-          <TouchableOpacity
-            ref={backdropRef}
-            onLayout={onBackdropLayout}
-            style={StyleSheet.absoluteFill}
-            onPress={handleClose}
-            activeOpacity={1}
-            testID="popover-modal-backdrop"
-            {...metaAttribute({ name: MetaConstants.Popover })}
-          >
-            <PopoverContent
-              titleLeading={titleLeading}
-              title={title}
-              footer={footer}
-              isVisible={controllableIsOpen}
-              ref={refs.setFloating}
-              side={computedSide}
-              style={{
-                ...floatingStyles,
-                left: (floatingStyles.left || -200) - backdropOffset.x,
-                top:
-                  (floatingStyles.top || -200) -
-                  backdropOffset.y -
-                  (Platform.OS === 'ios' ? IOS_OFFSET_CORRECTION : 0),
-                zIndex,
-              }}
-              arrow={
-                <PopupArrow
-                  ref={arrowRef as never}
-                  context={context}
-                  width={ARROW_WIDTH}
-                  height={ARROW_HEIGHT}
-                  fillColor={theme.colors.popup.background.subtle}
-                  strokeColor={theme.colors.popup.border.subtle}
-                />
-              }
+          <PopoverContext.Provider value={contextValue}>
+            <TouchableOpacity
+              ref={backdropRef}
+              onLayout={onBackdropLayout}
+              style={StyleSheet.absoluteFill}
+              onPress={handleClose}
+              activeOpacity={1}
+              testID="popover-modal-backdrop"
+              {...metaAttribute({ name: MetaConstants.Popover })}
             >
-              {content}
-            </PopoverContent>
-          </TouchableOpacity>
+              <PopoverContent
+                titleLeading={titleLeading}
+                title={title}
+                footer={footer}
+                isVisible={controllableIsOpen}
+                ref={refs.setFloating}
+                side={computedSide}
+                style={{
+                  ...floatingStyles,
+                  left: (floatingStyles.left || -200) - backdropOffset.x,
+                  top:
+                    (floatingStyles.top || -200) -
+                    backdropOffset.y -
+                    (Platform.OS === 'ios' ? IOS_OFFSET_CORRECTION : 0),
+                  zIndex,
+                }}
+                arrow={
+                  <PopupArrow
+                    ref={arrowRef as never}
+                    context={context}
+                    width={ARROW_WIDTH}
+                    height={ARROW_HEIGHT}
+                    fillColor={theme.colors.popup.background.subtle}
+                    strokeColor={theme.colors.popup.border.subtle}
+                  />
+                }
+              >
+                {content}
+              </PopoverContent>
+            </TouchableOpacity>
+          </PopoverContext.Provider>
         </Portal>
       )}
     </PopoverContext.Provider>

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -65,11 +65,11 @@ const Popover = ({
   // between measureInWindow (used by floating-ui) and the Portal container's coordinate space
   const onBackdropLayout = React.useCallback(() => {
     if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
-      ((backdropRef.current as unknown) as { measureInWindow: Function }).measureInWindow(
-        (bx: number, by: number) => {
-          setBackdropOffset({ x: bx || 0, y: by || 0 });
-        },
-      );
+      ((backdropRef.current as unknown) as {
+        measureInWindow: (x: number, y: number, w: number, h: number) => void;
+      }).measureInWindow((bx: number, by: number) => {
+        setBackdropOffset({ x: bx || 0, y: by || 0 });
+      });
     }
   }, []);
 

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -66,7 +66,7 @@ const Popover = ({
   const onBackdropLayout = React.useCallback(() => {
     if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
       ((backdropRef.current as unknown) as {
-        measureInWindow: (x: number, y: number, w: number, h: number) => void;
+        measureInWindow: (cb: (x: number, y: number, w: number, h: number) => void) => void;
       }).measureInWindow((bx: number, by: number) => {
         setBackdropOffset({ x: bx || 0, y: by || 0 });
       });

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -3,18 +3,18 @@ import { arrow, shift, useFloating, flip, offset } from '@floating-ui/react-nati
 import React from 'react';
 import { TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { Portal } from '@gorhom/portal';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { PopoverContent } from './PopoverContent';
 import type { PopoverProps } from './types';
 import { ARROW_HEIGHT, ARROW_WIDTH } from './constants';
 import { PopoverContext } from './PopoverContext';
+import { useFloatingPortal } from './useFloatingPortal.native';
 import { useTheme } from '~components/BladeProvider';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { mergeProps } from '~utils/mergeProps';
 import { useControllableState } from '~utils/useControllable';
 import { PopupArrow } from '~components/PopupArrow';
-import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { componentZIndices } from '~utils/componentZIndices';
-import { useFloatingPortal } from './useFloatingPortal.native';
 
 const IOS_OFFSET_CORRECTION = 10;
 

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -3,19 +3,21 @@ import { arrow, shift, useFloating, flip, offset } from '@floating-ui/react-nati
 import React from 'react';
 import { TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { Portal } from '@gorhom/portal';
-import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
-import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { PopoverContent } from './PopoverContent';
 import type { PopoverProps } from './types';
 import { ARROW_HEIGHT, ARROW_WIDTH } from './constants';
 import { PopoverContext } from './PopoverContext';
 import { useFloatingPortal } from './useFloatingPortal.native';
-import { useTheme } from '~components/BladeProvider';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { mergeProps } from '~utils/mergeProps';
 import { useControllableState } from '~utils/useControllable';
-import { PopupArrow } from '~components/PopupArrow';
 import { componentZIndices } from '~utils/componentZIndices';
+import { useTheme } from '~components/BladeProvider';
+import { PopupArrow } from '~components/PopupArrow';
 
+// Portal container rendered by @gorhom/portal has a 10px top offset on iOS relative
+// to the window coordinate system that measureInWindow doesn't account for.
 const IOS_OFFSET_CORRECTION = 10;
 
 const Popover = ({

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 import { arrow, shift, useFloating, flip, offset } from '@floating-ui/react-native';
 import React from 'react';
-import { Modal, TouchableOpacity, Platform } from 'react-native';
+import { TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { Portal } from '@gorhom/portal';
 import { PopoverContent } from './PopoverContent';
 import type { PopoverProps } from './types';
 import { ARROW_HEIGHT, ARROW_WIDTH } from './constants';
@@ -13,6 +14,8 @@ import { useControllableState } from '~utils/useControllable';
 import { PopupArrow } from '~components/PopupArrow';
 import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { componentZIndices } from '~utils/componentZIndices';
+
+const IOS_OFFSET_CORRECTION = 10;
 
 const Popover = ({
   content,
@@ -38,6 +41,9 @@ const Popover = ({
   const [side] = getFloatingPlacementParts(placement);
   const isHorizontal = side === 'left' || side === 'right';
   const arrowRef = React.useRef();
+  const backdropRef = React.useRef<TouchableOpacity>(null);
+  const [backdropOffset, setBackdropOffset] = React.useState({ x: 0, y: 0 });
+
   const context = useFloating({
     sameScrollView: false,
     placement,
@@ -52,8 +58,20 @@ const Popover = ({
     ],
   });
 
-  const { refs, floatingStyles } = context;
+  const { refs, floatingStyles, update } = context;
   const [computedSide] = getFloatingPlacementParts(context.placement);
+
+  // Measure the Portal backdrop's window position to correct coordinate mismatch
+  // between measureInWindow (used by floating-ui) and the Portal container's coordinate space
+  const onBackdropLayout = React.useCallback(() => {
+    if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
+      ((backdropRef.current as unknown) as { measureInWindow: Function }).measureInWindow(
+        (bx: number, by: number) => {
+          setBackdropOffset({ x: bx || 0, y: by || 0 });
+        },
+      );
+    }
+  }, []);
 
   const handleOpen = React.useCallback(() => {
     controllableSetIsOpen(() => true);
@@ -65,7 +83,7 @@ const Popover = ({
     onOpenChange?.({ isOpen: false });
   }, [controllableSetIsOpen, onOpenChange]);
 
-  // wait for animation to finish before unmounting modal
+  // wait for animation to finish before unmounting
   const [isVisible, setIsVisible] = React.useState(() => controllableIsOpen);
   React.useEffect(() => {
     const id = setTimeout(() => {
@@ -79,6 +97,17 @@ const Popover = ({
     }
     return () => clearTimeout(id);
   }, [controllableIsOpen]);
+
+  // Re-run floating position computation after backdrop offset is measured
+  React.useEffect(() => {
+    if (isVisible && (backdropOffset.x !== 0 || backdropOffset.y !== 0)) {
+      const id = setTimeout(() => {
+        update();
+      }, 50);
+      return () => clearTimeout(id);
+    }
+    return undefined;
+  }, [backdropOffset, isVisible, update]);
 
   const contextValue = React.useMemo(() => {
     return {
@@ -101,52 +130,49 @@ const Popover = ({
         ),
         ref: refs.setReference,
       })}
-      <Modal
-        collapsable={false}
-        transparent
-        visible={Boolean(isVisible)}
-        {...metaAttribute({ testID: 'popover-modal' })}
-      >
-        <TouchableOpacity
-          style={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-          }}
-          onPress={handleClose}
-          activeOpacity={1}
-          testID="popover-modal-backdrop"
-          {...metaAttribute({ name: MetaConstants.Popover })}
-        />
-        <PopoverContent
-          titleLeading={titleLeading}
-          title={title}
-          footer={footer}
-          isVisible={controllableIsOpen}
-          ref={refs.setFloating}
-          side={computedSide}
-          style={{
-            ...floatingStyles,
-            top: (floatingStyles.top || 0) - (Platform.OS === 'ios' ? 10 : 0),
-            // TODO: Tokenize zIndex values
-            zIndex,
-          }}
-          arrow={
-            <PopupArrow
-              ref={arrowRef as never}
-              context={context}
-              width={ARROW_WIDTH}
-              height={ARROW_HEIGHT}
-              fillColor={theme.colors.popup.background.subtle}
-              strokeColor={theme.colors.popup.border.subtle}
-            />
-          }
-        >
-          {content}
-        </PopoverContent>
-      </Modal>
+      {isVisible && (
+        <Portal hostName="BladeBottomSheetPortal">
+          <TouchableOpacity
+            ref={backdropRef}
+            onLayout={onBackdropLayout}
+            style={StyleSheet.absoluteFill}
+            onPress={handleClose}
+            activeOpacity={1}
+            testID="popover-modal-backdrop"
+            {...metaAttribute({ name: MetaConstants.Popover })}
+          >
+            <PopoverContent
+              titleLeading={titleLeading}
+              title={title}
+              footer={footer}
+              isVisible={controllableIsOpen}
+              ref={refs.setFloating}
+              side={computedSide}
+              style={{
+                ...floatingStyles,
+                left: (floatingStyles.left || -200) - backdropOffset.x,
+                top:
+                  (floatingStyles.top || -200) -
+                  backdropOffset.y -
+                  (Platform.OS === 'ios' ? IOS_OFFSET_CORRECTION : 0),
+                zIndex,
+              }}
+              arrow={
+                <PopupArrow
+                  ref={arrowRef as never}
+                  context={context}
+                  width={ARROW_WIDTH}
+                  height={ARROW_HEIGHT}
+                  fillColor={theme.colors.popup.background.subtle}
+                  strokeColor={theme.colors.popup.border.subtle}
+                />
+              }
+            >
+              {content}
+            </PopoverContent>
+          </TouchableOpacity>
+        </Portal>
+      )}
     </PopoverContext.Provider>
   );
 };

--- a/packages/blade/src/components/Popover/Popover.native.tsx
+++ b/packages/blade/src/components/Popover/Popover.native.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 import { arrow, shift, useFloating, flip, offset } from '@floating-ui/react-native';
 import React from 'react';
-import { Modal, TouchableOpacity } from 'react-native';
+import { Modal, TouchableOpacity, Platform } from 'react-native';
 import { PopoverContent } from './PopoverContent';
 import type { PopoverProps } from './types';
 import { ARROW_HEIGHT, ARROW_WIDTH } from './constants';
@@ -129,6 +129,7 @@ const Popover = ({
           side={computedSide}
           style={{
             ...floatingStyles,
+            top: (floatingStyles.top || 0) - (Platform.OS === 'ios' ? 10 : 0),
             // TODO: Tokenize zIndex values
             zIndex,
           }}

--- a/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
+++ b/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
@@ -50,12 +50,14 @@ const PopoverContentWrapper = React.forwardRef<View, PopoverContentWrapperProps>
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isVisible]);
 
-    // @ts-expect-error types aren't liking the dynamic object prop `[transform]`
+    // Avoid computed property keys inside useAnimatedStyle — Babel compiles them to
+    // _defineProperty() which is not a worklet and crashes Reanimated v4 on the UI thread.
     const animatedStyles = useAnimatedStyle(() => {
-      const transform = isHorizontal ? 'translateX' : 'translateY';
       return {
         opacity: opacity.value,
-        transform: [{ [transform]: translate.value }],
+        transform: isHorizontal
+          ? [{ translateX: translate.value }]
+          : [{ translateY: translate.value }],
       };
     }, [isVisible]);
 

--- a/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
+++ b/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
@@ -59,7 +59,7 @@ const PopoverContentWrapper = React.forwardRef<View, PopoverContentWrapperProps>
           ? [{ translateX: translate.value }]
           : [{ translateY: translate.value }],
       };
-    }, [isVisible]);
+    }, [isVisible, isHorizontal]);
 
     return (
       <Animated.View style={animatedStyles}>

--- a/packages/blade/src/components/Popover/__tests__/Popover.native.test.tsx
+++ b/packages/blade/src/components/Popover/__tests__/Popover.native.test.tsx
@@ -13,7 +13,6 @@ import { InfoIcon } from '~components/Icons';
 
 const triggerId = 'popover-interactive-wrapper';
 const modalBackdropId = 'popover-modal-backdrop';
-const popoverModalId = 'popover-modal';
 const popoverInteractiveWrapperId = 'popover-interactive-wrapper';
 
 describe('<Popover />', () => {
@@ -22,12 +21,12 @@ describe('<Popover />', () => {
   it('should render', async () => {
     const popoverContent = 'Hello world';
     const buttonText = 'Click me';
-    const { toJSON, getByRole, getByTestId } = renderWithTheme(
+    const { toJSON, getByRole, getByTestId, queryByTestId } = renderWithTheme(
       <Popover content={<Text>{popoverContent}</Text>}>
         <Button>{buttonText}</Button>
       </Popover>,
     );
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
 
     expect(getByRole('button', { name: buttonText })).toBeTruthy();
     fireEvent(getByRole('button', { name: buttonText }), 'touchEnd');
@@ -35,7 +34,7 @@ describe('<Popover />', () => {
     await act(async () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.quick);
     });
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     expect(toJSON()).toMatchSnapshot();
   });
@@ -64,7 +63,7 @@ describe('<Popover />', () => {
   it('should work with PopoverInteractiveWrapper', () => {
     const triggerText = 'Press me';
     const popoverContent = 'hello world';
-    const { getByTestId } = renderWithTheme(
+    const { getByTestId, queryByTestId } = renderWithTheme(
       <Popover content={<Text>{popoverContent}</Text>}>
         <PopoverInteractiveWrapper testID={popoverInteractiveWrapperId}>
           <Text>{triggerText}</Text>
@@ -73,26 +72,26 @@ describe('<Popover />', () => {
     );
 
     expect(getByTestId(triggerId)).toBeTruthy();
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
 
     fireEvent(getByTestId(triggerId), 'touchEnd');
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
   });
 
   it('should close clicking the close icon', async () => {
     const buttonText = 'Click me';
     const popoverContent = 'hello world';
-    const { getByRole, getByTestId } = renderWithTheme(
+    const { getByRole, getByTestId, queryByTestId } = renderWithTheme(
       <Popover content={<Text>{popoverContent}</Text>}>
         <Button>{buttonText}</Button>
       </Popover>,
     );
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
 
     fireEvent(getByRole('button', { name: buttonText }), 'touchEnd');
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     // close on clicking close icon
     fireEvent.press(getByRole('button', { name: 'Close' }));
@@ -101,22 +100,22 @@ describe('<Popover />', () => {
     await act(async () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.gentle);
     });
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
   });
 
   it('should close on pressing outside of trigger', async () => {
     const buttonText = 'Press me';
     const popoverContent = 'hello world';
-    const { getByRole, getByTestId } = renderWithTheme(
+    const { getByRole, getByTestId, queryByTestId } = renderWithTheme(
       <Popover content={<Text>{popoverContent}</Text>}>
         <Button>{buttonText}</Button>
       </Popover>,
     );
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
 
     fireEvent(getByRole('button', { name: buttonText }), 'touchEnd');
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     // close on clicking backdrop
     fireEvent.press(getByTestId(modalBackdropId));
@@ -125,7 +124,7 @@ describe('<Popover />', () => {
     await act(async () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.gentle);
     });
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
   });
 
   it('should not close when interacting with internal components', async () => {
@@ -140,24 +139,24 @@ describe('<Popover />', () => {
 
     fireEvent(getByRole('button', { name: buttonText }), 'touchEnd');
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     // should not close when interacting with internal components
     fireEvent.press(getByRole('button', { name: internalButtonText }));
 
     expect(clickFn).toHaveBeenCalledTimes(1);
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
   });
 
   it('should work with uncontrolled state', async () => {
     const buttonText = 'Click me';
     const popoverContent = 'hello world';
-    const { getByRole, getByTestId } = renderWithTheme(
+    const { getByRole, getByTestId, queryByTestId } = renderWithTheme(
       <Popover content={<Text>{popoverContent}</Text>} defaultIsOpen>
         <Button>{buttonText}</Button>
       </Popover>,
     );
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     fireEvent(getByRole('button', { name: buttonText }), 'touchEnd');
 
@@ -168,7 +167,7 @@ describe('<Popover />', () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.gentle);
     });
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
   });
 
   it('should work with controlled isOpen', async () => {
@@ -191,10 +190,10 @@ describe('<Popover />', () => {
         </>
       );
     };
-    const { getByTestId, getByRole } = renderWithTheme(<ControlledExample />);
+    const { getByTestId, getByRole, queryByTestId } = renderWithTheme(<ControlledExample />);
 
     // should be opened by default
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     // close
     fireEvent.press(getByRole('button', { name: toggleButtonText }));
@@ -204,12 +203,12 @@ describe('<Popover />', () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.gentle);
     });
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
 
     // open again
     fireEvent.press(getByRole('button', { name: toggleButtonText }));
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     // close again with close icon
     fireEvent.press(getByRole('button', { name: 'Close' }));
@@ -219,7 +218,7 @@ describe('<Popover />', () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.gentle);
     });
 
-    expect(getByTestId(popoverModalId)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
   });
 
   it('should render popover with custom zIndex', () => {

--- a/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.native.test.tsx.snap
+++ b/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.native.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<Popover /> should render 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -175,53 +175,47 @@ exports[`<Popover /> should render 1`] = `
       </View>
     </View>
   </View>
-  <Modal
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
     collapsable={false}
-    hardwareAccelerated={false}
-    testID="popover-modal"
-    transparent={true}
-    visible={true}
+    focusable={true}
+    onClick={[Function]}
+    onLayout={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    testID="popover-modal-backdrop"
   >
-    <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 1,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      testID="popover-modal-backdrop"
-    />
     <View
       style={
         {
@@ -250,10 +244,10 @@ exports[`<Popover /> should render 1`] = `
               "borderStyle": "solid",
               "borderWidth": 0,
               "boxSizing": "border-box",
-              "left": 0,
+              "left": -200,
               "maxWidth": 288,
               "position": "absolute",
-              "top": 0,
+              "top": -210,
               "width": "100%",
               "zIndex": 1100,
             },
@@ -271,9 +265,9 @@ exports[`<Popover /> should render 1`] = `
         }
         styles={
           {
-            "left": 0,
+            "left": -200,
             "position": "absolute",
-            "top": 0,
+            "top": -210,
             "zIndex": 1100,
           }
         }
@@ -574,7 +568,7 @@ exports[`<Popover /> should render 1`] = `
         </View>
       </View>
     </View>
-  </Modal>
+  </View>
 </View>
 `;
 
@@ -606,7 +600,7 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -753,53 +747,47 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
       </View>
     </View>
   </View>
-  <Modal
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
     collapsable={false}
-    hardwareAccelerated={false}
-    testID="popover-modal"
-    transparent={true}
-    visible={true}
+    focusable={true}
+    onClick={[Function]}
+    onLayout={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    testID="popover-modal-backdrop"
   >
-    <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 1,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      testID="popover-modal-backdrop"
-    />
     <View
       style={
         {
@@ -828,10 +816,10 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
               "borderStyle": "solid",
               "borderWidth": 0,
               "boxSizing": "border-box",
-              "left": 0,
+              "left": -200,
               "maxWidth": 288,
               "position": "absolute",
-              "top": 0,
+              "top": -210,
               "width": "100%",
               "zIndex": 9999,
             },
@@ -849,9 +837,9 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
         }
         styles={
           {
-            "left": 0,
+            "left": -200,
             "position": "absolute",
-            "top": 0,
+            "top": -210,
             "zIndex": 9999,
           }
         }
@@ -1152,7 +1140,7 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
         </View>
       </View>
     </View>
-  </Modal>
+  </View>
 </View>
 `;
 
@@ -1184,7 +1172,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1331,53 +1319,47 @@ exports[`<Popover /> should render with title,footer 1`] = `
       </View>
     </View>
   </View>
-  <Modal
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
     collapsable={false}
-    hardwareAccelerated={false}
-    testID="popover-modal"
-    transparent={true}
-    visible={true}
+    focusable={true}
+    onClick={[Function]}
+    onLayout={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    testID="popover-modal-backdrop"
   >
-    <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        {
-          "bottom": 0,
-          "left": 0,
-          "opacity": 1,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        }
-      }
-      testID="popover-modal-backdrop"
-    />
     <View
       style={
         {
@@ -1406,10 +1388,10 @@ exports[`<Popover /> should render with title,footer 1`] = `
               "borderStyle": "solid",
               "borderWidth": 0,
               "boxSizing": "border-box",
-              "left": 0,
+              "left": -200,
               "maxWidth": 288,
               "position": "absolute",
-              "top": 0,
+              "top": -210,
               "width": "100%",
               "zIndex": 1100,
             },
@@ -1427,9 +1409,9 @@ exports[`<Popover /> should render with title,footer 1`] = `
         }
         styles={
           {
-            "left": 0,
+            "left": -200,
             "position": "absolute",
-            "top": 0,
+            "top": -210,
             "zIndex": 1100,
           }
         }
@@ -1913,6 +1895,6 @@ exports[`<Popover /> should render with title,footer 1`] = `
         </View>
       </View>
     </View>
-  </Modal>
+  </View>
 </View>
 `;

--- a/packages/blade/src/components/Popover/useFloatingPortal.native.ts
+++ b/packages/blade/src/components/Popover/useFloatingPortal.native.ts
@@ -1,0 +1,38 @@
+import React from 'react';
+import type { TouchableOpacity } from 'react-native';
+
+type UseFloatingPortalReturn = {
+  backdropRef: React.RefObject<TouchableOpacity>;
+  backdropOffset: { x: number; y: number };
+  onBackdropLayout: () => void;
+};
+
+const useFloatingPortal = (update: () => void, isVisible: boolean): UseFloatingPortalReturn => {
+  const backdropRef = React.useRef<TouchableOpacity>(null);
+  const [backdropOffset, setBackdropOffset] = React.useState({ x: 0, y: 0 });
+
+  const onBackdropLayout = React.useCallback(() => {
+    if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
+      ((backdropRef.current as unknown) as {
+        measureInWindow: (cb: (x: number, y: number, w: number, h: number) => void) => void;
+      }).measureInWindow((bx: number, by: number) => {
+        setBackdropOffset({ x: bx || 0, y: by || 0 });
+      });
+    }
+  }, []);
+
+  // Re-run floating position computation after backdrop offset is measured
+  React.useEffect(() => {
+    if (isVisible && (backdropOffset.x !== 0 || backdropOffset.y !== 0)) {
+      const id = setTimeout(() => {
+        update();
+      }, 50);
+      return () => clearTimeout(id);
+    }
+    return undefined;
+  }, [backdropOffset, isVisible, update]);
+
+  return { backdropRef, backdropOffset, onBackdropLayout };
+};
+
+export { useFloatingPortal };

--- a/packages/blade/src/components/Radio/__tests__/__snapshots__/RadioGroup.native.test.tsx.snap
+++ b/packages/blade/src/components/Radio/__tests__/__snapshots__/RadioGroup.native.test.tsx.snap
@@ -711,12 +711,14 @@ exports[`<RadioGroup /> should render with help text 1`] = `
             data-blade-component="base-box"
             display="flex"
             flexDirection="row"
+            gap="spacing.2"
             style={
               [
                 {
                   "alignItems": "center",
                   "display": "flex",
                   "flexDirection": "row",
+                  "gap": 4,
                 },
               ]
             }

--- a/packages/blade/src/components/Spark/RazorSenseGradient/FluidGradient.native.tsx
+++ b/packages/blade/src/components/Spark/RazorSenseGradient/FluidGradient.native.tsx
@@ -1,13 +1,6 @@
 import { throwBladeError } from '~utils/logger';
+import type { FluidGradientProps } from './FluidGradient';
 import { Text } from '~components/Typography';
-
-// Inline the type to avoid importing the web-only FluidGradient module
-export interface FluidGradientProps {
-  children?: React.ReactNode;
-  size?: number;
-  viewBox?: string;
-  origin?: [number, number];
-}
 
 const FluidGradient = (_props: FluidGradientProps): React.ReactElement => {
   throwBladeError({

--- a/packages/blade/src/components/Spark/RazorSenseGradient/FluidGradient.native.tsx
+++ b/packages/blade/src/components/Spark/RazorSenseGradient/FluidGradient.native.tsx
@@ -1,6 +1,13 @@
 import { throwBladeError } from '~utils/logger';
-import type { FluidGradientProps } from './FluidGradient';
 import { Text } from '~components/Typography';
+
+// Inline the type to avoid importing the web-only FluidGradient module
+export interface FluidGradientProps {
+  children?: React.ReactNode;
+  size?: number;
+  viewBox?: string;
+  origin?: [number, number];
+}
 
 const FluidGradient = (_props: FluidGradientProps): React.ReactElement => {
   throwBladeError({

--- a/packages/blade/src/components/Spark/RazorSenseGradient/FluidGradient.native.tsx
+++ b/packages/blade/src/components/Spark/RazorSenseGradient/FluidGradient.native.tsx
@@ -1,0 +1,21 @@
+import { throwBladeError } from '~utils/logger';
+import { Text } from '~components/Typography';
+
+// Inline the type to avoid importing the web-only FluidGradient module
+export interface FluidGradientProps {
+  children?: React.ReactNode;
+  size?: number;
+  viewBox?: string;
+  origin?: [number, number];
+}
+
+const FluidGradient = (_props: FluidGradientProps): React.ReactElement => {
+  throwBladeError({
+    message: 'RazorSenseGradient is not yet implemented for React Native',
+    moduleName: 'RazorSenseGradient',
+  });
+
+  return <Text>RazorSenseGradient Component is not available for Native mobile apps.</Text>;
+};
+
+export { FluidGradient };

--- a/packages/blade/src/components/Spark/RzpGlass/RzpGlass.native.tsx
+++ b/packages/blade/src/components/Spark/RzpGlass/RzpGlass.native.tsx
@@ -1,5 +1,5 @@
-import { throwBladeError } from '~utils/logger';
 import type { RzpGlassProps } from './types';
+import { throwBladeError } from '~utils/logger';
 import { Text } from '~components/Typography';
 
 const RzpGlass = (_props: RzpGlassProps): React.ReactElement => {

--- a/packages/blade/src/components/Spark/RzpGlass/RzpGlass.native.tsx
+++ b/packages/blade/src/components/Spark/RzpGlass/RzpGlass.native.tsx
@@ -1,0 +1,14 @@
+import { throwBladeError } from '~utils/logger';
+import type { RzpGlassProps } from './types';
+import { Text } from '~components/Typography';
+
+const RzpGlass = (_props: RzpGlassProps): React.ReactElement => {
+  throwBladeError({
+    message: 'RazorSense is not yet implemented for React Native',
+    moduleName: 'RazorSense',
+  });
+
+  return <Text>RazorSense Component is not available for Native mobile apps.</Text>;
+};
+
+export { RzpGlass };

--- a/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
+++ b/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
@@ -9,12 +9,14 @@ async function preloadRazorSenseAssets(
   // no-op on native
 }
 
-// no-op stubs for web-only utilities — not available on native
-async function loadImage(_src: string): Promise<HTMLImageElement> {
+// no-op stubs for web-only utilities — not available on native.
+// Return Promise<never> since these always reject and HTMLImageElement/HTMLVideoElement
+// are DOM types that don't exist in React Native's type environment.
+async function loadImage(_src: string): Promise<never> {
   return Promise.reject(new Error('loadImage is not supported on native'));
 }
 
-async function loadVideo(_src: string): Promise<HTMLVideoElement> {
+async function loadVideo(_src: string): Promise<never> {
   return Promise.reject(new Error('loadVideo is not supported on native'));
 }
 

--- a/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
+++ b/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
@@ -9,46 +9,4 @@ async function preloadRazorSenseAssets(
   // no-op on native
 }
 
-// no-op stubs for web-only utilities — not available on native
-async function loadImage(_src: string): Promise<HTMLImageElement> {
-  return Promise.reject(new Error('loadImage is not supported on native'));
-}
-
-async function loadVideo(_src: string): Promise<HTMLVideoElement> {
-  return Promise.reject(new Error('loadVideo is not supported on native'));
-}
-
-function isSafari(): boolean {
-  return false;
-}
-
-function bestGuessBrowserZoom(): number {
-  return 1;
-}
-
-function getDefaultAssets(_assetsPath: string): Record<string, string> {
-  return {};
-}
-
-function getPresetAssets(_preset: string | undefined, _assetsPath: string): Record<string, string> {
-  return {};
-}
-
-function resolveConfig(
-  _props: Record<string, unknown>,
-  _assetsPath: string,
-): Record<string, unknown> {
-  return {};
-}
-
-export {
-  DEFAULT_CDN_PATH,
-  preloadRazorSenseAssets,
-  loadImage,
-  loadVideo,
-  isSafari,
-  bestGuessBrowserZoom,
-  getDefaultAssets,
-  getPresetAssets,
-  resolveConfig,
-};
+export { DEFAULT_CDN_PATH, preloadRazorSenseAssets };

--- a/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
+++ b/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
@@ -9,4 +9,46 @@ async function preloadRazorSenseAssets(
   // no-op on native
 }
 
-export { DEFAULT_CDN_PATH, preloadRazorSenseAssets };
+// no-op stubs for web-only utilities — not available on native
+async function loadImage(_src: string): Promise<HTMLImageElement> {
+  return Promise.reject(new Error('loadImage is not supported on native'));
+}
+
+async function loadVideo(_src: string): Promise<HTMLVideoElement> {
+  return Promise.reject(new Error('loadVideo is not supported on native'));
+}
+
+function isSafari(): boolean {
+  return false;
+}
+
+function bestGuessBrowserZoom(): number {
+  return 1;
+}
+
+function getDefaultAssets(_assetsPath: string): Record<string, string> {
+  return {};
+}
+
+function getPresetAssets(_preset: string | undefined, _assetsPath: string): Record<string, string> {
+  return {};
+}
+
+function resolveConfig(
+  _props: Record<string, unknown>,
+  _assetsPath: string,
+): Record<string, unknown> {
+  return {};
+}
+
+export {
+  DEFAULT_CDN_PATH,
+  preloadRazorSenseAssets,
+  loadImage,
+  loadVideo,
+  isSafari,
+  bestGuessBrowserZoom,
+  getDefaultAssets,
+  getPresetAssets,
+  resolveConfig,
+};

--- a/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
+++ b/packages/blade/src/components/Spark/RzpGlass/utils.native.ts
@@ -1,0 +1,54 @@
+import type { RzpGlassPreset } from './presets';
+
+const DEFAULT_CDN_PATH = 'https://cdn.jsdelivr.net/npm/@razorpay/blade@latest/assets/spark';
+
+async function preloadRazorSenseAssets(
+  _preset: RzpGlassPreset = 'default',
+  _assetsPath: string = DEFAULT_CDN_PATH,
+): Promise<void> {
+  // no-op on native
+}
+
+// no-op stubs for web-only utilities — not available on native
+async function loadImage(_src: string): Promise<HTMLImageElement> {
+  return Promise.reject(new Error('loadImage is not supported on native'));
+}
+
+async function loadVideo(_src: string): Promise<HTMLVideoElement> {
+  return Promise.reject(new Error('loadVideo is not supported on native'));
+}
+
+function isSafari(): boolean {
+  return false;
+}
+
+function bestGuessBrowserZoom(): number {
+  return 1;
+}
+
+function getDefaultAssets(_assetsPath: string): Record<string, string> {
+  return {};
+}
+
+function getPresetAssets(_preset: string | undefined, _assetsPath: string): Record<string, string> {
+  return {};
+}
+
+function resolveConfig(
+  _props: Record<string, unknown>,
+  _assetsPath: string,
+): Record<string, unknown> {
+  return {};
+}
+
+export {
+  DEFAULT_CDN_PATH,
+  preloadRazorSenseAssets,
+  loadImage,
+  loadVideo,
+  isSafari,
+  bestGuessBrowserZoom,
+  getDefaultAssets,
+  getPresetAssets,
+  resolveConfig,
+};

--- a/packages/blade/src/components/Switch/AnimatedThumb.native.tsx
+++ b/packages/blade/src/components/Switch/AnimatedThumb.native.tsx
@@ -8,32 +8,36 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
-import { switchColors, switchMotion, switchSizes } from './switchTokens';
-import type { AnimatedThumbProps } from './types';
 import isNumber from '~utils/lodashButBetter/isNumber';
 import getIn from '~utils/lodashButBetter/get';
 import { useBreakpoint } from '~utils';
-import { useTheme } from '~components/BladeProvider';
 import { makeBorderSize } from '~utils/makeBorderSize';
+import type { AnimatedThumbProps } from './types';
+import { switchColors, switchMotion, switchSizes } from './switchTokens';
+import { useTheme } from '~components/BladeProvider';
 
-const StyledAnimatedThumb = styled(Animated.View)<{ isDisabled?: boolean }>(
-  ({ theme, isDisabled }) => {
-    const variant = isDisabled ? 'disabled' : 'default';
-    const backgroundColor = getIn(theme, switchColors.thumb[variant].background);
+const StyledAnimatedThumb = styled(Animated.View)<{
+  isDisabled?: boolean;
+  _thumbWidth?: number;
+  _thumbHeight?: number;
+}>(({ theme, isDisabled, _thumbWidth, _thumbHeight }) => {
+  const variant = isDisabled ? 'disabled' : 'default';
+  const backgroundColor = getIn(theme, switchColors.thumb[variant].background);
 
-    return {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexShrink: 0,
-      width: '100%',
-      height: '100%',
-      borderRadius: makeBorderSize(theme.border.radius.max),
-      backgroundColor,
-      position: 'absolute',
-    };
-  },
-);
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    // Explicit dimensions prevent '100%' from resolving to the track size (not Thumb)
+    // which would produce an oval. Falls back to '100%' before device type is resolved.
+    width: _thumbWidth || ('100%' as never),
+    height: _thumbHeight || ('100%' as never),
+    borderRadius: makeBorderSize(theme.border.radius.max),
+    backgroundColor,
+    position: 'absolute',
+  };
+});
 
 const AnimatedThumb = ({
   isChecked,
@@ -50,8 +54,14 @@ const AnimatedThumb = ({
 
   const easing = getIn(theme, switchMotion.easing.thumb);
   const duration = getIn(theme, switchMotion.duration.thumb);
-  const thumbWidth = switchSizes.thumb[matchedDeviceType][size].width;
-  const finalWidth = isNumber(thumbWidth) ? thumbWidth : getIn(theme, thumbWidth);
+  const thumbWidthToken = switchSizes.thumb[matchedDeviceType][size].width;
+  const thumbHeightToken = switchSizes.thumb[matchedDeviceType][size].height;
+  const finalWidth = isNumber(thumbWidthToken)
+    ? thumbWidthToken
+    : (getIn(theme, thumbWidthToken) as number);
+  const finalHeight = isNumber(thumbHeightToken)
+    ? thumbHeightToken
+    : (getIn(theme, thumbHeightToken) as number);
 
   React.useEffect(() => {
     sharedLeft.value = withTiming(isChecked ? 1 : 0, {
@@ -71,6 +81,8 @@ const AnimatedThumb = ({
     sharedShouldShiftOffset.value = Boolean(isChecked && isPressed);
   }, [isChecked, isPressed]);
 
+  // finalWidth must be in deps: useBreakpoint initialises with 'desktop' then updates to 'mobile'
+  // after mount, so the worklet would otherwise capture a stale desktop finalWidth value.
   const thumbAnimation = useAnimatedStyle(() => {
     return {
       width: interpolate(
@@ -91,10 +103,15 @@ const AnimatedThumb = ({
         },
       ],
     };
-  }, []);
+  }, [finalWidth]);
 
   return (
-    <StyledAnimatedThumb style={thumbAnimation} isDisabled={isDisabled}>
+    <StyledAnimatedThumb
+      style={thumbAnimation}
+      isDisabled={isDisabled}
+      _thumbWidth={finalWidth}
+      _thumbHeight={finalHeight}
+    >
       {children}
     </StyledAnimatedThumb>
   );

--- a/packages/blade/src/components/Switch/AnimatedThumb.native.tsx
+++ b/packages/blade/src/components/Switch/AnimatedThumb.native.tsx
@@ -8,12 +8,12 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import type { AnimatedThumbProps } from './types';
+import { switchColors, switchMotion, switchSizes } from './switchTokens';
 import isNumber from '~utils/lodashButBetter/isNumber';
 import getIn from '~utils/lodashButBetter/get';
 import { useBreakpoint } from '~utils';
 import { makeBorderSize } from '~utils/makeBorderSize';
-import type { AnimatedThumbProps } from './types';
-import { switchColors, switchMotion, switchSizes } from './switchTokens';
 import { useTheme } from '~components/BladeProvider';
 
 const StyledAnimatedThumb = styled(Animated.View)<{

--- a/packages/blade/src/components/Switch/__tests__/__snapshots__/Switch.native.test.tsx.snap
+++ b/packages/blade/src/components/Switch/__tests__/__snapshots__/Switch.native.test.tsx.snap
@@ -123,6 +123,8 @@ exports[`<Switch /> should render switch with label 1`] = `
           }
         >
           <View
+            _thumbHeight={20}
+            _thumbWidth={20}
             style={
               [
                 {
@@ -131,10 +133,10 @@ exports[`<Switch /> should render switch with label 1`] = `
                   "borderRadius": 9999,
                   "display": "flex",
                   "flexShrink": 0,
-                  "height": "100%",
+                  "height": 20,
                   "justifyContent": "center",
                   "position": "absolute",
-                  "width": "100%",
+                  "width": 20,
                 },
                 {
                   "left": 0,
@@ -347,6 +349,8 @@ exports[`<Switch /> should set disabled state with isDisabled 1`] = `
           }
         >
           <View
+            _thumbHeight={20}
+            _thumbWidth={20}
             isDisabled={true}
             style={
               [
@@ -356,10 +360,10 @@ exports[`<Switch /> should set disabled state with isDisabled 1`] = `
                   "borderRadius": 9999,
                   "display": "flex",
                   "flexShrink": 0,
-                  "height": "100%",
+                  "height": 20,
                   "justifyContent": "center",
                   "position": "absolute",
-                  "width": "100%",
+                  "width": 20,
                 },
                 {
                   "left": 0,

--- a/packages/blade/src/components/TimePicker/SpinWheel.native.tsx
+++ b/packages/blade/src/components/TimePicker/SpinWheel.native.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+const SpinWheel = (_props: Record<string, unknown>): React.ReactElement => (
+  <Text>SpinWheel is not available on native</Text>
+);
+
+export { SpinWheel };

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -54,11 +54,11 @@ const Tooltip = ({
   // between measureInWindow (used by floating-ui) and the Portal container's coordinate space
   const onBackdropLayout = React.useCallback(() => {
     if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
-      ((backdropRef.current as unknown) as { measureInWindow: Function }).measureInWindow(
-        (bx: number, by: number) => {
-          setBackdropOffset({ x: bx || 0, y: by || 0 });
-        },
-      );
+      ((backdropRef.current as unknown) as {
+        measureInWindow: (x: number, y: number, w: number, h: number) => void;
+      }).measureInWindow((bx: number, by: number) => {
+        setBackdropOffset({ x: bx || 0, y: by || 0 });
+      });
     }
   }, []);
 

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 import { arrow, shift, useFloating, flip, offset } from '@floating-ui/react-native';
 import React from 'react';
-import { Modal, TouchableOpacity } from 'react-native';
+import { TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { Portal } from '@gorhom/portal';
 import { TooltipContent } from './TooltipContent';
 import type { TooltipProps } from './types';
 import { ARROW_HEIGHT, ARROW_WIDTH } from './constants';
@@ -12,6 +13,8 @@ import { mergeProps } from '~utils/mergeProps';
 import { PopupArrow } from '~components/PopupArrow';
 import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { componentZIndices } from '~utils/componentZIndices';
+
+const IOS_OFFSET_CORRECTION = 10;
 
 const Tooltip = ({
   title,
@@ -28,6 +31,9 @@ const Tooltip = ({
   const [side] = getFloatingPlacementParts(placement);
   const isHorizontal = side === 'left' || side === 'right';
   const arrowRef = React.useRef();
+  const backdropRef = React.useRef<TouchableOpacity>(null);
+  const [backdropOffset, setBackdropOffset] = React.useState({ x: 0, y: 0 });
+
   const context = useFloating({
     sameScrollView: false,
     placement,
@@ -42,7 +48,19 @@ const Tooltip = ({
     ],
   });
 
-  const { refs, floatingStyles } = context;
+  const { refs, floatingStyles, update } = context;
+
+  // Measure the Portal backdrop's window position to correct coordinate mismatch
+  // between measureInWindow (used by floating-ui) and the Portal container's coordinate space
+  const onBackdropLayout = React.useCallback(() => {
+    if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
+      ((backdropRef.current as unknown) as { measureInWindow: Function }).measureInWindow(
+        (bx: number, by: number) => {
+          setBackdropOffset({ x: bx || 0, y: by || 0 });
+        },
+      );
+    }
+  }, []);
 
   const handleOpen = React.useCallback(() => {
     setIsOpen(true);
@@ -54,7 +72,7 @@ const Tooltip = ({
     onOpenChange?.({ isOpen: false });
   }, [onOpenChange]);
 
-  // wait for animation to finish before unmounting modal
+  // wait for animation to finish before unmounting
   const [isVisible, setIsVisible] = React.useState(() => isOpen);
   React.useEffect(() => {
     const id = setTimeout(() => {
@@ -69,6 +87,16 @@ const Tooltip = ({
     return () => clearTimeout(id);
   }, [isOpen]);
 
+  // Re-run floating position computation after backdrop offset is measured
+  React.useEffect(() => {
+    if (isVisible && (backdropOffset.x !== 0 || backdropOffset.y !== 0)) {
+      const id = setTimeout(() => {
+        update();
+      }, 50);
+      return () => clearTimeout(id);
+    }
+  }, [backdropOffset, isVisible, update]);
+
   return (
     <TooltipContext.Provider value={true}>
       {/* Cloning the trigger children to enhance it with ref and event handler */}
@@ -81,48 +109,50 @@ const Tooltip = ({
         ),
         ref: refs.setReference,
       })}
-      <Modal accessibilityLabel={content} collapsable={false} transparent visible={isVisible}>
-        <TouchableOpacity
-          style={{
-            flexShrink: 0,
-            flex: 1,
-          }}
-          onPress={handleClose}
-          activeOpacity={1}
-          testID="tooltip-modal-backdrop"
-          {...metaAttribute({ name: MetaConstants.Tooltip })}
-        >
-          <TooltipContent
-            title={title}
-            isVisible={isOpen}
-            ref={refs.setFloating}
-            side={side}
-            colorScheme={colorScheme}
-            style={{
-              ...floatingStyles,
-              // To avoid flash of floating ui content at top, this only happens in RN <70
-              // if the position is zero move the floating element outside of the viewport
-              // this happens because measure is async and it takes few miliseconds to calculate the positions.
-              left: floatingStyles.left || -200,
-              top: floatingStyles.top || -200,
-              // TODO: Tokenize zIndex values
-              zIndex,
-            }}
-            arrow={
-              <PopupArrow
-                ref={arrowRef as never}
-                context={context}
-                width={ARROW_WIDTH}
-                height={ARROW_HEIGHT}
-                fillColor={theme.colors.popup.background.gray.intense}
-                strokeColor={theme.colors.popup.border.gray.intense}
-              />
-            }
+      {isVisible && (
+        <Portal hostName="BladeBottomSheetPortal">
+          <TouchableOpacity
+            ref={backdropRef}
+            onLayout={onBackdropLayout}
+            style={StyleSheet.absoluteFill}
+            onPress={handleClose}
+            activeOpacity={1}
+            testID="tooltip-modal-backdrop"
+            {...metaAttribute({ name: MetaConstants.Tooltip })}
           >
-            {content}
-          </TooltipContent>
-        </TouchableOpacity>
-      </Modal>
+            <TooltipContent
+              title={title}
+              isVisible={isOpen}
+              ref={refs.setFloating}
+              side={side}
+              colorScheme={colorScheme}
+              style={{
+                ...floatingStyles,
+                // if the position is zero move the floating element outside of the viewport
+                // this happens because measure is async and it takes a few milliseconds to calculate positions
+                left: (floatingStyles.left || -200) - backdropOffset.x,
+                top:
+                  (floatingStyles.top || -200) -
+                  backdropOffset.y -
+                  (Platform.OS === 'ios' ? IOS_OFFSET_CORRECTION : 0),
+                zIndex,
+              }}
+              arrow={
+                <PopupArrow
+                  ref={arrowRef as never}
+                  context={context}
+                  width={ARROW_WIDTH}
+                  height={ARROW_HEIGHT}
+                  fillColor={theme.colors.popup.background.gray.intense}
+                  strokeColor={theme.colors.popup.border.gray.intense}
+                />
+              }
+            >
+              {content}
+            </TooltipContent>
+          </TouchableOpacity>
+        </Portal>
+      )}
     </TooltipContext.Provider>
   );
 };

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -7,14 +7,16 @@ import { TooltipContent } from './TooltipContent';
 import type { TooltipProps } from './types';
 import { ARROW_HEIGHT, ARROW_WIDTH } from './constants';
 import { TooltipContext } from './TooltipContext';
-import { useTheme } from '~components/BladeProvider';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
-import { mergeProps } from '~utils/mergeProps';
-import { PopupArrow } from '~components/PopupArrow';
 import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
+import { mergeProps } from '~utils/mergeProps';
 import { componentZIndices } from '~utils/componentZIndices';
+import { useTheme } from '~components/BladeProvider';
+import { PopupArrow } from '~components/PopupArrow';
 import { useFloatingPortal } from '~components/Popover/useFloatingPortal.native';
 
+// Portal container rendered by @gorhom/portal has a 10px top offset on iOS relative
+// to the window coordinate system that measureInWindow doesn't account for.
 const IOS_OFFSET_CORRECTION = 10;
 
 const Tooltip = ({

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -55,7 +55,7 @@ const Tooltip = ({
   const onBackdropLayout = React.useCallback(() => {
     if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
       ((backdropRef.current as unknown) as {
-        measureInWindow: (x: number, y: number, w: number, h: number) => void;
+        measureInWindow: (cb: (x: number, y: number, w: number, h: number) => void) => void;
       }).measureInWindow((bx: number, by: number) => {
         setBackdropOffset({ x: bx || 0, y: by || 0 });
       });

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -13,6 +13,7 @@ import { mergeProps } from '~utils/mergeProps';
 import { PopupArrow } from '~components/PopupArrow';
 import { getFloatingPlacementParts } from '~utils/getFloatingPlacementParts';
 import { componentZIndices } from '~utils/componentZIndices';
+import { useFloatingPortal } from '~components/Popover/useFloatingPortal.native';
 
 const IOS_OFFSET_CORRECTION = 10;
 
@@ -31,8 +32,6 @@ const Tooltip = ({
   const [side] = getFloatingPlacementParts(placement);
   const isHorizontal = side === 'left' || side === 'right';
   const arrowRef = React.useRef();
-  const backdropRef = React.useRef<TouchableOpacity>(null);
-  const [backdropOffset, setBackdropOffset] = React.useState({ x: 0, y: 0 });
 
   const context = useFloating({
     sameScrollView: false,
@@ -50,17 +49,8 @@ const Tooltip = ({
 
   const { refs, floatingStyles, update } = context;
 
-  // Measure the Portal backdrop's window position to correct coordinate mismatch
-  // between measureInWindow (used by floating-ui) and the Portal container's coordinate space
-  const onBackdropLayout = React.useCallback(() => {
-    if (backdropRef.current && 'measureInWindow' in backdropRef.current) {
-      ((backdropRef.current as unknown) as {
-        measureInWindow: (cb: (x: number, y: number, w: number, h: number) => void) => void;
-      }).measureInWindow((bx: number, by: number) => {
-        setBackdropOffset({ x: bx || 0, y: by || 0 });
-      });
-    }
-  }, []);
+  const [isVisible, setIsVisible] = React.useState(() => isOpen);
+  const { backdropRef, backdropOffset, onBackdropLayout } = useFloatingPortal(update, isVisible);
 
   const handleOpen = React.useCallback(() => {
     setIsOpen(true);
@@ -73,7 +63,6 @@ const Tooltip = ({
   }, [onOpenChange]);
 
   // wait for animation to finish before unmounting
-  const [isVisible, setIsVisible] = React.useState(() => isOpen);
   React.useEffect(() => {
     const id = setTimeout(() => {
       if (!isOpen) {
@@ -86,17 +75,6 @@ const Tooltip = ({
     }
     return () => clearTimeout(id);
   }, [isOpen]);
-
-  // Re-run floating position computation after backdrop offset is measured
-  React.useEffect(() => {
-    if (isVisible && (backdropOffset.x !== 0 || backdropOffset.y !== 0)) {
-      const id = setTimeout(() => {
-        update();
-      }, 50);
-      return () => clearTimeout(id);
-    }
-    return undefined;
-  }, [backdropOffset, isVisible, update]);
 
   return (
     <TooltipContext.Provider value={true}>

--- a/packages/blade/src/components/Tooltip/Tooltip.native.tsx
+++ b/packages/blade/src/components/Tooltip/Tooltip.native.tsx
@@ -95,6 +95,7 @@ const Tooltip = ({
       }, 50);
       return () => clearTimeout(id);
     }
+    return undefined;
   }, [backdropOffset, isVisible, update]);
 
   return (

--- a/packages/blade/src/components/Tooltip/TooltipContentWrapper.native.tsx
+++ b/packages/blade/src/components/Tooltip/TooltipContentWrapper.native.tsx
@@ -48,12 +48,14 @@ const TooltipContentWrapper = React.forwardRef<View, TooltipContentWrapperProps>
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isVisible]);
 
-    // @ts-expect-error types aren't liking the dynamic object prop `[transform]`
+    // Avoid computed property keys inside useAnimatedStyle — Babel compiles them to
+    // _defineProperty() which is not a worklet and crashes Reanimated v4 on the UI thread.
     const animatedStyles = useAnimatedStyle(() => {
-      const transform = isHorizontal ? 'translateX' : 'translateY';
       return {
         opacity: opacity.value,
-        transform: [{ [transform]: translate.value }],
+        transform: isHorizontal
+          ? [{ translateX: translate.value }]
+          : [{ translateY: translate.value }],
       };
     }, [isVisible]);
 

--- a/packages/blade/src/components/Tooltip/__tests__/Tooltip.native.test.tsx
+++ b/packages/blade/src/components/Tooltip/__tests__/Tooltip.native.test.tsx
@@ -18,7 +18,7 @@ describe('<Tooltip />', () => {
   it('should render', () => {
     const tooltipContent = 'Hello world';
     const buttonText = 'Hover me';
-    const { toJSON, getByRole, getByLabelText } = renderWithTheme(
+    const { toJSON, getByRole, getByTestId } = renderWithTheme(
       <Tooltip content={tooltipContent}>
         <Button>{buttonText}</Button>
       </Tooltip>,
@@ -27,7 +27,7 @@ describe('<Tooltip />', () => {
     expect(getByRole('button')).toBeTruthy();
     fireEvent(getByRole('button'), 'touchEnd');
 
-    expect(getByLabelText(tooltipContent)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     expect(toJSON()).toMatchSnapshot();
   });
@@ -35,7 +35,7 @@ describe('<Tooltip />', () => {
   it('should render with title', () => {
     const tooltipContent = 'Hello world';
     const buttonText = 'Hover me';
-    const { toJSON, getByRole, getByLabelText } = renderWithTheme(
+    const { toJSON, getByRole, getByTestId } = renderWithTheme(
       <Tooltip title="Tooltip title" content={tooltipContent}>
         <Button>{buttonText}</Button>
       </Tooltip>,
@@ -44,7 +44,7 @@ describe('<Tooltip />', () => {
     expect(getByRole('button')).toBeTruthy();
     fireEvent(getByRole('button'), 'touchEnd');
 
-    expect(getByLabelText(tooltipContent)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     expect(toJSON()).toMatchSnapshot();
   });
@@ -52,7 +52,7 @@ describe('<Tooltip />', () => {
   it('should open on pressing trigger', () => {
     const triggerText = 'Press me';
     const tooltipContent = 'hello world';
-    const { getByTestId, getByLabelText } = renderWithTheme(
+    const { getByTestId, queryByTestId } = renderWithTheme(
       <Tooltip content={tooltipContent}>
         <TooltipInteractiveWrapper>
           <Text>{triggerText}</Text>
@@ -61,17 +61,17 @@ describe('<Tooltip />', () => {
     );
 
     expect(getByTestId(triggerId)).toBeTruthy();
-    expect(getByLabelText(tooltipContent)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
 
     fireEvent(getByTestId(triggerId), 'touchEnd');
 
-    expect(getByLabelText(tooltipContent)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
   });
 
   it('should close on pressing outside of trigger', async () => {
     const triggerText = 'Press me';
     const tooltipContent = 'hello world';
-    const { getByTestId, getByLabelText } = renderWithTheme(
+    const { getByTestId, queryByTestId } = renderWithTheme(
       <Tooltip content={tooltipContent}>
         <TooltipInteractiveWrapper>
           <Text>{triggerText}</Text>
@@ -81,7 +81,7 @@ describe('<Tooltip />', () => {
 
     expect(getByTestId(triggerId)).toBeTruthy();
     fireEvent(getByTestId(triggerId), 'touchEnd');
-    expect(getByLabelText(tooltipContent)).toHaveProp('visible', true);
+    expect(getByTestId(modalBackdropId)).toBeTruthy();
 
     // close on clicking backdrop
     fireEvent.press(getByTestId(modalBackdropId));
@@ -90,7 +90,7 @@ describe('<Tooltip />', () => {
     await act(async () => {
       jest.advanceTimersByTime(bladeTheme.motion.duration.gentle);
     });
-    expect(getByLabelText(tooltipContent)).toHaveProp('visible', false);
+    expect(queryByTestId(modalBackdropId)).toBeNull();
   });
 
   it('should render tooltip with custom zIndex', () => {

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.native.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.native.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<Tooltip /> should render 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -175,244 +175,240 @@ exports[`<Tooltip /> should render 1`] = `
       </View>
     </View>
   </View>
-  <Modal
-    accessibilityLabel="Hello world"
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
     collapsable={false}
-    hardwareAccelerated={false}
-    transparent={true}
-    visible={true}
+    focusable={true}
+    onClick={[Function]}
+    onLayout={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    testID="tooltip-modal-backdrop"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         {
-          "flex": 1,
-          "flexShrink": 0,
-          "opacity": 1,
+          "opacity": 0,
+          "transform": [
+            {
+              "translateX": 4,
+            },
+          ],
         }
       }
-      testID="tooltip-modal-backdrop"
     >
       <View
+        collapse={false}
+        colorScheme="light"
+        data-blade-component="base-box"
+        display="flex"
+        elevation={20}
+        flexDirection="column"
+        gap="spacing.2"
+        maxWidth="200px"
+        position="absolute"
         style={
-          {
-            "opacity": 0,
-            "transform": [
-              {
-                "translateX": 4,
+          [
+            {
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": 4,
+              "maxWidth": 200,
+              "paddingBottom": 12,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 12,
+              "position": "absolute",
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 0%, 0.72)",
+              "borderRadius": 12,
+              "left": -200,
+              "position": "absolute",
+              "top": -210,
+              "zIndex": 1100,
+            },
+            {
+              "elevation": 8,
+              "shadowColor": "hsla(200, 10%, 18%, 1)",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
               },
-            ],
+              "shadowOpacity": 0.06,
+              "shadowRadius": 2,
+            },
+          ]
+        }
+        styles={
+          {
+            "left": -200,
+            "position": "absolute",
+            "top": -210,
+            "zIndex": 1100,
           }
         }
       >
-        <View
-          collapse={false}
-          colorScheme="light"
-          data-blade-component="base-box"
-          display="flex"
-          elevation={20}
-          flexDirection="column"
-          gap="spacing.2"
-          maxWidth="200px"
-          position="absolute"
+        <Text
+          accessible={true}
+          color="surface.text.staticWhite.subtle"
+          data-blade-component="text"
+          fontFamily="text"
+          fontSize={75}
+          fontStyle="normal"
+          fontWeight="regular"
+          lineHeight={75}
           style={
             [
               {
-                "display": "flex",
-                "flexDirection": "column",
-                "gap": 4,
-                "maxWidth": 200,
-                "paddingBottom": 12,
-                "paddingLeft": 12,
-                "paddingRight": 12,
-                "paddingTop": 12,
-                "position": "absolute",
-              },
-              {
-                "backgroundColor": "hsla(0, 0%, 0%, 0.72)",
-                "borderRadius": 12,
-                "left": -200,
-                "position": "absolute",
-                "top": -200,
-                "zIndex": 1100,
-              },
-              {
-                "elevation": 8,
-                "shadowColor": "hsla(200, 10%, 18%, 1)",
-                "shadowOffset": {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 0.06,
-                "shadowRadius": 2,
+                "color": "hsla(0, 0%, 100%, 0.88)",
+                "fontFamily": "Inter",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 17,
+                "marginBottom": 0,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "marginTop": 0,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "textDecorationLine": "none",
               },
             ]
           }
-          styles={
+        >
+          Hello world
+        </Text>
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
             {
-              "left": -200,
+              "bottom": 0,
+              "left": 0,
               "position": "absolute",
-              "top": -200,
-              "zIndex": 1100,
+              "right": 0,
+              "top": 0,
             }
           }
         >
-          <Text
-            accessible={true}
-            color="surface.text.staticWhite.subtle"
-            data-blade-component="text"
-            fontFamily="text"
-            fontSize={75}
-            fontStyle="normal"
-            fontWeight="regular"
-            lineHeight={75}
+          <RNSVGSvgView
+            accessibilityElementsHidden={true}
+            align="xMidYMid"
+            bbHeight="14px"
+            bbWidth="14px"
+            data-blade-component="icon"
+            focusable={false}
+            height="14px"
+            importantForAccessibility="no-hide-descendants"
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
             style={
               [
                 {
-                  "color": "hsla(0, 0%, 100%, 0.88)",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontStyle": "normal",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 17,
-                  "marginBottom": 0,
-                  "marginLeft": 0,
-                  "marginRight": 0,
-                  "marginTop": 0,
-                  "paddingBottom": 0,
-                  "paddingLeft": 0,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                  "textDecorationLine": "none",
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                [
+                  {},
+                  {},
+                ],
+                {
+                  "flex": 0,
+                  "height": 14,
+                  "width": 14,
                 },
               ]
             }
+            styles={{}}
+            vbHeight={14}
+            vbWidth={14}
+            width="14px"
           >
-            Hello world
-          </Text>
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
               }
-            }
-          >
-            <RNSVGSvgView
-              accessibilityElementsHidden={true}
-              align="xMidYMid"
-              bbHeight="14px"
-              bbWidth="14px"
-              data-blade-component="icon"
-              focusable={false}
-              height="14px"
-              importantForAccessibility="no-hide-descendants"
-              meetOrSlice={0}
-              minX={0}
-              minY={0}
-              style={
-                [
-                  {
-                    "backgroundColor": "transparent",
-                    "borderWidth": 0,
-                  },
-                  [
-                    {},
-                    {},
-                  ],
-                  {
-                    "flex": 0,
-                    "height": 14,
-                    "width": 14,
-                  },
-                ]
-              }
-              styles={{}}
-              vbHeight={14}
-              vbWidth={14}
-              width="14px"
             >
-              <RNSVGGroup
-                fill={
+              <RNSVGPath
+                d="M0,0 H14 L7,8 Q7,8 7,8 Z"
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                stroke={
                   {
-                    "payload": 4278190080,
+                    "payload": 4281810499,
                     "type": 0,
                   }
                 }
-              >
-                <RNSVGPath
-                  d="M0,0 H14 L7,8 Q7,8 7,8 Z"
-                  fill={null}
-                  propList={
-                    [
-                      "fill",
-                      "stroke",
-                      "strokeWidth",
-                    ]
+                strokeWidth="2px"
+              />
+              <RNSVGPath
+                d="M0,0 H14 L7,8 Q7,8 7,8 Z"
+                fill={
+                  {
+                    "payload": 3087007744,
+                    "type": 0,
                   }
-                  stroke={
-                    {
-                      "payload": 4281810499,
-                      "type": 0,
-                    }
-                  }
-                  strokeWidth="2px"
-                />
-                <RNSVGPath
-                  d="M0,0 H14 L7,8 Q7,8 7,8 Z"
-                  fill={
-                    {
-                      "payload": 3087007744,
-                      "type": 0,
-                    }
-                  }
-                  propList={
-                    [
-                      "fill",
-                      "stroke",
-                    ]
-                  }
-                  stroke={null}
-                />
-              </RNSVGGroup>
-            </RNSVGSvgView>
-          </View>
+                }
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                  ]
+                }
+                stroke={null}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
         </View>
       </View>
     </View>
-  </Modal>
+  </View>
 </View>
 `;
 
@@ -444,7 +440,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -591,244 +587,240 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
       </View>
     </View>
   </View>
-  <Modal
-    accessibilityLabel="Hello world"
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
     collapsable={false}
-    hardwareAccelerated={false}
-    transparent={true}
-    visible={true}
+    focusable={true}
+    onClick={[Function]}
+    onLayout={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    testID="tooltip-modal-backdrop"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         {
-          "flex": 1,
-          "flexShrink": 0,
-          "opacity": 1,
+          "opacity": 0,
+          "transform": [
+            {
+              "translateX": 4,
+            },
+          ],
         }
       }
-      testID="tooltip-modal-backdrop"
     >
       <View
+        collapse={false}
+        colorScheme="light"
+        data-blade-component="base-box"
+        display="flex"
+        elevation={20}
+        flexDirection="column"
+        gap="spacing.2"
+        maxWidth="200px"
+        position="absolute"
         style={
-          {
-            "opacity": 0,
-            "transform": [
-              {
-                "translateX": 4,
+          [
+            {
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": 4,
+              "maxWidth": 200,
+              "paddingBottom": 12,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 12,
+              "position": "absolute",
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 0%, 0.72)",
+              "borderRadius": 12,
+              "left": -200,
+              "position": "absolute",
+              "top": -210,
+              "zIndex": 9999,
+            },
+            {
+              "elevation": 8,
+              "shadowColor": "hsla(200, 10%, 18%, 1)",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
               },
-            ],
+              "shadowOpacity": 0.06,
+              "shadowRadius": 2,
+            },
+          ]
+        }
+        styles={
+          {
+            "left": -200,
+            "position": "absolute",
+            "top": -210,
+            "zIndex": 9999,
           }
         }
       >
-        <View
-          collapse={false}
-          colorScheme="light"
-          data-blade-component="base-box"
-          display="flex"
-          elevation={20}
-          flexDirection="column"
-          gap="spacing.2"
-          maxWidth="200px"
-          position="absolute"
+        <Text
+          accessible={true}
+          color="surface.text.staticWhite.subtle"
+          data-blade-component="text"
+          fontFamily="text"
+          fontSize={75}
+          fontStyle="normal"
+          fontWeight="regular"
+          lineHeight={75}
           style={
             [
               {
-                "display": "flex",
-                "flexDirection": "column",
-                "gap": 4,
-                "maxWidth": 200,
-                "paddingBottom": 12,
-                "paddingLeft": 12,
-                "paddingRight": 12,
-                "paddingTop": 12,
-                "position": "absolute",
-              },
-              {
-                "backgroundColor": "hsla(0, 0%, 0%, 0.72)",
-                "borderRadius": 12,
-                "left": -200,
-                "position": "absolute",
-                "top": -200,
-                "zIndex": 9999,
-              },
-              {
-                "elevation": 8,
-                "shadowColor": "hsla(200, 10%, 18%, 1)",
-                "shadowOffset": {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 0.06,
-                "shadowRadius": 2,
+                "color": "hsla(0, 0%, 100%, 0.88)",
+                "fontFamily": "Inter",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 17,
+                "marginBottom": 0,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "marginTop": 0,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "textDecorationLine": "none",
               },
             ]
           }
-          styles={
+        >
+          Hello world
+        </Text>
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
             {
-              "left": -200,
+              "bottom": 0,
+              "left": 0,
               "position": "absolute",
-              "top": -200,
-              "zIndex": 9999,
+              "right": 0,
+              "top": 0,
             }
           }
         >
-          <Text
-            accessible={true}
-            color="surface.text.staticWhite.subtle"
-            data-blade-component="text"
-            fontFamily="text"
-            fontSize={75}
-            fontStyle="normal"
-            fontWeight="regular"
-            lineHeight={75}
+          <RNSVGSvgView
+            accessibilityElementsHidden={true}
+            align="xMidYMid"
+            bbHeight="14px"
+            bbWidth="14px"
+            data-blade-component="icon"
+            focusable={false}
+            height="14px"
+            importantForAccessibility="no-hide-descendants"
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
             style={
               [
                 {
-                  "color": "hsla(0, 0%, 100%, 0.88)",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontStyle": "normal",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 17,
-                  "marginBottom": 0,
-                  "marginLeft": 0,
-                  "marginRight": 0,
-                  "marginTop": 0,
-                  "paddingBottom": 0,
-                  "paddingLeft": 0,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                  "textDecorationLine": "none",
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                [
+                  {},
+                  {},
+                ],
+                {
+                  "flex": 0,
+                  "height": 14,
+                  "width": 14,
                 },
               ]
             }
+            styles={{}}
+            vbHeight={14}
+            vbWidth={14}
+            width="14px"
           >
-            Hello world
-          </Text>
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
               }
-            }
-          >
-            <RNSVGSvgView
-              accessibilityElementsHidden={true}
-              align="xMidYMid"
-              bbHeight="14px"
-              bbWidth="14px"
-              data-blade-component="icon"
-              focusable={false}
-              height="14px"
-              importantForAccessibility="no-hide-descendants"
-              meetOrSlice={0}
-              minX={0}
-              minY={0}
-              style={
-                [
-                  {
-                    "backgroundColor": "transparent",
-                    "borderWidth": 0,
-                  },
-                  [
-                    {},
-                    {},
-                  ],
-                  {
-                    "flex": 0,
-                    "height": 14,
-                    "width": 14,
-                  },
-                ]
-              }
-              styles={{}}
-              vbHeight={14}
-              vbWidth={14}
-              width="14px"
             >
-              <RNSVGGroup
-                fill={
+              <RNSVGPath
+                d="M0,0 H14 L7,8 Q7,8 7,8 Z"
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                stroke={
                   {
-                    "payload": 4278190080,
+                    "payload": 4281810499,
                     "type": 0,
                   }
                 }
-              >
-                <RNSVGPath
-                  d="M0,0 H14 L7,8 Q7,8 7,8 Z"
-                  fill={null}
-                  propList={
-                    [
-                      "fill",
-                      "stroke",
-                      "strokeWidth",
-                    ]
+                strokeWidth="2px"
+              />
+              <RNSVGPath
+                d="M0,0 H14 L7,8 Q7,8 7,8 Z"
+                fill={
+                  {
+                    "payload": 3087007744,
+                    "type": 0,
                   }
-                  stroke={
-                    {
-                      "payload": 4281810499,
-                      "type": 0,
-                    }
-                  }
-                  strokeWidth="2px"
-                />
-                <RNSVGPath
-                  d="M0,0 H14 L7,8 Q7,8 7,8 Z"
-                  fill={
-                    {
-                      "payload": 3087007744,
-                      "type": 0,
-                    }
-                  }
-                  propList={
-                    [
-                      "fill",
-                      "stroke",
-                    ]
-                  }
-                  stroke={null}
-                />
-              </RNSVGGroup>
-            </RNSVGSvgView>
-          </View>
+                }
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                  ]
+                }
+                stroke={null}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
         </View>
       </View>
     </View>
-  </Modal>
+  </View>
 </View>
 `;
 
@@ -860,7 +852,7 @@ exports[`<Tooltip /> should render with title 1`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -1007,277 +999,273 @@ exports[`<Tooltip /> should render with title 1`] = `
       </View>
     </View>
   </View>
-  <Modal
-    accessibilityLabel="Hello world"
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
     collapsable={false}
-    hardwareAccelerated={false}
-    transparent={true}
-    visible={true}
+    focusable={true}
+    onClick={[Function]}
+    onLayout={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 1,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    testID="tooltip-modal-backdrop"
   >
     <View
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": undefined,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onClick={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         {
-          "flex": 1,
-          "flexShrink": 0,
-          "opacity": 1,
+          "opacity": 0,
+          "transform": [
+            {
+              "translateX": 4,
+            },
+          ],
         }
       }
-      testID="tooltip-modal-backdrop"
     >
       <View
+        collapse={false}
+        colorScheme="light"
+        data-blade-component="base-box"
+        display="flex"
+        elevation={20}
+        flexDirection="column"
+        gap="spacing.2"
+        maxWidth="200px"
+        position="absolute"
         style={
-          {
-            "opacity": 0,
-            "transform": [
-              {
-                "translateX": 4,
+          [
+            {
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": 4,
+              "maxWidth": 200,
+              "paddingBottom": 12,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 12,
+              "position": "absolute",
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 0%, 0.72)",
+              "borderRadius": 12,
+              "left": -200,
+              "position": "absolute",
+              "top": -210,
+              "zIndex": 1100,
+            },
+            {
+              "elevation": 8,
+              "shadowColor": "hsla(200, 10%, 18%, 1)",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
               },
-            ],
+              "shadowOpacity": 0.06,
+              "shadowRadius": 2,
+            },
+          ]
+        }
+        styles={
+          {
+            "left": -200,
+            "position": "absolute",
+            "top": -210,
+            "zIndex": 1100,
           }
         }
       >
-        <View
-          collapse={false}
-          colorScheme="light"
-          data-blade-component="base-box"
-          display="flex"
-          elevation={20}
-          flexDirection="column"
-          gap="spacing.2"
-          maxWidth="200px"
-          position="absolute"
+        <Text
+          accessible={true}
+          color="surface.text.staticWhite.normal"
+          data-blade-component="text"
+          fontFamily="text"
+          fontSize={100}
+          fontStyle="normal"
+          fontWeight="semibold"
+          lineHeight={100}
           style={
             [
               {
-                "display": "flex",
-                "flexDirection": "column",
-                "gap": 4,
-                "maxWidth": 200,
-                "paddingBottom": 12,
-                "paddingLeft": 12,
-                "paddingRight": 12,
-                "paddingTop": 12,
-                "position": "absolute",
-              },
-              {
-                "backgroundColor": "hsla(0, 0%, 0%, 0.72)",
-                "borderRadius": 12,
-                "left": -200,
-                "position": "absolute",
-                "top": -200,
-                "zIndex": 1100,
-              },
-              {
-                "elevation": 8,
-                "shadowColor": "hsla(200, 10%, 18%, 1)",
-                "shadowOffset": {
-                  "height": 2,
-                  "width": 0,
-                },
-                "shadowOpacity": 0.06,
-                "shadowRadius": 2,
+                "color": "hsla(0, 0%, 100%, 1)",
+                "fontFamily": "Inter",
+                "fontSize": 14,
+                "fontStyle": "normal",
+                "fontWeight": "600",
+                "letterSpacing": 0,
+                "lineHeight": 20,
+                "marginBottom": 0,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "marginTop": 0,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "textDecorationLine": "none",
               },
             ]
           }
-          styles={
+        >
+          Tooltip title
+        </Text>
+        <Text
+          accessible={true}
+          color="surface.text.staticWhite.subtle"
+          data-blade-component="text"
+          fontFamily="text"
+          fontSize={75}
+          fontStyle="normal"
+          fontWeight="regular"
+          lineHeight={75}
+          style={
+            [
+              {
+                "color": "hsla(0, 0%, 100%, 0.88)",
+                "fontFamily": "Inter",
+                "fontSize": 12,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "letterSpacing": 0,
+                "lineHeight": 17,
+                "marginBottom": 0,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "marginTop": 0,
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "textDecorationLine": "none",
+              },
+            ]
+          }
+        >
+          Hello world
+        </Text>
+        <View
+          collapsable={false}
+          pointerEvents="none"
+          style={
             {
-              "left": -200,
+              "bottom": 0,
+              "left": 0,
               "position": "absolute",
-              "top": -200,
-              "zIndex": 1100,
+              "right": 0,
+              "top": 0,
             }
           }
         >
-          <Text
-            accessible={true}
-            color="surface.text.staticWhite.normal"
-            data-blade-component="text"
-            fontFamily="text"
-            fontSize={100}
-            fontStyle="normal"
-            fontWeight="semibold"
-            lineHeight={100}
+          <RNSVGSvgView
+            accessibilityElementsHidden={true}
+            align="xMidYMid"
+            bbHeight="14px"
+            bbWidth="14px"
+            data-blade-component="icon"
+            focusable={false}
+            height="14px"
+            importantForAccessibility="no-hide-descendants"
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
             style={
               [
                 {
-                  "color": "hsla(0, 0%, 100%, 1)",
-                  "fontFamily": "Inter",
-                  "fontSize": 14,
-                  "fontStyle": "normal",
-                  "fontWeight": "600",
-                  "letterSpacing": 0,
-                  "lineHeight": 20,
-                  "marginBottom": 0,
-                  "marginLeft": 0,
-                  "marginRight": 0,
-                  "marginTop": 0,
-                  "paddingBottom": 0,
-                  "paddingLeft": 0,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                  "textDecorationLine": "none",
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
                 },
-              ]
-            }
-          >
-            Tooltip title
-          </Text>
-          <Text
-            accessible={true}
-            color="surface.text.staticWhite.subtle"
-            data-blade-component="text"
-            fontFamily="text"
-            fontSize={75}
-            fontStyle="normal"
-            fontWeight="regular"
-            lineHeight={75}
-            style={
-              [
-                {
-                  "color": "hsla(0, 0%, 100%, 0.88)",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontStyle": "normal",
-                  "fontWeight": "400",
-                  "letterSpacing": 0,
-                  "lineHeight": 17,
-                  "marginBottom": 0,
-                  "marginLeft": 0,
-                  "marginRight": 0,
-                  "marginTop": 0,
-                  "paddingBottom": 0,
-                  "paddingLeft": 0,
-                  "paddingRight": 0,
-                  "paddingTop": 0,
-                  "textDecorationLine": "none",
-                },
-              ]
-            }
-          >
-            Hello world
-          </Text>
-          <View
-            collapsable={false}
-            pointerEvents="none"
-            style={
-              {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              }
-            }
-          >
-            <RNSVGSvgView
-              accessibilityElementsHidden={true}
-              align="xMidYMid"
-              bbHeight="14px"
-              bbWidth="14px"
-              data-blade-component="icon"
-              focusable={false}
-              height="14px"
-              importantForAccessibility="no-hide-descendants"
-              meetOrSlice={0}
-              minX={0}
-              minY={0}
-              style={
                 [
-                  {
-                    "backgroundColor": "transparent",
-                    "borderWidth": 0,
-                  },
-                  [
-                    {},
-                    {},
-                  ],
-                  {
-                    "flex": 0,
-                    "height": 14,
-                    "width": 14,
-                  },
-                ]
+                  {},
+                  {},
+                ],
+                {
+                  "flex": 0,
+                  "height": 14,
+                  "width": 14,
+                },
+              ]
+            }
+            styles={{}}
+            vbHeight={14}
+            vbWidth={14}
+            width="14px"
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
               }
-              styles={{}}
-              vbHeight={14}
-              vbWidth={14}
-              width="14px"
             >
-              <RNSVGGroup
-                fill={
+              <RNSVGPath
+                d="M0,0 H14 L7,8 Q7,8 7,8 Z"
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                stroke={
                   {
-                    "payload": 4278190080,
+                    "payload": 4281810499,
                     "type": 0,
                   }
                 }
-              >
-                <RNSVGPath
-                  d="M0,0 H14 L7,8 Q7,8 7,8 Z"
-                  fill={null}
-                  propList={
-                    [
-                      "fill",
-                      "stroke",
-                      "strokeWidth",
-                    ]
+                strokeWidth="2px"
+              />
+              <RNSVGPath
+                d="M0,0 H14 L7,8 Q7,8 7,8 Z"
+                fill={
+                  {
+                    "payload": 3087007744,
+                    "type": 0,
                   }
-                  stroke={
-                    {
-                      "payload": 4281810499,
-                      "type": 0,
-                    }
-                  }
-                  strokeWidth="2px"
-                />
-                <RNSVGPath
-                  d="M0,0 H14 L7,8 Q7,8 7,8 Z"
-                  fill={
-                    {
-                      "payload": 3087007744,
-                      "type": 0,
-                    }
-                  }
-                  propList={
-                    [
-                      "fill",
-                      "stroke",
-                    ]
-                  }
-                  stroke={null}
-                />
-              </RNSVGGroup>
-            </RNSVGSvgView>
-          </View>
+                }
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                  ]
+                }
+                stroke={null}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
         </View>
       </View>
     </View>
-  </Modal>
+  </View>
 </View>
 `;

--- a/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.native.test.tsx.snap
+++ b/packages/blade/src/tokens/theme/__tests__/__snapshots__/createTheme.native.test.tsx.snap
@@ -1698,7 +1698,7 @@ exports[`createTheme should create a theme with the correct brand colors 3`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"
@@ -3546,7 +3546,7 @@ exports[`createTheme should create a theme with the correct brand colors 6`] = `
       }
     }
     accessible={true}
-    borderRadius="8px"
+    borderRadius={8}
     buttonPaddingBottom="0px"
     buttonPaddingLeft="12px"
     buttonPaddingRight="12px"

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
@@ -11,7 +11,7 @@ export function makeBorderSize<T extends number>(size: T): `${T}px`;
 export function makeBorderSize<T extends string>(size: T): T;
 export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T {
   if (typeof size === 'number') {
-    return size as unknown as `${T}px`;
+    return (size as unknown) as `${T}px`;
   }
-  return (parseFloat(size as string) || 0) as unknown as T;
+  return ((parseFloat(size as string) || 0) as unknown) as T;
 }

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
@@ -3,17 +3,14 @@
  * `borderWidth` and `borderRadius`. Old Architecture auto-coerced strings but Fabric
  * enforces strict types and throws "java.lang.String cannot be cast to java.lang.Double".
  *
- * Overload signatures intentionally match the web version (`${T}px`) so all existing
- * call sites remain type-safe — the `as unknown as` casts are only in the implementation
- * body and are never visible to callers.
+ * Unlike the web version which returns `${T}px` strings, the native version honestly
+ * returns numbers — callers on native receive numeric values, not string representations.
  */
-export function makeBorderSize<T extends number>(size: T): `${T}px`;
-export function makeBorderSize<T extends string>(size: T): T;
-export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T {
+export function makeBorderSize<T extends number>(size: T): number;
+export function makeBorderSize<T extends string>(size: T): number;
+export function makeBorderSize<T extends number | string>(size: T): number {
   if (typeof size === 'number') {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (size as any) as `${T}px`;
+    return size;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return ((parseFloat(size) || 0) as any) as T;
+  return parseFloat(size) || 0;
 }

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
@@ -11,7 +11,9 @@ export function makeBorderSize<T extends number>(size: T): `${T}px`;
 export function makeBorderSize<T extends string>(size: T): T;
 export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T {
   if (typeof size === 'number') {
-    return (size as unknown) as `${T}px`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (size as any) as `${T}px`;
   }
-  return ((parseFloat(size as string) || 0) as unknown) as T;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((parseFloat(size) || 0) as any) as T;
 }

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.native.ts
@@ -1,0 +1,17 @@
+/**
+ * React Native (Fabric/New Architecture) requires numeric values for style props like
+ * `borderWidth` and `borderRadius`. Old Architecture auto-coerced strings but Fabric
+ * enforces strict types and throws "java.lang.String cannot be cast to java.lang.Double".
+ *
+ * Overload signatures intentionally match the web version (`${T}px`) so all existing
+ * call sites remain type-safe — the `as unknown as` casts are only in the implementation
+ * body and are never visible to callers.
+ */
+export function makeBorderSize<T extends number>(size: T): `${T}px`;
+export function makeBorderSize<T extends string>(size: T): T;
+export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T {
+  if (typeof size === 'number') {
+    return size as unknown as `${T}px`;
+  }
+  return (parseFloat(size as string) || 0) as unknown as T;
+}

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.test.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.test.ts
@@ -1,17 +1,20 @@
 import { makeBorderSize } from '.';
 import { border } from '~tokens/global';
+import { isReactNative } from '~utils';
 
 describe('makeBorderSize', () => {
   it('should return the border width in `px`', () => {
     const space = makeBorderSize(border.width.thin);
-    expect(space).toEqual('1px');
+    // Native returns raw numbers; web returns `${n}px` strings
+    expect(space).toEqual(isReactNative() ? 1 : '1px');
   });
   it('should return the border radius in `px`', () => {
     const space = makeBorderSize(border.radius.small);
-    expect(space).toEqual('8px');
+    expect(space).toEqual(isReactNative() ? 8 : '8px');
   });
   it('should return the border radius in `%`', () => {
     const space = makeBorderSize(border.radius.round);
-    expect(space).toEqual('50%');
+    // On native, `parseFloat("50%")` → 50 (RN uses numeric border radii)
+    expect(space).toEqual(isReactNative() ? 50 : '50%');
   });
 });

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.ts
@@ -1,6 +1,24 @@
-export function makeBorderSize<T extends number>(size: T): `${T}px`;
-export function makeBorderSize<T extends string>(size: T): T;
-export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T {
+import { getPlatformType } from '~utils/getPlatformType';
+
+/**
+ * On React Native (all versions), style props like `borderWidth` and `borderRadius`
+ * must be numbers. Old Architecture auto-coerced strings but New Architecture (Fabric,
+ * enabled by default from RN 0.76+) enforces strict types and throws:
+ *   "java.lang.String cannot be cast to java.lang.Double"
+ *
+ * Web continues to receive the "Npx" string which is required for CSS.
+ */
+export function makeBorderSize<T extends number>(size: T): `${T}px` | T;
+export function makeBorderSize<T extends string>(size: T): T | number;
+export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T | number {
+  if (getPlatformType() === 'react-native') {
+    // Return raw number — works on all RN versions (Old Arch coerces, New Arch requires it)
+    if (typeof size === 'number') {
+      return size;
+    }
+    return parseFloat(size) || 0;
+  }
+  // Web: return CSS px string
   if (typeof size === 'number') {
     return `${size}px`;
   }

--- a/packages/blade/src/utils/makeBorderSize/makeBorderSize.ts
+++ b/packages/blade/src/utils/makeBorderSize/makeBorderSize.ts
@@ -1,24 +1,6 @@
-import { getPlatformType } from '~utils/getPlatformType';
-
-/**
- * On React Native (all versions), style props like `borderWidth` and `borderRadius`
- * must be numbers. Old Architecture auto-coerced strings but New Architecture (Fabric,
- * enabled by default from RN 0.76+) enforces strict types and throws:
- *   "java.lang.String cannot be cast to java.lang.Double"
- *
- * Web continues to receive the "Npx" string which is required for CSS.
- */
-export function makeBorderSize<T extends number>(size: T): `${T}px` | T;
-export function makeBorderSize<T extends string>(size: T): T | number;
-export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T | number {
-  if (getPlatformType() === 'react-native') {
-    // Return raw number — works on all RN versions (Old Arch coerces, New Arch requires it)
-    if (typeof size === 'number') {
-      return size;
-    }
-    return parseFloat(size) || 0;
-  }
-  // Web: return CSS px string
+export function makeBorderSize<T extends number>(size: T): `${T}px`;
+export function makeBorderSize<T extends string>(size: T): T;
+export function makeBorderSize<T extends number | string>(size: T): `${T}px` | T {
   if (typeof size === 'number') {
     return `${size}px`;
   }

--- a/packages/blade/src/utils/storybook/componentStatusData.ts
+++ b/packages/blade/src/utils/storybook/componentStatusData.ts
@@ -31,7 +31,7 @@ const componentData: ComponentStatusDataType = [
     frameworks: {
       react: {
         status: 'released',
-        releasedIn: '12.102.0',
+        releasedIn: '12.101.6',
         storybookLink: 'Components/Avatar/Avatar',
       },
       svelte: {
@@ -46,7 +46,7 @@ const componentData: ComponentStatusDataType = [
     frameworks: {
       react: {
         status: 'released',
-        releasedIn: '12.102.0',
+        releasedIn: '12.101.6',
         storybookLink: 'Components/Avatar/AvatarGroup',
       },
       svelte: {

--- a/packages/blade/src/utils/storybook/componentStatusData.ts
+++ b/packages/blade/src/utils/storybook/componentStatusData.ts
@@ -25,6 +25,36 @@ type ComponentStatusDataType = {
 
 const componentData: ComponentStatusDataType = [
   {
+    name: 'Avatar',
+    description: 'Avatar component for displaying user profile images or initials.',
+    platform: 'all',
+    frameworks: {
+      react: {
+        status: 'released',
+        releasedIn: '11.18.0',
+        storybookLink: 'Components/Avatar/Avatar',
+      },
+      svelte: {
+        status: 'to-be-decided',
+      },
+    },
+  },
+  {
+    name: 'AvatarGroup',
+    description: 'AvatarGroup component for displaying a group of avatars with overflow count.',
+    platform: 'all',
+    frameworks: {
+      react: {
+        status: 'released',
+        releasedIn: '11.18.0',
+        storybookLink: 'Components/Avatar/AvatarGroup',
+      },
+      svelte: {
+        status: 'to-be-decided',
+      },
+    },
+  },
+  {
     name: 'EmptyState',
     description: 'EmptyState component for displaying empty state messages and illustrations.',
     platform: 'all',

--- a/packages/blade/src/utils/storybook/componentStatusData.ts
+++ b/packages/blade/src/utils/storybook/componentStatusData.ts
@@ -31,7 +31,7 @@ const componentData: ComponentStatusDataType = [
     frameworks: {
       react: {
         status: 'released',
-        releasedIn: '11.18.0',
+        releasedIn: '12.102.0',
         storybookLink: 'Components/Avatar/Avatar',
       },
       svelte: {
@@ -46,7 +46,7 @@ const componentData: ComponentStatusDataType = [
     frameworks: {
       react: {
         status: 'released',
-        releasedIn: '11.18.0',
+        releasedIn: '12.102.0',
         storybookLink: 'Components/Avatar/AvatarGroup',
       },
       svelte: {


### PR DESCRIPTION
## Summary

- Fix styled-components v6 error in `BaseBox.native.tsx`
- Fix `makeBorderSize` string issue with a native-only implementation
- Fix reanimated crash in Popover and Tooltip content wrappers
- Fix badge spacing, chips styling, switch AnimatedThumb, and TextInput label on native
- Fix Tooltip native implementation
- Fix Popover on iOS, Android, and crash on re-render
- Add Avatar, AvatarGroup, and EmptyState native implementations
- Add Spark native stubs (FluidGradient, RzpGlass)
- Add native stubs for web-only components (MotionDashboard, StepperRouter, Rotate, Calendar, CustomMenu, SpinWheel)
- Add StyledDropdownOverlay native stub

## What's excluded

This branch intentionally excludes all storybook-specific changes (rollup config, metro config, storybook mocks, storybook.requires.js) from the `chore/storybook-rn-working` branch. The Toast stub is also excluded since master already ships a complete `useToast.native.tsx` implementation.

## Test plan

- [ ] Build the React Native app and verify no native build errors
- [ ] Verify Avatar, AvatarGroup, EmptyState render correctly on iOS and Android
- [ ] Verify Popover opens/closes correctly on iOS and Android without crashes
- [ ] Verify Tooltip renders correctly on native
- [ ] Verify Switch, Chips, Badge render with correct styling on native
- [ ] Verify TextInput label alignment on native