### PR TITLE
fix(BaseInput): correct height tokens for xsmall and small sizes

### DIFF
--- a/packages/blade/src/components/Input/BaseInput/__tests__/BaseInput.native.test.tsx
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/BaseInput.native.test.tsx
@@ -114,6 +114,23 @@ describe('<BaseInput />', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
+  it('should render with small size input', () => {
+    const { toJSON } = renderWithTheme(
+      <BaseInput
+        label="Enter name"
+        placeholder="First Last"
+        id="name"
+        leadingIcon={EyeIcon}
+        trailingIcon={CloseIcon}
+        successText="Success"
+        validationState="success"
+        size="small"
+      />,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
   it('should render with large size input', () => {
     const { toJSON } = renderWithTheme(
       <BaseInput

--- a/packages/blade/src/components/Input/BaseInput/__tests__/BaseInput.web.test.tsx
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/BaseInput.web.test.tsx
@@ -130,6 +130,23 @@ describe('<BaseInput />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should render with small size input', () => {
+    const { container } = renderWithTheme(
+      <BaseInput
+        label="Enter name"
+        placeholder="First Last"
+        id="name"
+        leadingIcon={EyeIcon}
+        trailingIcon={CloseIcon}
+        successText="Success"
+        validationState="success"
+        size="small"
+      />,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('should render with large size input', () => {
     const { container } = renderWithTheme(
       <BaseInput

--- a/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.native.test.tsx.snap
@@ -2465,7 +2465,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
             </View>
           </View>
           <TextInput
-            accessibilityDescribedBy="name-97-successtext-101"
+            accessibilityDescribedBy="name-109-successtext-113"
             accessibilityInvalid={false}
             accessibilityRequired={false}
             accessibilityState={
@@ -2479,7 +2479,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
             editable={true}
             hasLeadingDropdown={false}
             hasTags={false}
-            id="name-97-input-98"
+            id="name-109-input-110"
             isFocused={false}
             isInsideCounterInput={false}
             isTableInputCell={false}
@@ -2674,7 +2674,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
       >
         <View
           data-blade-component="base-box"
-          id="name-97-successtext-101"
+          id="name-109-successtext-113"
           style={
             [
               {
@@ -2798,6 +2798,697 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                     "marginLeft": 0,
                     "marginRight": 0,
                     "marginTop": 2,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+            >
+              Success
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`<BaseInput /> should render with small size input 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    data-blade-component="base-box"
+    style={
+      [
+        {},
+      ]
+    }
+  >
+    <View
+      data-blade-component="base-box"
+      display="flex"
+      flexDirection="column"
+      position="relative"
+      style={
+        [
+          {
+            "display": "flex",
+            "flexDirection": "column",
+            "position": "relative",
+            "width": "100%",
+          },
+        ]
+      }
+      width="100%"
+    >
+      <View
+        data-blade-component="base-box"
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        style={
+          [
+            {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+              "marginBottom": 0,
+              "marginTop": 0,
+            },
+          ]
+        }
+      >
+        <View
+          data-blade-component="base-box"
+          style={
+            [
+              {
+                "marginBottom": 4,
+                "marginRight": 16,
+              },
+            ]
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            gap="spacing.0"
+            maxHeight="36px"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                  "gap": 0,
+                  "maxHeight": 36,
+                },
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              color="surface.text.gray.subtle"
+              data-blade-component="text"
+              fontFamily="text"
+              fontSize={75}
+              fontStyle="normal"
+              fontWeight="medium"
+              lineHeight={75}
+              numberOfLines={2}
+              style={
+                [
+                  {
+                    "color": "hsla(200, 10%, 18%, 1)",
+                    "fontFamily": "Inter",
+                    "fontSize": 12,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 17,
+                    "marginBottom": 0,
+                    "marginLeft": 0,
+                    "marginRight": 0,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+            >
+              Enter name
+            </Text>
+            <View
+              data-blade-component="visually-hidden"
+              style={
+                [
+                  {
+                    "borderColor": "black",
+                    "borderStyle": "solid",
+                    "borderWidth": 0,
+                    "clip": "rect(0 0 0 0)",
+                    "clipPath": "inset(50%)",
+                    "height": 1,
+                    "left": -10000,
+                    "marginBottom": -1,
+                    "marginLeft": 0,
+                    "marginRight": -1,
+                    "marginTop": 0,
+                    "overflow": "hidden",
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": 1,
+                    "wordWrap": "normal",
+                  },
+                ]
+              }
+            >
+              <Text
+                accessible={true}
+                color="surface.text.gray.normal"
+                data-blade-component="text"
+                fontFamily="text"
+                fontSize={100}
+                fontStyle="normal"
+                fontWeight="regular"
+                lineHeight={100}
+                style={
+                  [
+                    {
+                      "color": "hsla(0, 0%, 2%, 1)",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontStyle": "normal",
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 20,
+                      "marginBottom": 0,
+                      "marginLeft": 0,
+                      "marginRight": 0,
+                      "marginTop": 0,
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                      "textDecorationLine": "none",
+                    },
+                  ]
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        className="focus-ring-wrapper"
+        currentInteraction="default"
+        data-blade-component="base-box"
+        isTableInputCell={false}
+        shouldAddLimitedFocus={false}
+        style={
+          [
+            {},
+            {
+              "borderRadius": 8,
+              "width": "100%",
+            },
+          ]
+        }
+      >
+        <View
+          currentInteraction="default"
+          isTableInputCell={false}
+          onClick={[Function]}
+          setShowAllTagsWithAnimation={[Function]}
+          size="small"
+          style={
+            [
+              {
+                "alignItems": "center",
+                "backgroundColor": "hsla(0, 0%, 100%, 1)",
+                "borderColor": "hsla(150, 100%, 28%, 1)",
+                "borderRadius": 8,
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "display": "flex",
+                "flexDirection": "row",
+                "overflow": "hidden",
+                "position": "relative",
+                "width": "100%",
+                "zIndex": 1,
+              },
+              {},
+              {
+                "backgroundColor": "hsla(0, 0%, 100%, 1)",
+                "borderColor": "hsla(150, 100%, 28%, 1)",
+                "borderRadius": 8,
+                "borderStyle": "solid",
+                "borderWidth": 1,
+              },
+            ]
+          }
+          validationState="success"
+        >
+          <View
+            alignItems="center"
+            alignSelf="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "alignSelf": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              data-blade-component="base-box"
+              display="flex"
+              style={
+                [
+                  {
+                    "display": "flex",
+                    "paddingLeft": 12,
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="12px"
+                bbWidth="12px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="12px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 12,
+                      "width": 12,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="12px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    clipRule={0}
+                    d="M12 8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8ZM10 12C10 10.8954 10.8954 10 12 10C13.1046 10 14 10.8954 14 12C14 13.1046 13.1046 14 12 14C10.8954 14 10 13.1046 10 12Z"
+                    fill={
+                      {
+                        "payload": 4284575093,
+                        "type": 0,
+                      }
+                    }
+                    fillRule={0}
+                    propList={
+                      [
+                        "fill",
+                        "fillRule",
+                      ]
+                    }
+                  />
+                  <RNSVGPath
+                    clipRule={0}
+                    d="M12 3C8.8711 3 6.22807 4.48937 4.23728 6.25113C2.24678 8.01264 0.822273 10.1194 0.105573 11.5528C-0.0351909 11.8343 -0.0351909 12.1657 0.105573 12.4472C0.822273 13.8806 2.24678 15.9874 4.23728 17.7489C6.22807 19.5106 8.8711 21 12 21C15.1289 21 17.7719 19.5106 19.7627 17.7489C21.7532 15.9874 23.1777 13.8806 23.8944 12.4472C24.0352 12.1657 24.0352 11.8343 23.8944 11.5528C23.1777 10.1194 21.7532 8.01264 19.7627 6.25113C17.7719 4.48937 15.1289 3 12 3ZM5.56272 16.2511C3.98954 14.8589 2.80913 13.2146 2.13142 12C2.80913 10.7854 3.98954 9.14106 5.56272 7.74887C7.3386 6.17729 9.5289 5 12 5C14.4711 5 16.6614 6.17729 18.4373 7.74887C20.0105 9.14106 21.1909 10.7854 21.8686 12C21.1909 13.2146 20.0105 14.8589 18.4373 16.2511C16.6614 17.8227 14.4711 19 12 19C9.5289 19 7.3386 17.8227 5.56272 16.2511Z"
+                    fill={
+                      {
+                        "payload": 4284575093,
+                        "type": 0,
+                      }
+                    }
+                    fillRule={0}
+                    propList={
+                      [
+                        "fill",
+                        "fillRule",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+          </View>
+          <TextInput
+            accessibilityDescribedBy="name-97-successtext-101"
+            accessibilityInvalid={false}
+            accessibilityRequired={false}
+            accessibilityState={
+              {
+                "disabled": false,
+                "expanded": undefined,
+              }
+            }
+            accessible={true}
+            data-blade-component="styled-base-input"
+            editable={true}
+            hasLeadingDropdown={false}
+            hasTags={false}
+            id="name-97-input-98"
+            isFocused={false}
+            isInsideCounterInput={false}
+            isTableInputCell={false}
+            isTextArea={false}
+            keyboardType="default"
+            leadingIcon={[Function]}
+            multiline={false}
+            onBlur={[Function]}
+            onChangeText={[Function]}
+            onEndEditing={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            onSubmitEditing={[Function]}
+            placeholder="First Last"
+            placeholderTextColor="hsla(206, 10%, 29%, 0.32)"
+            secureTextEntry={false}
+            style={
+              [
+                {
+                  "backgroundColor": "hsla(0, 0%, 100%, 0)",
+                  "color": "hsla(0, 0%, 2%, 1)",
+                  "flexBasis": 0,
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "height": 32,
+                  "letterSpacing": -0.15600000000000003,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "minHeight": 32,
+                  "paddingBottom": 4,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 4,
+                  "textAlignVertical": "top",
+                  "textDecorationLine": "none",
+                  "width": "100%",
+                },
+              ]
+            }
+            trailingIcon={[Function]}
+            validationState="success"
+            valueComponentType="text"
+          />
+          <View
+            alignItems="center"
+            alignSelf="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "alignSelf": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                    "paddingRight": 12,
+                  },
+                ]
+              }
+            >
+              <View
+                alignItems="center"
+                data-blade-component="box"
+                display="flex"
+                justifyContent="center"
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "display": "flex",
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <RNSVGSvgView
+                  accessibilityElementsHidden={true}
+                  align="xMidYMid"
+                  bbHeight="12px"
+                  bbWidth="12px"
+                  data-blade-component="icon"
+                  fill="none"
+                  focusable={false}
+                  height="12px"
+                  importantForAccessibility="no-hide-descendants"
+                  meetOrSlice={0}
+                  minX={0}
+                  minY={0}
+                  style={
+                    [
+                      {
+                        "backgroundColor": "transparent",
+                        "borderWidth": 0,
+                      },
+                      [
+                        {},
+                      ],
+                      {
+                        "flex": 0,
+                        "height": 12,
+                        "width": 12,
+                      },
+                    ]
+                  }
+                  vbHeight={24}
+                  vbWidth={24}
+                  width="12px"
+                >
+                  <RNSVGGroup
+                    fill={null}
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  >
+                    <RNSVGPath
+                      d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
+                      fill={
+                        {
+                          "payload": 4278220091,
+                          "type": 0,
+                        }
+                      }
+                      propList={
+                        [
+                          "fill",
+                        ]
+                      }
+                    />
+                  </RNSVGGroup>
+                </RNSVGSvgView>
+              </View>
+              <Modal
+                accessibilityLabel="Success"
+                collapsable={false}
+                hardwareAccelerated={false}
+                transparent={true}
+                visible={false}
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <View
+      data-blade-component="base-box"
+      style={
+        [
+          {
+            "marginLeft": 0,
+          },
+        ]
+      }
+    >
+      <View
+        data-blade-component="base-box"
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        style={
+          [
+            {
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "space-between",
+            },
+          ]
+        }
+      >
+        <View
+          data-blade-component="base-box"
+          id="name-97-successtext-101"
+          style={
+            [
+              {
+                "marginTop": 4,
+              },
+            ]
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              data-blade-component="box"
+              flexShrink={0}
+              style={
+                [
+                  {
+                    "flexShrink": 0,
+                    "marginTop": 2,
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="12px"
+                bbWidth="12px"
+                data-blade-component="icon"
+                display="block"
+                fill="none"
+                focusable={false}
+                height="12px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {
+                        "display": "block",
+                      },
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 12,
+                      "width": 12,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="12px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    clipRule={0}
+                    d="M20.7071 5.29289C21.0976 5.68342 21.0976 6.31658 20.7071 6.70711L9.70711 17.7071C9.31658 18.0976 8.68342 18.0976 8.29289 17.7071L3.29289 12.7071C2.90237 12.3166 2.90237 11.6834 3.29289 11.2929C3.68342 10.9024 4.31658 10.9024 4.70711 11.2929L9 15.5858L19.2929 5.29289C19.6834 4.90237 20.3166 4.90237 20.7071 5.29289Z"
+                    fill={
+                      {
+                        "payload": 4278220091,
+                        "type": 0,
+                      }
+                    }
+                    fillRule={0}
+                    propList={
+                      [
+                        "fill",
+                        "fillRule",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <Text
+              accessible={true}
+              color="feedback.text.positive.intense"
+              data-blade-component="text"
+              fontFamily="text"
+              fontSize={50}
+              fontStyle="normal"
+              fontWeight="regular"
+              lineHeight={50}
+              marginTop="spacing.0"
+              style={
+                [
+                  {
+                    "color": "hsla(150, 100%, 23%, 1)",
+                    "fontFamily": "Inter",
+                    "fontSize": 11,
+                    "fontStyle": "normal",
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                    "lineHeight": 16,
+                    "marginBottom": 0,
+                    "marginLeft": 0,
+                    "marginRight": 0,
+                    "marginTop": 0,
                     "paddingBottom": 0,
                     "paddingLeft": 0,
                     "paddingRight": 0,
@@ -3060,7 +3751,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
             editable={true}
             hasLeadingDropdown={false}
             hasTags={false}
-            id="coupon-109-input-110"
+            id="coupon-121-input-122"
             isFocused={false}
             isInsideCounterInput={false}
             isTableInputCell={false}

--- a/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.web.test.tsx.snap
@@ -459,7 +459,7 @@ exports[`<BaseInput /> should have a label & labelSuffix & labelTrailing 1`] = `
       >
         <label
           data-blade-component="form-label"
-          for="name-555-input-556"
+          for="name-575-input-576"
           style="width: 100%; flex-shrink: 0; margin-right: 0px;"
         >
           <div
@@ -562,7 +562,7 @@ exports[`<BaseInput /> should have a label & labelSuffix & labelTrailing 1`] = `
             aria-required="false"
             class="c15"
             data-blade-component="styled-base-input"
-            id="name-555-input-556"
+            id="name-575-input-576"
             type="text"
             value=""
           />
@@ -2433,7 +2433,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
       >
         <label
           data-blade-component="form-label"
-          for="name-145-input-146"
+          for="name-165-input-166"
           style="width: 100%; flex-shrink: 0; margin-right: 0px;"
         >
           <div
@@ -2518,13 +2518,13 @@ exports[`<BaseInput /> should render with large size input 1`] = `
             </div>
           </div>
           <input
-            aria-describedby="name-145-successtext-149"
+            aria-describedby="name-165-successtext-169"
             aria-disabled="false"
             aria-invalid="false"
             aria-required="false"
             class="c12"
             data-blade-component="styled-base-input"
-            id="name-145-input-146"
+            id="name-165-input-166"
             placeholder="First Last"
             type="text"
             value=""
@@ -2573,7 +2573,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
         <div
           class="c17"
           data-blade-component="base-box"
-          id="name-145-successtext-149"
+          id="name-165-successtext-169"
         >
           <span
             class="c18"
@@ -2591,6 +2591,674 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                 height="16px"
                 viewBox="0 0 24 24"
                 width="16px"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M20.7071 5.29289C21.0976 5.68342 21.0976 6.31658 20.7071 6.70711L9.70711 17.7071C9.31658 18.0976 8.68342 18.0976 8.29289 17.7071L3.29289 12.7071C2.90237 12.3166 2.90237 11.6834 3.29289 11.2929C3.68342 10.9024 4.31658 10.9024 4.70711 11.2929L9 15.5858L19.2929 5.29289C19.6834 4.90237 20.3166 4.90237 20.7071 5.29289Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(150, 100%, 23%, 1)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+            <span
+              class="c21"
+              data-blade-component="text"
+              letter-spacing="50"
+            >
+              Success
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<BaseInput /> should render with small size input 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+}
+
+.c1.c1.c1.c1.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
+.c2.c2.c2.c2.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 4px;
+  width: 100%;
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.c4.c4.c4.c4.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-height: 36px;
+  gap: 0px;
+}
+
+.c10.c10.c10.c10.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c11.c11.c11.c11.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-left: 12px;
+}
+
+.c13.c13.c13.c13.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-right: 12px;
+}
+
+.c14.c14.c14.c14.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c15.c15.c15.c15.c15 {
+  margin-left: 0px;
+}
+
+.c16.c16.c16.c16.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c17.c17.c17.c17.c17 {
+  margin-top: 4px;
+}
+
+.c18.c18.c18.c18.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.c19.c19.c19.c19.c19 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.c5.c5.c5.c5.c5 {
+  color: hsla(200,10%,18%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
+}
+
+.c7.c7.c7.c7.c7 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+}
+
+.c21.c21.c21.c21.c21 {
+  color: hsla(150,100%,23%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1rem;
+  -webkit-letter-spacing: -0.14300000000000002px;
+  -moz-letter-spacing: -0.14300000000000002px;
+  -ms-letter-spacing: -0.14300000000000002px;
+  letter-spacing: -0.14300000000000002px;
+  margin: 0;
+  padding: 0;
+  word-break: break-word;
+  margin-top: 0px;
+}
+
+.c12.c12.c12.c12.c12 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background-color: hsla(0,0%,100%,0);
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 8px;
+  padding-right: 8px;
+  width: 100%;
+  height: 32px;
+  min-height: 32px;
+  resize: none;
+  box-sizing: border-box;
+  outline: none;
+  border: none;
+  cursor: auto;
+}
+
+.c12.c12.c12.c12.c12::-webkit-input-placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+}
+
+.c12.c12.c12.c12.c12::-moz-placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+}
+
+.c12.c12.c12.c12.c12:-ms-input-placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+}
+
+.c12.c12.c12.c12.c12::placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+}
+
+.c12.c12.c12.c12.c12:focus {
+  outline: none;
+}
+
+.c9.c9.c9.c9.c9 {
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 8px;
+  overflow: hidden;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  z-index: 1;
+  border-width: 0px;
+  box-shadow: hsla(150,100%,28%,1) 0px 0px 0px 1.5px;
+  -webkit-transition-property: box-shadow,background-color;
+  transition-property: box-shadow,background-color;
+  -webkit-transition-duration: 640ms;
+  transition-duration: 640ms;
+  -webkit-transition-easing: cubic-bezier(0.5,0,0,1);
+  transition-easing: cubic-bezier(0.5,0,0,1);
+}
+
+.c9.c9.c9.c9.c9:hover {
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 8px;
+  overflow: hidden;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  z-index: 1;
+  border-width: 0px;
+  box-shadow: hsla(150,100%,28%,1) 0px 0px 0px 1.5px;
+  -webkit-transition-property: background-color;
+  transition-property: background-color;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-easing: cubic-bezier(0.5,0,0,1);
+  transition-easing: cubic-bezier(0.5,0,0,1);
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c9.c9.c9.c9.c9:focus-within {
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 8px;
+  overflow: hidden;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  z-index: 1;
+  border-width: 0px;
+  box-shadow: hsla(150,100%,28%,1) 0px 0px 0px 1.5px;
+  -webkit-transition-property: box-shadow,background-color;
+  transition-property: box-shadow,background-color;
+  -webkit-transition-duration: 640ms;
+  transition-duration: 640ms;
+  -webkit-transition-easing: cubic-bezier(0.5,0,0,1);
+  transition-easing: cubic-bezier(0.5,0,0,1);
+}
+
+.c20.c20.c20.c20.c20 {
+  display: block;
+}
+
+.c6.c6.c6.c6.c6 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c8.c8.c8.c8.c8 {
+  border-radius: 8px;
+  width: 100%;
+}
+
+.c8.c8.c8.c8.c8:focus-within {
+  outline: 4px solid hsla(218,89%,51%,0.18);
+  outline-offset: 1px;
+  -webkit-transition-property: outline-width;
+  transition-property: outline-width;
+  -webkit-transition-duration: 640ms;
+  transition-duration: 640ms;
+  -webkit-transition-timing-function: cubic-bezier(0.5,0,0,1);
+  transition-timing-function: cubic-bezier(0.5,0,0,1);
+  z-index: 2;
+}
+
+<div>
+  <div
+    class=""
+    data-blade-component="base-box"
+  >
+    <div
+      class="c0"
+      data-blade-component="base-box"
+    >
+      <div
+        class="c1"
+        data-blade-component="base-box"
+      >
+        <label
+          data-blade-component="form-label"
+          for="name-145-input-146"
+          style="width: 100%; flex-shrink: 0; margin-right: 0px;"
+        >
+          <div
+            class="c2"
+            data-blade-component="base-box"
+          >
+            <div
+              class="c3"
+              data-blade-component="base-box"
+            >
+              <div
+                class=""
+                data-blade-component="base-box"
+              >
+                <div
+                  class="c4"
+                  data-blade-component="base-box"
+                >
+                  <p
+                    class="c5"
+                    data-blade-component="text"
+                    letter-spacing="50"
+                  >
+                    Enter name
+                  </p>
+                  <div
+                    class="c6"
+                    data-blade-component="visually-hidden"
+                  >
+                    <p
+                      class="c7"
+                      data-blade-component="text"
+                      letter-spacing="50"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+      </div>
+      <div
+        class=" c8 focus-ring-wrapper"
+        data-blade-component="base-box"
+      >
+        <div
+          class="AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1  c9 __blade-base-input-wrapper"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c10"
+            data-blade-component="base-box"
+          >
+            <div
+              class="c11"
+              data-blade-component="base-box"
+            >
+              <svg
+                aria-hidden="true"
+                class=""
+                data-blade-component="icon"
+                fill="none"
+                height="12px"
+                viewBox="0 0 24 24"
+                width="12px"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M12 8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8ZM10 12C10 10.8954 10.8954 10 12 10C13.1046 10 14 10.8954 14 12C14 13.1046 13.1046 14 12 14C10.8954 14 10 13.1046 10 12Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(204, 9%, 42%, 1)"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M12 3C8.8711 3 6.22807 4.48937 4.23728 6.25113C2.24678 8.01264 0.822273 10.1194 0.105573 11.5528C-0.0351909 11.8343 -0.0351909 12.1657 0.105573 12.4472C0.822273 13.8806 2.24678 15.9874 4.23728 17.7489C6.22807 19.5106 8.8711 21 12 21C15.1289 21 17.7719 19.5106 19.7627 17.7489C21.7532 15.9874 23.1777 13.8806 23.8944 12.4472C24.0352 12.1657 24.0352 11.8343 23.8944 11.5528C23.1777 10.1194 21.7532 8.01264 19.7627 6.25113C17.7719 4.48937 15.1289 3 12 3ZM5.56272 16.2511C3.98954 14.8589 2.80913 13.2146 2.13142 12C2.80913 10.7854 3.98954 9.14106 5.56272 7.74887C7.3386 6.17729 9.5289 5 12 5C14.4711 5 16.6614 6.17729 18.4373 7.74887C20.0105 9.14106 21.1909 10.7854 21.8686 12C21.1909 13.2146 20.0105 14.8589 18.4373 16.2511C16.6614 17.8227 14.4711 19 12 19C9.5289 19 7.3386 17.8227 5.56272 16.2511Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(204, 9%, 42%, 1)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+          </div>
+          <input
+            aria-describedby="name-145-successtext-149"
+            aria-disabled="false"
+            aria-invalid="false"
+            aria-required="false"
+            class="c12"
+            data-blade-component="styled-base-input"
+            id="name-145-input-146"
+            placeholder="First Last"
+            type="text"
+            value=""
+          />
+          <div
+            class="c10"
+            data-blade-component="base-box"
+          >
+            <div
+              class="c13"
+              data-blade-component="base-box"
+            >
+              <div
+                class="c14"
+                data-blade-component="box"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-blade-component="icon"
+                  fill="none"
+                  height="12px"
+                  viewBox="0 0 24 24"
+                  width="12px"
+                >
+                  <path
+                    d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
+                    data-blade-component="svg-path"
+                    fill="hsla(150, 100%, 23%, 1)"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c15"
+      data-blade-component="base-box"
+    >
+      <div
+        class="c16"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c17"
+          data-blade-component="base-box"
+          id="name-145-successtext-149"
+        >
+          <span
+            class="c18"
+            data-blade-component="base-box"
+          >
+            <div
+              class="c19"
+              data-blade-component="box"
+            >
+              <svg
+                aria-hidden="true"
+                class="c20"
+                data-blade-component="icon"
+                fill="none"
+                height="12px"
+                viewBox="0 0 24 24"
+                width="12px"
               >
                 <path
                   clip-rule="evenodd"
@@ -3089,7 +3757,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
       >
         <label
           data-blade-component="form-label"
-          for="coupon-165-input-166"
+          for="coupon-185-input-186"
           style="width: 100%; flex-shrink: 0; margin-right: 0px;"
         >
           <div
@@ -3146,7 +3814,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
             aria-required="false"
             class="c10"
             data-blade-component="styled-base-input"
-            id="coupon-165-input-166"
+            id="coupon-185-input-186"
             type="text"
             value=""
           />
@@ -3572,7 +4240,7 @@ exports[`<BaseInput /> should support passing data-analytics-* attributes to the
       >
         <label
           data-blade-component="form-label"
-          for="name-573-input-574"
+          for="name-593-input-594"
           style="width: 100%; flex-shrink: 0; margin-right: 0px;"
         >
           <div
@@ -3630,7 +4298,7 @@ exports[`<BaseInput /> should support passing data-analytics-* attributes to the
             class="c10"
             data-analytics-name="base-input"
             data-blade-component="styled-base-input"
-            id="name-573-input-574"
+            id="name-593-input-594"
             type="text"
             value=""
           />

--- a/packages/blade/src/components/Input/BaseInput/baseInputTokens.ts
+++ b/packages/blade/src/components/Input/BaseInput/baseInputTokens.ts
@@ -17,6 +17,8 @@ export const baseInputHeight: Record<
 };
 
 /**
+ * xsmall - 112px (28px height * 4 rows)
+ * small - 128px (32px height * 4 rows)
  * medium - 144px (36px height * 4 rows)
  * large - 192px (48px height * 4 rows)
  */

--- a/packages/blade/src/components/Input/BaseInput/baseInputTokens.ts
+++ b/packages/blade/src/components/Input/BaseInput/baseInputTokens.ts
@@ -6,15 +6,12 @@ export const BASEINPUT_MAX_ROWS = 4;
 export const TAG_HEIGHT = size['20'];
 export const TAG_GAP = spacing['3'];
 
-/**
- * 36px
- */
 export const baseInputHeight: Record<
   NonNullable<BaseInputProps['size']>,
   typeof size[keyof typeof size]
 > = {
-  xsmall: size['26'],
-  small: size['30'],
+  xsmall: size['28'],
+  small: size['32'],
   medium: size['36'],
   large: size['48'],
 };


### PR DESCRIPTION
## Summary

- `xsmall`: `size['26']` (26px) → `size['28']` (28px)
- `small`: `size['30']` (30px) → `size['32']` (32px)
- `medium` and `large` were already correct at 36px and 48px

`baseInputWrapperMaxHeight` (used for animated height in tagged inputs) updates automatically since it derives from `baseInputHeight`.

Updated the JSDoc comment for `baseInputWrapperMaxHeight` to document all four sizes.

Added web and native snapshot tests for the `small` size variant, confirming `min-height: 32px`.

## Test plan

- [ ] Snapshot tests pass for web and native
- [ ] Visually verify `xsmall` and `small` input heights match the spec (28px / 32px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)