### PR TITLE
fix(ci): add testTimeout to native Jest config and cap test job at 30m

### DIFF
--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -59,6 +59,7 @@ jobs:
   test:
     name: Run Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/packages/blade/jest.native.config.js
+++ b/packages/blade/jest.native.config.js
@@ -12,6 +12,7 @@ module.exports = {
       statements: 75,
     },
   },
+  testTimeout: 10000,
   moduleFileExtensions: ['native.ts', 'native.tsx', 'ts', 'tsx', 'js', 'json', 'node'],
   testMatch: ['**/*.test.{ts,tsx}'],
   transform: {


### PR DESCRIPTION
## Summary

Addresses the root causes of the 6-hour native test hang in CI (observed in #3397).

- **`jest.native.config.js`**: Add `testTimeout: 10000` to match `jest.web.config.js`. Without this, a deadlocked native Jest worker has no per-test deadline and can hold the runner indefinitely. The `--forceExit` flag only triggers after all tests resolve, so it doesn't help when a worker is frozen.

- **`blade-validate.yml`** (`test` job): Add `timeout-minutes: 30`. The job previously had no timeout, defaulting to GitHub's 360-minute limit — which is exactly how long shard 2 burned before being cancelled. Normal shards finish in under 10 minutes; 30 minutes gives enough headroom while surfacing future hangs in a reasonable window.

## Test plan

- [ ] All 4 test shards pass within 30 minutes
- [ ] Native snapshot tests pass (no regression from timeout config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)