### PR TITLE
feat(native): Added Skeleton Loader for React Native

### DIFF
--- a/.changeset/yellow-feet-dig.md
+++ b/.changeset/yellow-feet-dig.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(native): Added Skeleton Loader for React Native

--- a/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
+++ b/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 import Animated, {
   cancelAnimation,
-  interpolateColor,
+  interpolate,
   useAnimatedStyle,
   useSharedValue,
   withDelay,
@@ -17,46 +17,15 @@ import { castNativeType, makeMotionTime } from '~utils';
 import { useTheme } from '~components/BladeProvider';
 import type { BladeElementRef } from '~utils/types';
 
-const hslaToRgba = (color: string): string => {
+const parseHsla = (color: string): { base: string; alpha: number } => {
   const match = color.match(
-    /hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*(?:,\s*([\d.]+))?\s*\)/,
+    /hsla?\(\s*([\d.]+)\s*,\s*([\d.]+%)\s*,\s*([\d.]+%)\s*(?:,\s*([\d.]+))?\s*\)/,
   );
-  if (!match) return color;
-
-  const h = parseFloat(match[1]);
-  const s = parseFloat(match[2]) / 100;
-  const l = parseFloat(match[3]) / 100;
-  const a = match[4] !== undefined ? parseFloat(match[4]) : 1;
-
-  const c = (1 - Math.abs(2 * l - 1)) * s;
-  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
-  const m = l - c / 2;
-
-  let r = 0;
-  let g = 0;
-  let b = 0;
-
-  if (h < 60) {
-    r = c;
-    g = x;
-  } else if (h < 120) {
-    r = x;
-    g = c;
-  } else if (h < 180) {
-    g = c;
-    b = x;
-  } else if (h < 240) {
-    g = x;
-    b = c;
-  } else if (h < 300) {
-    r = x;
-    b = c;
-  } else {
-    r = c;
-    b = x;
-  }
-
-  return `rgba(${Math.round((r + m) * 255)}, ${Math.round((g + m) * 255)}, ${Math.round((b + m) * 255)}, ${a})`;
+  if (!match) return { base: color, alpha: 1 };
+  return {
+    base: `hsl(${match[1]}, ${match[2]}, ${match[3]})`,
+    alpha: match[4] !== undefined ? parseFloat(match[4]) : 1,
+  };
 };
 
 const styles = StyleSheet.create({
@@ -74,14 +43,14 @@ const _PulseAnimation = (
   const fadeInDuration = castNativeType(makeMotionTime(durationPulseOn));
   const easing = castNativeType(theme.motion.easing.standard);
 
-  const grayDefault = hslaToRgba(theme.colors.interactive.background.gray.default);
-  const grayHighlighted = hslaToRgba(theme.colors.interactive.background.gray.highlighted);
+  const grayDefault = parseHsla(theme.colors.interactive.background.gray.default);
+  const grayHighlighted = parseHsla(theme.colors.interactive.background.gray.highlighted);
 
-  const opacity = useSharedValue(0);
+  const fadeIn = useSharedValue(0);
   const pulseProgress = useSharedValue(0);
 
   React.useEffect(() => {
-    opacity.value = withTiming(1, { duration: fadeInDuration, easing });
+    fadeIn.value = withTiming(1, { duration: fadeInDuration, easing });
 
     pulseProgress.value = withDelay(
       fadeInDuration,
@@ -89,14 +58,16 @@ const _PulseAnimation = (
     );
 
     return () => {
-      cancelAnimation(opacity);
+      cancelAnimation(fadeIn);
       cancelAnimation(pulseProgress);
     };
-  }, [easing, fadeInDuration, opacity, pulseProgress, totalDuration]);
+  }, [easing, fadeIn, fadeInDuration, pulseProgress, totalDuration]);
 
   const animatedStyle = useAnimatedStyle(() => ({
-    opacity: opacity.value,
-    backgroundColor: interpolateColor(pulseProgress.value, [0, 1], [grayDefault, grayHighlighted]),
+    opacity:
+      fadeIn.value *
+      interpolate(pulseProgress.value, [0, 1], [grayDefault.alpha, grayHighlighted.alpha]),
+    backgroundColor: grayDefault.base,
   }));
 
   return (

--- a/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
+++ b/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
@@ -96,11 +96,7 @@ const _PulseAnimation = (
 
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,
-    backgroundColor: interpolateColor(
-      pulseProgress.value,
-      [0, 1],
-      [grayDefault, grayHighlighted],
-    ),
+    backgroundColor: interpolateColor(pulseProgress.value, [0, 1], [grayDefault, grayHighlighted]),
   }));
 
   return (

--- a/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
+++ b/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
@@ -17,6 +17,7 @@ import { castNativeType, makeMotionTime } from '~utils';
 import { useTheme } from '~components/BladeProvider';
 import type { BladeElementRef } from '~utils/types';
 
+// Reanimated's interpolateColor doesn't support hsla(). Split into base hsl + alpha so we can animate it properly.
 const parseHsla = (color: string): { base: string; alpha: number } => {
   const match = color.match(
     /hsla?\(\s*([\d.]+)\s*,\s*([\d.]+%)\s*,\s*([\d.]+%)\s*(?:,\s*([\d.]+))?\s*\)/,

--- a/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
+++ b/packages/blade/src/components/Skeleton/PulseAnimation.native.tsx
@@ -5,78 +5,109 @@ import Animated, {
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,
+  withDelay,
   withRepeat,
-  withSequence,
   withTiming,
 } from 'react-native-reanimated';
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import type { SkeletonProps } from './types';
 import BaseBox from '~components/Box/BaseBox';
 import { castNativeType, makeMotionTime } from '~utils';
 import { useTheme } from '~components/BladeProvider';
 import type { BladeElementRef } from '~utils/types';
 
-const AnimatedBox = Animated.createAnimatedComponent(BaseBox);
+const hslaToRgba = (color: string): string => {
+  const match = color.match(
+    /hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*(?:,\s*([\d.]+))?\s*\)/,
+  );
+  if (!match) return color;
+
+  const h = parseFloat(match[1]);
+  const s = parseFloat(match[2]) / 100;
+  const l = parseFloat(match[3]) / 100;
+  const a = match[4] !== undefined ? parseFloat(match[4]) : 1;
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+
+  return `rgba(${Math.round((r + m) * 255)}, ${Math.round((g + m) * 255)}, ${Math.round((b + m) * 255)}, ${a})`;
+};
+
+const styles = StyleSheet.create({
+  fill: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
+});
 
 const _PulseAnimation = (
   props: SkeletonProps,
   ref: React.Ref<BladeElementRef>,
 ): React.ReactElement => {
   const { theme } = useTheme();
-  const durationPluseOff = theme.motion.duration.xmoderate;
-  const durationPluseOn = theme.motion.duration['2xgentle'];
-  const totalDuration = castNativeType(makeMotionTime(durationPluseOn + durationPluseOff));
-  const easing = castNativeType(theme.motion.easing.emphasized);
-  const progress = useSharedValue(0);
+  const durationPulseOff = theme.motion.duration.xmoderate;
+  const durationPulseOn = theme.motion.duration['2xgentle'];
+  const totalDuration = castNativeType(makeMotionTime(durationPulseOn + durationPulseOff));
+  const fadeInDuration = castNativeType(makeMotionTime(durationPulseOn));
+  const easing = castNativeType(theme.motion.easing.standard);
 
-  const fadeIn = () => {
-    'worklet';
-    const animations = {
-      opacity: withTiming(1, { duration: totalDuration, easing }),
-    };
-    const initialValues = {
-      opacity: 0,
-    };
-    return {
-      initialValues,
-      animations,
-    };
-  };
+  const grayDefault = hslaToRgba(theme.colors.interactive.background.gray.default);
+  const grayHighlighted = hslaToRgba(theme.colors.interactive.background.gray.highlighted);
 
-  // Trigger pulsating animation
+  const opacity = useSharedValue(0);
+  const pulseProgress = useSharedValue(0);
+
   React.useEffect(() => {
-    const pulsatingAnimationTimingConfig = {
-      duration: totalDuration,
-      easing,
-    };
-    progress.value = withRepeat(
-      withSequence(
-        withTiming(0, pulsatingAnimationTimingConfig),
-        withTiming(1, pulsatingAnimationTimingConfig),
-      ),
-      -1,
-      true,
+    opacity.value = withTiming(1, { duration: fadeInDuration, easing });
+
+    pulseProgress.value = withDelay(
+      fadeInDuration,
+      withRepeat(withTiming(1, { duration: totalDuration, easing }), -1, true),
     );
 
     return () => {
-      cancelAnimation(progress);
+      cancelAnimation(opacity);
+      cancelAnimation(pulseProgress);
     };
-  }, [easing, progress, totalDuration]);
+  }, [easing, fadeInDuration, opacity, pulseProgress, totalDuration]);
 
-  const pulseAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      backgroundColor: interpolateColor(
-        progress.value,
-        [1, 0],
-        [
-          theme.colors.interactive.background.gray.highlighted,
-          theme.colors.interactive.background.gray.default,
-        ],
-      ),
-    };
-  });
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    backgroundColor: interpolateColor(
+      pulseProgress.value,
+      [0, 1],
+      [grayDefault, grayHighlighted],
+    ),
+  }));
 
-  return <AnimatedBox ref={ref as never} entering={fadeIn} style={pulseAnimatedStyle} {...props} />;
+  return (
+    <BaseBox ref={ref as never} {...props} style={{ overflow: 'hidden' }}>
+      <Animated.View style={[styles.fill, animatedStyle]} />
+    </BaseBox>
+  );
 };
 
 const PulseAnimation = React.forwardRef(_PulseAnimation);

--- a/packages/blade/src/components/Skeleton/__tests__/__snapshots__/Skeleton.native.test.tsx.snap
+++ b/packages/blade/src/components/Skeleton/__tests__/__snapshots__/Skeleton.native.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`<Skeleton /> should render skeleton 1`] = `
             "top": 0,
           },
           {
-            "backgroundColor": undefined,
-            "opacity": 0,
+            "backgroundColor": "hsl(206, 10%, 29%)",
+            "opacity": NaN,
           },
         ]
       }

--- a/packages/blade/src/components/Skeleton/__tests__/__snapshots__/Skeleton.native.test.tsx.snap
+++ b/packages/blade/src/components/Skeleton/__tests__/__snapshots__/Skeleton.native.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`<Skeleton /> should render skeleton 1`] = `
   <View
     accessibilityElementsHidden={true}
     data-blade-component="skeleton"
-    entering={[Function]}
     height="50px"
     importantForAccessibility="no-hide-descendants"
     style={
@@ -21,12 +20,30 @@ exports[`<Skeleton /> should render skeleton 1`] = `
           "width": "100%",
         },
         {
-          "backgroundColor": undefined,
+          "overflow": "hidden",
         },
       ]
     }
     width="100%"
-  />
+  >
+    <View
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "backgroundColor": undefined,
+            "opacity": 0,
+          },
+        ]
+      }
+    />
+  </View>
 </View>
 `;
 


### PR DESCRIPTION
The Skeleton component's native pulse animation was broken due to two issues:

1. HSLA color format incompatibility - Reanimated's interpolateColor does not support hsla() strings. Added hslaToRgba converter to transform theme colors to rgba() before interpolation.

2. Animated styled-component conflict - Animated.createAnimatedComponent wrapping a styled-component (BaseBox) prevented animated styles from being applied. Switched to BaseBox for layout with an inner Animated.View for the pulse animation.

Also aligned easing with web (standard instead of emphasized) and added proper fade-in delay before pulse starts.

## Description

<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
