### PR TITLE
fix(native): externalize react-native-safe-area-context as peer dependency

### DIFF
--- a/.changeset/old-snakes-return.md
+++ b/.changeset/old-snakes-return.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix: externalize react-native-safe-area-context as peer dependency

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -312,6 +312,7 @@
     "react-native-gesture-handler": "^2.9.0",
     "react-native-pager-view": "^6.2.1 || ^8.0.0",
     "react-native-reanimated": "^3.4.1",
+    "react-native-safe-area-context": "^3.4.1",
     "react-native-svg": "^12.3.0",
     "styled-components": "^5"
   },
@@ -320,6 +321,9 @@
       "optional": true
     },
     "react-native-reanimated": {
+      "optional": true
+    },
+    "react-native-safe-area-context": {
       "optional": true
     }
   }


### PR DESCRIPTION
## Summary
- Moves `react-native-safe-area-context` from `devDependencies` to `peerDependencies` (with `optional: true`)
- Fixes "Could not find component config for native component" runtime error in consumer RN apps using `BottomNav`
- Aligns with how `react-native-reanimated` and `react-native-gesture-handler` are already declared

## Problem
Rollup wasn't externalizing `react-native-safe-area-context` because it was only in `devDependencies`. The build bundled the JS from v3.4.1 into `build/lib/native/node_modules/`, but consumer apps install their own version (e.g. 5.x) with matching native code. The JS↔native version mismatch causes `codegenNativeComponent('RNCSafeAreaView')` to fail at runtime.

## Fix
Adding it to `peerDependencies` makes `pluginPeerDepsExternal()` in the Rollup config externalize the import. The built output will have a bare `import { useSafeAreaInsets } from 'react-native-safe-area-context'` instead of a vendored relative path, resolving to the consumer's single copy.

## Test plan
- [ ] Verify Rollup build output for `BottomNav.native.js` uses bare import instead of relative `../../node_modules/` path
- [ ] Test in a consumer RN app (BladeShowcase) that `BottomNav` renders without "Could not find component config" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)