### PR TITLE
fix(native): accordion animation race condition

### DIFF
--- a/.changeset/cold-singers-attend.md
+++ b/.changeset/cold-singers-attend.md
@@ -2,4 +2,4 @@
 "@razorpay/blade": patch
 ---
 
-Fix/accordion animation race condition
+fix(Accordion): animation race condition

--- a/.changeset/cold-singers-attend.md
+++ b/.changeset/cold-singers-attend.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+Fix/accordion animation race condition

--- a/packages/blade/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/blade/src/components/Accordion/Accordion.stories.tsx
@@ -612,6 +612,11 @@ const AccordionDeprecatedAPITemplate: StoryFn<typeof AccordionComponent> = ({ ..
           <Text>Deprecated slot</Text>
         </Box>
       </AccordionItem>
+      <AccordionItem
+        icon={AnnouncementIcon}
+        title="How can I setup Payouts?"
+        description="Use Razorpay Payouts to send money to bank accounts, UPI IDs, or wallets instantly. You can automate bulk payouts via APIs or manage them from the dashboard."
+      />
     </AccordionComponent>
   );
 };

--- a/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
@@ -54,6 +54,10 @@ const CollapsibleBodyContent = ({
   const isAnimatingRef = useRef(false);
   const animationIdRef = useRef(0);
   const onAnimationComplete = useCallback((id: number): void => {
+    // Defer to next repaint to avoid state update delays when toggling rapidly.
+    // The id check ensures only the most recent animation can mark itself complete —
+    // if a new animation started before this fires, animationIdRef.current will have
+    // advanced past id and we skip the update (the new animation owns the state now).
     requestAnimationFrame(() => {
       if (animationIdRef.current === id) {
         isAnimatingRef.current = false;
@@ -71,10 +75,14 @@ const CollapsibleBodyContent = ({
     setIsAnimating(true);
 
     opacity.value = withTiming(getOpacity({ isExpanded }), { duration, easing });
+    // Animates height to the last measured content height, or 0 when collapsing.
     height.value = withTiming(
       isExpanded && layoutHeightRef.current ? layoutHeightRef.current : 0,
       { duration, easing },
       (isComplete) => {
+        // Only mark complete if animation ran uninterrupted (e.g. not reversed mid-way by
+        // the user toggling before it finished). onAnimationComplete must be called via
+        // runOnJS since withTiming callbacks run on the UI thread.
         if (isComplete) {
           runOnJS(onAnimationComplete)(currentId);
         }
@@ -100,10 +108,20 @@ const CollapsibleBodyContent = ({
       const newHeight = event.nativeEvent.layout.height;
       if (isAnimatingRef.current) {
         if (newHeight > layoutHeightRef.current) {
+          /**
+           * During animation, update the target height only if the new measurement is larger.
+           *
+           * The greater-than check is intentional: for multi-line Text, the first onLayout
+           * event reports height as if the text were single-line. Once the text actually wraps
+           * on screen a second onLayout fires with the real height. We only update upward to
+           * avoid shrinking the animation target to an intermediate measurement.
+           */
           layoutHeightRef.current = newHeight;
           height.value = withTiming(newHeight, { duration, easing });
         }
       } else if (newHeight !== layoutHeightRef.current) {
+        // When not animating, always sync layoutHeightRef to the latest measurement so
+        // dynamic content changes (e.g. items added to the slot) are picked up correctly.
         layoutHeightRef.current = newHeight;
       }
     },

--- a/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
@@ -45,14 +45,16 @@ const CollapsibleBodyContent = ({
 
   // `undefined` implies no height restrictions which is analogous to `auto` on web
   const height = useSharedValue(isExpanded ? undefined : 0);
-  const [layoutHeight, setLayoutHeight] = useState(0);
+  const layoutHeightRef = useRef(0);
 
   // Keeps track of running animation to control absolute / relative positioning and handling layout event
   const [isAnimating, setIsAnimating] = useState(false);
+  const isAnimatingRef = useRef(false);
   const animationIdRef = useRef(0);
   const onAnimationComplete = useCallback((id: number): void => {
     requestAnimationFrame(() => {
       if (animationIdRef.current === id) {
+        isAnimatingRef.current = false;
         setIsAnimating(false);
       }
     });
@@ -63,22 +65,20 @@ const CollapsibleBodyContent = ({
 
   useEffect(() => {
     const currentId = ++animationIdRef.current;
+    isAnimatingRef.current = true;
     setIsAnimating(true);
 
     opacity.value = withTiming(getOpacity({ isExpanded }), { duration, easing });
     height.value = withTiming(
-      // Animates the height to the measured value
-      isExpanded && layoutHeight ? layoutHeight : 0,
+      isExpanded && layoutHeightRef.current ? layoutHeightRef.current : 0,
       { duration, easing },
       (isComplete) => {
-        // Only run this if the animation ran uninterrupted, for eg collapsing the content before it expanded fully
         if (isComplete) {
-          // The callback `onAnimationComplete` has to be declared outside this, on JS thread
           runOnJS(onAnimationComplete)(currentId);
         }
       },
     );
-  }, [isExpanded, opacity, duration, easing, height, layoutHeight, onAnimationComplete]);
+  }, [isExpanded, opacity, duration, easing, height, onAnimationComplete]);
 
   const animatedStyles = useAnimatedStyle(
     (): ViewStyle => {
@@ -95,28 +95,17 @@ const CollapsibleBodyContent = ({
    */
   const onLayout: (event: LayoutChangeEvent) => void = useCallback(
     (event) => {
-      if (isAnimating) {
-        if (event.nativeEvent.layout.height > layoutHeight) {
-          /**
-           * During animation, we set `layoutHeight` if the native event's layout height is larger.
-           *
-           * The greater than comparison is needed because sometimes the native event's layout height is smaller than actual content height 🤯
-           * For example, this happens if you try to render a lengthy `Text` that wraps onto multiple lines.
-           * In this case the initial native event's layout height only counts height of `Text` as if it were single line.
-           * So, when the `Text` actually renders on screen and wraps, another `nativeEvent` is triggered which gives us the actual content height.
-           * `nativeEvent` is triggered multiple times during animation but we only set `layoutHeight` if the height value is greater, hence the check.
-           */
-          setLayoutHeight(event.nativeEvent.layout.height);
+      const newHeight = event.nativeEvent.layout.height;
+      if (isAnimatingRef.current) {
+        if (newHeight > layoutHeightRef.current) {
+          layoutHeightRef.current = newHeight;
+          height.value = withTiming(newHeight, { duration, easing });
         }
-      } else if (event.nativeEvent.layout.height !== layoutHeight) {
-        /**
-         * When not animating, we set `layoutHeight` anytime `nativeEvent` layout height changes.
-         * This handles userland dynamic content inside the slot.
-         */
-        setLayoutHeight(event.nativeEvent.layout.height);
+      } else if (newHeight !== layoutHeightRef.current) {
+        layoutHeightRef.current = newHeight;
       }
     },
-    [layoutHeight, isAnimating],
+    [height, duration, easing],
   );
 
   return (

--- a/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components/native';
 import Animated, {
   runOnJS,
@@ -49,15 +49,20 @@ const CollapsibleBodyContent = ({
 
   // Keeps track of running animation to control absolute / relative positioning and handling layout event
   const [isAnimating, setIsAnimating] = useState(false);
-  const onAnimationComplete = useCallback((): void => {
-    // Only mark the animation complete before the next repaint, otherwise, sometimes leads to state update delays when you try to quickly toggle multiple times
-    requestAnimationFrame(() => setIsAnimating(false));
+  const animationIdRef = useRef(0);
+  const onAnimationComplete = useCallback((id: number): void => {
+    requestAnimationFrame(() => {
+      if (animationIdRef.current === id) {
+        setIsAnimating(false);
+      }
+    });
   }, []);
 
   const duration = castNativeType(getTransitionDuration(theme));
   const easing = castNativeType(getTransitionEasing(theme));
 
   useEffect(() => {
+    const currentId = ++animationIdRef.current;
     setIsAnimating(true);
 
     opacity.value = withTiming(getOpacity({ isExpanded }), { duration, easing });
@@ -69,7 +74,7 @@ const CollapsibleBodyContent = ({
         // Only run this if the animation ran uninterrupted, for eg collapsing the content before it expanded fully
         if (isComplete) {
           // The callback `onAnimationComplete` has to be declared outside this, on JS thread
-          runOnJS(onAnimationComplete)();
+          runOnJS(onAnimationComplete)(currentId);
         }
       },
     );

--- a/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
+++ b/packages/blade/src/components/Collapsible/CollapsibleBodyContent.native.tsx
@@ -47,7 +47,9 @@ const CollapsibleBodyContent = ({
   const height = useSharedValue(isExpanded ? undefined : 0);
   const layoutHeightRef = useRef(0);
 
-  // Keeps track of running animation to control absolute / relative positioning and handling layout event
+  // Dual tracking is intentional: isAnimating (state) triggers re-renders so the absolute↔relative
+  // position switch in the render path is reactive; isAnimatingRef (ref) gives synchronous reads
+  // in onLayout/onAnimationComplete callbacks where stale closure state would be unreliable.
   const [isAnimating, setIsAnimating] = useState(false);
   const isAnimatingRef = useRef(false);
   const animationIdRef = useRef(0);


### PR DESCRIPTION
## Description

before:

https://github.com/user-attachments/assets/7844ee03-060d-42bb-b496-98ea4fa458fb

after:

https://github.com/user-attachments/assets/9ee8f97d-2fa6-4ee5-b92f-d57ba2135570



## Changes

    - Fix animation race condition on rapid toggling 
    - Added generation counter (animationIdRef) to prevent stale requestAnimationFrame callbacks from   setting isAnimating=false mid-animation
    - Replaced layoutHeight state with a ref to stop useEffect re-runs on every onLayout event
    - Retarget animations directly from onLayout via Reanimated shared values instead of React state cycle
   

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset
