### PR TITLE
fix(Tabs): center tab labels on React Native to match web

### DIFF
--- a/.changeset/tabs-native-center-label.md
+++ b/.changeset/tabs-native-center-label.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(Tabs): center tab labels on React Native to match web
+
+`TabItem.native`'s `StyledTabButton` was missing `justifyContent: 'center'`, so full-width tab items (`isFullWidthTabItem`) left-aligned their labels on React Native, while the web variant (`TabItem.web`) centers them. Added the missing property to restore web/native parity.

--- a/packages/blade/src/components/Tabs/TabItem.native.tsx
+++ b/packages/blade/src/components/Tabs/TabItem.native.tsx
@@ -18,6 +18,10 @@ const StyledTabButton = styled(BaseBox)<{
     display: 'flex',
     alignItems: 'center',
     flexDirection: 'row',
+    // Center the tab label, matching TabItem.web's `justifyContent: 'center'`.
+    // Without this, full-width tab items (`isFullWidthTabItem`) left-align their
+    // label on native while web centers it — a web/native parity gap.
+    justifyContent: 'center',
     width: isFullWidthTabItem ? '100%' : undefined,
     paddingTop: makeSpace(get(theme, paddingTop[_variant].horizontal[size!])),
     paddingBottom: makeSpace(get(theme, paddingBottom[_variant].horizontal[size!])),


### PR DESCRIPTION
## Problem
On React Native, full-width tab items (`isFullWidthTabItem`) render their labels **left-aligned**, while on web they are **centered**.

## Root cause
`TabItem.native.tsx`'s `StyledTabButton` sets `alignItems: 'center'` + `width: '100%'` but is **missing `justifyContent: 'center'`**, which the web variant has:

```ts
// TabItem.web.tsx
justifyContent: isVertical ? 'left' : 'center',
```

So a full-width tab's label packs to the start of the button on native — a web/native parity gap.

## Fix
Add `justifyContent: 'center'` to the native `StyledTabButton`. Native Tabs are horizontal, so this mirrors web's horizontal (`'center'`) case.

```diff
    display: 'flex',
    alignItems: 'center',
    flexDirection: 'row',
+   justifyContent: 'center',
    width: isFullWidthTabItem ? '100%' : undefined,
```

## Before / After (full-width 2-tab bar)
- **Before:** `Transactions` hugs the far left, `Settlements` left-of-center.
- **After:** both labels centered within their tabs.

Reproduced in the Razorpay merchant mobile app (RN 0.85, New Architecture, `@razorpay/blade@12.105.1`). Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)