### PR TITLE
fix(native): pass letterSpacing prop through BaseText.native.tsx

### DIFF
--- a/.changeset/slimy-lines-drum.md
+++ b/.changeset/slimy-lines-drum.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(native): pass letterSpacing prop through BaseText.native.tsx

--- a/packages/blade/src/components/Accordion/__tests__/__snapshots__/Accordion.native.test.tsx.snap
+++ b/packages/blade/src/components/Accordion/__tests__/__snapshots__/Accordion.native.test.tsx.snap
@@ -256,6 +256,7 @@ exports[`<Accordion /> should render 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -266,7 +267,7 @@ exports[`<Accordion /> should render 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -500,6 +501,7 @@ exports[`<Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -509,7 +511,7 @@ exports[`<Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -545,6 +547,7 @@ exports[`<Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -554,7 +557,7 @@ exports[`<Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -815,6 +818,7 @@ exports[`<Accordion /> should render 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -825,7 +829,7 @@ exports[`<Accordion /> should render 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -1059,6 +1063,7 @@ exports[`<Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -1068,7 +1073,7 @@ exports[`<Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -1104,6 +1109,7 @@ exports[`<Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -1113,7 +1119,7 @@ exports[`<Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -1374,6 +1380,7 @@ exports[`<Accordion /> should render 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -1384,7 +1391,7 @@ exports[`<Accordion /> should render 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -1618,6 +1625,7 @@ exports[`<Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -1627,7 +1635,7 @@ exports[`<Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -1663,6 +1671,7 @@ exports[`<Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -1672,7 +1681,7 @@ exports[`<Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -1983,6 +1992,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -1993,7 +2003,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -2217,6 +2227,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -2226,7 +2237,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -2271,6 +2282,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -2280,7 +2292,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -2542,6 +2554,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -2552,7 +2565,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -2776,6 +2789,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -2785,7 +2799,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -2830,6 +2844,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -2839,7 +2854,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -3101,6 +3116,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -3111,7 +3127,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -3335,6 +3351,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -3344,7 +3361,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -3389,6 +3406,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -3398,7 +3416,7 @@ exports[`Deprecated <Accordion /> should render 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -3709,6 +3727,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -3719,7 +3738,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -3943,6 +3962,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -3952,7 +3972,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -3997,6 +4017,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -4006,7 +4027,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -4268,6 +4289,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -4278,7 +4300,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -4502,6 +4524,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -4511,7 +4534,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -4556,6 +4579,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -4565,7 +4589,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -4827,6 +4851,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                 fontSize={200}
                                 fontStyle="normal"
                                 fontWeight="semibold"
+                                letterSpacing={25}
                                 lineHeight={200}
                                 marginTop="1px"
                                 style={
@@ -4837,7 +4862,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                       "fontSize": 16,
                                       "fontStyle": "normal",
                                       "fontWeight": "600",
-                                      "letterSpacing": 0,
+                                      "letterSpacing": -0.528,
                                       "lineHeight": 24,
                                       "marginBottom": 0,
                                       "marginLeft": 0,
@@ -5061,6 +5086,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -5070,7 +5096,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -5115,6 +5141,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                             fontSize={100}
                             fontStyle="normal"
                             fontWeight="regular"
+                            letterSpacing={50}
                             lineHeight={100}
                             style={
                               [
@@ -5124,7 +5151,7 @@ exports[`Deprecated <Accordion /> should render deprecated API 1`] = `
                                   "fontSize": 14,
                                   "fontStyle": "normal",
                                   "fontWeight": "400",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.18200000000000002,
                                   "lineHeight": 20,
                                   "marginBottom": 0,
                                   "marginLeft": 0,

--- a/packages/blade/src/components/Alert/__tests__/__snapshots__/Alert.native.test.tsx.snap
+++ b/packages/blade/src/components/Alert/__tests__/__snapshots__/Alert.native.test.tsx.snap
@@ -181,6 +181,7 @@ exports[`<Alert /> should render 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -190,7 +191,7 @@ exports[`<Alert /> should render 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -487,6 +488,7 @@ exports[`<Alert /> should render positive color and full width 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -496,7 +498,7 @@ exports[`<Alert /> should render positive color and full width 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -793,6 +795,7 @@ exports[`<Alert /> should render positive color and full width 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -802,7 +805,7 @@ exports[`<Alert /> should render positive color and full width 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,

--- a/packages/blade/src/components/Amount/__tests__/__snapshots__/Amount.native.test.tsx.snap
+++ b/packages/blade/src/components/Amount/__tests__/__snapshots__/Amount.native.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`<Amount /> should allow customizing number of fraction digits 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -90,7 +91,7 @@ exports[`<Amount /> should allow customizing number of fraction digits 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -259,6 +260,7 @@ exports[`<Amount /> should render AED currency Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -268,7 +270,7 @@ exports[`<Amount /> should render AED currency Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -437,6 +439,7 @@ exports[`<Amount /> should render Amount with default props 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -446,7 +449,7 @@ exports[`<Amount /> should render Amount with default props 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -648,6 +651,7 @@ exports[`<Amount /> should render Amount with negative sign 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -657,7 +661,7 @@ exports[`<Amount /> should render Amount with negative sign 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -826,6 +830,7 @@ exports[`<Amount /> should render MYR currency Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -835,7 +840,7 @@ exports[`<Amount /> should render MYR currency Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -1004,6 +1009,7 @@ exports[`<Amount /> should render USD currency Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -1013,7 +1019,7 @@ exports[`<Amount /> should render USD currency Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -1182,6 +1188,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -1191,7 +1198,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -1349,6 +1356,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -1358,7 +1366,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -1516,6 +1524,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -1525,7 +1534,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -1683,6 +1692,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -1692,7 +1702,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -1850,6 +1860,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -1859,7 +1870,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -2017,6 +2028,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -2026,7 +2038,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -2184,6 +2196,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -2193,7 +2206,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -2351,6 +2364,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -2360,7 +2374,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -2518,6 +2532,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -2527,7 +2542,7 @@ exports[`<Amount /> should render all sizes of Amount 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -2696,6 +2711,7 @@ exports[`<Amount /> should render amount with Decimal value 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -2705,7 +2721,7 @@ exports[`<Amount /> should render amount with Decimal value 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -2985,6 +3001,7 @@ exports[`<Amount /> should render currencyIndicator="currency-code" 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -2994,7 +3011,7 @@ exports[`<Amount /> should render currencyIndicator="currency-code" 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -3163,6 +3180,7 @@ exports[`<Amount /> should render currencyIndicator="currency-symbol" 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -3172,7 +3190,7 @@ exports[`<Amount /> should render currencyIndicator="currency-symbol" 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -3453,6 +3471,7 @@ exports[`<Amount /> should render isStrikethrough={true} 1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -3462,7 +3481,7 @@ exports[`<Amount /> should render isStrikethrough={true} 1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -3652,6 +3671,7 @@ exports[`<Amount /> should render positive intent Amount  1`] = `
         fontSize={100}
         fontStyle="normal"
         fontWeight="regular"
+        letterSpacing={50}
         lineHeight={100}
         style={
           [
@@ -3661,7 +3681,7 @@ exports[`<Amount /> should render positive intent Amount  1`] = `
               "fontSize": 14,
               "fontStyle": "normal",
               "fontWeight": "400",
-              "letterSpacing": 0,
+              "letterSpacing": -0.18200000000000002,
               "lineHeight": 20,
               "marginBottom": 0,
               "marginLeft": 0,

--- a/packages/blade/src/components/Badge/__tests__/__snapshots__/Badge.native.test.tsx.snap
+++ b/packages/blade/src/components/Badge/__tests__/__snapshots__/Badge.native.test.tsx.snap
@@ -173,6 +173,7 @@ exports[`<Badge /> should render Badge with Icon 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -184,7 +185,7 @@ exports[`<Badge /> should render Badge with Icon 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -280,6 +281,7 @@ exports[`<Badge /> should render Badge with default props 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -291,7 +293,7 @@ exports[`<Badge /> should render Badge with default props 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -387,6 +389,7 @@ exports[`<Badge /> should render intense emphasis information color Badge 1`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -398,7 +401,7 @@ exports[`<Badge /> should render intense emphasis information color Badge 1`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -494,6 +497,7 @@ exports[`<Badge /> should render intense emphasis information color Badge 2`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -505,7 +509,7 @@ exports[`<Badge /> should render intense emphasis information color Badge 2`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -601,6 +605,7 @@ exports[`<Badge /> should render intense emphasis negative color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -612,7 +617,7 @@ exports[`<Badge /> should render intense emphasis negative color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -708,6 +713,7 @@ exports[`<Badge /> should render intense emphasis negative color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -719,7 +725,7 @@ exports[`<Badge /> should render intense emphasis negative color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -815,6 +821,7 @@ exports[`<Badge /> should render intense emphasis neutral color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -826,7 +833,7 @@ exports[`<Badge /> should render intense emphasis neutral color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -922,6 +929,7 @@ exports[`<Badge /> should render intense emphasis neutral color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -933,7 +941,7 @@ exports[`<Badge /> should render intense emphasis neutral color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1029,6 +1037,7 @@ exports[`<Badge /> should render intense emphasis notice color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1040,7 +1049,7 @@ exports[`<Badge /> should render intense emphasis notice color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1136,6 +1145,7 @@ exports[`<Badge /> should render intense emphasis notice color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1147,7 +1157,7 @@ exports[`<Badge /> should render intense emphasis notice color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1243,6 +1253,7 @@ exports[`<Badge /> should render intense emphasis positive color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1254,7 +1265,7 @@ exports[`<Badge /> should render intense emphasis positive color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1350,6 +1361,7 @@ exports[`<Badge /> should render intense emphasis positive color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1361,7 +1373,7 @@ exports[`<Badge /> should render intense emphasis positive color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1457,6 +1469,7 @@ exports[`<Badge /> should render intense emphasis primary color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1468,7 +1481,7 @@ exports[`<Badge /> should render intense emphasis primary color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1564,6 +1577,7 @@ exports[`<Badge /> should render intense emphasis primary color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1575,7 +1589,7 @@ exports[`<Badge /> should render intense emphasis primary color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1671,6 +1685,7 @@ exports[`<Badge /> should render large size Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1682,7 +1697,7 @@ exports[`<Badge /> should render large size Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1778,6 +1793,7 @@ exports[`<Badge /> should render medium size Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -1789,7 +1805,7 @@ exports[`<Badge /> should render medium size Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -1885,6 +1901,7 @@ exports[`<Badge /> should render small size Badge 1`] = `
           fontSize={25}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={25}
           marginX="spacing.1"
           numberOfLines={1}
@@ -1896,7 +1913,7 @@ exports[`<Badge /> should render small size Badge 1`] = `
                 "fontSize": 10,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.13,
                 "lineHeight": 13,
                 "marginBottom": 0,
                 "marginLeft": 2,
@@ -1992,6 +2009,7 @@ exports[`<Badge /> should render subtle emphasis information color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2003,7 +2021,7 @@ exports[`<Badge /> should render subtle emphasis information color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2099,6 +2117,7 @@ exports[`<Badge /> should render subtle emphasis information color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2110,7 +2129,7 @@ exports[`<Badge /> should render subtle emphasis information color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2206,6 +2225,7 @@ exports[`<Badge /> should render subtle emphasis negative color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2217,7 +2237,7 @@ exports[`<Badge /> should render subtle emphasis negative color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2313,6 +2333,7 @@ exports[`<Badge /> should render subtle emphasis negative color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2324,7 +2345,7 @@ exports[`<Badge /> should render subtle emphasis negative color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2420,6 +2441,7 @@ exports[`<Badge /> should render subtle emphasis neutral color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2431,7 +2453,7 @@ exports[`<Badge /> should render subtle emphasis neutral color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2527,6 +2549,7 @@ exports[`<Badge /> should render subtle emphasis neutral color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2538,7 +2561,7 @@ exports[`<Badge /> should render subtle emphasis neutral color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2634,6 +2657,7 @@ exports[`<Badge /> should render subtle emphasis notice color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2645,7 +2669,7 @@ exports[`<Badge /> should render subtle emphasis notice color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2741,6 +2765,7 @@ exports[`<Badge /> should render subtle emphasis notice color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2752,7 +2777,7 @@ exports[`<Badge /> should render subtle emphasis notice color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2848,6 +2873,7 @@ exports[`<Badge /> should render subtle emphasis positive color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2859,7 +2885,7 @@ exports[`<Badge /> should render subtle emphasis positive color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -2955,6 +2981,7 @@ exports[`<Badge /> should render subtle emphasis positive color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -2966,7 +2993,7 @@ exports[`<Badge /> should render subtle emphasis positive color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -3062,6 +3089,7 @@ exports[`<Badge /> should render subtle emphasis primary color Badge 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -3073,7 +3101,7 @@ exports[`<Badge /> should render subtle emphasis primary color Badge 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,
@@ -3169,6 +3197,7 @@ exports[`<Badge /> should render subtle emphasis primary color Badge 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           marginX="spacing.2"
           numberOfLines={1}
@@ -3180,7 +3209,7 @@ exports[`<Badge /> should render subtle emphasis primary color Badge 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 4,

--- a/packages/blade/src/components/BottomNav/__tests__/__snapshots__/BottomNav.native.test.tsx.snap
+++ b/packages/blade/src/components/BottomNav/__tests__/__snapshots__/BottomNav.native.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`<BottomNav /> (native) should render 1`] = `
         fontSize={25}
         fontStyle="normal"
         fontWeight="semibold"
+        letterSpacing={50}
         lineHeight={25}
         numberOfLines={1}
         style={
@@ -168,7 +169,7 @@ exports[`<BottomNav /> (native) should render 1`] = `
               "fontSize": 10,
               "fontStyle": "normal",
               "fontWeight": "600",
-              "letterSpacing": 0,
+              "letterSpacing": -0.13,
               "lineHeight": 13,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -296,6 +297,7 @@ exports[`<BottomNav /> (native) should render 1`] = `
         fontSize={25}
         fontStyle="normal"
         fontWeight="semibold"
+        letterSpacing={50}
         lineHeight={25}
         numberOfLines={1}
         style={
@@ -306,7 +308,7 @@ exports[`<BottomNav /> (native) should render 1`] = `
               "fontSize": 10,
               "fontStyle": "normal",
               "fontWeight": "600",
-              "letterSpacing": 0,
+              "letterSpacing": -0.13,
               "lineHeight": 13,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -437,6 +439,7 @@ exports[`<BottomNav /> (native) should render 1`] = `
         fontSize={25}
         fontStyle="normal"
         fontWeight="semibold"
+        letterSpacing={50}
         lineHeight={25}
         numberOfLines={1}
         style={
@@ -447,7 +450,7 @@ exports[`<BottomNav /> (native) should render 1`] = `
               "fontSize": 10,
               "fontStyle": "normal",
               "fontWeight": "600",
-              "letterSpacing": 0,
+              "letterSpacing": -0.13,
               "lineHeight": 13,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -626,6 +629,7 @@ exports[`<BottomNav /> (native) should render with active item 1`] = `
         fontSize={25}
         fontStyle="normal"
         fontWeight="semibold"
+        letterSpacing={50}
         lineHeight={25}
         numberOfLines={1}
         style={
@@ -636,7 +640,7 @@ exports[`<BottomNav /> (native) should render with active item 1`] = `
               "fontSize": 10,
               "fontStyle": "normal",
               "fontWeight": "600",
-              "letterSpacing": 0,
+              "letterSpacing": -0.13,
               "lineHeight": 13,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -765,6 +769,7 @@ exports[`<BottomNav /> (native) should render with active item 1`] = `
         fontSize={25}
         fontStyle="normal"
         fontWeight="semibold"
+        letterSpacing={50}
         lineHeight={25}
         numberOfLines={1}
         style={
@@ -775,7 +780,7 @@ exports[`<BottomNav /> (native) should render with active item 1`] = `
               "fontSize": 10,
               "fontStyle": "normal",
               "fontWeight": "600",
-              "letterSpacing": 0,
+              "letterSpacing": -0.13,
               "lineHeight": 13,
               "marginBottom": 0,
               "marginLeft": 0,
@@ -906,6 +911,7 @@ exports[`<BottomNav /> (native) should render with active item 1`] = `
         fontSize={25}
         fontStyle="normal"
         fontWeight="semibold"
+        letterSpacing={50}
         lineHeight={25}
         numberOfLines={1}
         style={
@@ -916,7 +922,7 @@ exports[`<BottomNav /> (native) should render with active item 1`] = `
               "fontSize": 10,
               "fontStyle": "normal",
               "fontWeight": "600",
-              "letterSpacing": 0,
+              "letterSpacing": -0.13,
               "lineHeight": 13,
               "marginBottom": 0,
               "marginLeft": 0,

--- a/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
+++ b/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
@@ -597,6 +597,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                           fontSize={200}
                           fontStyle="normal"
                           fontWeight="semibold"
+                          letterSpacing={25}
                           lineHeight={200}
                           marginTop="1px"
                           style={
@@ -607,7 +608,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                                 "fontSize": 16,
                                 "fontStyle": "normal",
                                 "fontWeight": "600",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.528,
                                 "lineHeight": 24,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -720,6 +721,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                                     fontSize={75}
                                     fontStyle="normal"
                                     fontWeight="medium"
+                                    letterSpacing={50}
                                     lineHeight={75}
                                     numberOfLines={1}
                                     style={
@@ -730,7 +732,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                                           "fontSize": 12,
                                           "fontStyle": "normal",
                                           "fontWeight": "500",
-                                          "letterSpacing": 0,
+                                          "letterSpacing": -0.15600000000000003,
                                           "lineHeight": 17,
                                           "marginBottom": 0,
                                           "marginLeft": 0,
@@ -763,6 +765,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                         fontSize={75}
                         fontStyle="normal"
                         fontWeight="regular"
+                        letterSpacing={50}
                         lineHeight={75}
                         style={
                           [
@@ -772,7 +775,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                               "fontSize": 12,
                               "fontStyle": "normal",
                               "fontWeight": "400",
-                              "letterSpacing": 0,
+                              "letterSpacing": -0.15600000000000003,
                               "lineHeight": 17,
                               "marginBottom": 0,
                               "marginLeft": 0,
@@ -883,6 +886,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                               fontSize={75}
                               fontStyle="normal"
                               fontWeight="medium"
+                              letterSpacing={50}
                               lineHeight={75}
                               marginX="spacing.2"
                               numberOfLines={1}
@@ -894,7 +898,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
                                     "fontSize": 12,
                                     "fontStyle": "normal",
                                     "fontWeight": "500",
-                                    "letterSpacing": 0,
+                                    "letterSpacing": -0.15600000000000003,
                                     "lineHeight": 17,
                                     "marginBottom": 0,
                                     "marginLeft": 4,

--- a/packages/blade/src/components/Box/__tests__/__snapshots__/BaseBox.native.test.tsx.snap
+++ b/packages/blade/src/components/Box/__tests__/__snapshots__/BaseBox.native.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`<BaseBox /> should render BaseBox component with elevation 1`] = `
       fontSize={100}
       fontStyle="normal"
       fontWeight="regular"
+      letterSpacing={50}
       lineHeight={100}
       style={
         [
@@ -52,7 +53,7 @@ exports[`<BaseBox /> should render BaseBox component with elevation 1`] = `
             "fontSize": 14,
             "fontStyle": "normal",
             "fontWeight": "400",
-            "letterSpacing": 0,
+            "letterSpacing": -0.18200000000000002,
             "lineHeight": 20,
             "marginBottom": 0,
             "marginLeft": 0,

--- a/packages/blade/src/components/Card/__tests__/__snapshots__/Card.native.test.tsx.snap
+++ b/packages/blade/src/components/Card/__tests__/__snapshots__/Card.native.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -93,7 +94,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -180,6 +181,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -189,7 +191,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -214,6 +216,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -223,7 +226,7 @@ exports[`<Card /> should render a Card with Footer 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -899,6 +902,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                     fontSize={200}
                     fontStyle="normal"
                     fontWeight="semibold"
+                    letterSpacing={25}
                     lineHeight={200}
                     style={
                       [
@@ -908,7 +912,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                           "fontSize": 16,
                           "fontStyle": "normal",
                           "fontWeight": "600",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.528,
                           "lineHeight": 24,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -1006,6 +1010,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                             fontSize={75}
                             fontStyle="normal"
                             fontWeight="medium"
+                            letterSpacing={50}
                             lineHeight={75}
                             numberOfLines={1}
                             style={
@@ -1016,7 +1021,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                                   "fontSize": 12,
                                   "fontStyle": "normal",
                                   "fontWeight": "500",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.15600000000000003,
                                   "lineHeight": 17,
                                   "marginBottom": 0,
                                   "marginLeft": 0,
@@ -1048,6 +1053,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                   fontSize={75}
                   fontStyle="normal"
                   fontWeight="regular"
+                  letterSpacing={50}
                   lineHeight={75}
                   style={
                     [
@@ -1057,7 +1063,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                         "fontSize": 12,
                         "fontStyle": "normal",
                         "fontWeight": "400",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.15600000000000003,
                         "lineHeight": 17,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -1155,6 +1161,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                     fontSize={75}
                     fontStyle="normal"
                     fontWeight="medium"
+                    letterSpacing={50}
                     lineHeight={75}
                     marginX="spacing.2"
                     numberOfLines={1}
@@ -1166,7 +1173,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                           "fontSize": 12,
                           "fontStyle": "normal",
                           "fontWeight": "500",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.15600000000000003,
                           "lineHeight": 17,
                           "marginBottom": 0,
                           "marginLeft": 4,
@@ -1227,6 +1234,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -1236,7 +1244,7 @@ exports[`<Card /> should render a Card with Header 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1426,6 +1434,7 @@ exports[`<Card /> should render a border when elevation is \`none\` 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -1435,7 +1444,7 @@ exports[`<Card /> should render a border when elevation is \`none\` 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1542,6 +1551,7 @@ exports[`<Card /> should render a plain Card 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -1551,7 +1561,7 @@ exports[`<Card /> should render a plain Card 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Carousel/__tests__/__snapshots__/Carousel.native.test.tsx.snap
+++ b/packages/blade/src/components/Carousel/__tests__/__snapshots__/Carousel.native.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`Carousel Snapshots should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -120,7 +121,7 @@ exports[`Carousel Snapshots should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -173,6 +174,7 @@ exports[`Carousel Snapshots should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -182,7 +184,7 @@ exports[`Carousel Snapshots should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -776,6 +778,7 @@ exports[`Carousel Snapshots should render with visibleItems but always renders 1
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -785,7 +788,7 @@ exports[`Carousel Snapshots should render with visibleItems but always renders 1
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -838,6 +841,7 @@ exports[`Carousel Snapshots should render with visibleItems but always renders 1
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -847,7 +851,7 @@ exports[`Carousel Snapshots should render with visibleItems but always renders 1
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -900,6 +904,7 @@ exports[`Carousel Snapshots should render with visibleItems but always renders 1
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -909,7 +914,7 @@ exports[`Carousel Snapshots should render with visibleItems but always renders 1
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,

--- a/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.native.test.tsx.snap
+++ b/packages/blade/src/components/Checkbox/__tests__/__snapshots__/Checkbox.native.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -142,7 +143,7 @@ exports[`<Checkbox /> should render checkbox with label 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -300,6 +301,7 @@ exports[`<Checkbox /> should set disabled state with isDisabled 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -309,7 +311,7 @@ exports[`<Checkbox /> should set disabled state with isDisabled 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -467,6 +469,7 @@ exports[`<Checkbox /> should set error state with validationState 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -476,7 +479,7 @@ exports[`<Checkbox /> should set error state with validationState 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -635,6 +638,7 @@ exports[`<Checkbox /> should set error state with validationState 1`] = `
           fontSize={50}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={50}
           marginTop="spacing.0"
           style={
@@ -645,7 +649,7 @@ exports[`<Checkbox /> should set error state with validationState 1`] = `
                 "fontSize": 11,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.14300000000000002,
                 "lineHeight": 16,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Checkbox/__tests__/__snapshots__/CheckboxGroup.native.test.tsx.snap
+++ b/packages/blade/src/components/Checkbox/__tests__/__snapshots__/CheckboxGroup.native.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -79,7 +80,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -133,6 +134,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -142,7 +144,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -322,6 +324,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -331,7 +334,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -488,6 +491,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -497,7 +501,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -654,6 +658,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -663,7 +668,7 @@ exports[`<CheckboxGroup /> should render with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -761,6 +766,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -771,7 +777,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -825,6 +831,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -834,7 +841,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1014,6 +1021,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -1023,7 +1031,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -1180,6 +1188,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -1189,7 +1198,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -1346,6 +1355,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -1355,7 +1365,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -1413,6 +1423,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
               fontSize={50}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={50}
               marginTop="spacing.0"
               style={
@@ -1423,7 +1434,7 @@ exports[`<CheckboxGroup /> should render with label 2`] = `
                     "fontSize": 11,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.14300000000000002,
                     "lineHeight": 16,
                     "marginBottom": 0,
                     "marginLeft": 0,

--- a/packages/blade/src/components/Chip/__tests__/__snapshots__/Chip.native.test.tsx.snap
+++ b/packages/blade/src/components/Chip/__tests__/__snapshots__/Chip.native.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -86,7 +87,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -302,6 +303,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -312,7 +314,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -514,6 +516,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -524,7 +527,7 @@ exports[`<Chip /> should prioritize Chip's isDisabled prop instead of ChipGroup 
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -632,6 +635,7 @@ exports[`<Chip /> should render chip 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -641,7 +645,7 @@ exports[`<Chip /> should render chip 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -857,6 +861,7 @@ exports[`<Chip /> should render chip 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -867,7 +872,7 @@ exports[`<Chip /> should render chip 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -1069,6 +1074,7 @@ exports[`<Chip /> should render chip 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -1079,7 +1085,7 @@ exports[`<Chip /> should render chip 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -1187,6 +1193,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1196,7 +1203,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1512,6 +1519,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -1522,7 +1530,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -1824,6 +1832,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -1834,7 +1843,7 @@ exports[`<Chip /> should render chip with icon 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -1942,6 +1951,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1951,7 +1961,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -2167,6 +2177,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -2177,7 +2188,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -2379,6 +2390,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -2389,7 +2401,7 @@ exports[`<Chip /> should set disabled state with isDisabled 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,

--- a/packages/blade/src/components/Chip/__tests__/__snapshots__/ChipGroup.native.test.tsx.snap
+++ b/packages/blade/src/components/Chip/__tests__/__snapshots__/ChipGroup.native.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -79,7 +80,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -133,6 +134,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -142,7 +144,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -205,6 +207,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -214,7 +217,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -427,6 +430,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -437,7 +441,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -638,6 +642,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -648,7 +653,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -849,6 +854,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -859,7 +865,7 @@ exports[`<ChipGroup /> selectionType="multiple" should render with selectionType
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -960,6 +966,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -970,7 +977,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1024,6 +1031,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -1033,7 +1041,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1096,6 +1104,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1105,7 +1114,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1319,6 +1328,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -1329,7 +1339,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -1531,6 +1541,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -1541,7 +1552,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -1743,6 +1754,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           numberOfLines={1}
                           style={
@@ -1753,7 +1765,7 @@ exports[`<ChipGroup /> selectionType="single" should render with selectionType="
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,

--- a/packages/blade/src/components/Collapsible/__tests__/__snapshots__/Collapsible.native.test.tsx.snap
+++ b/packages/blade/src/components/Collapsible/__tests__/__snapshots__/Collapsible.native.test.tsx.snap
@@ -278,6 +278,7 @@ exports[`<Collapsible /> should render with CollapsibleButton 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="regular"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -287,7 +288,7 @@ exports[`<Collapsible /> should render with CollapsibleButton 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "400",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -376,6 +377,7 @@ exports[`<Collapsible /> should render with CollapsibleButton 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -385,7 +387,7 @@ exports[`<Collapsible /> should render with CollapsibleButton 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -784,6 +786,7 @@ exports[`<Collapsible /> should render with CollapsibleLink 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="regular"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -793,7 +796,7 @@ exports[`<Collapsible /> should render with CollapsibleLink 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "400",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -882,6 +885,7 @@ exports[`<Collapsible /> should render with CollapsibleLink 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -891,7 +895,7 @@ exports[`<Collapsible /> should render with CollapsibleLink 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,

--- a/packages/blade/src/components/Counter/__tests__/__snapshots__/Counter.native.test.tsx.snap
+++ b/packages/blade/src/components/Counter/__tests__/__snapshots__/Counter.native.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`<Counter /> should render Counter with default props 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -89,7 +90,7 @@ exports[`<Counter /> should render Counter with default props 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -193,6 +194,7 @@ exports[`<Counter /> should render intense emphasis information color Counter 1`
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -203,7 +205,7 @@ exports[`<Counter /> should render intense emphasis information color Counter 1`
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -307,6 +309,7 @@ exports[`<Counter /> should render intense emphasis information color Counter 2`
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -317,7 +320,7 @@ exports[`<Counter /> should render intense emphasis information color Counter 2`
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -421,6 +424,7 @@ exports[`<Counter /> should render intense emphasis negative color Counter 1`] =
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -431,7 +435,7 @@ exports[`<Counter /> should render intense emphasis negative color Counter 1`] =
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -535,6 +539,7 @@ exports[`<Counter /> should render intense emphasis negative color Counter 2`] =
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -545,7 +550,7 @@ exports[`<Counter /> should render intense emphasis negative color Counter 2`] =
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -649,6 +654,7 @@ exports[`<Counter /> should render intense emphasis neutral color Counter 1`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -659,7 +665,7 @@ exports[`<Counter /> should render intense emphasis neutral color Counter 1`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -763,6 +769,7 @@ exports[`<Counter /> should render intense emphasis neutral color Counter 2`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -773,7 +780,7 @@ exports[`<Counter /> should render intense emphasis neutral color Counter 2`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -877,6 +884,7 @@ exports[`<Counter /> should render intense emphasis notice color Counter 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -887,7 +895,7 @@ exports[`<Counter /> should render intense emphasis notice color Counter 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -991,6 +999,7 @@ exports[`<Counter /> should render intense emphasis notice color Counter 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1001,7 +1010,7 @@ exports[`<Counter /> should render intense emphasis notice color Counter 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1105,6 +1114,7 @@ exports[`<Counter /> should render intense emphasis positive color Counter 1`] =
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1115,7 +1125,7 @@ exports[`<Counter /> should render intense emphasis positive color Counter 1`] =
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1219,6 +1229,7 @@ exports[`<Counter /> should render intense emphasis positive color Counter 2`] =
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1229,7 +1240,7 @@ exports[`<Counter /> should render intense emphasis positive color Counter 2`] =
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1333,6 +1344,7 @@ exports[`<Counter /> should render intense emphasis primary color Counter 1`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1343,7 +1355,7 @@ exports[`<Counter /> should render intense emphasis primary color Counter 1`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1447,6 +1459,7 @@ exports[`<Counter /> should render intense emphasis primary color Counter 2`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1457,7 +1470,7 @@ exports[`<Counter /> should render intense emphasis primary color Counter 2`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1561,6 +1574,7 @@ exports[`<Counter /> should render large size Counter 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={100}
           numberOfLines={1}
           style={
@@ -1571,7 +1585,7 @@ exports[`<Counter /> should render large size Counter 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1675,6 +1689,7 @@ exports[`<Counter /> should render medium size Counter 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1685,7 +1700,7 @@ exports[`<Counter /> should render medium size Counter 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1789,6 +1804,7 @@ exports[`<Counter /> should render small size Counter 1`] = `
           fontSize={25}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={25}
           numberOfLines={1}
           style={
@@ -1799,7 +1815,7 @@ exports[`<Counter /> should render small size Counter 1`] = `
                 "fontSize": 10,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.13,
                 "lineHeight": 13,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1903,6 +1919,7 @@ exports[`<Counter /> should render subtle emphasis information color Counter 1`]
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -1913,7 +1930,7 @@ exports[`<Counter /> should render subtle emphasis information color Counter 1`]
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2017,6 +2034,7 @@ exports[`<Counter /> should render subtle emphasis information color Counter 2`]
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2027,7 +2045,7 @@ exports[`<Counter /> should render subtle emphasis information color Counter 2`]
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2131,6 +2149,7 @@ exports[`<Counter /> should render subtle emphasis negative color Counter 1`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2141,7 +2160,7 @@ exports[`<Counter /> should render subtle emphasis negative color Counter 1`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2245,6 +2264,7 @@ exports[`<Counter /> should render subtle emphasis negative color Counter 2`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2255,7 +2275,7 @@ exports[`<Counter /> should render subtle emphasis negative color Counter 2`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2359,6 +2379,7 @@ exports[`<Counter /> should render subtle emphasis neutral color Counter 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2369,7 +2390,7 @@ exports[`<Counter /> should render subtle emphasis neutral color Counter 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2473,6 +2494,7 @@ exports[`<Counter /> should render subtle emphasis neutral color Counter 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2483,7 +2505,7 @@ exports[`<Counter /> should render subtle emphasis neutral color Counter 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2587,6 +2609,7 @@ exports[`<Counter /> should render subtle emphasis notice color Counter 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2597,7 +2620,7 @@ exports[`<Counter /> should render subtle emphasis notice color Counter 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2701,6 +2724,7 @@ exports[`<Counter /> should render subtle emphasis notice color Counter 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2711,7 +2735,7 @@ exports[`<Counter /> should render subtle emphasis notice color Counter 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2815,6 +2839,7 @@ exports[`<Counter /> should render subtle emphasis positive color Counter 1`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2825,7 +2850,7 @@ exports[`<Counter /> should render subtle emphasis positive color Counter 1`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -2929,6 +2954,7 @@ exports[`<Counter /> should render subtle emphasis positive color Counter 2`] = 
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -2939,7 +2965,7 @@ exports[`<Counter /> should render subtle emphasis positive color Counter 2`] = 
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -3043,6 +3069,7 @@ exports[`<Counter /> should render subtle emphasis primary color Counter 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -3053,7 +3080,7 @@ exports[`<Counter /> should render subtle emphasis primary color Counter 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -3157,6 +3184,7 @@ exports[`<Counter /> should render subtle emphasis primary color Counter 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           numberOfLines={1}
           style={
@@ -3167,7 +3195,7 @@ exports[`<Counter /> should render subtle emphasis primary color Counter 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                     fontSize={75}
                     fontStyle="normal"
                     fontWeight="medium"
+                    letterSpacing={50}
                     lineHeight={75}
                     numberOfLines={2}
                     style={
@@ -132,7 +133,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                           "fontSize": 12,
                           "fontStyle": "normal",
                           "fontWeight": "500",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.15600000000000003,
                           "lineHeight": 17,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -186,6 +187,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -195,7 +197,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -435,6 +437,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                               fontSize={100}
                               fontStyle="normal"
                               fontWeight="regular"
+                              letterSpacing={50}
                               lineHeight={100}
                               numberOfLines={1}
                               style={
@@ -445,7 +448,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                                     "fontSize": 14,
                                     "fontStyle": "normal",
                                     "fontWeight": "400",
-                                    "letterSpacing": 0,
+                                    "letterSpacing": -0.18200000000000002,
                                     "lineHeight": 20,
                                     "marginBottom": 0,
                                     "marginLeft": 0,
@@ -952,6 +955,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                             fontSize={200}
                             fontStyle="normal"
                             fontWeight="semibold"
+                            letterSpacing={25}
                             lineHeight={200}
                             marginTop="1px"
                             style={
@@ -962,7 +966,7 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                                   "fontSize": 16,
                                   "fontStyle": "normal",
                                   "fontWeight": "600",
-                                  "letterSpacing": 0,
+                                  "letterSpacing": -0.528,
                                   "lineHeight": 24,
                                   "marginBottom": 0,
                                   "marginLeft": 0,

--- a/packages/blade/src/components/Indicator/__tests__/__snapshots__/Indicator.native.test.tsx.snap
+++ b/packages/blade/src/components/Indicator/__tests__/__snapshots__/Indicator.native.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`<Indicator /> should render 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -122,7 +123,7 @@ exports[`<Indicator /> should render 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -258,6 +259,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -267,7 +269,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -392,6 +394,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
           fontSize={100}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -401,7 +404,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -526,6 +529,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
           fontSize={100}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -535,7 +539,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -660,6 +664,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
           fontSize={100}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -669,7 +674,7 @@ exports[`<Indicator /> should render different variants for size and color 1`] =
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -821,6 +826,7 @@ exports[`<Indicator /> should render with intense emphasis 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="medium"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -830,7 +836,7 @@ exports[`<Indicator /> should render with intense emphasis 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "500",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/BaseInput/__tests__/__snapshots__/BaseInput.native.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`<BaseInput /> should render 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -98,7 +99,7 @@ exports[`<BaseInput /> should render 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -152,6 +153,7 @@ exports[`<BaseInput /> should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -161,7 +163,7 @@ exports[`<BaseInput /> should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -410,6 +412,7 @@ exports[`<BaseInput /> should render input with no borders 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -420,7 +423,7 @@ exports[`<BaseInput /> should render input with no borders 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -474,6 +477,7 @@ exports[`<BaseInput /> should render input with no borders 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -483,7 +487,7 @@ exports[`<BaseInput /> should render input with no borders 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -732,6 +736,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -742,7 +747,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -796,6 +801,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -805,7 +811,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -1103,6 +1109,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
               fontSize={50}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={50}
               marginTop="spacing.0"
               style={
@@ -1113,7 +1120,7 @@ exports[`<BaseInput /> should render input with no borders in error state 1`] = 
                     "fontSize": 11,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.14300000000000002,
                     "lineHeight": 16,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1226,6 +1233,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -1236,7 +1244,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1290,6 +1298,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -1299,7 +1308,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -1570,6 +1579,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
               fontSize={50}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={50}
               marginTop="spacing.0"
               style={
@@ -1580,7 +1590,7 @@ exports[`<BaseInput /> should render input with no borders in success state 1`] 
                     "fontSize": 11,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.14300000000000002,
                     "lineHeight": 16,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1693,6 +1703,7 @@ exports[`<BaseInput /> should render with icons 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -1703,7 +1714,7 @@ exports[`<BaseInput /> should render with icons 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1757,6 +1768,7 @@ exports[`<BaseInput /> should render with icons 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -1766,7 +1778,7 @@ exports[`<BaseInput /> should render with icons 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -2218,6 +2230,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={100}
               numberOfLines={2}
               style={
@@ -2228,7 +2241,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2282,6 +2295,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -2291,7 +2305,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -2781,6 +2795,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={50}
               marginTop="spacing.0"
               style={
@@ -2791,7 +2806,7 @@ exports[`<BaseInput /> should render with large size input 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 16,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2904,6 +2919,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -2914,7 +2930,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2968,6 +2984,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -2977,7 +2994,7 @@ exports[`<BaseInput /> should render with trailingButton 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                     fontSize={75}
                     fontStyle="normal"
                     fontWeight="medium"
+                    letterSpacing={50}
                     lineHeight={75}
                     numberOfLines={2}
                     style={
@@ -132,7 +133,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                           "fontSize": 12,
                           "fontStyle": "normal",
                           "fontWeight": "500",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.15600000000000003,
                           "lineHeight": 17,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -186,6 +187,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -195,7 +197,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,

--- a/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.native.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`<OTPInput /> should render 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -79,7 +80,7 @@ exports[`<OTPInput /> should render 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -133,6 +134,7 @@ exports[`<OTPInput /> should render 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -142,7 +144,7 @@ exports[`<OTPInput /> should render 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1206,6 +1208,7 @@ exports[`<OTPInput /> should render large size 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={100}
             numberOfLines={2}
             style={
@@ -1216,7 +1219,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1270,6 +1273,7 @@ exports[`<OTPInput /> should render large size 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -1279,7 +1283,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,

--- a/packages/blade/src/components/Input/PasswordInput/__tests__/__snapshots__/PasswordInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/PasswordInput/__tests__/__snapshots__/PasswordInput.native.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`<PasswordInput /> should render 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -98,7 +99,7 @@ exports[`<PasswordInput /> should render 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -152,6 +153,7 @@ exports[`<PasswordInput /> should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -161,7 +163,7 @@ exports[`<PasswordInput /> should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -594,6 +596,7 @@ exports[`<PasswordInput /> should render large size 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={100}
               numberOfLines={2}
               style={
@@ -604,7 +607,7 @@ exports[`<PasswordInput /> should render large size 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -658,6 +661,7 @@ exports[`<PasswordInput /> should render large size 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -667,7 +671,7 @@ exports[`<PasswordInput /> should render large size 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,

--- a/packages/blade/src/components/Input/SearchInput/__tests__/__snapshots__/SearchInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/SearchInput/__tests__/__snapshots__/SearchInput.native.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`<SearchInput /> should render 1`] = `
                 fontSize={75}
                 fontStyle="normal"
                 fontWeight="medium"
+                letterSpacing={50}
                 lineHeight={75}
                 numberOfLines={2}
                 style={
@@ -109,7 +110,7 @@ exports[`<SearchInput /> should render 1`] = `
                       "fontSize": 12,
                       "fontStyle": "normal",
                       "fontWeight": "500",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.15600000000000003,
                       "lineHeight": 17,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -163,6 +164,7 @@ exports[`<SearchInput /> should render 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="regular"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -172,7 +174,7 @@ exports[`<SearchInput /> should render 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "400",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,

--- a/packages/blade/src/components/Input/TextArea/__tests__/__snapshots__/TextArea.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/TextArea/__tests__/__snapshots__/TextArea.native.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`<TextArea /> should render 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -98,7 +99,7 @@ exports[`<TextArea /> should render 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -152,6 +153,7 @@ exports[`<TextArea /> should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -161,7 +163,7 @@ exports[`<TextArea /> should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,

--- a/packages/blade/src/components/Input/TextInput/__tests__/__snapshots__/TextInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/TextInput/__tests__/__snapshots__/TextInput.native.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`<TextInput /> should render 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -98,7 +99,7 @@ exports[`<TextInput /> should render 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -152,6 +153,7 @@ exports[`<TextInput /> should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -161,7 +163,7 @@ exports[`<TextInput /> should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -415,6 +417,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="medium"
+              letterSpacing={50}
               lineHeight={75}
               numberOfLines={2}
               style={
@@ -425,7 +428,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "500",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -479,6 +482,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -488,7 +492,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -691,6 +695,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -700,7 +705,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -825,6 +830,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -834,7 +840,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,

--- a/packages/blade/src/components/List/__tests__/__snapshots__/List.native.test.tsx.snap
+++ b/packages/blade/src/components/List/__tests__/__snapshots__/List.native.test.tsx.snap
@@ -153,6 +153,7 @@ exports[`<List /> should render List with default properties 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -162,7 +163,7 @@ exports[`<List /> should render List with default properties 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -332,6 +333,7 @@ exports[`<List /> should render List with default properties 1`] = `
                     fontSize={100}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={50}
                     lineHeight={100}
                     style={
                       [
@@ -341,7 +343,7 @@ exports[`<List /> should render List with default properties 1`] = `
                           "fontSize": 14,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.18200000000000002,
                           "lineHeight": 20,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -509,6 +511,7 @@ exports[`<List /> should render List with default properties 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -518,7 +521,7 @@ exports[`<List /> should render List with default properties 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -702,6 +705,7 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -711,7 +715,7 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -757,6 +761,7 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
                 fontFamily="code"
                 fontSize={25}
                 fontWeight="regular"
+                letterSpacing={100}
                 lineHeight={25}
                 style={
                   [
@@ -914,6 +919,7 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -923,7 +929,7 @@ exports[`<List /> should render List with inline ListItemCode 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1101,6 +1107,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -1110,7 +1117,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1361,6 +1368,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -1370,7 +1378,7 @@ exports[`<List /> should render List with inline ListItemLink 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1548,6 +1556,7 @@ exports[`<List /> should render List with inline ListItemText 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -1557,7 +1566,7 @@ exports[`<List /> should render List with inline ListItemText 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1670,6 +1679,7 @@ exports[`<List /> should render large ordered List 1`] = `
               fontSize={200}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={25}
               lineHeight={200}
               style={
                 [
@@ -1679,7 +1689,7 @@ exports[`<List /> should render large ordered List 1`] = `
                     "fontSize": 16,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.528,
                     "lineHeight": 24,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1720,6 +1730,7 @@ exports[`<List /> should render large ordered List 1`] = `
               fontSize={200}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={25}
               lineHeight={200}
               style={
                 [
@@ -1729,7 +1740,7 @@ exports[`<List /> should render large ordered List 1`] = `
                     "fontSize": 16,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.528,
                     "lineHeight": 24,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1899,6 +1910,7 @@ exports[`<List /> should render large ordered List 1`] = `
                     fontSize={200}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={25}
                     lineHeight={200}
                     style={
                       [
@@ -1908,7 +1920,7 @@ exports[`<List /> should render large ordered List 1`] = `
                           "fontSize": 16,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.528,
                           "lineHeight": 24,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -2076,6 +2088,7 @@ exports[`<List /> should render large ordered List 1`] = `
                           fontSize={200}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={25}
                           lineHeight={200}
                           style={
                             [
@@ -2085,7 +2098,7 @@ exports[`<List /> should render large ordered List 1`] = `
                                 "fontSize": 16,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.528,
                                 "lineHeight": 24,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -2208,6 +2221,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -2217,7 +2231,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2258,6 +2272,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
               fontSize={200}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={25}
               lineHeight={200}
               style={
                 [
@@ -2267,7 +2282,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
                     "fontSize": 16,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.528,
                     "lineHeight": 24,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2353,6 +2368,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -2362,7 +2378,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2403,6 +2419,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
               fontSize={200}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={25}
               lineHeight={200}
               style={
                 [
@@ -2412,7 +2429,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
                     "fontSize": 16,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.528,
                     "lineHeight": 24,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2498,6 +2515,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -2507,7 +2525,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2548,6 +2566,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
               fontSize={200}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={25}
               lineHeight={200}
               style={
                 [
@@ -2557,7 +2576,7 @@ exports[`<List /> should render large ordered-filled List 1`] = `
                     "fontSize": 16,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.528,
                     "lineHeight": 24,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2733,6 +2752,7 @@ exports[`<List /> should render large unordered List with icon 1`] = `
               fontSize={200}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={25}
               lineHeight={200}
               style={
                 [
@@ -2742,7 +2762,7 @@ exports[`<List /> should render large unordered List with icon 1`] = `
                     "fontSize": 16,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.528,
                     "lineHeight": 24,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -2904,6 +2924,7 @@ exports[`<List /> should render large unordered List with icon 1`] = `
                     fontSize={200}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={25}
                     lineHeight={200}
                     style={
                       [
@@ -2913,7 +2934,7 @@ exports[`<List /> should render large unordered List with icon 1`] = `
                           "fontSize": 16,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.528,
                           "lineHeight": 24,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -3081,6 +3102,7 @@ exports[`<List /> should render large unordered List with icon 1`] = `
                           fontSize={200}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={25}
                           lineHeight={200}
                           style={
                             [
@@ -3090,7 +3112,7 @@ exports[`<List /> should render large unordered List with icon 1`] = `
                                 "fontSize": 16,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.528,
                                 "lineHeight": 24,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -3209,6 +3231,7 @@ exports[`<List /> should render medium ordered List 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -3218,7 +3241,7 @@ exports[`<List /> should render medium ordered List 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -3259,6 +3282,7 @@ exports[`<List /> should render medium ordered List 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -3268,7 +3292,7 @@ exports[`<List /> should render medium ordered List 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -3438,6 +3462,7 @@ exports[`<List /> should render medium ordered List 1`] = `
                     fontSize={100}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={50}
                     lineHeight={100}
                     style={
                       [
@@ -3447,7 +3472,7 @@ exports[`<List /> should render medium ordered List 1`] = `
                           "fontSize": 14,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.18200000000000002,
                           "lineHeight": 20,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -3615,6 +3640,7 @@ exports[`<List /> should render medium ordered List 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -3624,7 +3650,7 @@ exports[`<List /> should render medium ordered List 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -3747,6 +3773,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -3756,7 +3783,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -3797,6 +3824,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -3806,7 +3834,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -3892,6 +3920,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -3901,7 +3930,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -3942,6 +3971,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -3951,7 +3981,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4037,6 +4067,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -4046,7 +4077,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4087,6 +4118,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -4096,7 +4128,7 @@ exports[`<List /> should render medium ordered-filled List 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4272,6 +4304,7 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -4281,7 +4314,7 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4443,6 +4476,7 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                     fontSize={100}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={50}
                     lineHeight={100}
                     style={
                       [
@@ -4452,7 +4486,7 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                           "fontSize": 14,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.18200000000000002,
                           "lineHeight": 20,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -4620,6 +4654,7 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                           fontSize={100}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={100}
                           style={
                             [
@@ -4629,7 +4664,7 @@ exports[`<List /> should render medium unordered List with icon 1`] = `
                                 "fontSize": 14,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.18200000000000002,
                                 "lineHeight": 20,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -4748,6 +4783,7 @@ exports[`<List /> should render small ordered List 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -4757,7 +4793,7 @@ exports[`<List /> should render small ordered List 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4798,6 +4834,7 @@ exports[`<List /> should render small ordered List 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -4807,7 +4844,7 @@ exports[`<List /> should render small ordered List 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4977,6 +5014,7 @@ exports[`<List /> should render small ordered List 1`] = `
                     fontSize={75}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={50}
                     lineHeight={75}
                     style={
                       [
@@ -4986,7 +5024,7 @@ exports[`<List /> should render small ordered List 1`] = `
                           "fontSize": 12,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.15600000000000003,
                           "lineHeight": 17,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -5154,6 +5192,7 @@ exports[`<List /> should render small ordered List 1`] = `
                           fontSize={75}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={75}
                           style={
                             [
@@ -5163,7 +5202,7 @@ exports[`<List /> should render small ordered List 1`] = `
                                 "fontSize": 12,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.15600000000000003,
                                 "lineHeight": 17,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -5286,6 +5325,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -5295,7 +5335,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5336,6 +5376,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -5345,7 +5386,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5431,6 +5472,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -5440,7 +5482,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5481,6 +5523,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -5490,7 +5533,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5576,6 +5619,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
               fontSize={25}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={25}
               style={
                 [
@@ -5585,7 +5629,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
                     "fontSize": 10,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.13,
                     "lineHeight": 13,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5626,6 +5670,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -5635,7 +5680,7 @@ exports[`<List /> should render small ordered-filled List 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5811,6 +5856,7 @@ exports[`<List /> should render small unordered List with icon 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -5820,7 +5866,7 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5982,6 +6028,7 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                     fontSize={75}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={50}
                     lineHeight={75}
                     style={
                       [
@@ -5991,7 +6038,7 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                           "fontSize": 12,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.15600000000000003,
                           "lineHeight": 17,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -6159,6 +6206,7 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                           fontSize={75}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={75}
                           style={
                             [
@@ -6168,7 +6216,7 @@ exports[`<List /> should render small unordered List with icon 1`] = `
                                 "fontSize": 12,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.15600000000000003,
                                 "lineHeight": 17,
                                 "marginBottom": 0,
                                 "marginLeft": 0,
@@ -6352,6 +6400,7 @@ exports[`<List /> should render unordered List of small size 1`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               style={
                 [
@@ -6361,7 +6410,7 @@ exports[`<List /> should render unordered List of small size 1`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -6531,6 +6580,7 @@ exports[`<List /> should render unordered List of small size 1`] = `
                     fontSize={75}
                     fontStyle="normal"
                     fontWeight="regular"
+                    letterSpacing={50}
                     lineHeight={75}
                     style={
                       [
@@ -6540,7 +6590,7 @@ exports[`<List /> should render unordered List of small size 1`] = `
                           "fontSize": 12,
                           "fontStyle": "normal",
                           "fontWeight": "400",
-                          "letterSpacing": 0,
+                          "letterSpacing": -0.15600000000000003,
                           "lineHeight": 17,
                           "marginBottom": 0,
                           "marginLeft": 0,
@@ -6708,6 +6758,7 @@ exports[`<List /> should render unordered List of small size 1`] = `
                           fontSize={75}
                           fontStyle="normal"
                           fontWeight="regular"
+                          letterSpacing={50}
                           lineHeight={75}
                           style={
                             [
@@ -6717,7 +6768,7 @@ exports[`<List /> should render unordered List of small size 1`] = `
                                 "fontSize": 12,
                                 "fontStyle": "normal",
                                 "fontWeight": "400",
-                                "letterSpacing": 0,
+                                "letterSpacing": -0.15600000000000003,
                                 "lineHeight": 17,
                                 "marginBottom": 0,
                                 "marginLeft": 0,

--- a/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.native.test.tsx.snap
+++ b/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.native.test.tsx.snap
@@ -445,6 +445,7 @@ exports[`<Popover /> should render 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -454,7 +455,7 @@ exports[`<Popover /> should render 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -1033,6 +1034,7 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -1042,7 +1044,7 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -1607,6 +1609,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
                   fontSize={200}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={25}
                   lineHeight={200}
                   style={
                     [
@@ -1616,7 +1619,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
                         "fontSize": 16,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.528,
                         "lineHeight": 24,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -1761,6 +1764,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
                 fontSize={100}
                 fontStyle="normal"
                 fontWeight="regular"
+                letterSpacing={50}
                 lineHeight={100}
                 style={
                   [
@@ -1770,7 +1774,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
                       "fontSize": 14,
                       "fontStyle": "normal",
                       "fontWeight": "400",
-                      "letterSpacing": 0,
+                      "letterSpacing": -0.18200000000000002,
                       "lineHeight": 20,
                       "marginBottom": 0,
                       "marginLeft": 0,
@@ -1805,6 +1809,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -1814,7 +1819,7 @@ exports[`<Popover /> should render with title,footer 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,

--- a/packages/blade/src/components/ProgressBar/__tests__/__snapshots__/ProgressBar.native.test.tsx.snap
+++ b/packages/blade/src/components/ProgressBar/__tests__/__snapshots__/ProgressBar.native.test.tsx.snap
@@ -504,6 +504,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with default
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -514,7 +515,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with default
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -539,6 +540,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with default
               fontSize={75}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.0"
               style={
@@ -549,7 +551,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with default
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -825,6 +827,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with large s
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -835,7 +838,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with large s
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1110,6 +1113,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with medium 
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -1120,7 +1124,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with medium 
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1336,6 +1340,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with small s
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -1346,7 +1351,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with small s
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1371,6 +1376,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with small s
               fontSize={75}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.0"
               style={
@@ -1381,7 +1387,7 @@ exports[`<ProgressBar /> should render circular variant ProgressBar with small s
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1471,6 +1477,7 @@ exports[`<ProgressBar /> should render color=information ProgressBar 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -1480,7 +1487,7 @@ exports[`<ProgressBar /> should render color=information ProgressBar 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1641,6 +1648,7 @@ exports[`<ProgressBar /> should render color=information ProgressBar 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -1650,7 +1658,7 @@ exports[`<ProgressBar /> should render color=information ProgressBar 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1811,6 +1819,7 @@ exports[`<ProgressBar /> should render color=negative ProgressBar 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -1820,7 +1829,7 @@ exports[`<ProgressBar /> should render color=negative ProgressBar 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1981,6 +1990,7 @@ exports[`<ProgressBar /> should render color=negative ProgressBar 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -1990,7 +2000,7 @@ exports[`<ProgressBar /> should render color=negative ProgressBar 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -2151,6 +2161,7 @@ exports[`<ProgressBar /> should render color=neutral ProgressBar 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -2160,7 +2171,7 @@ exports[`<ProgressBar /> should render color=neutral ProgressBar 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -2321,6 +2332,7 @@ exports[`<ProgressBar /> should render color=neutral ProgressBar 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -2330,7 +2342,7 @@ exports[`<ProgressBar /> should render color=neutral ProgressBar 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -2491,6 +2503,7 @@ exports[`<ProgressBar /> should render color=notice ProgressBar 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -2500,7 +2513,7 @@ exports[`<ProgressBar /> should render color=notice ProgressBar 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -2661,6 +2674,7 @@ exports[`<ProgressBar /> should render color=notice ProgressBar 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -2670,7 +2684,7 @@ exports[`<ProgressBar /> should render color=notice ProgressBar 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -2831,6 +2845,7 @@ exports[`<ProgressBar /> should render color=positive ProgressBar 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -2840,7 +2855,7 @@ exports[`<ProgressBar /> should render color=positive ProgressBar 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -3001,6 +3016,7 @@ exports[`<ProgressBar /> should render color=positive ProgressBar 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -3010,7 +3026,7 @@ exports[`<ProgressBar /> should render color=positive ProgressBar 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -3161,6 +3177,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with default p
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -3170,7 +3187,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with default p
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -3205,6 +3222,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with default p
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -3214,7 +3232,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with default p
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -3366,6 +3384,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with medium si
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -3375,7 +3394,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with medium si
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -3410,6 +3429,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with medium si
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -3419,7 +3439,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with medium si
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -3571,6 +3591,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with small siz
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -3580,7 +3601,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with small siz
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -3615,6 +3636,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with small siz
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -3624,7 +3646,7 @@ exports[`<ProgressBar /> should render linear variant ProgressBar with small siz
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -4036,6 +4058,7 @@ exports[`<ProgressBar /> should render meter variant of ProgressBar  2`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -4046,7 +4069,7 @@ exports[`<ProgressBar /> should render meter variant of ProgressBar  2`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -4293,6 +4316,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -4302,7 +4326,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -4337,6 +4361,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -4346,7 +4371,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -4665,6 +4690,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 2`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -4674,7 +4700,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 2`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -4709,6 +4735,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 2`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={75}
             style={
               [
@@ -4718,7 +4745,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 2`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -5174,6 +5201,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 3`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -5184,7 +5212,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 3`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5209,6 +5237,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 3`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.0"
               style={
@@ -5219,7 +5248,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 3`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5603,6 +5632,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 4`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.3"
               style={
@@ -5613,7 +5643,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 4`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -5638,6 +5668,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 4`] = `
               fontSize={75}
               fontStyle="normal"
               fontWeight="semibold"
+              letterSpacing={50}
               lineHeight={75}
               marginTop="spacing.0"
               style={
@@ -5648,7 +5679,7 @@ exports[`<ProgressBar /> should update the progress value appropriately 4`] = `
                     "fontSize": 12,
                     "fontStyle": "normal",
                     "fontWeight": "600",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.15600000000000003,
                     "lineHeight": 17,
                     "marginBottom": 0,
                     "marginLeft": 0,

--- a/packages/blade/src/components/Radio/__tests__/__snapshots__/Radio.native.test.tsx.snap
+++ b/packages/blade/src/components/Radio/__tests__/__snapshots__/Radio.native.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<Radio /> should render radio with label 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -80,7 +81,7 @@ exports[`<Radio /> should render radio with label 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -134,6 +135,7 @@ exports[`<Radio /> should render radio with label 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -143,7 +145,7 @@ exports[`<Radio /> should render radio with label 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -324,6 +326,7 @@ exports[`<Radio /> should render radio with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -333,7 +336,7 @@ exports[`<Radio /> should render radio with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -432,6 +435,7 @@ exports[`<Radio /> should set disabled state with isDisabled 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -442,7 +446,7 @@ exports[`<Radio /> should set disabled state with isDisabled 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -496,6 +500,7 @@ exports[`<Radio /> should set disabled state with isDisabled 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -505,7 +510,7 @@ exports[`<Radio /> should set disabled state with isDisabled 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -686,6 +691,7 @@ exports[`<Radio /> should set disabled state with isDisabled 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -695,7 +701,7 @@ exports[`<Radio /> should set disabled state with isDisabled 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,

--- a/packages/blade/src/components/Radio/__tests__/__snapshots__/RadioGroup.native.test.tsx.snap
+++ b/packages/blade/src/components/Radio/__tests__/__snapshots__/RadioGroup.native.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -80,7 +81,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -134,6 +135,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -143,7 +145,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -326,6 +328,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -335,7 +338,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -495,6 +498,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -504,7 +508,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -664,6 +668,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -673,7 +678,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -731,6 +736,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
               fontSize={50}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={50}
               marginTop="spacing.0"
               style={
@@ -741,7 +747,7 @@ exports[`<RadioGroup /> should render with help text 1`] = `
                     "fontSize": 11,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.14300000000000002,
                     "lineHeight": 16,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -836,6 +842,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
             fontSize={75}
             fontStyle="normal"
             fontWeight="medium"
+            letterSpacing={50}
             lineHeight={75}
             numberOfLines={2}
             style={
@@ -846,7 +853,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                   "fontSize": 12,
                   "fontStyle": "normal",
                   "fontWeight": "500",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.15600000000000003,
                   "lineHeight": 17,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -900,6 +907,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
               fontSize={100}
               fontStyle="normal"
               fontWeight="regular"
+              letterSpacing={50}
               lineHeight={100}
               style={
                 [
@@ -909,7 +917,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                     "fontSize": 14,
                     "fontStyle": "normal",
                     "fontWeight": "400",
-                    "letterSpacing": 0,
+                    "letterSpacing": -0.18200000000000002,
                     "lineHeight": 20,
                     "marginBottom": 0,
                     "marginLeft": 0,
@@ -1090,6 +1098,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -1099,7 +1108,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -1259,6 +1268,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -1268,7 +1278,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,
@@ -1428,6 +1438,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                       fontSize={100}
                       fontStyle="normal"
                       fontWeight="regular"
+                      letterSpacing={50}
                       lineHeight={100}
                       style={
                         [
@@ -1437,7 +1448,7 @@ exports[`<RadioGroup /> should render with label 1`] = `
                             "fontSize": 14,
                             "fontStyle": "normal",
                             "fontWeight": "400",
-                            "letterSpacing": 0,
+                            "letterSpacing": -0.18200000000000002,
                             "lineHeight": 20,
                             "marginBottom": 0,
                             "marginLeft": 0,

--- a/packages/blade/src/components/Spinner/BaseSpinner/__tests__/__snapshots__/BaseSpinner.native.test.tsx.snap
+++ b/packages/blade/src/components/Spinner/BaseSpinner/__tests__/__snapshots__/BaseSpinner.native.test.tsx.snap
@@ -314,6 +314,7 @@ exports[`<BaseSpinner /> should render high contrast BaseSpinner with bottom lab
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -323,7 +324,7 @@ exports[`<BaseSpinner /> should render high contrast BaseSpinner with bottom lab
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -810,6 +811,7 @@ exports[`<BaseSpinner /> should render low contrast BaseSpinner with right label
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -819,7 +821,7 @@ exports[`<BaseSpinner /> should render low contrast BaseSpinner with right label
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Tabs/__tests__/__snapshots__/Tabs.native.test.tsx.snap
+++ b/packages/blade/src/components/Tabs/__tests__/__snapshots__/Tabs.native.test.tsx.snap
@@ -117,6 +117,7 @@ exports[`Tabs should render 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -126,7 +127,7 @@ exports[`Tabs should render 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -224,6 +225,7 @@ exports[`Tabs should render 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -233,7 +235,7 @@ exports[`Tabs should render 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -318,6 +320,7 @@ exports[`Tabs should render 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -327,7 +330,7 @@ exports[`Tabs should render 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -382,6 +385,7 @@ exports[`Tabs should render 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -391,7 +395,7 @@ exports[`Tabs should render 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -543,6 +547,7 @@ exports[`Tabs should render with filled variant 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -552,7 +557,7 @@ exports[`Tabs should render with filled variant 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -683,6 +688,7 @@ exports[`Tabs should render with filled variant 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -692,7 +698,7 @@ exports[`Tabs should render with filled variant 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -777,6 +783,7 @@ exports[`Tabs should render with filled variant 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -786,7 +793,7 @@ exports[`Tabs should render with filled variant 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -841,6 +848,7 @@ exports[`Tabs should render with filled variant 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -850,7 +858,7 @@ exports[`Tabs should render with filled variant 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1000,6 +1008,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -1009,7 +1018,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -1111,6 +1120,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
                   fontSize={100}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={50}
                   lineHeight={100}
                   style={
                     [
@@ -1120,7 +1130,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
                         "fontSize": 14,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.18200000000000002,
                         "lineHeight": 20,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -1205,6 +1215,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1214,7 +1225,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1269,6 +1280,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1278,7 +1290,7 @@ exports[`Tabs should render with isFullWidthTabItem 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1419,6 +1431,7 @@ exports[`Tabs should render with large size 1`] = `
                   fontSize={200}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={25}
                   lineHeight={200}
                   style={
                     [
@@ -1428,7 +1441,7 @@ exports[`Tabs should render with large size 1`] = `
                         "fontSize": 16,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.528,
                         "lineHeight": 24,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -1526,6 +1539,7 @@ exports[`Tabs should render with large size 1`] = `
                   fontSize={200}
                   fontStyle="normal"
                   fontWeight="semibold"
+                  letterSpacing={25}
                   lineHeight={200}
                   style={
                     [
@@ -1535,7 +1549,7 @@ exports[`Tabs should render with large size 1`] = `
                         "fontSize": 16,
                         "fontStyle": "normal",
                         "fontWeight": "600",
-                        "letterSpacing": 0,
+                        "letterSpacing": -0.528,
                         "lineHeight": 24,
                         "marginBottom": 0,
                         "marginLeft": 0,
@@ -1620,6 +1634,7 @@ exports[`Tabs should render with large size 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1629,7 +1644,7 @@ exports[`Tabs should render with large size 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,
@@ -1684,6 +1699,7 @@ exports[`Tabs should render with large size 1`] = `
             fontSize={100}
             fontStyle="normal"
             fontWeight="regular"
+            letterSpacing={50}
             lineHeight={100}
             style={
               [
@@ -1693,7 +1709,7 @@ exports[`Tabs should render with large size 1`] = `
                   "fontSize": 14,
                   "fontStyle": "normal",
                   "fontWeight": "400",
-                  "letterSpacing": 0,
+                  "letterSpacing": -0.18200000000000002,
                   "lineHeight": 20,
                   "marginBottom": 0,
                   "marginLeft": 0,

--- a/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.native.test.tsx.snap
+++ b/packages/blade/src/components/Tag/__tests__/__snapshots__/Tag.native.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`<Tag /> should render tag 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           marginRight="spacing.2"
           numberOfLines={1}
@@ -79,7 +80,7 @@ exports[`<Tag /> should render tag 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Toast/__tests__/__snapshots__/Toast.native.test.tsx.snap
+++ b/packages/blade/src/components/Toast/__tests__/__snapshots__/Toast.native.test.tsx.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ToastContainer /> (native) renders nothing when there are no toasts 1`] = `
-<View
-  style={
-    {
-      "flex": 1,
-    }
-  }
-/>
-`;
-
 exports[`<Toast /> (native) renders a positive informational toast 1`] = `
 <View
   style={
@@ -167,6 +157,7 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -176,7 +167,7 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -483,6 +474,7 @@ exports[`<Toast /> (native) renders a promotional toast 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -492,7 +484,7 @@ exports[`<Toast /> (native) renders a promotional toast 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -623,4 +615,14 @@ exports[`<Toast /> (native) renders a promotional toast 1`] = `
     </View>
   </View>
 </View>
+`;
+
+exports[`<ToastContainer /> (native) renders nothing when there are no toasts 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+/>
 `;

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.native.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.native.test.tsx.snap
@@ -289,6 +289,7 @@ exports[`<Tooltip /> should render 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -298,7 +299,7 @@ exports[`<Tooltip /> should render 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -700,6 +701,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -709,7 +711,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1111,6 +1113,7 @@ exports[`<Tooltip /> should render with title 1`] = `
           fontSize={100}
           fontStyle="normal"
           fontWeight="semibold"
+          letterSpacing={50}
           lineHeight={100}
           style={
             [
@@ -1120,7 +1123,7 @@ exports[`<Tooltip /> should render with title 1`] = `
                 "fontSize": 14,
                 "fontStyle": "normal",
                 "fontWeight": "600",
-                "letterSpacing": 0,
+                "letterSpacing": -0.18200000000000002,
                 "lineHeight": 20,
                 "marginBottom": 0,
                 "marginLeft": 0,
@@ -1145,6 +1148,7 @@ exports[`<Tooltip /> should render with title 1`] = `
           fontSize={75}
           fontStyle="normal"
           fontWeight="regular"
+          letterSpacing={50}
           lineHeight={75}
           style={
             [
@@ -1154,7 +1158,7 @@ exports[`<Tooltip /> should render with title 1`] = `
                 "fontSize": 12,
                 "fontStyle": "normal",
                 "fontWeight": "400",
-                "letterSpacing": 0,
+                "letterSpacing": -0.15600000000000003,
                 "lineHeight": 17,
                 "marginBottom": 0,
                 "marginLeft": 0,

--- a/packages/blade/src/components/Typography/BaseText/BaseText.native.tsx
+++ b/packages/blade/src/components/Typography/BaseText/BaseText.native.tsx
@@ -58,6 +58,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
     fontStyle,
     textDecorationLine,
     lineHeight,
+    letterSpacing,
     textAlign,
     children,
     truncateAfterLines,
@@ -83,6 +84,7 @@ const _BaseText: React.ForwardRefRenderFunction<BladeElementRef, BaseTextProps> 
       fontStyle={fontStyle}
       textDecorationLine={textDecorationLine}
       lineHeight={lineHeight}
+      letterSpacing={letterSpacing}
       as={undefined}
       textAlign={textAlign}
       numberOfLines={truncateAfterLines}

--- a/packages/blade/src/components/Typography/Code/__tests__/__snapshots__/Code.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Code/__tests__/__snapshots__/Code.native.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`<Code /> should render Code with color 1`] = `
       fontFamily="code"
       fontSize={25}
       fontWeight="regular"
+      letterSpacing={100}
       lineHeight={25}
       style={
         [
@@ -103,6 +104,7 @@ exports[`<Code /> should render Code with default properties 1`] = `
       fontFamily="code"
       fontSize={25}
       fontWeight="regular"
+      letterSpacing={100}
       lineHeight={25}
       style={
         [
@@ -169,6 +171,7 @@ exports[`<Code /> should render isHighlighted false Code 1`] = `
       fontFamily="code"
       fontSize={25}
       fontWeight="regular"
+      letterSpacing={100}
       lineHeight={25}
       style={
         [
@@ -236,6 +239,7 @@ exports[`<Code /> should render medium Code 1`] = `
       fontFamily="code"
       fontSize={75}
       fontWeight="regular"
+      letterSpacing={100}
       lineHeight={75}
       style={
         [
@@ -303,6 +307,7 @@ exports[`<Code /> should render small Code 1`] = `
       fontFamily="code"
       fontSize={25}
       fontWeight="regular"
+      letterSpacing={100}
       lineHeight={25}
       style={
         [

--- a/packages/blade/src/components/Typography/Display/__tests__/__snapshots__/Display.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Display/__tests__/__snapshots__/Display.native.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`<Display /> should render Display with color 1`] = `
     fontSize={800}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={800}
     style={
       [
@@ -63,6 +64,7 @@ exports[`<Display /> should render Display with default properties 1`] = `
     fontSize={800}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={800}
     style={
       [
@@ -109,6 +111,7 @@ exports[`<Display /> should render Display with mixed color 1`] = `
     fontSize={800}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={800}
     style={
       [
@@ -144,6 +147,7 @@ exports[`<Display /> should render Display with mixed color 1`] = `
       fontSize={800}
       fontStyle="normal"
       fontWeight="semibold"
+      letterSpacing={100}
       lineHeight={800}
       style={
         [
@@ -191,6 +195,7 @@ exports[`<Display /> should render Display with variant "large" 1`] = `
     fontSize={1000}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={1000}
     style={
       [
@@ -237,6 +242,7 @@ exports[`<Display /> should render Display with variant "medium" 1`] = `
     fontSize={900}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={900}
     style={
       [
@@ -283,6 +289,7 @@ exports[`<Display /> should render Display with variant "small" 1`] = `
     fontSize={800}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={800}
     style={
       [
@@ -329,6 +336,7 @@ exports[`<Display /> should render Display with variant "small" and contrast "hi
     fontSize={800}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={800}
     style={
       [
@@ -375,6 +383,7 @@ exports[`<Display /> should render Display with variant "xlarge" 1`] = `
     fontSize={1100}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={100}
     lineHeight={1100}
     style={
       [

--- a/packages/blade/src/components/Typography/Text/__tests__/__snapshots__/Text.native.test.tsx.snap
+++ b/packages/blade/src/components/Typography/Text/__tests__/__snapshots__/Text.native.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`<Text /> should render Text with center textAlign 1`] = `
     fontSize={100}
     fontStyle="normal"
     fontWeight="regular"
+    letterSpacing={50}
     lineHeight={100}
     style={
       [
@@ -25,7 +26,7 @@ exports[`<Text /> should render Text with center textAlign 1`] = `
           "fontSize": 14,
           "fontStyle": "normal",
           "fontWeight": "400",
-          "letterSpacing": 0,
+          "letterSpacing": -0.18200000000000002,
           "lineHeight": 20,
           "marginBottom": 0,
           "marginLeft": 0,
@@ -63,6 +64,7 @@ exports[`<Text /> should render Text with color 1`] = `
     fontSize={100}
     fontStyle="normal"
     fontWeight="regular"
+    letterSpacing={50}
     lineHeight={100}
     style={
       [
@@ -72,7 +74,7 @@ exports[`<Text /> should render Text with color 1`] = `
           "fontSize": 14,
           "fontStyle": "normal",
           "fontWeight": "400",
-          "letterSpacing": 0,
+          "letterSpacing": -0.18200000000000002,
           "lineHeight": 20,
           "marginBottom": 0,
           "marginLeft": 0,
@@ -108,6 +110,7 @@ exports[`<Text /> should render Text with default properties 1`] = `
     fontSize={100}
     fontStyle="normal"
     fontWeight="regular"
+    letterSpacing={50}
     lineHeight={100}
     style={
       [
@@ -117,7 +120,7 @@ exports[`<Text /> should render Text with default properties 1`] = `
           "fontSize": 14,
           "fontStyle": "normal",
           "fontWeight": "400",
-          "letterSpacing": 0,
+          "letterSpacing": -0.18200000000000002,
           "lineHeight": 20,
           "marginBottom": 0,
           "marginLeft": 0,
@@ -153,6 +156,7 @@ exports[`<Text /> should render Text with variant "body" 1`] = `
     fontSize={100}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={50}
     lineHeight={100}
     numberOfLines={3}
     style={
@@ -163,7 +167,7 @@ exports[`<Text /> should render Text with variant "body" 1`] = `
           "fontSize": 14,
           "fontStyle": "normal",
           "fontWeight": "600",
-          "letterSpacing": 0,
+          "letterSpacing": -0.18200000000000002,
           "lineHeight": 20,
           "marginBottom": 0,
           "marginLeft": 0,
@@ -199,6 +203,7 @@ exports[`<Text /> should render Text with variant "body" and contrast "high" 1`]
     fontSize={100}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={50}
     lineHeight={100}
     numberOfLines={3}
     style={
@@ -209,7 +214,7 @@ exports[`<Text /> should render Text with variant "body" and contrast "high" 1`]
           "fontSize": 14,
           "fontStyle": "normal",
           "fontWeight": "600",
-          "letterSpacing": 0,
+          "letterSpacing": -0.18200000000000002,
           "lineHeight": 20,
           "marginBottom": 0,
           "marginLeft": 0,
@@ -245,6 +250,7 @@ exports[`<Text /> should render Text with variant "body" and size "small" 1`] = 
     fontSize={75}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={50}
     lineHeight={75}
     numberOfLines={3}
     style={
@@ -255,7 +261,7 @@ exports[`<Text /> should render Text with variant "body" and size "small" 1`] = 
           "fontSize": 12,
           "fontStyle": "normal",
           "fontWeight": "600",
-          "letterSpacing": 0,
+          "letterSpacing": -0.15600000000000003,
           "lineHeight": 17,
           "marginBottom": 0,
           "marginLeft": 0,
@@ -291,6 +297,7 @@ exports[`<Text /> should render Text with variant "caption" 1`] = `
     fontSize={100}
     fontStyle="normal"
     fontWeight="semibold"
+    letterSpacing={50}
     lineHeight={100}
     style={
       [
@@ -300,7 +307,7 @@ exports[`<Text /> should render Text with variant "caption" 1`] = `
           "fontSize": 14,
           "fontStyle": "normal",
           "fontWeight": "600",
-          "letterSpacing": 0,
+          "letterSpacing": -0.18200000000000002,
           "lineHeight": 20,
           "marginBottom": 0,
           "marginLeft": 0,


### PR DESCRIPTION


## Description

The Spark upgrade added variable letterSpacing to Text and Code components but BaseText.native.tsx never destructured or forwarded the prop to StyledBaseText. This caused all letterSpacing values to be silently ignored on React Native.

## Changes

Added letterSpacing prop to BaseText.native

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
