### PR TITLE
feat(ci): add Slash AI code review workflow

### DIFF
--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -1,0 +1,54 @@
+name: Slash Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# One review per PR at a time — cancel any in-flight run for the same PR
+# when a new commit is pushed before it finishes.
+concurrency:
+  group: slash-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  slash-review:
+    name: Request Slash AI review
+    # Skip draft PRs — Slash reviews ready PRs only
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
+
+    steps:
+      - name: Request Slash review
+        env:
+          SLASH_API_TOKEN: ${{ secrets.SLASH_API_TOKEN }}
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPOSITORY="razorpay/blade"
+          SLASH_API="https://slash-api.concierge.razorpay.com/api/v1/pr-review"
+
+          echo "Requesting Slash review for PR #${PR_NUMBER} (${PR_URL})"
+
+          HTTP_STATUS=$(curl --silent --output /tmp/slash_response.json \
+            --write-out "%{http_code}" \
+            --request POST "${SLASH_API}" \
+            --user "blade_ci:${SLASH_API_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "{
+              \"pr_url\": \"${PR_URL}\",
+              \"repository\": \"${REPOSITORY}\",
+              \"pr_number\": ${PR_NUMBER}
+            }")
+
+          echo "HTTP status: ${HTTP_STATUS}"
+          cat /tmp/slash_response.json
+
+          if [ "${HTTP_STATUS}" = "202" ]; then
+            REVIEW_ID=$(cat /tmp/slash_response.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('review_id',''))" 2>/dev/null || true)
+            echo "Review accepted — review_id: ${REVIEW_ID}"
+          elif [ "${HTTP_STATUS}" = "200" ]; then
+            echo "Review deduplicated — this PR was already queued or reviewed."
+          else
+            echo "Slash review request failed with HTTP ${HTTP_STATUS}"
+            exit 1
+          fi

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -20,15 +20,21 @@ jobs:
         env:
           SLASH_API_USERNAME: ${{ secrets.SLASH_API_USERNAME }}
           SLASH_API_PASSWORD: ${{ secrets.SLASH_API_PASSWORD }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.head_ref }}
+          PR_TARGET_BRANCH: ${{ github.base_ref }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
           REPOSITORY="razorpay/blade"
           SLASH_API="https://slash-api-ext.razorpay.com/api/v1/pr-review"
+          ESCAPED_PR_TITLE=$(printf '%s' "${PR_TITLE}" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')
 
           echo "Requesting Slash review for PR #${PR_NUMBER} (${PR_URL})"
 
-          HTTP_STATUS=$(curl --silent --output /tmp/slash_response.json \
+          HTTP_STATUS=$(curl --silent --output "/tmp/slash_response.json" \
             --write-out "%{http_code}" \
             --request POST "${SLASH_API}" \
             --user "${SLASH_API_USERNAME}:${SLASH_API_PASSWORD}" \
@@ -38,12 +44,12 @@ jobs:
                 \"pr_url\": \"${PR_URL}\",
                 \"pr_number\": ${PR_NUMBER},
                 \"repository\": \"${REPOSITORY}\",
-                \"author\": \"${{ github.event.pull_request.user.login }}\",
-                \"title\": $(echo '${{ github.event.pull_request.title }}' | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))'),
-                \"branch\": \"${{ github.head_ref }}\",
-                \"target_branch\": \"${{ github.base_ref }}\"
+                \"author\": \"${PR_AUTHOR}\",
+                \"title\": ${ESCAPED_PR_TITLE},
+                \"branch\": \"${PR_BRANCH}\",
+                \"target_branch\": \"${PR_TARGET_BRANCH}\"
               },
-              \"idempotency_key\": \"${REPOSITORY}:${PR_NUMBER}:${{ github.run_id }}\"
+              \"idempotency_key\": \"${REPOSITORY}:${PR_NUMBER}:${RUN_ID}\"
             }")
 
           echo "HTTP status: ${HTTP_STATUS}"

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -34,9 +34,16 @@ jobs:
             --user "${SLASH_API_USERNAME}:${SLASH_API_PASSWORD}" \
             --header "Content-Type: application/json" \
             --data "{
-              \"pr_url\": \"${PR_URL}\",
-              \"repository\": \"${REPOSITORY}\",
-              \"pr_number\": ${PR_NUMBER}
+              \"pr_metadata\": {
+                \"pr_url\": \"${PR_URL}\",
+                \"pr_number\": ${PR_NUMBER},
+                \"repository\": \"${REPOSITORY}\",
+                \"author\": \"${{ github.event.pull_request.user.login }}\",
+                \"title\": $(echo '${{ github.event.pull_request.title }}' | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))'),
+                \"branch\": \"${{ github.head_ref }}\",
+                \"target_branch\": \"${{ github.base_ref }}\"
+              },
+              \"idempotency_key\": \"${REPOSITORY}:${PR_NUMBER}:${{ github.run_id }}\"
             }")
 
           echo "HTTP status: ${HTTP_STATUS}"

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -2,7 +2,7 @@ name: Slash Code Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.repository }}-${{ github.event.pull_request.number || github.head_ref || github.sha }}-${{ github.workflow }}
@@ -11,8 +11,15 @@ concurrency:
 jobs:
   slash-review:
     name: Request Slash AI review
-    # Skip bot-triggered runs to prevent feedback loops
-    if: github.actor != 'rzp-code-review[bot]' && github.actor != 'github-actions[bot]'
+    # Skip bot-triggered runs to prevent feedback loops.
+    # For labeled events, only fire on the 'Run Slash Review' label — not every label addition.
+    if: |
+      github.actor != 'rzp-slash-public[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      (
+        github.event.action != 'labeled' ||
+        github.event.label.name == 'Run Slash Review'
+      )
     runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
 
     steps:

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -2,19 +2,17 @@ name: Slash Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, ready_for_review]
 
-# One review per PR at a time — cancel any in-flight run for the same PR
-# when a new commit is pushed before it finishes.
 concurrency:
-  group: slash-review-${{ github.event.pull_request.number }}
+  group: ${{ github.repository }}-${{ github.event.pull_request.number || github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
   slash-review:
     name: Request Slash AI review
-    # Skip draft PRs — Slash reviews ready PRs only
-    if: github.event.pull_request.draft == false
+    # Skip bot-triggered runs to prevent feedback loops
+    if: github.actor != 'rzp-code-review[bot]' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
 
     steps:

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Request Slash review
         env:
+          SLASH_API_USERNAME: ${{ secrets.SLASH_API_USERNAME }}
           SLASH_API_PASSWORD: ${{ secrets.SLASH_API_PASSWORD }}
         run: |
           PR_URL="${{ github.event.pull_request.html_url }}"
@@ -30,7 +31,7 @@ jobs:
           HTTP_STATUS=$(curl --silent --output /tmp/slash_response.json \
             --write-out "%{http_code}" \
             --request POST "${SLASH_API}" \
-            --user "blade_ci:${SLASH_API_PASSWORD}" \
+            --user "${SLASH_API_USERNAME}:${SLASH_API_PASSWORD}" \
             --header "Content-Type: application/json" \
             --data "{
               \"pr_url\": \"${PR_URL}\",

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Request Slash review
         env:
-          SLASH_API_TOKEN: ${{ secrets.SLASH_API_TOKEN }}
+          SLASH_API_PASSWORD: ${{ secrets.SLASH_API_PASSWORD }}
         run: |
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -32,7 +32,7 @@ jobs:
           HTTP_STATUS=$(curl --silent --output /tmp/slash_response.json \
             --write-out "%{http_code}" \
             --request POST "${SLASH_API}" \
-            --user "blade_ci:${SLASH_API_TOKEN}" \
+            --user "blade_ci:${SLASH_API_PASSWORD}" \
             --header "Content-Type: application/json" \
             --data "{
               \"pr_url\": \"${PR_URL}\",

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -26,11 +26,26 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BRANCH: ${{ github.head_ref }}
           PR_TARGET_BRANCH: ${{ github.base_ref }}
+          PR_REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          REPOSITORY="razorpay/blade"
           SLASH_API="https://slash-api-ext.razorpay.com/api/v1/pr-review"
-          ESCAPED_PR_TITLE=$(printf '%s' "${PR_TITLE}" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read().strip()))')
+
+          PAYLOAD=$(python3 -c "
+          import json, os
+          print(json.dumps({
+            'pr_metadata': {
+              'pr_url': os.environ['PR_URL'],
+              'pr_number': int(os.environ['PR_NUMBER']),
+              'repository': os.environ['PR_REPOSITORY'],
+              'author': os.environ['PR_AUTHOR'],
+              'title': os.environ['PR_TITLE'],
+              'branch': os.environ['PR_BRANCH'],
+              'target_branch': os.environ['PR_TARGET_BRANCH'],
+            },
+            'idempotency_key': f\"{os.environ['PR_REPOSITORY']}:{os.environ['PR_NUMBER']}:{os.environ['RUN_ID']}\"
+          }))
+          ")
 
           echo "Requesting Slash review for PR #${PR_NUMBER} (${PR_URL})"
 
@@ -39,24 +54,14 @@ jobs:
             --request POST "${SLASH_API}" \
             --user "${SLASH_API_USERNAME}:${SLASH_API_PASSWORD}" \
             --header "Content-Type: application/json" \
-            --data "{
-              \"pr_metadata\": {
-                \"pr_url\": \"${PR_URL}\",
-                \"pr_number\": ${PR_NUMBER},
-                \"repository\": \"${REPOSITORY}\",
-                \"author\": \"${PR_AUTHOR}\",
-                \"title\": ${ESCAPED_PR_TITLE},
-                \"branch\": \"${PR_BRANCH}\",
-                \"target_branch\": \"${PR_TARGET_BRANCH}\"
-              },
-              \"idempotency_key\": \"${REPOSITORY}:${PR_NUMBER}:${RUN_ID}\"
-            }")
+            --data "${PAYLOAD}")
 
+          RESPONSE=$(cat /tmp/slash_response.json)
           echo "HTTP status: ${HTTP_STATUS}"
-          cat /tmp/slash_response.json
+          echo "${RESPONSE}"
 
           if [ "${HTTP_STATUS}" = "202" ]; then
-            REVIEW_ID=$(cat /tmp/slash_response.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('review_id',''))" 2>/dev/null || true)
+            REVIEW_ID=$(echo "${RESPONSE}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('review_id',''))" 2>/dev/null || true)
             echo "Review accepted — review_id: ${REVIEW_ID}"
           elif [ "${HTTP_STATUS}" = "200" ]; then
             echo "Review deduplicated — this PR was already queued or reviewed."

--- a/.github/workflows/slash-review.yml
+++ b/.github/workflows/slash-review.yml
@@ -24,7 +24,7 @@ jobs:
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
           REPOSITORY="razorpay/blade"
-          SLASH_API="https://slash-api.concierge.razorpay.com/api/v1/pr-review"
+          SLASH_API="https://slash-api-ext.razorpay.com/api/v1/pr-review"
 
           echo "Requesting Slash review for PR #${PR_NUMBER} (${PR_URL})"
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/slash-review.yml` which calls the Slash AI code review API on every non-draft PR event (opened, synchronize, reopened)
- Uses a dedicated `blade_ci` credential (`SLASH_API_TOKEN` secret) so Blade team access is managed independently
- Concurrency group per PR number cancels stale in-flight reviews when a new commit is pushed

## How it works

1. On `pull_request` (opened / synchronize / reopened), skips drafts via `if: github.event.pull_request.draft == false`
2. POSTs to `https://slash-api.concierge.razorpay.com/api/v1/pr-review` with HTTP Basic auth (`blade_ci` + `SLASH_API_TOKEN`)
3. Handles responses:
   - **202** — review queued, logs `review_id`
   - **200** — already queued/reviewed (dedup), logs message and exits 0
   - **other** — logs body and fails the step

## Pre-requisites before merging

- [ ] Add `SLASH_API_TOKEN` as a repository secret in `razorpay/blade` — value is the `blade_ci` password set via `AUTH__USERS__BLADE_CI` in the swe-agent deployment (coordinate with the swe-agent team: razorpay/swe-agent#1352)

## Test plan

- [ ] Open a non-draft PR and confirm the `slash-review` check appears and returns green
- [ ] Push a second commit to the same PR; confirm the previous run is cancelled and a new one starts
- [ ] Open a draft PR and confirm the `slash-review` job is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)