### PR TITLE
fix(ci): update labeler.yml to actions/labeler v5 config format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
 blade-svelte:
-  - packages/blade-svelte/**
-  - packages/blade-core/**
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/blade-svelte/**
+      - packages/blade-core/**


### PR DESCRIPTION
## Summary

- Fixes the `label` CI check failing on all PRs with: `found unexpected type for label 'blade-svelte' (should be array of config options)`
- `actions/labeler@v5` requires array elements to be config objects (`changed-files:`) instead of raw glob strings (v4 format)

## Change

```yaml
# Before (v4 format)
blade-svelte:
  - packages/blade-svelte/**
  - packages/blade-core/**

# After (v5 format)
blade-svelte:
  - changed-files:
    - any-glob-to-any-file:
      - packages/blade-svelte/**
      - packages/blade-core/**
```

## Affected PRs

Fixes `label` check on #3451 and #3427.