### PR TITLE
fix(rn): fix Avatar story label wrapping on React Native

### DIFF
--- a/.changeset/deep-coins-wink.md
+++ b/.changeset/deep-coins-wink.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(rn): fix Avatar story label wrapping on React Native

--- a/packages/blade/src/components/Avatar/docs/Avatar.stories.tsx
+++ b/packages/blade/src/components/Avatar/docs/Avatar.stories.tsx
@@ -116,13 +116,7 @@ const AvatarSizesTemplate: StoryFn<typeof AvatarComponent> = (args) => {
   return (
     <Box display="flex" flexDirection="column" gap="spacing.5" alignItems="flex-start">
       {sizes.map((size) => (
-        <Box
-          key={size}
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          gap="spacing.5"
-        >
+        <Box key={size} display="flex" flexDirection="row" alignItems="center" gap="spacing.5">
           <Box minWidth="80px">
             <Heading>{size}</Heading>
           </Box>
@@ -141,13 +135,7 @@ const AvatarColorsTemplate: StoryFn<typeof AvatarComponent> = (args) => {
   return (
     <Box display="flex" flexDirection="column" gap="spacing.5" alignItems="flex-start">
       {colors.map((color) => (
-        <Box
-          key={color}
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          gap="spacing.5"
-        >
+        <Box key={color} display="flex" flexDirection="row" alignItems="center" gap="spacing.5">
           <Box minWidth="100px">
             <Heading>{color}</Heading>
           </Box>
@@ -166,13 +154,7 @@ const AvatarVariantsTemplate: StoryFn<typeof AvatarComponent> = (args) => {
   return (
     <Box display="flex" flexDirection="column" gap="spacing.5" alignItems="flex-start">
       {variants.map((variant) => (
-        <Box
-          key={variant}
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          gap="spacing.5"
-        >
+        <Box key={variant} display="flex" flexDirection="row" alignItems="center" gap="spacing.5">
           <Box minWidth="80px">
             <Heading>{variant}</Heading>
           </Box>

--- a/packages/blade/src/components/Avatar/docs/Avatar.stories.tsx
+++ b/packages/blade/src/components/Avatar/docs/Avatar.stories.tsx
@@ -114,25 +114,19 @@ InteractiveNonInteractive.storyName = 'Interactive and NonInteractive Avatar';
 const AvatarSizesTemplate: StoryFn<typeof AvatarComponent> = (args) => {
   const sizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'] as const;
   return (
-    <Box display="flex" flexDirection="column" gap="spacing.5">
+    <Box display="flex" flexDirection="column" gap="spacing.5" alignItems="flex-start">
       {sizes.map((size) => (
         <Box
           key={size}
           display="flex"
-          flex="1 1 auto"
+          flexDirection="row"
           alignItems="center"
-          justifyItems="center"
-          alignContent="center"
           gap="spacing.5"
-          flexWrap="nowrap"
-          width="120px"
         >
-          <Box width="50px">
+          <Box minWidth="80px">
             <Heading>{size}</Heading>
           </Box>
-          <Box display="flex" flex="1 1 auto" justifyContent="center">
-            <AvatarComponent {...args} size={size} />
-          </Box>
+          <AvatarComponent {...args} size={size} />
         </Box>
       ))}
     </Box>
@@ -145,25 +139,19 @@ AllSizes.storyName = 'All Sizes';
 const AvatarColorsTemplate: StoryFn<typeof AvatarComponent> = (args) => {
   const colors = ['primary', 'positive', 'negative', 'neutral', 'notice', 'information'] as const;
   return (
-    <Box display="flex" flexDirection="column" gap="spacing.5">
+    <Box display="flex" flexDirection="column" gap="spacing.5" alignItems="flex-start">
       {colors.map((color) => (
         <Box
           key={color}
           display="flex"
-          flex="1 1 auto"
+          flexDirection="row"
           alignItems="center"
-          justifyItems="center"
-          alignContent="center"
           gap="spacing.5"
-          flexWrap="nowrap"
-          width="200px"
         >
-          <Box width="40px">
+          <Box minWidth="100px">
             <Heading>{color}</Heading>
           </Box>
-          <Box display="flex" flex="1 1 auto" justifyContent="center">
-            <AvatarComponent size="medium" {...args} color={color} />
-          </Box>
+          <AvatarComponent size="medium" {...args} color={color} />
         </Box>
       ))}
     </Box>
@@ -176,25 +164,19 @@ AllColors.storyName = 'All Colors';
 const AvatarVariantsTemplate: StoryFn<typeof AvatarComponent> = (args) => {
   const variants = ['circle', 'square'] as const;
   return (
-    <Box display="flex" flexDirection="column" gap="spacing.5">
+    <Box display="flex" flexDirection="column" gap="spacing.5" alignItems="flex-start">
       {variants.map((variant) => (
         <Box
           key={variant}
           display="flex"
-          flex="1 1 auto"
+          flexDirection="row"
           alignItems="center"
-          justifyItems="center"
-          alignContent="center"
           gap="spacing.5"
-          flexWrap="nowrap"
-          width="120px"
         >
-          <Box width="40px">
+          <Box minWidth="80px">
             <Heading>{variant}</Heading>
           </Box>
-          <Box display="flex" flex="1 1 auto" justifyContent="center">
-            <AvatarComponent size="medium" {...args} variant={variant} />
-          </Box>
+          <AvatarComponent size="medium" {...args} variant={variant} />
         </Box>
       ))}
     </Box>


### PR DESCRIPTION
## Summary

- Fixes `AllSizes`, `AllColors`, and `AllVariants` Avatar stories where label text (e.g. \"primary\", \"information\", \"xlarge\") was wrapping mid-word on React Native
- Root cause: story rows used `flex=\"1 1 auto\"` (invalid CSS shorthand on RN), hard `width` constraints on label boxes too narrow for RN font metrics, and unused props (`justifyItems`, `alignContent`, `flexWrap`) that don't apply to RN's flex model
- Fix: replaced broken props with `flexDirection=\"row\"` on each row, switched label boxes from `width` to `minWidth` to let text breathe, and removed the unnecessary wrapper box around avatars

##Description

Before:
<img width="361" height="770" alt="Screenshot 2026-06-09 at 5 56 09 PM" src="https://github.com/user-attachments/assets/288fca76-c514-4584-8f0a-f0a875b97969" />

After:
<img width="343" height="697" alt="Screenshot 2026-06-09 at 10 39 52 PM" src="https://github.com/user-attachments/assets/a5c45819-19c1-49cb-af25-622a8e59cc65" />


## Test plan

- [ ] Open Avatar → All Colors story on RN: all 6 color labels render on a single line beside their avatar
- [ ] Open Avatar → All Sizes story on RN: all 5 size labels render without wrapping
- [ ] Open Avatar → All Variants story on RN: \"circle\" and \"square\" labels render correctly
- [ ] Verify web Storybook is unaffected for the same three stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)