### PR TITLE
fix(rn): fix story layout issues for Divider, Link, and Code components

### DIFF
--- a/.changeset/silent-poets-look.md
+++ b/.changeset/silent-poets-look.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(rn): fix story layout issues for Divider, Link, and Code components

--- a/packages/blade/src/components/Divider/Divider.stories.tsx
+++ b/packages/blade/src/components/Divider/Divider.stories.tsx
@@ -159,7 +159,7 @@ const DividerWithTextTemplate: StoryFn<typeof DividerComponent> = () => {
           <Heading marginBottom="spacing.4">Explore multiple payment options</Heading>
           <DividerComponent />
           <BaseBox display="flex" gap="spacing.6" flexDirection="row">
-            <BaseBox width="30%">
+            <BaseBox flex={1}>
               <Text margin="spacing.4">
                 Accept payments with a custom-branded online store using Payment Pages. Accept
                 international and domestic payments with automated payment receipts. Take your store
@@ -167,14 +167,14 @@ const DividerWithTextTemplate: StoryFn<typeof DividerComponent> = () => {
               </Text>
             </BaseBox>
             <DividerComponent orientation="vertical" />
-            <BaseBox width="30%">
+            <BaseBox flex={1}>
               <Text margin="spacing.4">
                 Create payment links which can be shared via an email, SMS, messenger, chatbot etc.
                 and get paid immediately. Accepting payments from customers is now just a link away.
               </Text>
             </BaseBox>
             <DividerComponent orientation="vertical" />
-            <BaseBox width="30%">
+            <BaseBox flex={1}>
               <Text margin="spacing.4">
                 Accept one time and subscription payments on your website in less than 5 minutes.
                 Thousands of NGOs, SMEs, and freelancers are collecting payments by adding a payment

--- a/packages/blade/src/components/Link/Link/Link.stories.tsx
+++ b/packages/blade/src/components/Link/Link/Link.stories.tsx
@@ -1,4 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/react-vite';
+import { getPlatformType } from '~utils';
 import { Title, Description } from '@storybook/addon-docs/blocks';
 import type { ReactElement } from 'react';
 import type { LinkProps } from './Link';
@@ -90,7 +91,13 @@ Default.args = {
 };
 
 const LinkInlineTemplate: StoryFn<typeof LinkComponent> = ({ icon, children = '', ...args }) => {
-  return (
+  const isReactNative = getPlatformType() === 'react-native';
+  return isReactNative ? (
+    <BaseBox display="flex" flexDirection="row" alignItems="center">
+      <Text>Find more details at the </Text>
+      <LinkComponent {...args}>{children}</LinkComponent>
+    </BaseBox>
+  ) : (
     <Text>
       Find more details at the <LinkComponent {...args}>{children}</LinkComponent>
     </Text>
@@ -132,7 +139,13 @@ const LinkButtonInlineTemplate: StoryFn<typeof LinkComponent> = ({
   children = '',
   ...args
 }) => {
-  return (
+  const isReactNative = getPlatformType() === 'react-native';
+  return isReactNative ? (
+    <BaseBox display="flex" flexDirection="row" alignItems="center">
+      <Text>Forgot Password? </Text>
+      <LinkComponent {...args}>{children}</LinkComponent>
+    </BaseBox>
+  ) : (
     <Text>
       Forgot Password? <LinkComponent {...args}>{children}</LinkComponent>
     </Text>

--- a/packages/blade/src/components/Typography/Code/Code.stories.tsx
+++ b/packages/blade/src/components/Typography/Code/Code.stories.tsx
@@ -1,4 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/react-vite';
+import { getPlatformType } from '~utils';
 import { Title } from '@storybook/addon-docs/blocks';
 import type { ReactElement } from 'react';
 import { Text } from '../Text';
@@ -53,17 +54,32 @@ const CodeStoryMeta: Meta = {
   argTypes: getStyledPropsArgTypes(),
 };
 
-const CodeTemplate: StoryFn<typeof CodeComponent> = (args) => (
-  // For React Native, use flex to align items correctly
-  <>
-    <Text size="medium">
-      Lorem ipsum normal text <CodeComponent {...args} size="medium" /> component
-    </Text>
-    <Text size="small">
-      Lorem ipsum normal text <CodeComponent {...args} size="small" /> component
-    </Text>
-  </>
-);
+const CodeTemplate: StoryFn<typeof CodeComponent> = (args) => {
+  const isReactNative = getPlatformType() === 'react-native';
+  return isReactNative ? (
+    <>
+      <BaseBox display="flex" flexDirection="row" alignItems="center" flexWrap="wrap">
+        <Text size="medium">Lorem ipsum normal text </Text>
+        <CodeComponent {...args} size="medium" />
+        <Text size="medium"> component</Text>
+      </BaseBox>
+      <BaseBox display="flex" flexDirection="row" alignItems="center" flexWrap="wrap">
+        <Text size="small">Lorem ipsum normal text </Text>
+        <CodeComponent {...args} size="small" />
+        <Text size="small"> component</Text>
+      </BaseBox>
+    </>
+  ) : (
+    <>
+      <Text size="medium">
+        Lorem ipsum normal text <CodeComponent {...args} size="medium" /> component
+      </Text>
+      <Text size="small">
+        Lorem ipsum normal text <CodeComponent {...args} size="small" /> component
+      </Text>
+    </>
+  );
+};
 
 export default CodeStoryMeta;
 export const Code = CodeTemplate.bind({});


### PR DESCRIPTION
## Summary

- **Divider**: Use `flex={1}` instead of `width="30%"` on columns in the `DividerWithText` story to prevent text overflow on the right side on React Native
- **Link**: Add platform gate in inline Link stories — original `<Text>` nesting on web, `Box flexDirection="row"` on React Native to fix vertical misalignment of inline links
- **Code**: Add platform gate in `Code` story template — original inline `<Text>` on web, `Box flexDirection="row"` on React Native to fix vertical misalignment of inline code

##Description-
Before:
<img width="353" height="773" alt="Screenshot 2026-06-09 at 6 23 22 PM" src="https://github.com/user-attachments/assets/ed571313-8c68-4304-86f0-ab769cac80bf" />
<img width="363" height="769" alt="Screenshot 2026-06-09 at 6 25 36 PM" src="https://github.com/user-attachments/assets/34c38a56-4f5a-44ab-bb06-ebf9ec64701e" />

<img width="368" height="774" alt="Screenshot 2026-06-09 at 6 48 45 PM" src="https://github.com/user-attachments/assets/ecd0330e-4f3c-4913-a081-2d6fe757a128" />

after:

<img width="309" height="586" alt="Screenshot 2026-06-10 at 11 30 20 AM" src="https://github.com/user-attachments/assets/2a592700-48f2-423f-bb0d-e9558fc952d0" />
<img width="370" height="777" alt="Screenshot 2026-06-10 at 11 43 11 AM" src="https://github.com/user-attachments/assets/fec3e775-4bb4-4a27-8e95-4fc303e6f795" />
<img width="354" height="778" alt="Screenshot 2026-06-10 at 11 49 13 AM" src="https://github.com/user-attachments/assets/1fa48ab8-9626-4620-9690-c1445b7177e9" />

## Test plan

- [ ] Divider story "Divider with Text columns" — verify text no longer overflows on RN
- [ ] Link story "Link - Inline" and "Link Button - Inline" — verify link is vertically aligned with surrounding text on RN, and spacing is preserved on web
- [ ] Code story — verify Code component is vertically aligned with surrounding text on RN, and inline rendering is preserved on web

🤖 Generated with [Claude Code](https://claude.com/claude-code)