### PR TITLE
fix(rn): fix Popover animation flash and story flex layout

### DIFF
--- a/.changeset/orange-eyes-tie.md
+++ b/.changeset/orange-eyes-tie.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(rn): fix Popover animation flash and story flex layout

--- a/packages/blade/src/components/Popover/Popover.stories.tsx
+++ b/packages/blade/src/components/Popover/Popover.stories.tsx
@@ -112,16 +112,16 @@ const Content = () => {
         borderWidth="thin"
         borderColor="surface.border.gray.subtle"
       >
-        <Box display="flex" justifyContent="space-between" gap="spacing.5">
+        <Box display="flex" flexDirection="row" justifyContent="space-between" gap="spacing.5">
           <Text size="medium">Gross Settlements</Text>
           <Amount size="medium" value={5000} />
         </Box>
-        <Box display="flex" justifyContent="space-between" gap="spacing.5">
+        <Box display="flex" flexDirection="row" justifyContent="space-between" gap="spacing.5">
           <Text size="medium">Deductions</Text>
           <Amount color="negative" size="medium" value={250} />
         </Box>
         <Divider variant="subtle" />
-        <Box display="flex" justifyContent="space-between" gap="spacing.5">
+        <Box display="flex" flexDirection="row" justifyContent="space-between" gap="spacing.5">
           <Text weight="semibold" size="medium">
             Net Settlements
           </Text>

--- a/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
+++ b/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
@@ -6,20 +6,21 @@ import type { EasingFn } from 'react-native-reanimated';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
-  withDelay,
   withTiming,
 } from 'react-native-reanimated';
 import React from 'react';
 import type { View } from 'react-native';
 import { getPopoverContentWrapperStyles } from './getPopoverContentWrapperStyles';
 import type { PopoverContentWrapperProps } from './types';
-import BaseBox from '~components/Box/BaseBox';
 import { useTheme } from '~components/BladeProvider';
 import { size } from '~tokens/global';
 import type { ColorSchemeNames } from '~tokens/theme';
 import { castNativeType } from '~utils';
 
-const StyledPopoverContentWrapper = styled(BaseBox)<{
+// Use styled(Animated.View) so opacity animates on the same View that has elevation.
+// On Android, elevation renders its shadow independently of a parent Animated.View's
+// opacity — co-locating opacity and elevation on the same View fixes the flash.
+const StyledPopoverContentWrapper = styled(Animated.View)<{
   collapse?: boolean;
   styles: CSSProperties;
   isMobile: boolean;
@@ -45,29 +46,34 @@ const PopoverContentWrapper = React.forwardRef<View, PopoverContentWrapperProps>
 
     React.useEffect(() => {
       const timings = { easing, duration };
-      opacity.value = withDelay(duration, withTiming(isVisible ? 1 : 0, timings));
-      translate.value = withDelay(duration, withTiming(isVisible ? 0 : offset, timings));
+      opacity.value = withTiming(isVisible ? 1 : 0, timings);
+      translate.value = withTiming(isVisible ? 0 : offset, timings);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isVisible]);
 
     // Avoid computed property keys inside useAnimatedStyle — Babel compiles them to
     // _defineProperty() which is not a worklet and crashes Reanimated v4 on the UI thread.
-    const animatedStyles = useAnimatedStyle(() => {
+    const translateAnimatedStyle = useAnimatedStyle(() => {
       return {
-        opacity: opacity.value,
         transform: isHorizontal
           ? [{ translateX: translate.value }]
           : [{ translateY: translate.value }],
       };
     }, [isVisible, isHorizontal]);
 
+    const opacityAnimatedStyle = useAnimatedStyle(() => {
+      return {
+        opacity: opacity.value,
+      };
+    }, [isVisible]);
+
     return (
-      <Animated.View style={animatedStyles}>
+      <Animated.View style={translateAnimatedStyle}>
         <StyledPopoverContentWrapper
           styles={styles}
           // Shadow styles need to be passed directly through native style prop
           // Cannot be done via styled components
-          style={castNativeType(theme.elevation.lowRaised)}
+          style={[castNativeType(theme.elevation.lowRaised), opacityAnimatedStyle]}
           elevation={20}
           ref={ref as never}
           collapse={false}

--- a/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
+++ b/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
@@ -3,11 +3,7 @@
 import type { CSSProperties } from 'react';
 import styled from 'styled-components/native';
 import type { EasingFn } from 'react-native-reanimated';
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import React from 'react';
 import type { View } from 'react-native';
 import { getPopoverContentWrapperStyles } from './getPopoverContentWrapperStyles';

--- a/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
+++ b/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
@@ -11,12 +11,15 @@ import type { PopoverContentWrapperProps } from './types';
 import { useTheme } from '~components/BladeProvider';
 import { size } from '~tokens/global';
 import type { ColorSchemeNames } from '~tokens/theme';
-import { castNativeType } from '~utils';
+import BaseBox from '~components/Box/BaseBox';
 
-// Use styled(Animated.View) so opacity animates on the same View that has elevation.
-// On Android, elevation renders its shadow independently of a parent Animated.View's
-// opacity — co-locating opacity and elevation on the same View fixes the flash.
-const StyledPopoverContentWrapper = styled(Animated.View)<{
+// Animated.createAnimatedComponent(BaseBox) so BaseBox handles elevation prop resolution
+// (getElevationValue → shadow styles) while Animated handles opacity on the same View.
+// On Android, elevation shadow renders independently of a parent View's opacity —
+// co-locating opacity and elevation on the same View fixes the flash.
+const AnimatedBaseBox = Animated.createAnimatedComponent(BaseBox as React.ComponentType<any>);
+
+const StyledPopoverContentWrapper = styled(AnimatedBaseBox)<{
   collapse?: boolean;
   styles: CSSProperties;
   isMobile: boolean;
@@ -67,10 +70,8 @@ const PopoverContentWrapper = React.forwardRef<View, PopoverContentWrapperProps>
       <Animated.View style={translateAnimatedStyle}>
         <StyledPopoverContentWrapper
           styles={styles}
-          // Shadow styles need to be passed directly through native style prop
-          // Cannot be done via styled components
-          style={[castNativeType(theme.elevation.lowRaised), opacityAnimatedStyle]}
-          elevation={20}
+          style={opacityAnimatedStyle}
+          elevation="lowRaised"
           ref={ref as never}
           collapse={false}
           isMobile={isMobile}

--- a/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
+++ b/packages/blade/src/components/Popover/PopoverContentWrapper.native.tsx
@@ -17,7 +17,7 @@ import BaseBox from '~components/Box/BaseBox';
 // (getElevationValue → shadow styles) while Animated handles opacity on the same View.
 // On Android, elevation shadow renders independently of a parent View's opacity —
 // co-locating opacity and elevation on the same View fixes the flash.
-const AnimatedBaseBox = Animated.createAnimatedComponent(BaseBox as React.ComponentType<any>);
+const AnimatedBaseBox = Animated.createAnimatedComponent(BaseBox as React.FunctionComponent<any>);
 
 const StyledPopoverContentWrapper = styled(AnimatedBaseBox)<{
   collapse?: boolean;

--- a/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.native.test.tsx.snap
+++ b/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.native.test.tsx.snap
@@ -219,7 +219,6 @@ exports[`<Popover /> should render 1`] = `
     <View
       style={
         {
-          "opacity": 0,
           "transform": [
             {
               "translateY": 4,
@@ -232,25 +231,11 @@ exports[`<Popover /> should render 1`] = `
         collapse={false}
         colorScheme="light"
         data-blade-component="base-box"
-        elevation={20}
+        elevation="lowRaised"
         isMobile={true}
         style={
           [
             {},
-            {
-              "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
-              "borderColor": "black",
-              "borderRadius": 16,
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "left": -200,
-              "maxWidth": 288,
-              "position": "absolute",
-              "top": -210,
-              "width": "100%",
-              "zIndex": 1100,
-            },
             {
               "elevation": 8,
               "shadowColor": "hsla(200, 10%, 18%, 1)",
@@ -261,6 +246,25 @@ exports[`<Popover /> should render 1`] = `
               "shadowOpacity": 0.06,
               "shadowRadius": 2,
             },
+            [
+              {
+                "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                "borderColor": "black",
+                "borderRadius": 16,
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
+                "left": -200,
+                "maxWidth": 288,
+                "position": "absolute",
+                "top": -210,
+                "width": "100%",
+                "zIndex": 1100,
+              },
+              {
+                "opacity": 0,
+              },
+            ],
           ]
         }
         styles={
@@ -808,7 +812,6 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
     <View
       style={
         {
-          "opacity": 0,
           "transform": [
             {
               "translateY": 4,
@@ -821,25 +824,11 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
         collapse={false}
         colorScheme="light"
         data-blade-component="base-box"
-        elevation={20}
+        elevation="lowRaised"
         isMobile={true}
         style={
           [
             {},
-            {
-              "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
-              "borderColor": "black",
-              "borderRadius": 16,
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "left": -200,
-              "maxWidth": 288,
-              "position": "absolute",
-              "top": -210,
-              "width": "100%",
-              "zIndex": 9999,
-            },
             {
               "elevation": 8,
               "shadowColor": "hsla(200, 10%, 18%, 1)",
@@ -850,6 +839,25 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
               "shadowOpacity": 0.06,
               "shadowRadius": 2,
             },
+            [
+              {
+                "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                "borderColor": "black",
+                "borderRadius": 16,
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
+                "left": -200,
+                "maxWidth": 288,
+                "position": "absolute",
+                "top": -210,
+                "width": "100%",
+                "zIndex": 9999,
+              },
+              {
+                "opacity": 0,
+              },
+            ],
           ]
         }
         styles={
@@ -1397,7 +1405,6 @@ exports[`<Popover /> should render with title,footer 1`] = `
     <View
       style={
         {
-          "opacity": 0,
           "transform": [
             {
               "translateY": 4,
@@ -1410,25 +1417,11 @@ exports[`<Popover /> should render with title,footer 1`] = `
         collapse={false}
         colorScheme="light"
         data-blade-component="base-box"
-        elevation={20}
+        elevation="lowRaised"
         isMobile={true}
         style={
           [
             {},
-            {
-              "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
-              "borderColor": "black",
-              "borderRadius": 16,
-              "borderStyle": "solid",
-              "borderWidth": 0,
-              "boxSizing": "border-box",
-              "left": -200,
-              "maxWidth": 288,
-              "position": "absolute",
-              "top": -210,
-              "width": "100%",
-              "zIndex": 1100,
-            },
             {
               "elevation": 8,
               "shadowColor": "hsla(200, 10%, 18%, 1)",
@@ -1439,6 +1432,25 @@ exports[`<Popover /> should render with title,footer 1`] = `
               "shadowOpacity": 0.06,
               "shadowRadius": 2,
             },
+            [
+              {
+                "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                "borderColor": "black",
+                "borderRadius": 16,
+                "borderStyle": "solid",
+                "borderWidth": 0,
+                "boxSizing": "border-box",
+                "left": -200,
+                "maxWidth": 288,
+                "position": "absolute",
+                "top": -210,
+                "width": "100%",
+                "zIndex": 1100,
+              },
+              {
+                "opacity": 0,
+              },
+            ],
           ]
         }
         styles={


### PR DESCRIPTION
## Summary

- Use `styled(Animated.View)` as the base for `PopoverContentWrapper` instead of `styled(BaseBox)` so opacity is co-located with `elevation` on the same View. On Android, elevation renders its shadow independently of a parent `Animated.View`'s opacity — this caused the shadow/box to flash visible before the content faded in. Co-locating them fixes the flash.
- Add `flexDirection="row"` to the settlement rows in the Popover story so label and amount sit side by side instead of stacking vertically on React Native.

##Description-

before:

https://github.com/user-attachments/assets/98976f23-e4d7-4e04-80fe-4e098def94df


after:



https://github.com/user-attachments/assets/6cca48b2-1227-4c26-9d28-dbb619de20a9


##Test plan

- [ ] Open Popover on Android — shadow and content should fade in together, no white box flash
- [ ] Open Popover on iOS — animation should look the same as before
- [ ] Popover story shows "Gross Settlements / ₹5,000", "Deductions / ₹250", "Net Settlements / ₹4,750" in a single row each

🤖 Generated with [Claude Code](https://claude.com/claude-code)