### PR TITLE
fix(rn): display tags in a horizontal row in Tag story

### DIFF
--- a/.changeset/flat-swans-pick.md
+++ b/.changeset/flat-swans-pick.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(rn): display tags in a horizontal row in Tag story

--- a/packages/blade/src/components/Tag/Tag.stories.tsx
+++ b/packages/blade/src/components/Tag/Tag.stories.tsx
@@ -135,7 +135,7 @@ export const ControlledTags = (props: TagProps): React.ReactElement => {
 
   return (
     <Box>
-      <Box paddingY="spacing.4">
+      <Box paddingY="spacing.4" display="flex" flexDirection="row" flexWrap="wrap">
         {tags.map((tagName) => (
           <Tag
             key={tagName}


### PR DESCRIPTION
## Summary

- Added `flexDirection="row"` and `flexWrap="wrap"` to the tags container in the `ControlledTags` story so tags render side by side instead of stacking vertically on React Native.

## Test plan

- [ ] Add multiple tags in the ControlledTags story on React Native — tags should appear in a horizontal row and wrap to the next line when full

🤖 Generated with [Claude Code](https://claude.com/claude-code)