### PR TITLE
fix(rn): make overflow cards scrollable in Card story

### DIFF
--- a/.changeset/short-sides-switch.md
+++ b/.changeset/short-sides-switch.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(rn): make overflow cards scrollable in Card story

--- a/packages/blade/src/components/Card/Card.stories.tsx
+++ b/packages/blade/src/components/Card/Card.stories.tsx
@@ -644,7 +644,10 @@ const CardWithOverflowExample = (): React.ReactElement => {
           <CardHeaderLeading title="Scrollable Content" />
         </CardHeader>
         <CardBody>
-          <Box height={isReactNative() ? '120px' : undefined} overflow={isReactNative() ? 'hidden' : undefined}>
+          <Box
+            height={isReactNative() ? '120px' : undefined}
+            overflow={isReactNative() ? 'hidden' : undefined}
+          >
             <StoryScrollView>
               <Text>
                 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
@@ -689,7 +692,10 @@ const CardWithOverflowExample = (): React.ReactElement => {
           <CardHeaderLeading title="Vertical Scroll Only" />
         </CardHeader>
         <CardBody>
-          <Box height={isReactNative() ? '120px' : undefined} overflow={isReactNative() ? 'hidden' : undefined}>
+          <Box
+            height={isReactNative() ? '120px' : undefined}
+            overflow={isReactNative() ? 'hidden' : undefined}
+          >
             <StoryScrollView>
               <Text>
                 Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem

--- a/packages/blade/src/components/Card/Card.stories.tsx
+++ b/packages/blade/src/components/Card/Card.stories.tsx
@@ -44,6 +44,7 @@ import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgType
 import { Box } from '~components/Box';
 import BaseBox from '~components/Box/BaseBox';
 import { TextInput } from '~components/Input/TextInput';
+import { StoryScrollView } from '~utils/storybook/StoryScrollView';
 
 const Page = (): React.ReactElement => {
   return (

--- a/packages/blade/src/components/Card/Card.stories.tsx
+++ b/packages/blade/src/components/Card/Card.stories.tsx
@@ -36,6 +36,7 @@ import {
   ArrowRightIcon,
 } from '~components/Icons';
 import { useIsMobile } from '~utils/useIsMobile';
+import { isReactNative } from '~utils';
 
 import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
 import iconMap from '~components/Icons/iconMap';
@@ -643,19 +644,24 @@ const CardWithOverflowExample = (): React.ReactElement => {
           <CardHeaderLeading title="Scrollable Content" />
         </CardHeader>
         <CardBody>
-          <Text>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-            has been the industry's standard dummy text ever since the 1500s, when an unknown
-            printer took a galley of type and scrambled it to make a type specimen book. It has
-            survived not only five centuries, but also the leap into electronic typesetting,
-            remaining essentially unchanged. It was popularised in the 1960s with the release of
-            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-            publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-          </Text>
-          <Text marginTop="spacing.5">
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-            has been the industry's standard dummy text ever since the 1500s.
-          </Text>
+          <Box height={isReactNative() ? '120px' : undefined} overflow={isReactNative() ? 'hidden' : undefined}>
+            <StoryScrollView>
+              <Text>
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                unknown printer took a galley of type and scrambled it to make a type specimen book.
+                It has survived not only five centuries, but also the leap into electronic
+                typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                with desktop publishing software like Aldus PageMaker including versions of Lorem
+                Ipsum.
+              </Text>
+              <Text marginTop="spacing.5">
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                Ipsum has been the industry's standard dummy text ever since the 1500s.
+              </Text>
+            </StoryScrollView>
+          </Box>
         </CardBody>
       </Card>
 
@@ -683,15 +689,20 @@ const CardWithOverflowExample = (): React.ReactElement => {
           <CardHeaderLeading title="Vertical Scroll Only" />
         </CardHeader>
         <CardBody>
-          <Text>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-            has been the industry's standard dummy text ever since the 1500s, when an unknown
-            printer took a galley of type and scrambled it to make a type specimen book. It has
-            survived not only five centuries, but also the leap into electronic typesetting,
-            remaining essentially unchanged. It was popularised in the 1960s with the release of
-            Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-            publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-          </Text>
+          <Box height={isReactNative() ? '120px' : undefined} overflow={isReactNative() ? 'hidden' : undefined}>
+            <StoryScrollView>
+              <Text>
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                unknown printer took a galley of type and scrambled it to make a type specimen book.
+                It has survived not only five centuries, but also the leap into electronic
+                typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                with desktop publishing software like Aldus PageMaker including versions of Lorem
+                Ipsum.
+              </Text>
+            </StoryScrollView>
+          </Box>
         </CardBody>
       </Card>
     </Box>

--- a/packages/blade/src/utils/storybook/StoryScrollView.native.tsx
+++ b/packages/blade/src/utils/storybook/StoryScrollView.native.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ScrollView } from 'react-native';
+
+const StoryScrollView = ({ children }: { children: React.ReactNode }): React.ReactElement => {
+  return <ScrollView>{children}</ScrollView>;
+};
+
+export { StoryScrollView };

--- a/packages/blade/src/utils/storybook/StoryScrollView.tsx
+++ b/packages/blade/src/utils/storybook/StoryScrollView.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const StoryScrollView = ({ children }: { children: React.ReactNode }): React.ReactElement => {
+  return <>{children}</>;
+};
+
+export { StoryScrollView };


### PR DESCRIPTION
## Summary
- Wraps content in `overflow="auto"` and `overflowY="scroll"` card variants with a bounded `Box` + `StoryScrollView` on React Native
- On RN, `overflow="auto"` and `overflowY="scroll"` are invalid values — content would overflow freely without a bounded container
- Web behavior is completely unchanged (`isReactNative()` returns false, Box props are `undefined`, `StoryScrollView` is a passthrough)

##Description:
before:
<img width="355" height="736" alt="Screenshot 2026-06-10 at 10 40 09 PM" src="https://github.com/user-attachments/assets/7eb259a7-0d49-48fc-a43d-122f825919e2" />


after:


https://github.com/user-attachments/assets/8a93a306-dfd2-4438-9f14-a626102f7924



## Test plan
- [ ] Verify `overflow="auto"` card scrolls within its bounds on RN
- [ ] Verify `overflowY="scroll"` card scrolls within its bounds on RN
- [ ] Verify both cards look and scroll correctly on web (no regression)
- [ ] Verify `overflow="hidden"` card still clips content correctly on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)