### PR TITLE
fix(table): render correct skeleton columns count when selectionType is multiple

### DIFF
--- a/.changeset/fix-table-skeleton-columns.md
+++ b/.changeset/fix-table-skeleton-columns.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(table): render correct skeleton columns count when selectionType is multiple

--- a/packages/blade/src/components/Table/Table.web.tsx
+++ b/packages/blade/src/components/Table/Table.web.tsx
@@ -157,21 +157,23 @@ const SKELETON_CELL_WIDTHS = {
   headerRest: '60%',
 } as const;
 
-const StyledSkeletonRow = styled(BaseBox)<{ $columns: number; $isHeader?: boolean }>(
-  ({ theme, $columns, $isHeader }) => ({
-    display: 'grid',
-    gridTemplateColumns: `repeat(${$columns}, minmax(100px, 1fr))`,
-    paddingLeft: makeSpace(theme.spacing[4]),
-    paddingRight: makeSpace(theme.spacing[4]),
-    paddingTop: makeSpace(theme.spacing[$isHeader ? 3 : 4]),
-    paddingBottom: makeSpace(theme.spacing[$isHeader ? 3 : 4]),
-    borderBottomWidth: makeSpace(theme.border.width.thin),
-    borderBottomColor: theme.colors.surface.border.gray.muted,
-    borderBottomStyle: 'solid',
-    gap: makeSpace(theme.spacing[4]),
-    alignItems: 'center',
-  }),
-);
+const StyledSkeletonRow = styled(BaseBox)<{
+  $columns: number;
+  $isHeader?: boolean;
+  $gridTemplateColumns?: string;
+}>(({ theme, $columns, $isHeader, $gridTemplateColumns }) => ({
+  display: 'grid',
+  gridTemplateColumns: $gridTemplateColumns || `repeat(${$columns}, minmax(100px, 1fr))`,
+  paddingLeft: makeSpace(theme.spacing[4]),
+  paddingRight: makeSpace(theme.spacing[4]),
+  paddingTop: makeSpace(theme.spacing[$isHeader ? 3 : 4]),
+  paddingBottom: makeSpace(theme.spacing[$isHeader ? 3 : 4]),
+  borderBottomWidth: makeSpace(theme.border.width.thin),
+  borderBottomColor: theme.colors.surface.border.gray.muted,
+  borderBottomStyle: 'solid',
+  gap: makeSpace(theme.spacing[4]),
+  alignItems: 'center',
+}));
 
 const _Table = <Item,>({
   children,
@@ -603,44 +605,70 @@ const _Table = <Item,>({
         backgroundColor={isInsideListView ? 'transparent' : 'surface.background.gray.intense'}
       >
         {isLoading ? (
-          <BaseBox
-            flex={1}
-            {...getStyledProps(rest)}
-            {...metaAttribute({ name: MetaConstants.Table })}
-            {...makeAnalyticsAttribute(rest)}
-            testID="table-skeleton"
-          >
-            {/* Header skeleton row */}
-            <StyledSkeletonRow $columns={columnCount || 5} $isHeader>
-              {Array.from({ length: columnCount || 5 }).map((_, i) => (
-                <Skeleton
-                  key={i}
-                  width={
-                    i === 0 ? SKELETON_CELL_WIDTHS.headerFirst : SKELETON_CELL_WIDTHS.headerRest
-                  }
-                  height="16px"
-                  borderRadius="medium"
-                />
-              ))}
-            </StyledSkeletonRow>
-            {/* Body skeleton rows */}
-            {Array.from({ length: SKELETON_ROW_COUNT }).map((_, rowIdx) => (
-              <StyledSkeletonRow key={rowIdx} $columns={columnCount || 5}>
-                {Array.from({ length: columnCount || 5 }).map((_, colIdx) => {
-                  const cols = columnCount || 5;
-                  const width =
-                    colIdx === 0
-                      ? SKELETON_CELL_WIDTHS.first
-                      : colIdx === cols - 1
-                      ? SKELETON_CELL_WIDTHS.last
-                      : SKELETON_CELL_WIDTHS.middle;
-                  return (
-                    <Skeleton key={colIdx} width={width} height="14px" borderRadius="medium" />
-                  );
-                })}
-              </StyledSkeletonRow>
-            ))}
-          </BaseBox>
+          (() => {
+            const isMultiSelect = selectionType === 'multiple';
+            const skeletonColumnCount = isMultiSelect ? columnCount + 1 : columnCount;
+            const skeletonGridTemplateColumns = gridTemplateColumns
+              ? gridTemplateColumns
+              : `${isMultiSelect ? 'min-content' : ''} repeat(${columnCount}, minmax(100px, 1fr))`;
+            return (
+              <BaseBox
+                flex={1}
+                {...getStyledProps(rest)}
+                {...metaAttribute({ name: MetaConstants.Table })}
+                {...makeAnalyticsAttribute(rest)}
+                testID="table-skeleton"
+              >
+                {/* Header skeleton row */}
+                <StyledSkeletonRow
+                  $columns={skeletonColumnCount || 5}
+                  $gridTemplateColumns={skeletonGridTemplateColumns}
+                  $isHeader
+                >
+                  {Array.from({ length: skeletonColumnCount || 5 }).map((_, i) => {
+                    const isCheckboxColumn = isMultiSelect && i === 0;
+                    return (
+                      <Skeleton
+                        key={i}
+                        width={
+                          isCheckboxColumn
+                            ? '20px'
+                            : i === (isMultiSelect ? 1 : 0)
+                            ? SKELETON_CELL_WIDTHS.headerFirst
+                            : SKELETON_CELL_WIDTHS.headerRest
+                        }
+                        height="16px"
+                        borderRadius="medium"
+                      />
+                    );
+                  })}
+                </StyledSkeletonRow>
+                {/* Body skeleton rows */}
+                {Array.from({ length: SKELETON_ROW_COUNT }).map((_, rowIdx) => (
+                  <StyledSkeletonRow
+                    key={rowIdx}
+                    $columns={skeletonColumnCount || 5}
+                    $gridTemplateColumns={skeletonGridTemplateColumns}
+                  >
+                    {Array.from({ length: skeletonColumnCount || 5 }).map((_, colIdx) => {
+                      const isCheckboxColumn = isMultiSelect && colIdx === 0;
+                      const cols = skeletonColumnCount || 5;
+                      const width = isCheckboxColumn
+                        ? '20px'
+                        : colIdx === (isMultiSelect ? 1 : 0)
+                        ? SKELETON_CELL_WIDTHS.first
+                        : colIdx === cols - 1
+                        ? SKELETON_CELL_WIDTHS.last
+                        : SKELETON_CELL_WIDTHS.middle;
+                      return (
+                        <Skeleton key={colIdx} width={width} height="14px" borderRadius="medium" />
+                      );
+                    })}
+                  </StyledSkeletonRow>
+                ))}
+              </BaseBox>
+            );
+          })()
         ) : (
           <BaseBox
             flex={1}

--- a/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
+++ b/packages/blade/src/components/Table/__tests__/Table.web.test.tsx
@@ -508,6 +508,41 @@ describe('<Table />', () => {
     expect(container).toMatchSnapshot();
   });
 
+  it('should render correct number of columns in skeleton loader when selectionType is multiple', () => {
+    const { getByTestId } = renderWithTheme(
+      <Table data={{ nodes: nodes.slice(0, 2) }} selectionType="multiple" isLoading={true}>
+        {(tableData) => (
+          <>
+            <TableHeader>
+              <TableHeaderRow>
+                <TableHeaderCell>Payment ID</TableHeaderCell>
+                <TableHeaderCell>Amount</TableHeaderCell>
+                <TableHeaderCell>Status</TableHeaderCell>
+              </TableHeaderRow>
+            </TableHeader>
+            <TableBody>
+              {tableData.map((tableItem, index) => (
+                <TableRow item={tableItem} key={index}>
+                  <TableCell>{tableItem.paymentId}</TableCell>
+                  <TableCell>{tableItem.amount}</TableCell>
+                  <TableCell>{tableItem.status}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </>
+        )}
+      </Table>,
+    );
+
+    const skeletonContainer = getByTestId('table-skeleton');
+    const skeletonRows = skeletonContainer.childNodes;
+    expect(skeletonRows.length).toBeGreaterThan(0);
+
+    skeletonRows.forEach((row) => {
+      expect(row.childNodes.length).toBe(4); // 3 content columns + 1 checkbox column
+    });
+  });
+
   it('should render table with isRefreshing', () => {
     const { container } = renderWithTheme(
       <Table data={{ nodes: nodes.slice(0, 2) }} isRefreshing={true}>


### PR DESCRIPTION
## Description

Fixes an off-by-one bug in the `Table` component's skeleton loader (`isLoading={true}`) where it renders one fewer column than the actual table header when `selectionType="multiple"` is enabled, causing the last column to appear hidden/misaligned.

## Changes

* **Skeleton Column Count Alignment**: Updated `_Table` in [Table.web.tsx](file:///c:/projects/oss/blade/packages/blade/src/components/Table/Table.web.tsx) to calculate `skeletonColumnCount = isMultiSelect ? columnCount + 1 : columnCount`.
* **Grid and Width Styling**: Updated `StyledSkeletonRow` to dynamically receive `$gridTemplateColumns` to match the table's grid template (e.g., prepending `min-content` for the checkbox column).
* **Skeleton Cell Widths**: Rendered a small `20px` skeleton for the checkbox column (first column when `isMultiSelect` is true) and shifted index checks for standard column widths.
* **Unit Tests**: Added a unit test in [Table.web.test.tsx](file:///c:/projects/oss/blade/packages/blade/src/components/Table/__tests__/Table.web.test.tsx) asserting that the skeleton loader correctly renders `columnCount + 1` columns when selection is set to `multiple`.

## Additional Information

Closes #2461

## Component Checklist

- [x] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [x] Add KitchenSink Story
- [x] Add Interaction Tests (if applicable)
- [x] Add changeset
