### PR TITLE
fix: resolve YAML syntax error in slash-resolve-comments workflow

### DIFF
--- a/.github/workflows/slash-resolve-comments.yml
+++ b/.github/workflows/slash-resolve-comments.yml
@@ -71,15 +71,6 @@ jobs:
             exit 0
           fi
 
-          PROMPT="Resolve the following PR review comments that were just submitted in a single review.
-
-Comment URLs:
-${COMMENT_URLS}
-
-Instructions:
-  - Fetch the details of the PR and each comment with \`gh\` CLI.
-  - For each comment: when it asks for clarification, reply to the comment with a response (including \"resolved by agent\" at the end) OR push a code fix to the PR branch.
-  - Whenever applicable, create a fix commit and push it to the PR branch, reply to the relevant comment(s) with \"resolved by agent\" at the end.
-  - If you need clarification from the PR author for any comment, add the label \"Human Help Needed\" to the PR instead of guessing."
+          PROMPT=$'Resolve the following PR review comments that were just submitted in a single review.\n\nComment URLs:\n'"${COMMENT_URLS}"$'\n\nInstructions:\n  - Fetch the details of the PR and each comment with `gh` CLI.\n  - For each comment: when it asks for clarification, reply to the comment with a response (including "resolved by agent" at the end) OR push a code fix to the PR branch.\n  - Whenever applicable, create a fix commit and push it to the PR branch, reply to the relevant comment(s) with "resolved by agent" at the end.\n  - If you need clarification from the PR author for any comment, add the label "Human Help Needed" to the PR instead of guessing.'
 
           node .github/scripts/run-slash.js "$PROMPT"


### PR DESCRIPTION
## Summary
- Multiline bash string with unindented lines (`Comment URLs:` and `${COMMENT_URLS}`) was breaking YAML block scalar parsing, causing the workflow to fail with a syntax error on line 77
- Replaced the multiline double-quoted string with `$'...'` ANSI-C quoting so the entire `PROMPT=` assignment stays on a single properly-indented line

## Test plan
- [ ] Verify the workflow file passes YAML lint / GitHub Actions syntax check