### PR TITLE
feat(Button): add loadingType prop for loading state variants

### DIFF
--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -77,6 +77,12 @@ type BaseButtonCommonProps = {
   }>;
   type?: 'button' | 'reset' | 'submit';
   isLoading?: boolean;
+  /**
+   * Determines the type of loading indicator displayed when `isLoading` is true.
+   *
+   * @default 'indefinite'
+   */
+  loadingType?: 'indefinite';
   accessibilityProps?: Partial<AccessibilityProps>;
   variant?: 'primary' | 'secondary' | 'tertiary';
   color?:
@@ -393,6 +399,7 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
     isDisabled = false,
     isFullWidth = false,
     isLoading = false,
+    loadingType = 'indefinite',
     onClick,
     onBlur,
     onKeyDown,
@@ -594,7 +601,7 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
         motionEasing={motionEasing}
         isPressed={isPressed}
       >
-        {isLoading ? (
+        {isLoading && loadingType === 'indefinite' ? (
           <BaseBox
             display="flex"
             justifyContent="center"

--- a/packages/blade/src/components/Button/Button/Button.tsx
+++ b/packages/blade/src/components/Button/Button/Button.tsx
@@ -41,6 +41,12 @@ type ButtonCommonProps = {
   isDisabled?: boolean;
   isFullWidth?: boolean;
   isLoading?: boolean;
+  /**
+   * Determines the type of loading indicator displayed when `isLoading` is true.
+   *
+   * @default 'indefinite'
+   */
+  loadingType?: 'indefinite';
   accessibilityLabel?: string;
   type?: 'button' | 'reset' | 'submit';
 
@@ -111,6 +117,7 @@ const _Button: React.ForwardRefRenderFunction<BladeElementRef, ButtonProps> = (
     isDisabled = false,
     isFullWidth = false,
     isLoading = false,
+    loadingType = 'indefinite',
     href,
     target,
     rel,
@@ -160,6 +167,7 @@ const _Button: React.ForwardRefRenderFunction<BladeElementRef, ButtonProps> = (
       type={type}
       variant={variant}
       isLoading={isLoading}
+      loadingType={loadingType}
       testID={testID}
       onBlur={onBlur}
       onFocus={onFocus}


### PR DESCRIPTION
## Summary
- Adds a new `loadingType` prop to `Button` and `BaseButton` components
- Currently supports `'indefinite'` (default) — the existing spinner-based loading indicator
- Sets up the extensibility point for future loading types (e.g. determinate progress)

## Changes
- `Button.tsx`: Added `loadingType` prop to `ButtonCommonProps`, destructured with default `'indefinite'`, passed through to `BaseButton`
- `BaseButton.tsx`: Added `loadingType` to `BaseButtonCommonProps`, gated spinner rendering on `loadingType === 'indefinite'`

## Test plan
- [ ] Existing loading state behavior unchanged (spinner shows when `isLoading={true}`)
- [ ] `loadingType="indefinite"` is equivalent to current behavior
- [ ] TypeScript compiles without new errors
- [ ] Snapshot tests pass with `yarn test:react Button`