### PR TITLE
feat(blade-svelte): IconButton component

### DIFF
--- a/.changeset/blade-svelte-iconbutton-component.md
+++ b/.changeset/blade-svelte-iconbutton-component.md
@@ -1,0 +1,6 @@
+---
+'@razorpay/blade-core': patch
+'@razorpay/blade-svelte': patch
+---
+
+feat(blade-svelte): add IconButton component

--- a/packages/blade-core/src/styles/IconButton/iconButton.module.css
+++ b/packages/blade-core/src/styles/IconButton/iconButton.module.css
@@ -1,0 +1,105 @@
+/*
+ * IconButton — a transparent-background clickable icon.
+ * Mirrors React `StyledIconButton.web.tsx`. The <button> element directly wraps
+ * the <svg> icon (no inner wrappers). The icon inherits `currentColor` from the
+ * button; only the disabled-icon color is resolved in TS.
+ */
+.icon-button {
+  border: none;
+  padding: 0;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-radius: var(--border-radius-2xsmall);
+  transition-property: color, box-shadow;
+  transition-duration: var(--duration-xquick);
+  transition-timing-function: var(--easing-standard);
+
+  &[disabled] {
+    cursor: not-allowed;
+  }
+
+  /* Focus ring (mirrors getFocusRingStyles → Button pattern) */
+  &:focus-visible:not([disabled]) {
+    outline: 1px solid var(--surface-background-primary-subtle);
+    box-shadow: 0px 0px 0px 4px var(--surface-border-primary-muted);
+  }
+}
+
+/*
+ * ===== Emphasis: intense (gray) =====
+ * rest → muted, hover/focus/active → subtle, disabled → disabled.
+ */
+.emphasis-intense {
+  color: var(--interactive-icon-gray-muted);
+
+  &:hover:not([disabled]),
+  &:focus-visible:not([disabled]),
+  &:active:not([disabled]) {
+    color: var(--interactive-icon-gray-subtle);
+  }
+
+  &[disabled] {
+    color: var(--interactive-icon-gray-disabled);
+  }
+}
+
+/*
+ * ===== Emphasis: subtle (static white) =====
+ * For use on dark / intense surfaces.
+ */
+.emphasis-subtle {
+  color: var(--interactive-icon-static-white-muted);
+
+  &:hover:not([disabled]),
+  &:focus-visible:not([disabled]),
+  &:active:not([disabled]) {
+    color: var(--interactive-icon-static-white-subtle);
+  }
+
+  &[disabled] {
+    color: var(--interactive-icon-static-white-disabled);
+  }
+}
+
+/*
+ * ===== Highlighted (web-only) =====
+ * Rounder corners + fixed square size (set via compound size classes) + a faded
+ * hover/focus background (set via compound emphasis classes). `size="large"` is
+ * invalid with highlighted and is guarded in the component.
+ */
+.highlighted {
+  border-radius: var(--border-radius-small);
+}
+
+/* Fixed square sizes — only small & medium are valid when highlighted. */
+.highlighted-small {
+  width: 24px;
+  height: 24px;
+}
+
+.highlighted-medium {
+  width: 32px;
+  height: 32px;
+}
+
+/*
+ * Highlighted hover/focus background per emphasis. React's highlightedHoverColorMap
+ * and focusBackgroundColorMap are identical, so hover and focus-visible share one
+ * selector group here.
+ */
+.highlighted-intense {
+  &:hover:not([disabled]),
+  &:focus-visible:not([disabled]) {
+    background-color: var(--interactive-background-gray-faded-highlighted);
+  }
+}
+
+.highlighted-subtle {
+  &:hover:not([disabled]),
+  &:focus-visible:not([disabled]) {
+    background-color: var(--interactive-background-static-white-faded);
+  }
+}

--- a/packages/blade-core/src/styles/IconButton/iconButton.module.css
+++ b/packages/blade-core/src/styles/IconButton/iconButton.module.css
@@ -21,10 +21,20 @@
     cursor: not-allowed;
   }
 
-  /* Focus ring (mirrors getFocusRingStyles → Button pattern) */
-  &:focus-visible:not([disabled]) {
-    outline: 1px solid var(--surface-background-primary-subtle);
-    box-shadow: 0px 0px 0px 4px var(--surface-border-primary-muted);
+  /*
+   * Focus ring — faithful reproduction of React `getFocusRingStyles({ theme })`
+   * (see StyledIconButton.web.tsx `&:focus-visible`). React renders a true 4px
+   * solid outline offset by 1px (NOT the Button's box-shadow ring), animating
+   * `outline-width` over the 2xquick duration. Ungated to mirror React's styled
+   * object exactly — `:focus-visible` already cannot match a disabled button.
+   */
+  &:focus-visible {
+    outline: 4px solid var(--surface-border-primary-muted);
+    outline-offset: 1px;
+    transition-property: outline-width;
+    transition-duration: var(--duration-2xquick);
+    transition-timing-function: var(--easing-standard);
+    z-index: 2;
   }
 }
 

--- a/packages/blade-core/src/styles/IconButton/iconButton.ts
+++ b/packages/blade-core/src/styles/IconButton/iconButton.ts
@@ -1,0 +1,102 @@
+import { cva } from 'class-variance-authority';
+// @ts-expect-error - CSS modules may not have type definitions in build
+import styles from './iconButton.module.css';
+
+export type IconButtonEmphasis = 'subtle' | 'intense';
+export type IconButtonSize = 'small' | 'medium' | 'large';
+
+export type IconButtonVariants = {
+  emphasis?: IconButtonEmphasis;
+  size?: IconButtonSize;
+  isHighlighted?: boolean;
+};
+
+/**
+ * Fixed square dimensions (px) applied to the button when `isHighlighted` is true.
+ * `large` is intentionally absent — it is an invalid combination with `isHighlighted`.
+ */
+export const highlightedButtonSizeMap: Record<'small' | 'medium', number> = {
+  small: 24,
+  medium: 32,
+};
+
+/**
+ * Resolve the color token for the child `<Icon>`.
+ *
+ * The button sets its own `color` via CSS (per emphasis + interaction state) and the
+ * icon inherits it through `currentColor`. Only the disabled state needs an explicit
+ * token (matches React `StyledIconButton`).
+ */
+export function getIconButtonIconColorToken({
+  isDisabled,
+}: {
+  isDisabled?: boolean;
+}): 'interactive.icon.gray.disabled' | 'currentColor' {
+  return isDisabled ? 'interactive.icon.gray.disabled' : 'currentColor';
+}
+
+/**
+ * CVA-based IconButton styles.
+ *
+ * `size` carries no class on its own (the non-highlighted button is intrinsically
+ * sized); it exists so the compound variants can pin a fixed square size when
+ * `isHighlighted` is true.
+ */
+export const iconButtonStyles = cva(styles['icon-button'], {
+  variants: {
+    emphasis: {
+      intense: styles['emphasis-intense'],
+      subtle: styles['emphasis-subtle'],
+    },
+    size: {
+      small: null,
+      medium: null,
+      large: null,
+    },
+    isHighlighted: {
+      true: styles.highlighted,
+      false: null,
+    },
+  },
+  compoundVariants: [
+    // Fixed square size when highlighted (small/medium only).
+    { isHighlighted: true, size: 'small', class: styles['highlighted-small'] },
+    { isHighlighted: true, size: 'medium', class: styles['highlighted-medium'] },
+    // Faded hover/focus background when highlighted, per emphasis.
+    { isHighlighted: true, emphasis: 'intense', class: styles['highlighted-intense'] },
+    { isHighlighted: true, emphasis: 'subtle', class: styles['highlighted-subtle'] },
+  ],
+  defaultVariants: {
+    emphasis: 'intense',
+    size: 'medium',
+    isHighlighted: false,
+  },
+});
+
+/**
+ * Get all IconButton component template classes as an object.
+ * Call this in Svelte components to prevent tree-shaking from removing class
+ * imports that are only referenced through the CVA config.
+ */
+export function getIconButtonTemplateClasses(): Record<string, string> {
+  return {
+    iconButton: styles['icon-button'],
+    emphasisIntense: styles['emphasis-intense'],
+    emphasisSubtle: styles['emphasis-subtle'],
+    highlighted: styles.highlighted,
+    highlightedSmall: styles['highlighted-small'],
+    highlightedMedium: styles['highlighted-medium'],
+    highlightedIntense: styles['highlighted-intense'],
+    highlightedSubtle: styles['highlighted-subtle'],
+  } as const;
+}
+
+/**
+ * Generate all classes for the IconButton element.
+ * Single source of truth for IconButton styling — everything is class-based.
+ */
+export function getIconButtonClasses(props: IconButtonVariants & { className?: string }): string {
+  const { className, ...cvaProps } = props;
+
+  return [iconButtonStyles(cvaProps), className].filter(Boolean).join(' ');
+}

--- a/packages/blade-core/src/styles/IconButton/index.ts
+++ b/packages/blade-core/src/styles/IconButton/index.ts
@@ -1,0 +1,11 @@
+// Import CSS module to ensure it's processed by the bundler
+import './iconButton.module.css';
+
+export {
+  iconButtonStyles,
+  getIconButtonClasses,
+  getIconButtonTemplateClasses,
+  getIconButtonIconColorToken,
+  highlightedButtonSizeMap,
+} from './iconButton';
+export type { IconButtonVariants, IconButtonEmphasis, IconButtonSize } from './iconButton';

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -47,6 +47,18 @@ export {
   getButtonIconOnlySize,
 } from './Button';
 export type { ButtonVariants, ButtonColor, ButtonVariant } from './Button';
+export {
+  iconButtonStyles,
+  getIconButtonClasses,
+  getIconButtonTemplateClasses,
+  getIconButtonIconColorToken,
+  highlightedButtonSizeMap,
+} from './IconButton';
+export type {
+  IconButtonVariants,
+  IconButtonEmphasis,
+  IconButtonSize,
+} from './IconButton';
 export { utilityClasses, getUtilityClass } from './utilities';
 // @ts-expect-error - CSS modules may not have type definitions in build
 export { default as utilities } from './utilities.module.css';

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -54,11 +54,7 @@ export {
   getIconButtonIconColorToken,
   highlightedButtonSizeMap,
 } from './IconButton';
-export type {
-  IconButtonVariants,
-  IconButtonEmphasis,
-  IconButtonSize,
-} from './IconButton';
+export type { IconButtonVariants, IconButtonEmphasis, IconButtonSize } from './IconButton';
 export { utilityClasses, getUtilityClass } from './utilities';
 // @ts-expect-error - CSS modules may not have type definitions in build
 export { default as utilities } from './utilities.module.css';

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/BaseIconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/BaseIconButton.svelte
@@ -31,6 +31,8 @@
     onFocus,
     onMouseLeave,
     onMouseMove,
+    onMouseDown,
+    onMouseUp,
     onPointerDown,
     onPointerEnter,
     onTouchStart,
@@ -97,6 +99,18 @@
     }
   }
 
+  function handleMouseDown(event: MouseEvent): void {
+    if (!isDisabled) {
+      onMouseDown?.(event);
+    }
+  }
+
+  function handleMouseUp(event: MouseEvent): void {
+    if (!isDisabled) {
+      onMouseUp?.(event);
+    }
+  }
+
   function handlePointerDown(event: PointerEvent): void {
     if (!isDisabled) {
       onPointerDown?.(event);
@@ -141,6 +155,8 @@
   onfocus={handleFocus}
   onmouseleave={handleMouseLeave}
   onmousemove={handleMouseMove}
+  onmousedown={handleMouseDown}
+  onmouseup={handleMouseUp}
   onpointerdown={handlePointerDown}
   onpointerenter={handlePointerEnter}
   ontouchstart={handleTouchStart}

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/BaseIconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/BaseIconButton.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import {
+    makeAccessible,
+    makeAnalyticsAttribute,
+    metaAttribute,
+    MetaConstants,
+    getStyledPropsClasses,
+  } from '@razorpay/blade-core/utils';
+  import {
+    getIconButtonClasses,
+    getIconButtonTemplateClasses,
+    getIconButtonIconColorToken,
+  } from '@razorpay/blade-core/styles';
+  import type { BaseIconButtonProps } from './types';
+
+  // Call template classes fn to prevent Svelte tree-shaking of CVA-only classes.
+  getIconButtonTemplateClasses();
+
+  let {
+    icon: Icon,
+    size = 'medium',
+    emphasis = 'intense',
+    accessibilityLabel,
+    accessibilityProps,
+    isDisabled = false,
+    isHighlighted = false,
+    tabIndex,
+    testID,
+    onClick,
+    onBlur,
+    onFocus,
+    onMouseLeave,
+    onMouseMove,
+    onPointerDown,
+    onPointerEnter,
+    onTouchStart,
+    onTouchEnd,
+    onKeyDown,
+    ...rest
+  }: BaseIconButtonProps = $props();
+
+  // `size="large"` with `isHighlighted` is an invalid combination (React throws in
+  // __DEV__). Surface it as a localhost-only console error; still render the button.
+  $effect(() => {
+    if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+      if (size === 'large' && isHighlighted) {
+        console.error('[Blade: IconButton]: size "large" is not allowed with isHighlighted true');
+      }
+    }
+  });
+
+  const cvaClasses = $derived(getIconButtonClasses({ emphasis, size, isHighlighted }));
+  const styledProps = $derived(getStyledPropsClasses(rest));
+  const combinedClasses = $derived(
+    [cvaClasses, ...(styledProps.classes ?? [])].filter(Boolean).join(' '),
+  );
+
+  const iconColorToken = $derived(getIconButtonIconColorToken({ isDisabled }));
+
+  const accessibilityAttrs = $derived(
+    makeAccessible({
+      ...accessibilityProps,
+      label: accessibilityLabel ?? accessibilityProps?.label,
+    }),
+  );
+
+  const metaAttrs = $derived(metaAttribute({ name: MetaConstants.IconButton, testID }));
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+
+  function handleClick(event: MouseEvent): void {
+    if (!isDisabled) {
+      onClick?.(event);
+    }
+  }
+
+  function handleBlur(event: FocusEvent): void {
+    if (!isDisabled) {
+      onBlur?.(event);
+    }
+  }
+
+  function handleFocus(event: FocusEvent): void {
+    if (!isDisabled) {
+      onFocus?.(event);
+    }
+  }
+
+  function handleMouseLeave(event: MouseEvent): void {
+    if (!isDisabled) {
+      onMouseLeave?.(event);
+    }
+  }
+
+  function handleMouseMove(event: MouseEvent): void {
+    if (!isDisabled) {
+      onMouseMove?.(event);
+    }
+  }
+
+  function handlePointerDown(event: PointerEvent): void {
+    if (!isDisabled) {
+      onPointerDown?.(event);
+    }
+  }
+
+  function handlePointerEnter(event: PointerEvent): void {
+    if (!isDisabled) {
+      onPointerEnter?.(event);
+    }
+  }
+
+  function handleTouchStart(event: TouchEvent): void {
+    if (!isDisabled) {
+      onTouchStart?.(event);
+    }
+  }
+
+  function handleTouchEnd(event: TouchEvent): void {
+    if (!isDisabled) {
+      onTouchEnd?.(event);
+    }
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (!isDisabled) {
+      onKeyDown?.(event);
+    }
+  }
+</script>
+
+<button
+  type="button"
+  class={combinedClasses}
+  disabled={isDisabled || undefined}
+  tabindex={tabIndex}
+  {...accessibilityAttrs}
+  {...metaAttrs}
+  {...analyticsAttrs}
+  onclick={handleClick}
+  onblur={handleBlur}
+  onfocus={handleFocus}
+  onmouseleave={handleMouseLeave}
+  onmousemove={handleMouseMove}
+  onpointerdown={handlePointerDown}
+  onpointerenter={handlePointerEnter}
+  ontouchstart={handleTouchStart}
+  ontouchend={handleTouchEnd}
+  onkeydown={handleKeyDown}
+>
+  <Icon {size} color={iconColorToken} />
+</button>

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/BaseIconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/BaseIconButton.svelte
@@ -31,8 +31,6 @@
     onFocus,
     onMouseLeave,
     onMouseMove,
-    onMouseDown,
-    onMouseUp,
     onPointerDown,
     onPointerEnter,
     onTouchStart,
@@ -99,18 +97,6 @@
     }
   }
 
-  function handleMouseDown(event: MouseEvent): void {
-    if (!isDisabled) {
-      onMouseDown?.(event);
-    }
-  }
-
-  function handleMouseUp(event: MouseEvent): void {
-    if (!isDisabled) {
-      onMouseUp?.(event);
-    }
-  }
-
   function handlePointerDown(event: PointerEvent): void {
     if (!isDisabled) {
       onPointerDown?.(event);
@@ -155,8 +141,6 @@
   onfocus={handleFocus}
   onmouseleave={handleMouseLeave}
   onmousemove={handleMouseMove}
-  onmousedown={handleMouseDown}
-  onmouseup={handleMouseUp}
   onpointerdown={handlePointerDown}
   onpointerenter={handlePointerEnter}
   ontouchstart={handleTouchStart}

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/index.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/index.ts
@@ -1,0 +1,2 @@
+export { default as BaseIconButton } from './BaseIconButton.svelte';
+export type { BaseIconButtonProps } from './types';

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/types.ts
@@ -1,0 +1,69 @@
+import type { AccessibilityProps, StyledPropsBlade } from '@razorpay/blade-core/utils';
+import type { IconComponent } from '../../../Icons/iconMap';
+import type { IconButtonEmphasis, IconButtonSize } from '../types';
+
+export interface BaseIconButtonProps extends StyledPropsBlade {
+  /**
+   * Icon component to be rendered, eg. `CloseIcon`.
+   */
+  icon: IconComponent;
+  /**
+   * Icon size.
+   */
+  size?: IconButtonSize;
+  /**
+   * Icon emphasis (contrast).
+   */
+  emphasis?: IconButtonEmphasis;
+  /**
+   * Sets `aria-label` to help users know what the action does, eg 'Dismiss alert'.
+   */
+  accessibilityLabel: string;
+  /**
+   * Additional accessibility attributes merged into the rendered element.
+   */
+  accessibilityProps?: Partial<AccessibilityProps>;
+  /**
+   * Disabled state for IconButton.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Renders a fixed-size square with a faded hover/focus background. Web-only.
+   * Not supported with `size="large"`.
+   * @default false
+   */
+  isHighlighted?: boolean;
+  /**
+   * Sets the `tabindex` property on the button element.
+   */
+  tabIndex?: number;
+  /**
+   * Called when the IconButton is clicked.
+   */
+  onClick?: (event: MouseEvent) => void;
+  /** Called when the IconButton loses focus. */
+  onBlur?: (event: FocusEvent) => void;
+  /** Called when the IconButton receives focus. */
+  onFocus?: (event: FocusEvent) => void;
+  /** Called when the pointer leaves the IconButton. */
+  onMouseLeave?: (event: MouseEvent) => void;
+  /** Called when the pointer moves over the IconButton. */
+  onMouseMove?: (event: MouseEvent) => void;
+  /** Called when a pointer becomes active over the IconButton. */
+  onPointerDown?: (event: PointerEvent) => void;
+  /** Called when a pointer enters the IconButton. */
+  onPointerEnter?: (event: PointerEvent) => void;
+  /** Called when a touch point is placed on the IconButton. */
+  onTouchStart?: (event: TouchEvent) => void;
+  /** Called when a touch point is removed from the IconButton. */
+  onTouchEnd?: (event: TouchEvent) => void;
+  /** Called when a key is pressed while the IconButton is focused. */
+  onKeyDown?: (event: KeyboardEvent) => void;
+  /**
+   * Test id that can be used to select the element in testing environments.
+   */
+  testID?: string;
+  /** Analytics data attributes. */
+  [key: `data-analytics-${string}`]: string;
+}

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/types.ts
@@ -1,8 +1,12 @@
-import type { AccessibilityProps, StyledPropsBlade } from '@razorpay/blade-core/utils';
+import type {
+  AccessibilityProps,
+  DataAnalyticsAttribute,
+  StyledPropsBlade,
+} from '@razorpay/blade-core/utils';
 import type { IconComponent } from '../../../Icons/iconMap';
 import type { IconButtonEmphasis, IconButtonSize } from '../types';
 
-export interface BaseIconButtonProps extends StyledPropsBlade {
+export interface BaseIconButtonProps extends StyledPropsBlade, DataAnalyticsAttribute {
   /**
    * Icon component to be rendered, eg. `CloseIcon`.
    */
@@ -50,10 +54,6 @@ export interface BaseIconButtonProps extends StyledPropsBlade {
   onMouseLeave?: (event: MouseEvent) => void;
   /** Called when the pointer moves over the IconButton. */
   onMouseMove?: (event: MouseEvent) => void;
-  /** Called when a mouse button is pressed on the IconButton. */
-  onMouseDown?: (event: MouseEvent) => void;
-  /** Called when a mouse button is released over the IconButton. */
-  onMouseUp?: (event: MouseEvent) => void;
   /** Called when a pointer becomes active over the IconButton. */
   onPointerDown?: (event: PointerEvent) => void;
   /** Called when a pointer enters the IconButton. */
@@ -68,6 +68,4 @@ export interface BaseIconButtonProps extends StyledPropsBlade {
    * Test id that can be used to select the element in testing environments.
    */
   testID?: string;
-  /** Analytics data attributes. */
-  [key: `data-analytics-${string}`]: string;
 }

--- a/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/BaseIconButton/types.ts
@@ -50,6 +50,10 @@ export interface BaseIconButtonProps extends StyledPropsBlade {
   onMouseLeave?: (event: MouseEvent) => void;
   /** Called when the pointer moves over the IconButton. */
   onMouseMove?: (event: MouseEvent) => void;
+  /** Called when a mouse button is pressed on the IconButton. */
+  onMouseDown?: (event: MouseEvent) => void;
+  /** Called when a mouse button is released over the IconButton. */
+  onMouseUp?: (event: MouseEvent) => void;
   /** Called when a pointer becomes active over the IconButton. */
   onPointerDown?: (event: PointerEvent) => void;
   /** Called when a pointer enters the IconButton. */

--- a/packages/blade-svelte/src/components/Button/IconButton/IconButton.stories.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/IconButton.stories.svelte
@@ -1,0 +1,171 @@
+<script context="module">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import IconButton from './IconButton.svelte';
+  import { iconMap } from '../../Icons/iconMap';
+  import { CloseIcon } from '../../Icons';
+  import Text from '../../Typography/Text/Text.svelte';
+  import Heading from '../../Typography/Heading/Heading.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/IconButton',
+    component: IconButton,
+    tags: ['autodocs'],
+    args: {
+      size: 'medium',
+      emphasis: 'intense',
+      accessibilityLabel: 'Close',
+      icon: CloseIcon,
+    },
+    argTypes: {
+      icon: {
+        name: 'icon',
+        control: 'select',
+        options: Object.keys(iconMap),
+        mapping: iconMap,
+        description: 'Icon component to be rendered',
+      },
+      size: {
+        control: 'select',
+        options: ['small', 'medium', 'large'],
+        description: 'Icon size',
+      },
+      emphasis: {
+        control: 'select',
+        options: ['subtle', 'intense'],
+        description: 'Icon emphasis (contrast)',
+      },
+      accessibilityLabel: {
+        control: 'text',
+        description: 'Sets aria-label to describe the action',
+      },
+      isDisabled: {
+        control: 'boolean',
+        description: 'Disabled state for IconButton',
+      },
+      isHighlighted: {
+        control: 'boolean',
+        description: 'Highlights the icon with a faded background on hover/focus (web-only)',
+      },
+      onClick: { action: 'onClick' },
+    },
+  });
+</script>
+
+<script lang="ts">
+  const sizes = ['small', 'medium', 'large'] as const;
+  const highlightedSizes = ['small', 'medium'] as const;
+
+  const sizeLabels: Record<string, string> = {
+    small: '12px',
+    medium: '16px',
+    large: '20px',
+  };
+
+  const noop = (): void => {};
+</script>
+
+<!-- Playground - auto-renders IconButton driven by Storybook controls -->
+<Story name="IconButton" />
+
+<!-- Full matrix: emphasis x size x {default, disabled} + highlighted small/medium -->
+<Story name="All Variants & Sizes" asChild>
+  <div class="display-flex flex-col gap-spacing-7">
+    <!-- Emphasis: Intense (plain background) -->
+    <div
+      class="display-flex flex-col gap-spacing-5"
+      style="padding: var(--spacing-7); border-radius: var(--border-radius-medium);"
+    >
+      <Heading size="small" color="surface.text.gray.normal">Emphasis: Intense</Heading>
+
+      <div class="display-flex flex-row gap-spacing-8 items-center">
+        <div style="width: 100px;"></div>
+        <div style="width: 48px;">
+          <Text size="xsmall" weight="semibold" color="surface.text.gray.muted">Default</Text>
+        </div>
+        <div style="width: 48px;">
+          <Text size="xsmall" weight="semibold" color="surface.text.gray.muted">Disabled</Text>
+        </div>
+      </div>
+
+      {#each sizes as size (size)}
+        <div class="display-flex flex-row gap-spacing-8 items-center">
+          <div style="width: 100px;">
+            <Text size="xsmall" color="surface.text.gray.muted">Size {sizeLabels[size]}</Text>
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="intense" accessibilityLabel="Close" onClick={noop} />
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="intense" accessibilityLabel="Close" onClick={noop} isDisabled />
+          </div>
+        </div>
+      {/each}
+
+      <div class="margin-top-spacing-3">
+        <Text size="xsmall" weight="semibold" color="surface.text.gray.muted">Highlighted</Text>
+      </div>
+      {#each highlightedSizes as size (size)}
+        <div class="display-flex flex-row gap-spacing-8 items-center">
+          <div style="width: 100px;">
+            <Text size="xsmall" color="surface.text.gray.muted">Size {sizeLabels[size]}</Text>
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="intense" accessibilityLabel="Close" onClick={noop} isHighlighted />
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="intense" accessibilityLabel="Close" onClick={noop} isHighlighted isDisabled />
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <!-- Emphasis: Subtle (dark intense background) -->
+    <div
+      class="display-flex flex-col gap-spacing-5"
+      style="padding: var(--spacing-7); border-radius: var(--border-radius-medium); background-color: var(--surface-background-primary-intense);"
+    >
+      <Heading size="small" color="surface.text.staticWhite.normal">Emphasis: Subtle</Heading>
+
+      <div class="display-flex flex-row gap-spacing-8 items-center">
+        <div style="width: 100px;"></div>
+        <div style="width: 48px;">
+          <Text size="xsmall" weight="semibold" color="surface.text.staticWhite.muted">Default</Text>
+        </div>
+        <div style="width: 48px;">
+          <Text size="xsmall" weight="semibold" color="surface.text.staticWhite.muted">Disabled</Text>
+        </div>
+      </div>
+
+      {#each sizes as size (size)}
+        <div class="display-flex flex-row gap-spacing-8 items-center">
+          <div style="width: 100px;">
+            <Text size="xsmall" color="surface.text.staticWhite.muted">Size {sizeLabels[size]}</Text>
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="subtle" accessibilityLabel="Close" onClick={noop} />
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="subtle" accessibilityLabel="Close" onClick={noop} isDisabled />
+          </div>
+        </div>
+      {/each}
+
+      <div class="margin-top-spacing-3">
+        <Text size="xsmall" weight="semibold" color="surface.text.staticWhite.muted">Highlighted</Text>
+      </div>
+      {#each highlightedSizes as size (size)}
+        <div class="display-flex flex-row gap-spacing-8 items-center">
+          <div style="width: 100px;">
+            <Text size="xsmall" color="surface.text.staticWhite.muted">Size {sizeLabels[size]}</Text>
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="subtle" accessibilityLabel="Close" onClick={noop} isHighlighted />
+          </div>
+          <div class="display-flex items-center justify-center" style="width: 48px;">
+            <IconButton icon={CloseIcon} {size} emphasis="subtle" accessibilityLabel="Close" onClick={noop} isHighlighted isDisabled />
+          </div>
+        </div>
+      {/each}
+    </div>
+  </div>
+</Story>

--- a/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
@@ -16,6 +16,8 @@
     onFocus,
     onMouseLeave,
     onMouseMove,
+    onMouseDown,
+    onMouseUp,
     onPointerDown,
     onPointerEnter,
     onTouchStart,
@@ -41,6 +43,8 @@
   {onFocus}
   {onMouseLeave}
   {onMouseMove}
+  {onMouseDown}
+  {onMouseUp}
   {onPointerDown}
   {onPointerEnter}
   {onTouchStart}

--- a/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
@@ -22,6 +22,7 @@
     onPointerEnter,
     onTouchStart,
     onTouchEnd,
+    onKeyDown,
     ...rest
   }: IconButtonProps = $props();
 
@@ -49,4 +50,5 @@
   {onPointerEnter}
   {onTouchStart}
   {onTouchEnd}
+  {onKeyDown}
 />

--- a/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import BaseIconButton from './BaseIconButton/BaseIconButton.svelte';
+  import type { IconButtonProps } from './types';
+
+  let {
+    icon,
+    size = 'medium',
+    emphasis = 'intense',
+    accessibilityLabel,
+    isDisabled = false,
+    isHighlighted = false,
+    _tabIndex,
+    onClick,
+    onBlur,
+    onFocus,
+    onMouseLeave,
+    onMouseMove,
+    onPointerDown,
+    onPointerEnter,
+    onTouchStart,
+    onTouchEnd,
+    ...rest
+  }: IconButtonProps = $props();
+
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<BaseIconButton
+  {...rest}
+  {...analyticsAttrs}
+  {icon}
+  {size}
+  {emphasis}
+  {accessibilityLabel}
+  {isDisabled}
+  {isHighlighted}
+  tabIndex={_tabIndex}
+  {onClick}
+  {onBlur}
+  {onFocus}
+  {onMouseLeave}
+  {onMouseMove}
+  {onPointerDown}
+  {onPointerEnter}
+  {onTouchStart}
+  {onTouchEnd}
+/>

--- a/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/IconButton.svelte
@@ -16,8 +16,6 @@
     onFocus,
     onMouseLeave,
     onMouseMove,
-    onMouseDown,
-    onMouseUp,
     onPointerDown,
     onPointerEnter,
     onTouchStart,
@@ -44,8 +42,6 @@
   {onFocus}
   {onMouseLeave}
   {onMouseMove}
-  {onMouseDown}
-  {onMouseUp}
   {onPointerDown}
   {onPointerEnter}
   {onTouchStart}

--- a/packages/blade-svelte/src/components/Button/IconButton/index.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/index.ts
@@ -1,0 +1,23 @@
+/**
+ * IconButton — a clickable icon with a transparent background.
+ *
+ * Useful for making clickable icons, eg. close buttons for modals, inputs, etc.
+ * For other cases prefer the `Button` component with its `icon` prop.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { IconButton, CloseIcon } from '@razorpay/blade-svelte/components';
+ * </script>
+ *
+ * <IconButton
+ *   icon={CloseIcon}
+ *   accessibilityLabel="Close"
+ *   onClick={() => console.log('Clicked')}
+ * />
+ * ```
+ */
+export { default as IconButton } from './IconButton.svelte';
+export type { IconButtonProps, IconButtonEmphasis, IconButtonSize } from './types';
+export { BaseIconButton } from './BaseIconButton';
+export type { BaseIconButtonProps } from './BaseIconButton';

--- a/packages/blade-svelte/src/components/Button/IconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/types.ts
@@ -1,19 +1,10 @@
-import type { StyledPropsBlade } from '@razorpay/blade-core/utils';
+import type { DataAnalyticsAttribute, StyledPropsBlade } from '@razorpay/blade-core/utils';
+import type { IconButtonEmphasis, IconButtonSize } from '@razorpay/blade-core/styles';
 import type { IconComponent } from '../../Icons/iconMap';
 
-/**
- * Visual emphasis of the IconButton's icon.
- * - `intense`: gray icon (use on light/neutral surfaces)
- * - `subtle`: static white icon (use on dark/intense surfaces)
- */
-export type IconButtonEmphasis = 'subtle' | 'intense';
+export type { IconButtonEmphasis, IconButtonSize } from '@razorpay/blade-core/styles';
 
-/**
- * Size of the IconButton's icon.
- */
-export type IconButtonSize = 'small' | 'medium' | 'large';
-
-export interface IconButtonProps extends StyledPropsBlade {
+export interface IconButtonProps extends StyledPropsBlade, DataAnalyticsAttribute {
   /**
    * Icon component to be rendered, eg. `CloseIcon`.
    */
@@ -52,7 +43,7 @@ export interface IconButtonProps extends StyledPropsBlade {
   /**
    * Called when the IconButton is clicked.
    */
-  onClick?: (event: MouseEvent) => void;
+  onClick: (event: MouseEvent) => void;
   /** Called when the IconButton loses focus. */
   onBlur?: (event: FocusEvent) => void;
   /** Called when the IconButton receives focus. */
@@ -61,10 +52,6 @@ export interface IconButtonProps extends StyledPropsBlade {
   onMouseLeave?: (event: MouseEvent) => void;
   /** Called when the pointer moves over the IconButton. */
   onMouseMove?: (event: MouseEvent) => void;
-  /** Called when a mouse button is pressed on the IconButton. */
-  onMouseDown?: (event: MouseEvent) => void;
-  /** Called when a mouse button is released over the IconButton. */
-  onMouseUp?: (event: MouseEvent) => void;
   /** Called when a pointer becomes active over the IconButton. */
   onPointerDown?: (event: PointerEvent) => void;
   /** Called when a pointer enters the IconButton. */
@@ -75,6 +62,4 @@ export interface IconButtonProps extends StyledPropsBlade {
   onTouchEnd?: (event: TouchEvent) => void;
   /** Called when a key is pressed while the IconButton is focused. */
   onKeyDown?: (event: KeyboardEvent) => void;
-  /** Analytics data attributes. */
-  [key: `data-analytics-${string}`]: string;
 }

--- a/packages/blade-svelte/src/components/Button/IconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/types.ts
@@ -73,6 +73,8 @@ export interface IconButtonProps extends StyledPropsBlade {
   onTouchStart?: (event: TouchEvent) => void;
   /** Called when a touch point is removed from the IconButton. */
   onTouchEnd?: (event: TouchEvent) => void;
+  /** Called when a key is pressed while the IconButton is focused. */
+  onKeyDown?: (event: KeyboardEvent) => void;
   /** Analytics data attributes. */
   [key: `data-analytics-${string}`]: string;
 }

--- a/packages/blade-svelte/src/components/Button/IconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/types.ts
@@ -1,0 +1,74 @@
+import type { StyledPropsBlade } from '@razorpay/blade-core/utils';
+import type { IconComponent } from '../../Icons/iconMap';
+
+/**
+ * Visual emphasis of the IconButton's icon.
+ * - `intense`: gray icon (use on light/neutral surfaces)
+ * - `subtle`: static white icon (use on dark/intense surfaces)
+ */
+export type IconButtonEmphasis = 'subtle' | 'intense';
+
+/**
+ * Size of the IconButton's icon.
+ */
+export type IconButtonSize = 'small' | 'medium' | 'large';
+
+export interface IconButtonProps extends StyledPropsBlade {
+  /**
+   * Icon component to be rendered, eg. `CloseIcon`.
+   */
+  icon: IconComponent;
+  /**
+   * Icon size.
+   * @default 'medium'
+   */
+  size?: IconButtonSize;
+  /**
+   * Icon emphasis (contrast).
+   * @default 'intense'
+   */
+  emphasis?: IconButtonEmphasis;
+  /**
+   * Sets `aria-label` to help users know what the action does, eg 'Dismiss alert'.
+   */
+  accessibilityLabel: string;
+  /**
+   * Disabled state for IconButton.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Changes the hover/focus interaction to highlight the icon more by rendering a
+   * fixed-size square with a faded background. Web-only.
+   *
+   * Note: not supported with `size="large"`.
+   * @default false
+   */
+  isHighlighted?: boolean;
+  /**
+   * Sets the `tabindex` property on the button element.
+   */
+  _tabIndex?: number;
+  /**
+   * Called when the IconButton is clicked.
+   */
+  onClick?: (event: MouseEvent) => void;
+  /** Called when the IconButton loses focus. */
+  onBlur?: (event: FocusEvent) => void;
+  /** Called when the IconButton receives focus. */
+  onFocus?: (event: FocusEvent) => void;
+  /** Called when the pointer leaves the IconButton. */
+  onMouseLeave?: (event: MouseEvent) => void;
+  /** Called when the pointer moves over the IconButton. */
+  onMouseMove?: (event: MouseEvent) => void;
+  /** Called when a pointer becomes active over the IconButton. */
+  onPointerDown?: (event: PointerEvent) => void;
+  /** Called when a pointer enters the IconButton. */
+  onPointerEnter?: (event: PointerEvent) => void;
+  /** Called when a touch point is placed on the IconButton. */
+  onTouchStart?: (event: TouchEvent) => void;
+  /** Called when a touch point is removed from the IconButton. */
+  onTouchEnd?: (event: TouchEvent) => void;
+  /** Analytics data attributes. */
+  [key: `data-analytics-${string}`]: string;
+}

--- a/packages/blade-svelte/src/components/Button/IconButton/types.ts
+++ b/packages/blade-svelte/src/components/Button/IconButton/types.ts
@@ -61,6 +61,10 @@ export interface IconButtonProps extends StyledPropsBlade {
   onMouseLeave?: (event: MouseEvent) => void;
   /** Called when the pointer moves over the IconButton. */
   onMouseMove?: (event: MouseEvent) => void;
+  /** Called when a mouse button is pressed on the IconButton. */
+  onMouseDown?: (event: MouseEvent) => void;
+  /** Called when a mouse button is released over the IconButton. */
+  onMouseUp?: (event: MouseEvent) => void;
   /** Called when a pointer becomes active over the IconButton. */
   onPointerDown?: (event: PointerEvent) => void;
   /** Called when a pointer enters the IconButton. */

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -15,6 +15,11 @@ export { default as Code } from './Typography/Code/Code.svelte';
 // Button
 export { default as Button } from './Button/Button.svelte';
 
+// IconButton
+export { default as IconButton } from './Button/IconButton/IconButton.svelte';
+export type { IconButtonProps } from './Button/IconButton/types';
+export { BaseIconButton } from './Button/IconButton/BaseIconButton';
+
 // Link
 export { default as Link } from './Link/Link.svelte';
 


### PR DESCRIPTION
## Description

Migrates the React IconButton component to Svelte 5.

## Changes

- Adds `packages/blade-svelte/src/components/Button/IconButton/` (two-layer: `BaseIconButton` logic/render + `IconButton` public wrapper, mirrors the React `Button/IconButton/` path)
- Adds `packages/blade-core/src/styles/IconButton/` (CVA module + helpers, `compoundVariants` for highlighted square sizes and per-emphasis hover/focus backgrounds)
- Re-exports IconButton from `packages/blade-svelte/src/components/index.ts`
- Re-exports CSS from `packages/blade-core/src/styles/index.ts`
- Adds changeset

## Parity notes

- Pure-CSS interaction states (no `useInteraction`), matching React's CSS-pseudo approach
- Icon inherits `currentColor`; explicit `interactive.icon.gray.disabled` token only when disabled
- 9 forwarded event handlers — `onMouseDown`/`onMouseUp` intentionally excluded (React doesn't forward them)
- `size="large" + isHighlighted` invalid combo → localhost `console.error` (replicates React `__DEV__` guard), still renders
- 2 stories with exact parity names (`IconButton`, `All Variants & Sizes`) under title `Components/IconButton`

## Verification

- `svelte-check`: 0 errors
- blade-core + blade-svelte builds: pass
- CSS variable audit: all 14 vars resolve
- Computed-style spot-checks vs React: exact match (border-radius, color, cursor, transitions, highlighted 24/32px sizing, `<button> > <svg>` DOM)
- Visual comparison: pixel-matching

## Component Checklist

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset


Made with [Cursor](https://cursor.com)