### PR TITLE
feat(SegmentedControl): add new standalone SegmentedControl component

### DIFF
--- a/packages/blade/src/components/Form/Selector/SelectorGroupField.tsx
+++ b/packages/blade/src/components/Form/Selector/SelectorGroupField.tsx
@@ -13,7 +13,7 @@ type SelectorGroupFieldProps = {
   labelledBy: string;
   position?: 'top' | 'left';
   accessibilityRole?: AriaRoles;
-  componentName: 'checkbox-group' | 'radio-group' | 'chip-group';
+  componentName: 'checkbox-group' | 'radio-group' | 'chip-group' | 'segmented-control';
 } & TestID &
   DataAnalyticsAttribute;
 

--- a/packages/blade/src/components/SegmentedControl/SegmentedControl.native.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControl.native.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import type { SegmentedControlProps, SegmentedControlItemProps } from './types';
+import { SegmentedControlProvider } from './SegmentedControlContext';
+import { useSegmentedControl } from './useSegmentedControl';
+import {
+  trackBackgroundColor,
+  indicatorBorderRadius,
+  textColor,
+  iconColor,
+  textSizeMap,
+  iconSizeMap,
+} from './segmentedControlTokens';
+import BaseBox from '~components/Box/BaseBox';
+import { Box } from '~components/Box';
+import { Text } from '~components/Typography';
+import { FormHint, FormLabel } from '~components/Form';
+import { SelectorGroupField } from '~components/Form/Selector/SelectorGroupField';
+import { getStyledProps } from '~components/Box/styledProps';
+import { useTheme } from '~components/BladeProvider';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import getIn from '~utils/lodashButBetter/get';
+
+const nativeStyles = StyleSheet.create({
+  track: {
+    position: 'relative',
+    flexDirection: 'row',
+    overflow: 'hidden',
+  },
+  indicator: {
+    position: 'absolute',
+  },
+  itemContainer: {
+    flex: 1,
+  },
+  item: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 8,
+    zIndex: 1,
+  },
+});
+
+const SegmentedControl = ({
+  children,
+  label,
+  accessibilityLabel,
+  labelPosition = 'top',
+  value,
+  defaultValue,
+  onChange,
+  name,
+  isRequired = false,
+  isDisabled = false,
+  size = 'medium',
+  isFullWidth = false,
+  validationState = 'none',
+  helpText,
+  errorText,
+  testID,
+  ...rest
+}: SegmentedControlProps): React.ReactElement => {
+  const { contextValue, ids } = useSegmentedControl({
+    value,
+    defaultValue,
+    onChange,
+    name,
+    isDisabled,
+    size,
+  });
+  const { theme } = useTheme();
+
+  const showError = validationState === 'error' && errorText;
+  const showHelpText = !showError && helpText;
+  const accessibilityText = `${showError ? errorText : ''} ${showHelpText ? helpText : ''}`.trim();
+
+  const items = React.Children.toArray(children) as React.ReactElement<SegmentedControlItemProps>[];
+  const selectedIndex = items.findIndex((item) => item.props.value === contextValue.selectedValue);
+
+  const [itemWidths, setItemWidths] = React.useState<number[]>([]);
+
+  const handleItemLayout = React.useCallback((index: number, width: number) => {
+    setItemWidths((prev) => {
+      const next = [...prev];
+      next[index] = width;
+      return next;
+    });
+  }, []);
+
+  const targetLeft = itemWidths.slice(0, selectedIndex).reduce((sum, w) => sum + w, 0);
+  const targetWidth = itemWidths[selectedIndex] ?? 0;
+
+  const animLeft = useSharedValue(targetLeft);
+  const animWidth = useSharedValue(targetWidth);
+
+  React.useEffect(() => {
+    animLeft.value = withTiming(targetLeft, { duration: 200 });
+    animWidth.value = withTiming(targetWidth, { duration: 200 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetLeft, targetWidth]);
+
+  const indicatorStyle = useAnimatedStyle(() => ({
+    left: animLeft.value,
+    width: animWidth.value,
+  }));
+
+  return (
+    <SegmentedControlProvider value={contextValue}>
+      <BaseBox {...getStyledProps(rest)}>
+        <SelectorGroupField
+          position={labelPosition}
+          labelledBy={ids.labelId}
+          accessibilityRole="radiogroup"
+          componentName="segmented-control"
+          testID={testID}
+          {...makeAnalyticsAttribute(rest)}
+        >
+          {label ? (
+            <FormLabel
+              as="span"
+              necessityIndicator={isRequired ? 'required' : 'none'}
+              position={labelPosition}
+              id={ids.labelId}
+              accessibilityText={accessibilityText && `,${accessibilityText}`}
+              size={size}
+            >
+              {label}
+            </FormLabel>
+          ) : null}
+          <BaseBox>
+            <View
+              style={[
+                nativeStyles.track,
+                {
+                  borderRadius: theme.border.radius.medium,
+                  padding: theme.spacing[2],
+                  backgroundColor: getIn(theme.colors, trackBackgroundColor),
+                },
+              ]}
+              {...(accessibilityLabel ? makeAccessible({ label: accessibilityLabel }) : {})}
+              {...metaAttribute({ name: MetaConstants.SegmentedControl, testID })}
+            >
+              {targetWidth > 0 ? (
+                <Animated.View
+                  style={[
+                    nativeStyles.indicator,
+                    {
+                      top: theme.spacing[2],
+                      bottom: theme.spacing[2],
+                      backgroundColor: theme.colors.surface.background.gray.intense,
+                      borderRadius: theme.border.radius[indicatorBorderRadius],
+                    },
+                    indicatorStyle,
+                  ]}
+                  {...metaAttribute({ name: MetaConstants.SegmentedControlIndicator })}
+                />
+              ) : null}
+              {items.map((item, index) => {
+                const itemValue = item.props.value;
+                const itemLabel = item.props.label;
+                const Icon = item.props.icon;
+                const isItemDisabled = isDisabled || item.props.isDisabled;
+                const isSelected = contextValue.selectedValue === itemValue;
+                const selectedState = isSelected ? 'selected' : 'unselected';
+                const interaction = isItemDisabled ? 'disabled' : 'default';
+
+                return (
+                  <Pressable
+                    key={itemValue}
+                    style={nativeStyles.item}
+                    disabled={isItemDisabled}
+                    onPress={() => contextValue.setSelectedValue?.(itemValue)}
+                    onLayout={(e) => handleItemLayout(index, e.nativeEvent.layout.width)}
+                    {...makeAccessible({
+                      role: 'radio',
+                      checked: isSelected,
+                      disabled: isItemDisabled,
+                    })}
+                  >
+                    <Box
+                      display="flex"
+                      flexDirection="row"
+                      alignItems="center"
+                      gap="spacing.2"
+                      paddingY={size === 'large' ? 'spacing.3' : 'spacing.2'}
+                      paddingX="spacing.3"
+                    >
+                      {Icon ? (
+                        <Icon
+                          size={iconSizeMap[size]}
+                          color={iconColor[selectedState][interaction]}
+                        />
+                      ) : null}
+                      <Text
+                        color={textColor[selectedState][interaction]}
+                        size={textSizeMap[size]}
+                        weight="medium"
+                      >
+                        {itemLabel}
+                      </Text>
+                    </Box>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <FormHint
+              size={size}
+              type={validationState === 'error' ? 'error' : 'help'}
+              errorText={errorText}
+              helpText={helpText}
+            />
+          </BaseBox>
+        </SelectorGroupField>
+      </BaseBox>
+    </SegmentedControlProvider>
+  );
+};
+
+export { SegmentedControl };

--- a/packages/blade/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { SegmentedControl } from './SegmentedControl';
+import { SegmentedControlItem } from './SegmentedControlItem';
+import type { SegmentedControlProps } from './types';
+import { Box } from '~components/Box';
+import { CalendarIcon, ClockIcon, RepeatIcon, SettingsIcon } from '~components/Icons';
+
+export default {
+  title: 'Components/SegmentedControl',
+  component: SegmentedControl,
+  args: {
+    size: 'medium',
+    isDisabled: false,
+    isFullWidth: false,
+    labelPosition: 'top',
+    validationState: 'none',
+  },
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['medium', 'large'],
+    },
+    labelPosition: {
+      control: { type: 'select' },
+      options: ['top', 'left'],
+    },
+    validationState: {
+      control: { type: 'select' },
+      options: ['none', 'error', 'success'],
+    },
+  },
+} as Meta<SegmentedControlProps>;
+
+const BasicTemplate: StoryFn<SegmentedControlProps> = (args) => {
+  return (
+    <Box maxWidth="400px">
+      <SegmentedControl {...args} label="Billing duration" name="billing">
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="quarterly" label="Quarterly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const Default = BasicTemplate.bind({});
+
+const WithIconsTemplate: StoryFn<SegmentedControlProps> = (args) => {
+  return (
+    <Box maxWidth="500px">
+      <SegmentedControl {...args} label="Billing duration" name="billing">
+        <SegmentedControlItem value="until-cancelled" label="Until cancelled" icon={CalendarIcon} />
+        <SegmentedControlItem value="fixed-cycles" label="Fixed cycles" icon={RepeatIcon} />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const WithIcons = WithIconsTemplate.bind({});
+
+const ControlledTemplate: StoryFn<SegmentedControlProps> = (args) => {
+  const [value, setValue] = React.useState('monthly');
+  return (
+    <Box maxWidth="400px">
+      <SegmentedControl
+        {...args}
+        label="Billing frequency"
+        name="frequency"
+        value={value}
+        onChange={({ value: v }) => setValue(v)}
+      >
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="quarterly" label="Quarterly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>
+      <Box marginTop="spacing.4">
+        <code>Selected: {value}</code>
+      </Box>
+    </Box>
+  );
+};
+
+export const Controlled = ControlledTemplate.bind({});
+
+const SizesTemplate: StoryFn<SegmentedControlProps> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.6" maxWidth="400px">
+      <SegmentedControl label="Medium size" size="medium" name="medium-example">
+        <SegmentedControlItem value="option1" label="Option 1" />
+        <SegmentedControlItem value="option2" label="Option 2" />
+        <SegmentedControlItem value="option3" label="Option 3" />
+      </SegmentedControl>
+      <SegmentedControl label="Large size" size="large" name="large-example">
+        <SegmentedControlItem value="option1" label="Option 1" />
+        <SegmentedControlItem value="option2" label="Option 2" />
+        <SegmentedControlItem value="option3" label="Option 3" />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const Sizes = SizesTemplate.bind({});
+
+const DisabledTemplate: StoryFn<SegmentedControlProps> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.6" maxWidth="400px">
+      <SegmentedControl label="Fully disabled" isDisabled defaultValue="option1" name="disabled">
+        <SegmentedControlItem value="option1" label="Option 1" />
+        <SegmentedControlItem value="option2" label="Option 2" />
+        <SegmentedControlItem value="option3" label="Option 3" />
+      </SegmentedControl>
+      <SegmentedControl label="Item disabled" defaultValue="option1" name="item-disabled">
+        <SegmentedControlItem value="option1" label="Option 1" />
+        <SegmentedControlItem value="option2" label="Option 2" isDisabled />
+        <SegmentedControlItem value="option3" label="Option 3" />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const Disabled = DisabledTemplate.bind({});
+
+const ValidationTemplate: StoryFn<SegmentedControlProps> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.6" maxWidth="400px">
+      <SegmentedControl label="With help text" helpText="Choose a billing cycle" name="help">
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>
+      <SegmentedControl
+        label="Error state"
+        validationState="error"
+        errorText="Please select a billing duration"
+        name="error"
+      >
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>
+      <SegmentedControl
+        label="Success state"
+        validationState="success"
+        helpText="Selection confirmed"
+        defaultValue="monthly"
+        name="success"
+      >
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const Validation = ValidationTemplate.bind({});
+
+const FullWidthTemplate: StoryFn<SegmentedControlProps> = () => {
+  return (
+    <Box maxWidth="600px">
+      <SegmentedControl label="Full width" isFullWidth name="fullwidth">
+        <SegmentedControlItem value="day" label="Day" icon={CalendarIcon} />
+        <SegmentedControlItem value="week" label="Week" icon={ClockIcon} />
+        <SegmentedControlItem value="month" label="Month" icon={RepeatIcon} />
+        <SegmentedControlItem value="year" label="Year" icon={SettingsIcon} />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const FullWidth = FullWidthTemplate.bind({});
+
+const LabelPositionTemplate: StoryFn<SegmentedControlProps> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.6" maxWidth="500px">
+      <SegmentedControl label="Top label" labelPosition="top" name="top-label">
+        <SegmentedControlItem value="option1" label="Option 1" />
+        <SegmentedControlItem value="option2" label="Option 2" />
+      </SegmentedControl>
+      <SegmentedControl label="Left label" labelPosition="left" name="left-label">
+        <SegmentedControlItem value="option1" label="Option 1" />
+        <SegmentedControlItem value="option2" label="Option 2" />
+      </SegmentedControl>
+    </Box>
+  );
+};
+
+export const LabelPosition = LabelPositionTemplate.bind({});

--- a/packages/blade/src/components/SegmentedControl/SegmentedControl.web.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControl.web.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Composite } from '@floating-ui/react';
+import type { SegmentedControlProps } from './types';
+import { SegmentedControlProvider } from './SegmentedControlContext';
+import { useSegmentedControl } from './useSegmentedControl';
+import { SegmentedControlIndicator } from './SegmentedControlIndicator';
+import {
+  trackBackgroundColor,
+  trackBorderRadius,
+  trackGap,
+  trackPadding,
+} from './segmentedControlTokens';
+import BaseBox from '~components/Box/BaseBox';
+import { FormHint, FormLabel } from '~components/Form';
+import { SelectorGroupField } from '~components/Form/Selector/SelectorGroupField';
+import { getStyledProps } from '~components/Box/styledProps';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+
+const SegmentedControl = ({
+  children,
+  label,
+  accessibilityLabel,
+  labelPosition = 'top',
+  value,
+  defaultValue,
+  onChange,
+  name,
+  isRequired = false,
+  isDisabled = false,
+  size = 'medium',
+  isFullWidth = false,
+  validationState = 'none',
+  helpText,
+  errorText,
+  testID,
+  ...rest
+}: SegmentedControlProps): React.ReactElement => {
+  const { contextValue, ids } = useSegmentedControl({
+    value,
+    defaultValue,
+    onChange,
+    name,
+    isDisabled,
+    size,
+  });
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const showError = validationState === 'error' && errorText;
+  const showHelpText = !showError && helpText;
+  const accessibilityText = `${showError ? errorText : ''} ${showHelpText ? helpText : ''}`.trim();
+
+  return (
+    <SegmentedControlProvider value={contextValue}>
+      <BaseBox {...getStyledProps(rest)} width={isFullWidth ? '100%' : undefined}>
+        <SelectorGroupField
+          position={labelPosition}
+          labelledBy={ids.labelId}
+          accessibilityRole="radiogroup"
+          componentName="segmented-control"
+          testID={testID}
+          {...makeAnalyticsAttribute(rest)}
+        >
+          {label ? (
+            <FormLabel
+              as="span"
+              necessityIndicator={isRequired ? 'required' : 'none'}
+              position={labelPosition}
+              id={ids.labelId}
+              accessibilityText={accessibilityText && `,${accessibilityText}`}
+              size={size}
+            >
+              {label}
+            </FormLabel>
+          ) : null}
+          <BaseBox>
+            <BaseBox position="relative">
+              <Composite
+                render={(htmlProps) => (
+                  // @ts-expect-error spreading composite props
+                  <BaseBox
+                    {...htmlProps}
+                    ref={containerRef}
+                    display="flex"
+                    flexDirection="row"
+                    alignItems="center"
+                    borderRadius={trackBorderRadius}
+                    borderWidth="none"
+                    padding={trackPadding[size]}
+                    gap={trackGap}
+                    backgroundColor={trackBackgroundColor}
+                    width={isFullWidth ? '100%' : undefined}
+                    {...(accessibilityLabel ? makeAccessible({ label: accessibilityLabel }) : {})}
+                    {...metaAttribute({
+                      name: MetaConstants.SegmentedControl,
+                      testID,
+                    })}
+                  >
+                    {children}
+                  </BaseBox>
+                )}
+              />
+              <SegmentedControlIndicator containerRef={containerRef} />
+            </BaseBox>
+            <FormHint
+              size={size}
+              type={
+                validationState === 'error'
+                  ? 'error'
+                  : validationState === 'success'
+                  ? 'success'
+                  : 'help'
+              }
+              errorText={errorText}
+              helpText={helpText}
+              successText={validationState === 'success' ? helpText : undefined}
+            />
+          </BaseBox>
+        </SelectorGroupField>
+      </BaseBox>
+    </SegmentedControlProvider>
+  );
+};
+
+export { SegmentedControl };

--- a/packages/blade/src/components/SegmentedControl/SegmentedControlContext.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControlContext.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { SegmentedControlContextType } from './types';
+import { throwBladeError } from '~utils/logger';
+
+const SegmentedControlContext = React.createContext<SegmentedControlContextType>({});
+
+const SegmentedControlProvider = SegmentedControlContext.Provider;
+
+const useSegmentedControlContext = (): SegmentedControlContextType => {
+  const context = React.useContext(SegmentedControlContext);
+  if (__DEV__) {
+    if (typeof context === 'undefined') {
+      throwBladeError({
+        message: 'useSegmentedControlContext must be used within SegmentedControl',
+        moduleName: 'SegmentedControl',
+      });
+    }
+  }
+  return context;
+};
+
+export { useSegmentedControlContext, SegmentedControlProvider };

--- a/packages/blade/src/components/SegmentedControl/SegmentedControlIndicator.native.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControlIndicator.native.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { indicatorBorderRadius } from './segmentedControlTokens';
+import { useTheme } from '~components/BladeProvider';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+
+type SegmentedControlIndicatorProps = {
+  itemWidths: number[];
+  selectedIndex: number;
+};
+
+const styles = StyleSheet.create({
+  indicator: {
+    position: 'absolute',
+  },
+});
+
+const SegmentedControlIndicator = ({
+  itemWidths,
+  selectedIndex,
+}: SegmentedControlIndicatorProps): React.ReactElement | null => {
+  const { theme } = useTheme();
+
+  const targetLeft = itemWidths.slice(0, selectedIndex).reduce((sum, w) => sum + w, 0);
+  const targetWidth = itemWidths[selectedIndex] ?? 0;
+
+  const animLeft = useSharedValue(targetLeft);
+  const animWidth = useSharedValue(targetWidth);
+
+  React.useEffect(() => {
+    animLeft.value = withTiming(targetLeft, { duration: 200 });
+    animWidth.value = withTiming(targetWidth, { duration: 200 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetLeft, targetWidth]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    left: animLeft.value,
+    width: animWidth.value,
+  }));
+
+  if (itemWidths.length === 0 || targetWidth === 0) return null;
+
+  return (
+    <Animated.View
+      {...metaAttribute({ name: MetaConstants.SegmentedControlIndicator })}
+      style={[
+        styles.indicator,
+        {
+          top: theme.spacing[2],
+          bottom: theme.spacing[2],
+          backgroundColor: theme.colors.surface.background.gray.intense,
+          borderRadius: theme.border.radius[indicatorBorderRadius],
+        },
+        animStyle,
+      ]}
+    />
+  );
+};
+
+export { SegmentedControlIndicator };

--- a/packages/blade/src/components/SegmentedControl/SegmentedControlIndicator.web.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControlIndicator.web.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useSegmentedControlContext } from './SegmentedControlContext';
+import { indicatorBackgroundColor, indicatorBorderRadius } from './segmentedControlTokens';
+import { castWebType, makeMotionTime } from '~utils';
+import { useTheme } from '~components/BladeProvider';
+import { useIsomorphicLayoutEffect } from '~utils/useIsomorphicLayoutEffect';
+import { useResize } from '~utils/useResize';
+import BaseBox from '~components/Box/BaseBox';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+
+const StyledIndicator = styled(BaseBox)(({ theme }) => {
+  return {
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.colors.interactive.background.primary.fadedHighlighted,
+    },
+  };
+});
+
+const SegmentedControlIndicator = ({
+  containerRef,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>;
+}): React.ReactElement => {
+  const { theme } = useTheme();
+  const { selectedValue, baseId } = useSegmentedControlContext();
+  const [shouldAnimate, setShouldAnimate] = React.useState(false);
+  const [dimensions, setDimensions] = React.useState({ width: 0, height: 0, x: 0, y: 0 });
+
+  const updateDimensions = React.useCallback(() => {
+    const activeItem = document.getElementById(`${baseId}-${selectedValue}-item`);
+    if (!activeItem || activeItem.offsetWidth === 0) return;
+
+    setDimensions({
+      width: activeItem.offsetWidth,
+      height: activeItem.offsetHeight,
+      x: activeItem.offsetLeft,
+      y: activeItem.offsetTop,
+    });
+
+    setShouldAnimate((prev) => {
+      if (!prev) requestAnimationFrame(() => setShouldAnimate(true));
+      return prev;
+    });
+  }, [baseId, selectedValue]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!selectedValue) return;
+    updateDimensions();
+  }, [baseId, selectedValue, updateDimensions]);
+
+  React.useEffect(() => {
+    if ('fonts' in document) {
+      try {
+        void document.fonts.ready.then(() => {
+          updateDimensions();
+        });
+      } catch {
+        /* empty */
+      }
+    }
+  }, [updateDimensions]);
+
+  useResize(containerRef, updateDimensions);
+
+  const transitionProps = {
+    transitionProperty: 'transform, width, height, background-color',
+    transitionDuration: shouldAnimate
+      ? castWebType(makeMotionTime(theme.motion.duration.moderate))
+      : '0ms',
+    transitionTimingFunction: castWebType(theme.motion.easing.standard),
+  };
+
+  return (
+    <StyledIndicator
+      pointerEvents="none"
+      position="absolute"
+      left="0px"
+      top="0px"
+      borderRadius={indicatorBorderRadius}
+      backgroundColor={indicatorBackgroundColor}
+      style={{
+        ...transitionProps,
+        width: `${dimensions.width}px`,
+        height: `${dimensions.height}px`,
+        transform: `translate(${dimensions.x}px, ${dimensions.y}px)`,
+      }}
+      {...metaAttribute({ name: MetaConstants.SegmentedControlIndicator })}
+    />
+  );
+};
+
+export { SegmentedControlIndicator };

--- a/packages/blade/src/components/SegmentedControl/SegmentedControlItem.native.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControlItem.native.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import type { SegmentedControlItemProps } from './types';
+import { useSegmentedControlContext } from './SegmentedControlContext';
+import { textColor, iconColor, textSizeMap, iconSizeMap } from './segmentedControlTokens';
+import { Text } from '~components/Typography';
+import { Box } from '~components/Box';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+
+const styles = StyleSheet.create({
+  item: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+const SegmentedControlItem = ({
+  value,
+  label,
+  icon: Icon,
+  isDisabled: isItemDisabled = false,
+  testID,
+  ...rest
+}: SegmentedControlItemProps): React.ReactElement => {
+  const {
+    size = 'medium',
+    isDisabled: isGroupDisabled,
+    selectedValue,
+    setSelectedValue,
+  } = useSegmentedControlContext();
+
+  const isDisabled = isGroupDisabled || isItemDisabled;
+  const isSelected = selectedValue === value;
+  const selectedState = isSelected ? 'selected' : 'unselected';
+  const interaction = isDisabled ? 'disabled' : 'default';
+
+  return (
+    <Pressable
+      style={styles.item}
+      disabled={isDisabled}
+      onPress={() => {
+        if (!isDisabled) {
+          setSelectedValue?.(value);
+        }
+      }}
+      {...makeAccessible({
+        role: 'radio',
+        checked: isSelected,
+        disabled: isDisabled,
+      })}
+      {...metaAttribute({ name: MetaConstants.SegmentedControlItem, testID })}
+      {...makeAnalyticsAttribute(rest)}
+    >
+      <Box display="flex" flexDirection="row" alignItems="center" gap="spacing.2">
+        {Icon ? (
+          <Icon size={iconSizeMap[size]} color={iconColor[selectedState][interaction]} />
+        ) : null}
+        <Text
+          color={textColor[selectedState][interaction]}
+          size={textSizeMap[size]}
+          weight="medium"
+        >
+          {label}
+        </Text>
+      </Box>
+    </Pressable>
+  );
+};
+
+export { SegmentedControlItem };

--- a/packages/blade/src/components/SegmentedControl/SegmentedControlItem.web.tsx
+++ b/packages/blade/src/components/SegmentedControl/SegmentedControlItem.web.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import styled from 'styled-components';
+import { CompositeItem } from '@floating-ui/react';
+import type { SegmentedControlItemProps, SegmentedControlSize } from './types';
+import { useSegmentedControlContext } from './SegmentedControlContext';
+import {
+  paddingTop,
+  paddingBottom,
+  paddingX,
+  textColor,
+  iconColor,
+  itemBackgroundColor,
+  itemBorderRadius,
+  textSizeMap,
+  iconSizeMap,
+} from './segmentedControlTokens';
+import { Text } from '~components/Typography';
+import { castWebType, makeMotionTime, makeSpace } from '~utils';
+import useInteraction from '~utils/useInteraction';
+import { makeAccessible } from '~utils/makeAccessible';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import getIn from '~utils/lodashButBetter/get';
+
+const StyledSegmentedButton = styled.button<{
+  size: SegmentedControlSize;
+  isSelected: boolean;
+  isFullWidth?: boolean;
+}>(({ theme, size, isFullWidth }) => {
+  const background = itemBackgroundColor.unselected;
+  const borderRadius = itemBorderRadius[size];
+
+  return {
+    appearance: 'none',
+    textDecoration: 'none',
+    border: 'none',
+    outline: 'none',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: makeSpace(theme.spacing[2]),
+    width: isFullWidth ? '100%' : undefined,
+    flex: isFullWidth ? 1 : undefined,
+
+    paddingTop: makeSpace(getIn(theme, paddingTop[size])),
+    paddingBottom: makeSpace(getIn(theme, paddingBottom[size])),
+    paddingLeft: makeSpace(getIn(theme, paddingX[size])),
+    paddingRight: makeSpace(getIn(theme, paddingX[size])),
+
+    backgroundColor: getIn(theme, background.default),
+    borderRadius: theme.border.radius[borderRadius],
+
+    position: 'relative' as const,
+    zIndex: 1,
+
+    '&:hover': {
+      backgroundColor: getIn(theme, background.highlighted),
+    },
+    '&:focus-visible': {
+      borderRadius: makeSpace(theme.border.radius[borderRadius]),
+      boxShadow: `inset 0px 0px 0px 4px ${theme.colors.surface.border.primary.muted}`,
+      backgroundColor: theme.colors.interactive.background.gray.default,
+    },
+    '&:disabled': {
+      cursor: 'not-allowed',
+      backgroundColor: getIn(theme, background.disabled),
+    },
+    '&:disabled:hover': {
+      backgroundColor: getIn(theme, background.disabled),
+    },
+
+    transitionProperty: 'all',
+    transitionTimingFunction: castWebType(theme.motion.easing.standard),
+    transitionDuration: castWebType(makeMotionTime(theme.motion.duration.gentle)),
+    '*': {
+      transitionProperty: 'color, fill',
+      transitionTimingFunction: castWebType(theme.motion.easing.standard),
+      transitionDuration: castWebType(makeMotionTime(theme.motion.duration.xquick)),
+    },
+  };
+});
+
+const SegmentedControlItem = ({
+  value,
+  label,
+  icon: Icon,
+  isDisabled: isItemDisabled = false,
+  testID,
+  ...rest
+}: SegmentedControlItemProps): React.ReactElement => {
+  const {
+    size = 'medium',
+    isDisabled: isGroupDisabled,
+    selectedValue,
+    setSelectedValue,
+    baseId,
+  } = useSegmentedControlContext();
+
+  const { currentInteraction, ...interactionProps } = useInteraction();
+  const isDisabled = isGroupDisabled || isItemDisabled;
+  const isSelected = selectedValue === value;
+  const selectedState = isSelected ? 'selected' : 'unselected';
+  const itemId = `${baseId}-${value}-item`;
+
+  const interactionMap = {
+    default: 'default',
+    hover: 'highlighted',
+    focus: 'highlighted',
+    disabled: 'disabled',
+  } as const;
+  const interaction = isDisabled ? 'disabled' : interactionMap[currentInteraction];
+
+  return (
+    <CompositeItem
+      render={
+        <StyledSegmentedButton
+          type="button"
+          id={itemId}
+          size={size}
+          isSelected={isSelected}
+          isFullWidth={true}
+          disabled={isDisabled}
+          {...interactionProps}
+          onClick={() => {
+            if (!isDisabled) {
+              setSelectedValue?.(value);
+            }
+          }}
+          {...makeAccessible({
+            role: 'radio',
+            checked: isSelected,
+          })}
+          {...metaAttribute({ name: MetaConstants.SegmentedControlItem, testID })}
+          {...makeAnalyticsAttribute(rest)}
+        >
+          {Icon ? (
+            <Icon size={iconSizeMap[size]} color={iconColor[selectedState][interaction]} />
+          ) : null}
+          <Text
+            color={textColor[selectedState][interaction]}
+            size={textSizeMap[size]}
+            weight="medium"
+          >
+            {label}
+          </Text>
+        </StyledSegmentedButton>
+      }
+    />
+  );
+};
+
+export { SegmentedControlItem };

--- a/packages/blade/src/components/SegmentedControl/__tests__/SegmentedControl.web.test.tsx
+++ b/packages/blade/src/components/SegmentedControl/__tests__/SegmentedControl.web.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { SegmentedControl } from '../SegmentedControl';
+import { SegmentedControlItem } from '../SegmentedControlItem';
+import renderWithTheme from '~utils/testing/renderWithTheme.web';
+import { CalendarIcon } from '~components/Icons';
+
+describe('<SegmentedControl />', () => {
+  it('should render with label and items', () => {
+    const { getByText, getByRole } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration">
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    expect(getByText('Duration')).toBeInTheDocument();
+    expect(getByText('Monthly')).toBeInTheDocument();
+    expect(getByText('Yearly')).toBeInTheDocument();
+    expect(getByRole('radiogroup')).toBeInTheDocument();
+  });
+
+  it('should handle controlled value', () => {
+    const onChange = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration" value="monthly" onChange={onChange}>
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    const radios = getAllByRole('radio');
+    expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+    expect(radios[1]).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(radios[1]);
+    expect(onChange).toHaveBeenCalledWith({ name: 'duration', value: 'yearly' });
+  });
+
+  it('should handle uncontrolled defaultValue', () => {
+    const { getAllByRole } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration" defaultValue="yearly">
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    const radios = getAllByRole('radio');
+    expect(radios[0]).toHaveAttribute('aria-checked', 'false');
+    expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('should handle disabled group', () => {
+    const onChange = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration" isDisabled onChange={onChange}>
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    const radios = getAllByRole('radio');
+    expect(radios[0]).toBeDisabled();
+    expect(radios[1]).toBeDisabled();
+
+    fireEvent.click(radios[1]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should handle individual item disabled', () => {
+    const onChange = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration" onChange={onChange}>
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" isDisabled />
+      </SegmentedControl>,
+    );
+
+    const radios = getAllByRole('radio');
+    expect(radios[0]).not.toBeDisabled();
+    expect(radios[1]).toBeDisabled();
+
+    fireEvent.click(radios[1]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('should render with icon', () => {
+    const { container } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration">
+        <SegmentedControlItem value="monthly" label="Monthly" icon={CalendarIcon} />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render error state', () => {
+    const { getByText } = renderWithTheme(
+      <SegmentedControl
+        label="Duration"
+        name="duration"
+        validationState="error"
+        errorText="Please select a duration"
+      >
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    expect(getByText('Please select a duration')).toBeInTheDocument();
+  });
+
+  it('should render help text', () => {
+    const { getByText } = renderWithTheme(
+      <SegmentedControl label="Duration" name="duration" helpText="Choose a duration">
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    expect(getByText('Choose a duration')).toBeInTheDocument();
+  });
+
+  it('should support accessibilityLabel', () => {
+    const { getByRole } = renderWithTheme(
+      <SegmentedControl accessibilityLabel="Billing duration" name="duration">
+        <SegmentedControlItem value="monthly" label="Monthly" />
+        <SegmentedControlItem value="yearly" label="Yearly" />
+      </SegmentedControl>,
+    );
+
+    expect(getByRole('radiogroup')).toBeInTheDocument();
+  });
+});

--- a/packages/blade/src/components/SegmentedControl/__tests__/__snapshots__/SegmentedControl.web.test.tsx.snap
+++ b/packages/blade/src/components/SegmentedControl/__tests__/__snapshots__/SegmentedControl.web.test.tsx.snap
@@ -1,0 +1,457 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SegmentedControl /> should render with icon 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.c1.c1.c1.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 4px;
+  width: 100%;
+}
+
+.c2.c2.c2.c2.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-height: 36px;
+  gap: 0px;
+}
+
+.c7.c7.c7.c7.c7 {
+  position: relative;
+}
+
+.c8.c8.c8.c8.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  gap: 2px;
+  background-color: hsla(206,10%,29%,0.06);
+  border-radius: 12px;
+  border-width: 0px;
+  border-style: solid;
+}
+
+.c11.c11.c11.c11.c11 {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 8px;
+  pointer-events: none;
+}
+
+.c12.c12.c12.c12.c12 {
+  cursor: pointer;
+}
+
+.c12.c12.c12.c12.c12:hover {
+  background-color: hsla(218,89%,51%,0.18);
+}
+
+.c4.c4.c4.c4.c4 {
+  color: hsla(200,10%,18%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+}
+
+.c10.c10.c10.c10.c10 {
+  color: hsla(204,9%,42%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+}
+
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c9.c9.c9.c9.c9 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 8px;
+  padding-right: 8px;
+  background-color: hsla(0,0%,100%,0);
+  border-radius: 8px;
+  position: relative;
+  z-index: 1;
+  -webkit-transition-property: all;
+  transition-property: all;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 480ms;
+  transition-duration: 480ms;
+}
+
+.c9.c9.c9.c9.c9:hover {
+  background-color: hsla(206,10%,29%,0.06);
+}
+
+.c9.c9.c9.c9.c9:focus-visible {
+  border-radius: 8px;
+  box-shadow: inset 0px 0px 0px 4px hsla(218,89%,51%,0.18);
+  background-color: hsla(206,10%,29%,0.06);
+}
+
+.c9.c9.c9.c9.c9:disabled {
+  cursor: not-allowed;
+  background-color: hsla(0,0%,100%,0);
+}
+
+.c9.c9.c9.c9.c9:disabled:hover {
+  background-color: hsla(0,0%,100%,0);
+}
+
+.c9.c9.c9.c9.c9 * {
+  -webkit-transition-property: color,fill;
+  transition-property: color,fill;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+}
+
+@media screen and (min-width:320px) {
+  .c8.c8.c8.c8.c8 {
+    border-style: solid;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c8.c8.c8.c8.c8 {
+    border-style: solid;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c8.c8.c8.c8.c8 {
+    border-style: solid;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c8.c8.c8.c8.c8 {
+    border-style: solid;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c8.c8.c8.c8.c8 {
+    border-style: solid;
+  }
+}
+
+@media screen and (min-width:320px) {
+  .c11.c11.c11.c11.c11 {
+    pointer-events: none;
+  }
+}
+
+@media screen and (min-width:480px) {
+  .c11.c11.c11.c11.c11 {
+    pointer-events: none;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c11.c11.c11.c11.c11 {
+    pointer-events: none;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c11.c11.c11.c11.c11 {
+    pointer-events: none;
+  }
+}
+
+@media screen and (min-width:1200px) {
+  .c11.c11.c11.c11.c11 {
+    pointer-events: none;
+  }
+}
+
+<div>
+  <div
+    class=""
+    data-blade-component="base-box"
+  >
+    <div
+      aria-labelledby="segmented-control-7-label"
+      class="c0"
+      data-blade-component="segmented-control"
+      role="radiogroup"
+    >
+      <span
+        data-blade-component="form-label"
+        id="segmented-control-7-label"
+        style="width: 100%; flex-shrink: 0; margin-right: 0px;"
+      >
+        <div
+          class="c1"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c2"
+            data-blade-component="base-box"
+          >
+            <div
+              class=""
+              data-blade-component="base-box"
+            >
+              <div
+                class="c3"
+                data-blade-component="base-box"
+              >
+                <p
+                  class="c4"
+                  data-blade-component="text"
+                  letter-spacing="50"
+                >
+                  Duration
+                </p>
+                <div
+                  class="c5"
+                  data-blade-component="visually-hidden"
+                >
+                  <p
+                    class="c6"
+                    data-blade-component="text"
+                    letter-spacing="50"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+      <div
+        class=""
+        data-blade-component="base-box"
+      >
+        <div
+          class="c7"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c8"
+            data-blade-component="segmented-control"
+          >
+            <button
+              aria-checked="false"
+              class="c9"
+              data-active=""
+              data-blade-component="segmented-control-item"
+              id="segmented-control-7-monthly-item"
+              role="radio"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="Svgweb__StyledSvg-vcmjs8-0"
+                data-blade-component="icon"
+                fill="none"
+                height="12px"
+                viewBox="0 0 24 24"
+                width="12px"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M5 5C4.44772 5 4 5.44772 4 6V20C4 20.5523 4.44772 21 5 21H19C19.5523 21 20 20.5523 20 20V6C20 5.44772 19.5523 5 19 5H5ZM2 6C2 4.34315 3.34315 3 5 3H19C20.6569 3 22 4.34315 22 6V20C22 21.6569 20.6569 23 19 23H5C3.34315 23 2 21.6569 2 20V6Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(204, 9%, 42%, 1)"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M16 1C16.5523 1 17 1.44772 17 2V6C17 6.55228 16.5523 7 16 7C15.4477 7 15 6.55228 15 6V2C15 1.44772 15.4477 1 16 1Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(204, 9%, 42%, 1)"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M8 1C8.55228 1 9 1.44772 9 2V6C9 6.55228 8.55228 7 8 7C7.44772 7 7 6.55228 7 6V2C7 1.44772 7.44772 1 8 1Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(204, 9%, 42%, 1)"
+                  fill-rule="evenodd"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M2 10C2 9.44771 2.44772 9 3 9H21C21.5523 9 22 9.44771 22 10C22 10.5523 21.5523 11 21 11H3C2.44772 11 2 10.5523 2 10Z"
+                  data-blade-component="svg-path"
+                  fill="hsla(204, 9%, 42%, 1)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <p
+                class="c10"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                Monthly
+              </p>
+            </button>
+            <button
+              aria-checked="false"
+              class="c9"
+              data-blade-component="segmented-control-item"
+              id="segmented-control-7-yearly-item"
+              role="radio"
+              tabindex="-1"
+              type="button"
+            >
+              <p
+                class="c10"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                Yearly
+              </p>
+            </button>
+          </div>
+          <div
+            class="c11 c12"
+            data-blade-component="segmented-control-indicator"
+            pointer-events="none"
+            style="transition-property: transform, width, height, background-color; transition-duration: 0ms; transition-timing-function: cubic-bezier(0.3, 0, 0.2, 1); width: 0px; height: 0px; transform: translate(0px, 0px);"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/blade/src/components/SegmentedControl/index.ts
+++ b/packages/blade/src/components/SegmentedControl/index.ts
@@ -1,0 +1,3 @@
+export { SegmentedControl } from './SegmentedControl';
+export { SegmentedControlItem } from './SegmentedControlItem';
+export type { SegmentedControlProps, SegmentedControlItemProps } from './types';

--- a/packages/blade/src/components/SegmentedControl/segmentedControlTokens.ts
+++ b/packages/blade/src/components/SegmentedControl/segmentedControlTokens.ts
@@ -1,0 +1,104 @@
+import type { SegmentedControlSize } from './types';
+import type { DotNotationSpacingStringToken } from '~utils/types';
+
+type SizeTokenMap = Record<SegmentedControlSize, DotNotationSpacingStringToken>;
+
+const paddingTop: SizeTokenMap = {
+  medium: 'spacing.2',
+  large: 'spacing.3',
+};
+
+const paddingBottom: SizeTokenMap = {
+  medium: 'spacing.2',
+  large: 'spacing.3',
+};
+
+const paddingX: SizeTokenMap = {
+  medium: 'spacing.3',
+  large: 'spacing.3',
+};
+
+const trackPadding: SizeTokenMap = {
+  medium: 'spacing.2',
+  large: 'spacing.2',
+};
+
+const trackGap: DotNotationSpacingStringToken = 'spacing.1';
+
+const trackBorderRadius = 'medium' as const;
+const trackBackgroundColor = 'interactive.background.gray.faded';
+
+const indicatorBackgroundColor = 'surface.background.gray.intense';
+const indicatorBorderRadius = 'small' as const;
+
+const textColor = {
+  selected: {
+    default: 'interactive.text.gray.normal',
+    highlighted: 'interactive.text.gray.normal',
+    disabled: 'interactive.text.gray.disabled',
+  },
+  unselected: {
+    default: 'interactive.text.gray.muted',
+    highlighted: 'interactive.text.gray.subtle',
+    disabled: 'interactive.text.gray.disabled',
+  },
+} as const;
+
+const iconColor = {
+  selected: {
+    default: 'interactive.icon.gray.normal',
+    highlighted: 'interactive.icon.gray.normal',
+    disabled: 'interactive.icon.gray.disabled',
+  },
+  unselected: {
+    default: 'interactive.icon.gray.muted',
+    highlighted: 'interactive.icon.gray.subtle',
+    disabled: 'interactive.icon.gray.disabled',
+  },
+} as const;
+
+const itemBackgroundColor = {
+  selected: {
+    default: 'colors.transparent',
+    highlighted: 'colors.transparent',
+    disabled: 'colors.transparent',
+  },
+  unselected: {
+    default: 'colors.transparent',
+    highlighted: 'colors.interactive.background.gray.default',
+    disabled: 'colors.transparent',
+  },
+} as const;
+
+const itemBorderRadius: Record<SegmentedControlSize, 'small' | 'medium'> = {
+  medium: 'small',
+  large: 'small',
+};
+
+const textSizeMap = {
+  medium: 'medium',
+  large: 'large',
+} as const;
+
+const iconSizeMap: Record<SegmentedControlSize, 'small' | 'medium'> = {
+  medium: 'small',
+  large: 'medium',
+};
+
+export {
+  paddingTop,
+  paddingBottom,
+  paddingX,
+  trackPadding,
+  trackGap,
+  trackBorderRadius,
+  trackBackgroundColor,
+  indicatorBackgroundColor,
+  indicatorBorderRadius,
+  textColor,
+  iconColor,
+  itemBackgroundColor,
+  itemBorderRadius,
+  textSizeMap,
+  iconSizeMap,
+};

--- a/packages/blade/src/components/SegmentedControl/types.ts
+++ b/packages/blade/src/components/SegmentedControl/types.ts
@@ -1,0 +1,59 @@
+import type { IconComponent } from '~components/Icons';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import type { DataAnalyticsAttribute, TestID } from '~utils/types';
+
+type SegmentedControlSize = 'medium' | 'large';
+
+type SegmentedControlCommonProps = {
+  children: React.ReactNode;
+  labelPosition?: 'top' | 'left';
+  value?: string;
+  defaultValue?: string;
+  onChange?: ({ name, value }: { name: string; value: string }) => void;
+  name?: string;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  size?: SegmentedControlSize;
+  isFullWidth?: boolean;
+  validationState?: 'none' | 'error' | 'success';
+  helpText?: string;
+  errorText?: string;
+} & TestID &
+  DataAnalyticsAttribute &
+  StyledPropsBlade;
+
+type SegmentedControlPropsWithLabel = SegmentedControlCommonProps & {
+  label: string;
+  accessibilityLabel?: undefined;
+};
+
+type SegmentedControlPropsWithA11yLabel = SegmentedControlCommonProps & {
+  label?: undefined;
+  accessibilityLabel: string;
+};
+
+type SegmentedControlProps = SegmentedControlPropsWithLabel | SegmentedControlPropsWithA11yLabel;
+
+type SegmentedControlItemProps = {
+  value: string;
+  label: string;
+  icon?: IconComponent;
+  isDisabled?: boolean;
+} & TestID &
+  DataAnalyticsAttribute;
+
+type SegmentedControlContextType = {
+  size?: SegmentedControlSize;
+  isDisabled?: boolean;
+  name?: string;
+  selectedValue?: string;
+  setSelectedValue?: (value: string) => void;
+  baseId?: string;
+};
+
+export type {
+  SegmentedControlProps,
+  SegmentedControlItemProps,
+  SegmentedControlContextType,
+  SegmentedControlSize,
+};

--- a/packages/blade/src/components/SegmentedControl/useSegmentedControl.ts
+++ b/packages/blade/src/components/SegmentedControl/useSegmentedControl.ts
@@ -1,0 +1,62 @@
+import React from 'react';
+import type {
+  SegmentedControlProps,
+  SegmentedControlContextType,
+  SegmentedControlSize,
+} from './types';
+import { useControllableState } from '~utils/useControllable';
+import { useId } from '~utils/useId';
+
+type UseSegmentedControlProps = Pick<
+  SegmentedControlProps,
+  'isDisabled' | 'name' | 'value' | 'defaultValue' | 'onChange' | 'size'
+>;
+
+type UseSegmentedControlReturn = {
+  contextValue: SegmentedControlContextType;
+  ids: { labelId: string };
+};
+
+const useSegmentedControl = ({
+  value,
+  defaultValue,
+  isDisabled,
+  onChange,
+  name,
+  size,
+}: UseSegmentedControlProps): UseSegmentedControlReturn => {
+  const idBase = useId('segmented-control');
+  const labelId = `${idBase}-label`;
+  const fallbackName = name ?? idBase;
+
+  const [selectedValue, setSelectedValue] = useControllableState({
+    value,
+    defaultValue,
+    onChange: (v) => {
+      onChange?.({ value: v, name: fallbackName });
+    },
+  });
+
+  const setValueHandler = React.useCallback(
+    (newValue: string) => {
+      if (isDisabled) return;
+      setSelectedValue(() => newValue);
+    },
+    [isDisabled, setSelectedValue],
+  );
+
+  const contextValue = React.useMemo<SegmentedControlContextType>(() => {
+    return {
+      isDisabled,
+      name: fallbackName,
+      selectedValue,
+      setSelectedValue: setValueHandler,
+      size: size as SegmentedControlSize,
+      baseId: idBase,
+    };
+  }, [isDisabled, fallbackName, selectedValue, setValueHandler, size, idBase]);
+
+  return { contextValue, ids: { labelId } };
+};
+
+export { useSegmentedControl };

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -63,6 +63,7 @@ export * from './SpotlightPopoverTour';
 export * from './Stagger';
 export * from './StepGroup';
 export * from './Slide';
+export * from './SegmentedControl';
 export * from './Switch';
 export * from './Table';
 export * from './Tabs';

--- a/packages/blade/src/utils/metaAttribute/metaConstants.ts
+++ b/packages/blade/src/utils/metaAttribute/metaConstants.ts
@@ -158,4 +158,7 @@ export const MetaConstants = {
   PreviewFooter: 'preview-footer',
   Pagination: 'pagination',
   TimePicker: 'time-picker',
+  SegmentedControl: 'segmented-control',
+  SegmentedControlItem: 'segmented-control-item',
+  SegmentedControlIndicator: 'segmented-control-indicator',
 } as const;


### PR DESCRIPTION
Adds a new SegmentedControl input component with radiogroup semantics, visually styled like filled horizontal Tabs. Supports controlled/uncontrolled modes, label/accessibilityLabel, validation states, icons, sizes, and full-width layout. Includes web + React Native implementations with animated indicator pill.

## Description

<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
