### PR TITLE
feat(carousel): circular progress indicator on mobile

### DIFF
--- a/packages/blade/src/components/Carousel/Carousel.native.tsx
+++ b/packages/blade/src/components/Carousel/Carousel.native.tsx
@@ -135,6 +135,8 @@ const _Carousel = (
     goToSlideIndex(slideIndex);
   };
 
+  const isAutoPlaying = autoPlay && !shouldPauseAutoplay;
+
   const carouselContext = React.useMemo<CarouselContextProps>(() => {
     return {
       isResponsive: false,
@@ -148,8 +150,10 @@ const _Carousel = (
       setActiveIndicator: setActiveSlide,
       carouselItemAlignment: undefined,
       shouldAddStartEndSpacing: false,
+      isMobile: true,
+      isAutoPlaying,
     };
-  }, [carouselItemWidth, id, totalNumberOfSlides, slideWidth, activeSlide]);
+  }, [carouselItemWidth, id, totalNumberOfSlides, slideWidth, activeSlide, isAutoPlaying]);
 
   // auto play
   useInterval(

--- a/packages/blade/src/components/Carousel/Carousel.web.tsx
+++ b/packages/blade/src/components/Carousel/Carousel.web.tsx
@@ -489,6 +489,8 @@ const _Carousel = (
     scrollToSlide(activeSlide);
   }, [activeSlide]);
 
+  const isAutoPlaying = autoPlay && !shouldPauseAutoplay;
+
   const carouselContext = React.useMemo<CarouselContextProps>(() => {
     return {
       isResponsive,
@@ -501,6 +503,8 @@ const _Carousel = (
       activeSlide,
       startEndMargin,
       shouldAddStartEndSpacing,
+      isMobile,
+      isAutoPlaying,
     };
   }, [
     carouselId,
@@ -511,6 +515,8 @@ const _Carousel = (
     totalNumberOfSlides,
     activeSlide,
     shouldAddStartEndSpacing,
+    isMobile,
+    isAutoPlaying,
   ]);
 
   return (

--- a/packages/blade/src/components/Carousel/CarouselContext.tsx
+++ b/packages/blade/src/components/Carousel/CarouselContext.tsx
@@ -13,6 +13,8 @@ type CarouselContextProps =
       totalNumberOfSlides: number;
       isResponsive?: boolean;
       visibleItems?: 1 | 2 | 3;
+      isMobile?: boolean;
+      isAutoPlaying?: boolean;
       /**
        * React native only
        */

--- a/packages/blade/src/components/Carousel/Indicators/CircularIndicatorButton.tsx
+++ b/packages/blade/src/components/Carousel/Indicators/CircularIndicatorButton.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import styled, { css, keyframes } from 'styled-components';
+import type { IndicatorButtonProps } from './types';
+import { CAROUSEL_AUTOPLAY_INTERVAL } from '../constants';
+import { metaAttribute } from '~utils/metaAttribute';
+import { useTheme } from '~components/BladeProvider';
+import { getFocusRingStyles } from '~utils/getFocusRingStyles';
+
+const DOT_RADIUS = 3;
+const RING_GAP = 1;
+const RING_STROKE_WIDTH = 2;
+const RING_RADIUS = DOT_RADIUS + RING_GAP + RING_STROKE_WIDTH / 2;
+const SVG_SIZE = (RING_RADIUS + RING_STROKE_WIDTH / 2) * 2;
+const CENTER = SVG_SIZE / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+const progressAnimation = keyframes`
+  from {
+    stroke-dashoffset: ${CIRCUMFERENCE};
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+`;
+
+const progressAnimationStyles = css`
+  animation: ${progressAnimation} ${CAROUSEL_AUTOPLAY_INTERVAL}ms linear forwards;
+`;
+
+const StyledCircularButton = styled.button(({ theme }) => ({
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  backgroundColor: 'transparent',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: `${SVG_SIZE}px`,
+  minHeight: `${SVG_SIZE}px`,
+  position: 'relative' as const,
+  '&:focus-visible': {
+    ...getFocusRingStyles({ theme }),
+    borderRadius: theme.border.radius.max,
+  },
+}));
+
+type CircularIndicatorButtonProps = IndicatorButtonProps & {
+  isAutoPlaying?: boolean;
+};
+
+const CircularIndicatorButton = ({
+  onClick,
+  isActive,
+  variant,
+  isAutoPlaying,
+}: CircularIndicatorButtonProps): React.ReactElement => {
+  const { theme } = useTheme();
+
+  const activeColor = {
+    gray: theme.colors.interactive.icon.gray.muted,
+    white: theme.colors.interactive.icon.staticWhite.normal,
+    blue: theme.colors.interactive.icon.primary.subtle,
+  };
+
+  const inactiveColor = theme.colors.overlay.background.moderate;
+  const fillColor = isActive ? activeColor[variant] : inactiveColor;
+  const showProgressRing = isActive && isAutoPlaying;
+
+  return (
+    <StyledCircularButton
+      onClick={onClick}
+      {...metaAttribute({ name: 'carousel-indicator-button' })}
+    >
+      <svg
+        width={SVG_SIZE}
+        height={SVG_SIZE}
+        viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
+        style={{ display: 'block' }}
+      >
+        <circle cx={CENTER} cy={CENTER} r={DOT_RADIUS} fill={fillColor} stroke="none" />
+        {showProgressRing && (
+          <ProgressRing
+            cx={CENTER}
+            cy={CENTER}
+            r={RING_RADIUS}
+            fill="none"
+            stroke={activeColor[variant]}
+            strokeWidth={RING_STROKE_WIDTH}
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={CIRCUMFERENCE}
+            transform={`rotate(-90 ${CENTER} ${CENTER})`}
+          />
+        )}
+      </svg>
+    </StyledCircularButton>
+  );
+};
+
+const ProgressRing = styled.circle`
+  ${progressAnimationStyles}
+`;
+
+export { CircularIndicatorButton };
+export type { CircularIndicatorButtonProps };

--- a/packages/blade/src/components/Carousel/Indicators/Indicators.tsx
+++ b/packages/blade/src/components/Carousel/Indicators/Indicators.tsx
@@ -1,11 +1,12 @@
 import { useCarouselContext } from '../CarouselContext';
 import { IndicatorButton } from './IndicatorButton';
+import { CircularIndicatorButton } from './CircularIndicatorButton';
 import type { IndicatorsProps } from './types';
 import { makeAccessible } from '~utils/makeAccessible';
 import BaseBox from '~components/Box/BaseBox';
 
 const Indicators = (props: IndicatorsProps): React.ReactElement => {
-  const { carouselId, isResponsive, visibleItems } = useCarouselContext();
+  const { carouselId, isResponsive, visibleItems, isMobile, isAutoPlaying } = useCarouselContext();
   return (
     <BaseBox
       display="flex"
@@ -19,15 +20,31 @@ const Indicators = (props: IndicatorsProps): React.ReactElement => {
           _visibleItems = 1;
         }
 
+        const accessibleProps = makeAccessible({
+          role: 'tab',
+          label: `Slide ${idx * _visibleItems + 1}`,
+          selected: idx === props.activeIndex,
+          controls: `${carouselId}-carousel-item-${idx * _visibleItems}`,
+        });
+
+        if (isMobile) {
+          return (
+            <CircularIndicatorButton
+              key={`${props.activeIndex}-${idx}`}
+              {...accessibleProps}
+              slideIndex={idx * _visibleItems}
+              isActive={idx === props.activeIndex}
+              onClick={() => props?.onClick?.(idx)}
+              variant={props.variant}
+              isAutoPlaying={isAutoPlaying}
+            />
+          );
+        }
+
         return (
           <IndicatorButton
             key={idx}
-            {...makeAccessible({
-              role: 'tab',
-              label: `Slide ${idx * _visibleItems + 1}`,
-              selected: idx === props.activeIndex,
-              controls: `${carouselId}-carousel-item-${idx * _visibleItems}`,
-            })}
+            {...accessibleProps}
             slideIndex={idx * _visibleItems}
             isActive={idx === props.activeIndex}
             onClick={() => props?.onClick?.(idx)}


### PR DESCRIPTION
## Summary
- On mobile, carousel indicators are now circular dots instead of pill-shaped
- Active indicator shows a circular progress ring animation (stroke-dashoffset) during autoPlay, filling linearly over 6s
- When autoPlay is off/paused, active indicator is a solid filled circle (color-only distinction)
- Desktop behavior remains unchanged (pill-shaped indicators)

## Changes
- Extended CarouselContext with isMobile and isAutoPlaying
- Created CircularIndicatorButton component using SVG with CSS keyframe animation
- Indicators.tsx conditionally renders circular variant on mobile

## Test plan
- [x] yarn test:react Carousel passes (9 tests, 6 snapshots)
- [ ] Visual verification in Storybook at mobile breakpoint
- [ ] Verify autoPlay progress ring resets on slide change
- [ ] Verify desktop indicators unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)