### PR TITLE
feat(slash-review): add screenshots to ui review

### DIFF
--- a/.agents/agents/critiques/ui-critique.md
+++ b/.agents/agents/critiques/ui-critique.md
@@ -45,6 +45,12 @@ agent-browser open {url} [--headed]  # add --headed if HEADED=true
 
 Test the main flows and interactions for each changed component.
 
+After testing each story, take a screenshot and save it to a tmp path:
+
+```bash
+agent-browser screenshot /tmp/ui-critique-{story-id}.png --full
+```
+
 ### 4. Close browser
 
 ```bash
@@ -64,17 +70,19 @@ Return a JSON object:
       "name": "Button primary variant",
       "description": "Opened the Primary story and verified hover, focus, and click states render correctly.",
       "state": "SUCCESS",
-      "link": "https://abc123.chromatic.com/?path=/story/components-button--primary"
+      "link": "https://abc123.chromatic.com/?path=/story/components-button--primary",
+      "screenshot_path": "/tmp/ui-critique-components-button--primary.png"
     },
     {
       "name": "DatePicker range selection",
       "description": "Opened the Range Selection story, clicked a start date then an end date to complete a range.",
       "state": "FAILURE",
       "problem": "Clicking end date crashes the picker",
-      "link": "https://abc123.chromatic.com/?path=/story/components-datepicker--range-selection"
+      "link": "https://abc123.chromatic.com/?path=/story/components-datepicker--range-selection",
+      "screenshot_path": "/tmp/ui-critique-components-datepicker--range-selection.png"
     }
   ],
 }
 ```
 
-Each tested flow maps to one entry in `statuses`. `description` must briefly describe what was opened and what interaction was tested. Always include `link` — the full Storybook URL for the story (use `?path=/story/{story-id}` format, not the iframe URL). Only include `problem` when `state` is `"FAILURE"`. Omit `issues` entirely — ui-critique never produces issues.
+Each tested flow maps to one entry in `statuses`. `description` must briefly describe what was opened and what interaction was tested. Always include `link` — the full Storybook URL for the story (use `?path=/story/{story-id}` format, not the iframe URL). Always include `screenshot_path` — the `/tmp` path where the screenshot was saved. Only include `problem` when `state` is `"FAILURE"`. Omit `issues` entirely — ui-critique never produces issues.

--- a/.agents/agents/critiques/ui-critique.md
+++ b/.agents/agents/critiques/ui-critique.md
@@ -16,6 +16,13 @@ You are a subagent. Return structured data only — no commentary.
 - `PR_TITLE`: title of the PR
 - `PR_BODY`: body/description of the PR
 
+## Instructions
+
+- **Scope**: UI changes in `packages/blade` (test the {STORYBOOK_URL} for changes), and UI changes in `packages/blade-svelte` (test the {STORYBOOK_URL}/svelte for changes).
+- **Goals**:
+  - Verify if the PR does what it claims to do in PR diff
+  - Verify if no existing functionality is broken in parts that PR touches
+
 ## Steps
 
 ### 1. Fetch Storybook URL
@@ -35,7 +42,7 @@ agent-browser close
 Scan the provided `DIFF`, `PR_TITLE`, and `PR_BODY` for changed component names and map them to Storybook story IDs.
 
 - Open stories via iframe: `{STORYBOOK_URL}/iframe.html?args=&id={story-id}&viewMode=story`
-- If svelte files changed, also check `{STORYBOOK_URL}/svelte/`
+- If svelte files changed, check `{STORYBOOK_URL}/svelte/iframe.html?args=&id={story-id}&viewMode=story`
 
 ### 3. Open and test each story
 
@@ -50,6 +57,10 @@ After testing each story, take a screenshot and save it to a tmp path:
 ```bash
 agent-browser screenshot /tmp/ui-critique-{story-id}.png --full
 ```
+
+If relevant and needed, compare it with same story in master storybook.
+
+- Storybook URL for master: https://blade.razorpay.com/
 
 ### 4. Close browser
 
@@ -81,7 +92,7 @@ Return a JSON object:
       "link": "https://abc123.chromatic.com/?path=/story/components-datepicker--range-selection",
       "screenshot_path": "/tmp/ui-critique-components-datepicker--range-selection.png"
     }
-  ],
+  ]
 }
 ```
 

--- a/.agents/agents/critiques/ui-critique.md
+++ b/.agents/agents/critiques/ui-critique.md
@@ -60,7 +60,9 @@ agent-browser screenshot /tmp/ui-critique-{story-id}.png --full
 
 If relevant and needed, compare it with same story in master storybook.
 
-- Storybook URL for master: https://blade.razorpay.com/
+Storybook URL for master:
+- For packages/blade changes: https://blade.razorpay.com/
+- For packages/blade-svelte changes: https://blade.razorpay.com/svelte
 
 ### 4. Close browser
 

--- a/.agents/agents/critiques/ui-critique.md
+++ b/.agents/agents/critiques/ui-critique.md
@@ -61,6 +61,7 @@ agent-browser screenshot /tmp/ui-critique-{story-id}.png --full
 If relevant and needed, compare it with same story in master storybook.
 
 Storybook URL for master:
+
 - For packages/blade changes: https://blade.razorpay.com/
 - For packages/blade-svelte changes: https://blade.razorpay.com/svelte
 
@@ -87,11 +88,11 @@ Return a JSON object:
       "screenshot_path": "/tmp/ui-critique-components-button--primary.png"
     },
     {
-      "name": "DatePicker range selection",
-      "description": "Opened the Range Selection story, clicked a start date then an end date to complete a range.",
+      "name": "DatePicker range selection (Svelte)",
+      "description": "Opened the Range Selection story in /svelte storybook, clicked a start date then an end date to complete a range.",
       "state": "FAILURE",
       "problem": "Clicking end date crashes the picker",
-      "link": "https://abc123.chromatic.com/?path=/story/components-datepicker--range-selection",
+      "link": "https://abc123.chromatic.com/svelte?path=/story/components-datepicker--range-selection",
       "screenshot_path": "/tmp/ui-critique-components-datepicker--range-selection.png"
     }
   ]

--- a/.agents/skills/review-pr/references/output-format.md
+++ b/.agents/skills/review-pr/references/output-format.md
@@ -21,13 +21,16 @@ Assemble the outputs from all critique agents into a single JSON object matching
         {
           "name": "Button primary variant",
           "description": "Opened the Primary story and verified hover, focus, and click states.",
-          "state": "SUCCESS"
+          "state": "SUCCESS",
+          "link": "https://chromatic.com/?path=/story/...",
+          "screenshot_path": "/tmp/ui-critique-button-primary.png"
         },
         {
           "name": "Button disabled state",
           "description": "Opened the Disabled story and attempted to hover and click the button.",
           "state": "FAILURE",
-          "problem": "Disabled button still shows hover styles"
+          "problem": "Disabled button still shows hover styles",
+          "screenshot_path": "/tmp/ui-critique-button-disabled.png"
         }
       ]
     },
@@ -81,7 +84,7 @@ Assemble the outputs from all critique agents into a single JSON object matching
 
 ## Assembly rules
 
-- `overview-comment.ui-review`: populated from `ui-critique.statuses`. Omit this key entirely if `ShouldReviewUI` is false.
+- `overview-comment.ui-review`: populated from `ui-critique.statuses`. Omit this key entirely if `ShouldReviewUI` is false. Preserve all fields from the agent output verbatim, including `screenshot_path` — the post-review script uses this to upload screenshots and embed them in the comment.
 - `overview-comment.sanity-review`: `statuses` and `issues` come directly from `pr-sanity-critique`.
 - `inlined-comments`: one entry per item in `issues[]` from `code-quality-critique`, `api-decision-critique`, and `usecase-critique`. Inject `critique` (the agent's `critique_name`) and copy `file`, `line`, `side`, `severity`, `problem`, `suggestion` directly. Sort by severity: critical → major → minor.
 - `side`: `"RIGHT"` for added/modified lines, `"LEFT"` for deleted lines.

--- a/.agents/skills/review-pr/scripts/post-review.js
+++ b/.agents/skills/review-pr/scripts/post-review.js
@@ -50,7 +50,7 @@ function buildStatusSection(statuses, screenshotCdnMap = {}) {
 
   const screenshotCell = (s) => {
     const cdn = s.screenshot_path && screenshotCdnMap[s.screenshot_path];
-    return cdn ? `<a href="${cdn}"><img src="${cdn}" width="200" /></a>` : '';
+    return cdn ? `<a href="${cdn}"><img src="${cdn}" width="400" /></a>` : '';
   };
 
   const parts = [];
@@ -87,9 +87,7 @@ function buildStatusSection(statuses, screenshotCdnMap = {}) {
       : ['| Check |', '|-------|'];
     const rows = passed.map((s) => {
       const name = s.link ? `[${s.name}](${s.link})` : s.name;
-      return hasScreenshots
-        ? `| ✅ ${name} | ${screenshotCell(s)} |`
-        : `| ✅ ${name} |`;
+      return hasScreenshots ? `| ✅ ${name} | ${screenshotCell(s)} |` : `| ✅ ${name} |`;
     });
     const inner = [...header, ...rows].join('\n');
     parts.push(

--- a/.agents/skills/review-pr/scripts/post-review.js
+++ b/.agents/skills/review-pr/scripts/post-review.js
@@ -41,10 +41,17 @@ function stateIcon(state) {
   return '⏳';
 }
 
-function buildStatusSection(statuses) {
+function buildStatusSection(statuses, screenshotCdnMap = {}) {
   const failed = statuses.filter((s) => s.state !== 'SUCCESS' && s.state !== 'SKIPPED');
   const passed = statuses.filter((s) => s.state === 'SUCCESS');
   const skipped = statuses.filter((s) => s.state === 'SKIPPED');
+
+  const hasScreenshots = statuses.some((s) => screenshotCdnMap[s.screenshot_path]);
+
+  const screenshotCell = (s) => {
+    const cdn = s.screenshot_path && screenshotCdnMap[s.screenshot_path];
+    return cdn ? `<a href="${cdn}"><img src="${cdn}" width="200" /></a>` : '';
+  };
 
   const parts = [];
 
@@ -58,23 +65,33 @@ function buildStatusSection(statuses) {
     .join(' · ');
   parts.push(summary);
 
-  // Failures table (2 columns — no empty Details clutter)
+  // Failures table
   if (failed.length) {
+    const header = hasScreenshots
+      ? ['| Check | Problem | Screenshot |', '|-------|---------|------------|']
+      : ['| Check | Problem |', '|-------|---------|'];
     const rows = failed.map((s) => {
       const name = s.link ? `[${s.name}](${s.link})` : s.name;
       const detail = [s.problem, s.suggestion].filter(Boolean).join('<br><br>**Suggestion:** ');
-      return `| ${name} | ${detail} |`;
+      return hasScreenshots
+        ? `| ${name} | ${detail} | ${screenshotCell(s)} |`
+        : `| ${name} | ${detail} |`;
     });
-    parts.push(['| Check | Problem |', '|-------|---------|', ...rows].join('\n'));
+    parts.push([...header, ...rows].join('\n'));
   }
 
   // Passing checks collapsed
   if (passed.length) {
+    const header = hasScreenshots
+      ? ['| Check | Screenshot |', '|-------|------------|']
+      : ['| Check |', '|-------|'];
     const rows = passed.map((s) => {
       const name = s.link ? `[${s.name}](${s.link})` : s.name;
-      return `| ✅ ${name} |`;
+      return hasScreenshots
+        ? `| ✅ ${name} | ${screenshotCell(s)} |`
+        : `| ✅ ${name} |`;
     });
-    const inner = ['| Check |', '|-------|', ...rows].join('\n');
+    const inner = [...header, ...rows].join('\n');
     parts.push(
       `<details>\n<summary>Passing checks (${passed.length})</summary>\n\n${inner}\n\n</details>`,
     );
@@ -83,7 +100,7 @@ function buildStatusSection(statuses) {
   return parts.join('\n\n');
 }
 
-function formatOverviewComment(overview, reviewStatus, isSelfReview) {
+function formatOverviewComment(overview, reviewStatus, isSelfReview, screenshotCdnMap = {}) {
   const parts = ['## ✨ Agentic PR Review ✨'];
 
   if (reviewStatus === 'approved') {
@@ -109,7 +126,7 @@ function formatOverviewComment(overview, reviewStatus, isSelfReview) {
 
     parts.push('### UI Review');
     if (storybookLine) parts.push(storybookLine);
-    parts.push(buildStatusSection(ui.statuses));
+    parts.push(buildStatusSection(ui.statuses, screenshotCdnMap));
   }
 
   if (sanity) {
@@ -139,6 +156,74 @@ function formatInlineComment(c) {
   if (c.suggestion) lines.push('', `**Suggestion:** ${c.suggestion}`);
   return lines.join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// Archive UI critique screenshots to __ci_artifacts branch
+// ---------------------------------------------------------------------------
+
+function archiveUiScreenshots(reviewJson, repoArg) {
+  const uiStatuses = reviewJson?.['overview-comment']?.['ui-review']?.statuses ?? [];
+  const screenshots = uiStatuses.filter((s) => s.screenshot_path);
+  if (screenshots.length === 0) return {};
+
+  const now = new Date();
+  const dd = String(now.getDate()).padStart(2, '0');
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const yy = String(now.getFullYear()).slice(-2);
+  const hh = String(now.getHours()).padStart(2, '0');
+  const min = String(now.getMinutes()).padStart(2, '0');
+  const sec = String(now.getSeconds()).padStart(2, '0');
+  const timestamp = `${dd}-${mm}-${yy}--${hh}-${min}-${sec}`;
+  const destDir = `artifacts/review/${timestamp}/ui-critique`;
+
+  const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  const cdnMap = {};
+  let stashed = false;
+
+  try {
+    const dirty = execSync('git status --porcelain').toString().trim();
+    if (dirty) {
+      execSync('git stash --include-untracked', { stdio: 'pipe' });
+      stashed = true;
+    }
+
+    try {
+      execSync('git fetch origin __ci_artifacts:__ci_artifacts --no-tags', { stdio: 'pipe' });
+    } catch (_) {
+      // branch may not exist on remote yet — that's fine
+    }
+    try {
+      execSync('git checkout __ci_artifacts', { stdio: 'pipe' });
+    } catch (_) {
+      execSync('git checkout --orphan __ci_artifacts', { stdio: 'pipe' });
+      execSync('git rm -rf . --quiet', { stdio: 'pipe' });
+    }
+
+    execSync(`mkdir -p ${destDir}`);
+
+    screenshots.forEach((s, i) => {
+      if (!fs.existsSync(s.screenshot_path)) return;
+      const storyIdMatch = s.link?.match(/[?&]path=\/story\/([^&]+)/);
+      const storyId = storyIdMatch ? storyIdMatch[1].replace(/[^a-zA-Z0-9_-]/g, '-') : `story-${i}`;
+      const dest = `${destDir}/${storyId}-${i + 1}.png`;
+      fs.copyFileSync(s.screenshot_path, dest);
+      execSync(`git add ${dest}`);
+      cdnMap[s.screenshot_path] =
+        `https://raw.githubusercontent.com/${repoArg}/__ci_artifacts/${dest}`;
+    });
+
+    execSync(`git commit -m "chore: add ui-critique screenshots for ${timestamp}" --allow-empty`);
+    execSync('git push origin __ci_artifacts');
+    console.log(`\nUI screenshots archived to __ci_artifacts: ${destDir}`);
+  } finally {
+    execSync(`git checkout ${currentBranch}`);
+    if (stashed) execSync('git stash pop', { stdio: 'pipe' });
+  }
+
+  return cdnMap;
+}
+
+const screenshotCdnMap = archiveUiScreenshots(reviewJson, repo);
 
 // ---------------------------------------------------------------------------
 // Build payload
@@ -171,6 +256,7 @@ const overviewBody = formatOverviewComment(
   filterIgnoredChecks(reviewJson['overview-comment']),
   reviewJson['reviewStatus'],
   isSelfReview,
+  screenshotCdnMap,
 );
 
 const SEVERITY_ORDER = { critical: 0, major: 1, minor: 2 };


### PR DESCRIPTION
## Description

The agentic PR review's UI critique now captures and surfaces screenshots for every Storybook story it tests, making it easy to visually verify UI changes directly from the GitHub review comment.

<img width="1041" height="647" alt="image" src="https://github.com/user-attachments/assets/40b22ac3-88bb-466c-b5a8-b184d04aae6d" />

https://github.com/razorpay/blade/pull/3517#pullrequestreview-4503520092


## Changes

**`ui-critique` agent** (`.agents/agents/critiques/ui-critique.md`)
- After testing each story, takes a full-page screenshot saved to `/tmp/ui-critique-{story-id}.png`
- Returns a `screenshot_path` field per status entry in the output JSON

**`post-review.js`** (`.agents/skills/review-pr/scripts/post-review.js`)
- Added `archiveUiScreenshots()` that runs before posting the review:
  - Stashes any dirty working tree, checks out (or creates) the `__ci_artifacts` branch
  - Copies screenshots to `artifacts/review/<dd-mm-yy>--<hh-mm-ss>/ui-critique/<story-id>-<count>.png`
  - Commits and pushes to `__ci_artifacts`, then switches back to the original branch and pops the stash
  - Returns a `{ tmpPath → cdn_url }` map using `raw.githubusercontent.com` URLs
- `buildStatusSection()` now accepts a `screenshotCdnMap` and adds a **Screenshot** column to both the failures table and the passing-checks table when CDN URLs are available
- Screenshot cells render as a 200px thumbnail wrapped in an `<a>` link so clicking opens the full-size image

## Additional Information

- Screenshots are only uploaded and shown when the ui-critique agent actually produces `screenshot_path` values — fully backwards-compatible
- The `__ci_artifacts` branch is pushed by the CI bot, so it won't trigger the "recent pushes" banner for human contributors