### PR TITLE
fix(rn): change Tabs selected underline color to neutral to match web

### DIFF
--- a/packages/blade/.changeset/tabs-rn-underline-neutral.md
+++ b/packages/blade/.changeset/tabs-rn-underline-neutral.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(rn): change Tabs selected tab underline color to neutral to match web

--- a/packages/blade/src/components/Tabs/Tabs.native.tsx
+++ b/packages/blade/src/components/Tabs/Tabs.native.tsx
@@ -170,7 +170,7 @@ const TabBarIndicator = ({
           : {
               height: theme.border.width.thicker,
               bottom: 0,
-              backgroundColor: theme.colors.interactive.border.primary.default,
+              backgroundColor: theme.colors.interactive.border.neutral.highlighted,
             },
         animStyle,
       ]}


### PR DESCRIPTION
## Summary
- Changes the React Native Tabs selected-tab underline indicator color from `interactive.border.primary.default` (blue) to `interactive.border.neutral.highlighted` (neutral), matching the web implementation.

This is the underline-color portion split out of #3463. The scrollable-panel change from that PR is intentionally **not** included here — consumers can provide their own scroll container, so we keep that flexibility rather than auto-wrapping panels.

## Notes
- No snapshot changes: in the test renderer `onLayout` never fires, so `TabBarIndicator` returns `null` (empty `tabWidths`) and the indicator color isn't serialized into snapshots.

## Test plan
- [ ] Open Tabs stories in RN storybook
- [ ] Verify the selected tab underline is neutral/black (not blue) for bordered and borderless variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)