### PR TITLE
feat(button): native button with SVG inset shadows

### DIFF
--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -291,6 +291,52 @@ const getProps = ({
     return shadows.join(', ');
   };
 
+  const getNativeShadowColors = (
+    btnColor: BaseButtonProps['color'],
+  ): {
+    shadowHighlightColor?: string;
+    shadowHighlightHeight?: number;
+    shadowBottomColor?: string;
+    shadowBottomHeight?: number;
+    shadowBorderColor?: string;
+    shadowRingWidth?: number;
+    shadowShowGradient?: boolean;
+  } => {
+    const shadowTokens = getBoxShadowToken({ variant, color: btnColor, state: 'default' });
+    if (shadowTokens.length === 0) return {};
+
+    let highlightColor: string | undefined;
+    let highlightHeight = 0;
+    let bottomColor: string | undefined;
+    let bottomHeight = 0;
+    let borderColor: string | undefined;
+    let ringWidth = 0;
+
+    for (const shadow of shadowTokens) {
+      const resolved = getIn(theme.colors, shadow.color);
+      if (shadow.y > 0 && !highlightColor) {
+        highlightColor = resolved;
+        highlightHeight = shadow.y;
+      } else if (shadow.y < 0 && !bottomColor) {
+        bottomColor = resolved;
+        bottomHeight = Math.abs(shadow.y);
+      } else if (shadow.spread > 0 && !borderColor) {
+        borderColor = resolved;
+        ringWidth = shadow.spread;
+      }
+    }
+
+    return {
+      shadowHighlightColor: highlightColor,
+      shadowHighlightHeight: highlightHeight || undefined,
+      shadowBottomColor: bottomColor,
+      shadowBottomHeight: bottomHeight || undefined,
+      shadowBorderColor: borderColor,
+      shadowRingWidth: ringWidth || undefined,
+      shadowShowGradient: variant === 'primary',
+    };
+  };
+
   const props: BaseButtonStyleProps = {
     iconSize: isIconOnly ? buttonIconOnlySizeToIconSizeMap[size] : buttonSizeToIconSizeMap[size],
     spinnerSize: buttonSizeToSpinnerSizeMap[size],
@@ -345,6 +391,7 @@ const getProps = ({
     borderRadius: makeBorderSize(theme.border.radius[buttonBorderRadius[size]]),
     motionDuration: 'duration.xquick',
     motionEasing: 'easing.standard',
+    ...getNativeShadowColors(color),
   };
 
   if (isDisabled) {
@@ -369,6 +416,13 @@ const getProps = ({
     props.hoverBoxShadow = getBoxShadow('disabled', color);
     props.focusBackgroundColor = disabledBackgroundColor;
     props.focusBoxShadow = getBoxShadow('disabled', color);
+    props.shadowHighlightColor = undefined;
+    props.shadowHighlightHeight = undefined;
+    props.shadowBottomColor = undefined;
+    props.shadowBottomHeight = undefined;
+    props.shadowBorderColor = undefined;
+    props.shadowRingWidth = undefined;
+    props.shadowShowGradient = undefined;
   }
 
   return props;

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import Svg, { Defs, RadialGradient, Stop, Rect, ClipPath } from 'react-native-svg';
+import Svg, {
+  Defs,
+  RadialGradient,
+  LinearGradient,
+  Stop,
+  Rect,
+  Mask,
+} from 'react-native-svg';
 
 type ButtonShadowOverlayProps = {
   borderRadius: number;
@@ -26,12 +33,20 @@ const ButtonShadowOverlay = ({
   <View style={StyleSheet.absoluteFill} pointerEvents="none">
     <Svg style={StyleSheet.absoluteFill} pointerEvents="none">
       <Defs>
-        <ClipPath id="topClip">
-          <Rect x="0" y="0" width="100%" height="20%" />
-        </ClipPath>
-        <ClipPath id="bottomClip">
-          <Rect x="0" y="80%" width="100%" height="20%" />
-        </ClipPath>
+        <LinearGradient id="topFade" x1="0" y1="0" x2="0" y2="1">
+          <Stop offset="0" stopColor="white" stopOpacity={1} />
+          <Stop offset="1" stopColor="white" stopOpacity={0} />
+        </LinearGradient>
+        <LinearGradient id="bottomFade" x1="0" y1="1" x2="0" y2="0">
+          <Stop offset="0" stopColor="white" stopOpacity={1} />
+          <Stop offset="1" stopColor="white" stopOpacity={0} />
+        </LinearGradient>
+        <Mask id="topMask">
+          <Rect x="0" y="0" width="100%" height="20%" fill="url(#topFade)" />
+        </Mask>
+        <Mask id="bottomMask">
+          <Rect x="0" y="80%" width="100%" height="20%" fill="url(#bottomFade)" />
+        </Mask>
         {showGradient ? (
           <RadialGradient
             id="btnGlow"
@@ -56,8 +71,8 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="none"
           stroke={highlightColor}
-          strokeWidth={4}
-          clipPath="url(#bottomClip)"
+          strokeWidth={6}
+          mask="url(#bottomMask)"
         />
       ) : null}
       {highlightColor ? (
@@ -70,8 +85,8 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="none"
           stroke={highlightColor}
-          strokeWidth={highlightHeight * 2}
-          clipPath="url(#topClip)"
+          strokeWidth={(highlightHeight + 1) * 2}
+          mask="url(#topMask)"
         />
       ) : null}
       <Rect
@@ -96,7 +111,7 @@ const ButtonShadowOverlay = ({
           fill="none"
           stroke={shadowColor}
           strokeWidth={shadowHeight * 2}
-          clipPath="url(#bottomClip)"
+          mask="url(#bottomMask)"
         />
       ) : null}
       {showGradient ? (

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
@@ -71,7 +71,7 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="none"
           stroke={highlightColor}
-          strokeWidth={4}
+          strokeWidth={7}
           mask="url(#bottomMask)"
         />
       ) : null}
@@ -110,7 +110,7 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="none"
           stroke={shadowColor}
-          strokeWidth={shadowHeight * 2}
+          strokeWidth={(shadowHeight + 1) * 2}
           mask="url(#bottomMask)"
         />
       ) : null}

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
@@ -85,7 +85,7 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="none"
           stroke={highlightColor}
-          strokeWidth={(highlightHeight + 1) * 2}
+          strokeWidth={(highlightHeight + 0.5) * 2}
           mask="url(#topMask)"
         />
       ) : null}

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import Svg, { Defs, RadialGradient, Stop, Rect } from 'react-native-svg';
+import Svg, { Defs, RadialGradient, Stop, Rect, ClipPath } from 'react-native-svg';
 
 type ButtonShadowOverlayProps = {
   borderRadius: number;
@@ -24,50 +24,15 @@ const ButtonShadowOverlay = ({
   showGradient = false,
 }: ButtonShadowOverlayProps): React.ReactElement => (
   <View style={StyleSheet.absoluteFill} pointerEvents="none">
-    {highlightColor ? (
-      <View
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          height: highlightHeight,
-          backgroundColor: highlightColor,
-          borderTopLeftRadius: borderRadius,
-          borderTopRightRadius: borderRadius,
-        }}
-      />
-    ) : null}
-    {shadowColor ? (
-      <View
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: borderRadius,
-          right: borderRadius,
-          height: shadowHeight,
-          backgroundColor: shadowColor,
-        }}
-      />
-    ) : null}
-    <View
-      style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        borderTopWidth: ringWidth,
-        borderBottomWidth: ringWidth,
-        borderLeftWidth: 0,
-        borderRightWidth: 0,
-        borderColor: borderColor,
-        borderRadius: borderRadius,
-      }}
-    />
-    {showGradient ? (
-      <Svg style={StyleSheet.absoluteFill} pointerEvents="none">
-        <Defs>
+    <Svg style={StyleSheet.absoluteFill} pointerEvents="none">
+      <Defs>
+        <ClipPath id="topClip">
+          <Rect x="0" y="0" width="100%" height="20%" />
+        </ClipPath>
+        <ClipPath id="bottomClip">
+          <Rect x="0" y="80%" width="100%" height="20%" />
+        </ClipPath>
+        {showGradient ? (
           <RadialGradient
             id="btnGlow"
             cx={0}
@@ -79,7 +44,62 @@ const ButtonShadowOverlay = ({
             <Stop offset="0" stopColor="#ffffff" stopOpacity={0.18} />
             <Stop offset="1" stopColor="#ffffff" stopOpacity={0} />
           </RadialGradient>
-        </Defs>
+        ) : null}
+      </Defs>
+      {highlightColor ? (
+        <Rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          rx={borderRadius}
+          ry={borderRadius}
+          fill="none"
+          stroke={highlightColor}
+          strokeWidth={4}
+          clipPath="url(#bottomClip)"
+        />
+      ) : null}
+      {highlightColor ? (
+        <Rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          rx={borderRadius}
+          ry={borderRadius}
+          fill="none"
+          stroke={highlightColor}
+          strokeWidth={highlightHeight * 2}
+          clipPath="url(#topClip)"
+        />
+      ) : null}
+      <Rect
+        x="0"
+        y="0"
+        width="100%"
+        height="100%"
+        rx={borderRadius}
+        ry={borderRadius}
+        fill="none"
+        stroke={borderColor}
+        strokeWidth={ringWidth * 2}
+      />
+      {shadowColor ? (
+        <Rect
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          rx={borderRadius}
+          ry={borderRadius}
+          fill="none"
+          stroke={shadowColor}
+          strokeWidth={shadowHeight * 2}
+          clipPath="url(#bottomClip)"
+        />
+      ) : null}
+      {showGradient ? (
         <Rect
           x={0}
           y={0}
@@ -89,8 +109,8 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="url(#btnGlow)"
         />
-      </Svg>
-    ) : null}
+      ) : null}
+    </Svg>
   </View>
 );
 

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
@@ -71,7 +71,7 @@ const ButtonShadowOverlay = ({
           ry={borderRadius}
           fill="none"
           stroke={highlightColor}
-          strokeWidth={6}
+          strokeWidth={4}
           mask="url(#bottomMask)"
         />
       ) : null}

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.native.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Defs, RadialGradient, Stop, Rect } from 'react-native-svg';
+
+type ButtonShadowOverlayProps = {
+  borderRadius: number;
+  highlightColor?: string;
+  highlightHeight?: number;
+  shadowColor?: string;
+  shadowHeight?: number;
+  borderColor: string;
+  ringWidth?: number;
+  showGradient?: boolean;
+};
+
+const ButtonShadowOverlay = ({
+  borderRadius,
+  highlightColor,
+  highlightHeight = 1.5,
+  shadowColor,
+  shadowHeight = 1.5,
+  borderColor,
+  ringWidth = 0.5,
+  showGradient = false,
+}: ButtonShadowOverlayProps): React.ReactElement => (
+  <View style={StyleSheet.absoluteFill} pointerEvents="none">
+    {highlightColor ? (
+      <View
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: highlightHeight,
+          backgroundColor: highlightColor,
+          borderTopLeftRadius: borderRadius,
+          borderTopRightRadius: borderRadius,
+        }}
+      />
+    ) : null}
+    {shadowColor ? (
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: borderRadius,
+          right: borderRadius,
+          height: shadowHeight,
+          backgroundColor: shadowColor,
+        }}
+      />
+    ) : null}
+    <View
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        borderTopWidth: ringWidth,
+        borderBottomWidth: ringWidth,
+        borderLeftWidth: 0,
+        borderRightWidth: 0,
+        borderColor: borderColor,
+        borderRadius: borderRadius,
+      }}
+    />
+    {showGradient ? (
+      <Svg style={StyleSheet.absoluteFill} pointerEvents="none">
+        <Defs>
+          <RadialGradient
+            id="btnGlow"
+            cx={0}
+            cy={0}
+            rx={64}
+            ry={64}
+            gradientUnits="userSpaceOnUse"
+          >
+            <Stop offset="0" stopColor="#ffffff" stopOpacity={0.18} />
+            <Stop offset="1" stopColor="#ffffff" stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Rect
+          x={0}
+          y={0}
+          width="100%"
+          height="100%"
+          rx={borderRadius}
+          ry={borderRadius}
+          fill="url(#btnGlow)"
+        />
+      </Svg>
+    ) : null}
+  </View>
+);
+
+export { ButtonShadowOverlay };
+export type { ButtonShadowOverlayProps };

--- a/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.web.tsx
+++ b/packages/blade/src/components/Button/BaseButton/ButtonShadowOverlay.web.tsx
@@ -1,0 +1,3 @@
+const ButtonShadowOverlay = (): null => null;
+
+export { ButtonShadowOverlay };

--- a/packages/blade/src/components/Button/BaseButton/StyledBaseButton.native.tsx
+++ b/packages/blade/src/components/Button/BaseButton/StyledBaseButton.native.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components/native';
 import React from 'react';
 import type { TextInput, GestureResponderEvent } from 'react-native';
 import getStyledBaseButtonStyles from './getStyledBaseButtonStyles';
+import { ButtonShadowOverlay } from './ButtonShadowOverlay';
 import type { StyledBaseButtonProps } from './types';
 import getIn from '~utils/lodashButBetter/get';
 import { useStyledProps } from '~components/Box/styledProps';
@@ -25,6 +26,7 @@ const StyledPressable = styled(Animated.createAnimatedComponent(Pressable))<
     alignSelf: 'center',
     display: 'flex',
     flexDirection: 'row',
+    overflow: 'hidden',
     ...styledPropsCSSObject,
   };
 });
@@ -80,6 +82,13 @@ const _StyledBaseButton: React.ForwardRefRenderFunction<TextInput, StyledBaseBut
     onPointerEnter,
     onPointerDown,
     onFocus,
+    shadowHighlightColor,
+    shadowHighlightHeight,
+    shadowBottomColor,
+    shadowBottomHeight,
+    shadowBorderColor,
+    shadowRingWidth,
+    shadowShowGradient,
     ...styledProps
   },
   ref,
@@ -158,7 +167,23 @@ const _StyledBaseButton: React.ForwardRefRenderFunction<TextInput, StyledBaseBut
       {/* @ts-ignore */}
       {({ pressed }): React.ReactNode => {
         isPressed.value = pressed;
-        return children;
+        return (
+          <>
+            {shadowBorderColor ? (
+              <ButtonShadowOverlay
+                borderRadius={parseFloat(String(borderRadius)) || 0}
+                highlightColor={shadowHighlightColor}
+                highlightHeight={shadowHighlightHeight}
+                shadowColor={shadowBottomColor}
+                shadowHeight={shadowBottomHeight}
+                borderColor={shadowBorderColor}
+                ringWidth={shadowRingWidth}
+                showGradient={shadowShowGradient}
+              />
+            ) : null}
+            {children}
+          </>
+        );
       }}
     </StyledPressable>
   );

--- a/packages/blade/src/components/Button/BaseButton/types.ts
+++ b/packages/blade/src/components/Button/BaseButton/types.ts
@@ -44,6 +44,13 @@ export type BaseButtonStyleProps = {
   borderRadius: BorderRadiusValues | number;
   height?: string;
   width?: string;
+  shadowHighlightColor?: string;
+  shadowHighlightHeight?: number;
+  shadowBottomColor?: string;
+  shadowBottomHeight?: number;
+  shadowBorderColor?: string;
+  shadowRingWidth?: number;
+  shadowShowGradient?: boolean;
 };
 
 export type StyledBaseButtonProps = Omit<
@@ -75,6 +82,13 @@ export type StyledBaseButtonProps = Omit<
   motionEasing: EasingString;
   borderRadius: BorderRadiusValues | number;
   borderWidth?: string;
+  shadowHighlightColor?: string;
+  shadowHighlightHeight?: number;
+  shadowBottomColor?: string;
+  shadowBottomHeight?: number;
+  shadowBorderColor?: string;
+  shadowRingWidth?: number;
+  shadowShowGradient?: boolean;
   accessibilityProps: Record<string, unknown>;
   isPressed: boolean;
 } & StyledPropsBlade &


### PR DESCRIPTION
## Summary
- Implements SVG stroke-based inset shadows for native button overlay
- Uses mask-based fade for natural shadow taper
- Adjusts highlight and dark stroke sizes for proper visual depth

## Test plan
- [ ] Verify button renders correctly on iOS and Android
- [ ] Check shadow taper looks natural at button edges
- [ ] Confirm highlight strokes match design specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)