### PR TITLE
feat: add resolve-comments skill and update auto-resolve flow to use it

### DIFF
--- a/.agents/skills/resolve-comments/SKILL.md
+++ b/.agents/skills/resolve-comments/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: resolve-comments
+description: Resolve PR review comments by pushing code fixes or replying with explanations. Use when a PR has review comments that need to be auto-resolved.
+disable-model-invocation: true
+---
+
+# Resolve PR Review Comments
+
+## Arguments
+
+- PR: Link / Number of the PR to resolve comments on
+- COMMENT_URLS: Newline-separated list of comment URLs to resolve
+
+## Steps
+
+### 1. Fetch Comment Details
+
+Use `gh` CLI to fetch the PR and each comment:
+
+```bash
+gh pr view {PR_NUMBER} --repo razorpay/blade
+gh api repos/razorpay/blade/pulls/comments/{COMMENT_ID}
+```
+
+### 2. Resolve Each Comment
+
+For each comment in `COMMENT_URLS`, determine the appropriate resolution:
+
+- **Code fix required**: push a fix commit to the PR branch, reply to the comment with `[resolved by agent]` at the end, and mark the thread as resolved on GitHub.
+- **Clarification request**: reply to the comment with a clear explanation and `[resolved by agent]` at the end.
+- **Invalid or irrelevant comment**: skip resolving it, reply with why it is invalid or irrelevant, and add `[resolved by agent]` at the end.
+- **Needs PR author input**: add the label `Human Help Needed 🧑🏻‍💻` to the PR instead of guessing.
+
+### 3. Push Fixes
+
+If any code fixes were made:
+
+```bash
+git add -A && git diff --cached --quiet || (git commit -m "fix: resolve PR review comments via Slash" && git push)
+```
+
+### 4. Reply to Comments
+
+After resolving, reply to each addressed comment:
+
+```bash
+gh api "repos/razorpay/blade/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies" \
+  --method POST \
+  --field body="[resolved by agent]"
+```

--- a/.agents/skills/resolve-comments/SKILL.md
+++ b/.agents/skills/resolve-comments/SKILL.md
@@ -26,25 +26,32 @@ gh api repos/razorpay/blade/pulls/comments/{COMMENT_ID}
 
 For each comment in `COMMENT_URLS`, determine the appropriate resolution:
 
-- **Code fix required**: push a fix commit to the PR branch, reply to the comment with `[resolved by agent]` at the end, and mark the thread as resolved on GitHub.
-- **Clarification request**: reply to the comment with a clear explanation and `[resolved by agent]` at the end.
+- **Code fix required**: push a fix commit to the PR branch, reply to the inlined comment (mention `[resolved by agent]`) at the end, and mark the inlined comment thread as resolved on GitHub.
+- **Clarification request**: reply to the inlined comment with a clear explanation and `[resolved by agent]` at the end.
 - **Invalid or irrelevant comment**: skip resolving it, reply with why it is invalid or irrelevant, and add `[resolved by agent]` at the end.
+  - Go through the rest of the relevant code, commits, PR info, whenever applicable, to determine if the comment is invalid or irrelevant.
 - **Needs PR author input**: add the label `Human Help Needed 🧑🏻‍💻` to the PR instead of guessing.
 
-### 3. Push Fixes
+### 2.5 How to deal with different kind of comments
+
+- Case 1: Diff has peice of change that doesn't match the title or description of the PR.
+  - In most cases, its safe to assume that the code was changed but the PR info was not updated to reflect the changes. You can go and update the PR info instead of reverting the change.
+
+### 3. Making Changes in branch
+
+- Try not to deviate from the original change the PR was intended for (check PR info, diff, relevant code state in that branch, etc to get context whenever needed).
+- Its possible that while working on the change, you find out that the comment is invalid or irrelevant or you don't need to make the change at all. In that case, just reply to the inlined comment with small message and add `[resolved by agent]` at the end.
+
+### 4. Push Fixes
 
 If any code fixes were made:
 
 ```bash
-git add -A && git diff --cached --quiet || (git commit -m "fix: resolve PR review comments via Slash" && git push)
+git add -A && git diff --cached --quiet || (git commit -m "fix: <relevant commit message> [resolved by agent]" && git push)
 ```
 
-### 4. Reply to Comments
+### 5. Reply to Comments
 
-After resolving, reply to each addressed comment:
+After resolving, reply to each inlined comment with small message and add `[resolved by agent]` at the end (if you have not already done so).
 
-```bash
-gh api "repos/razorpay/blade/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies" \
-  --method POST \
-  --field body="[resolved by agent]"
-```
+- Never post a new comment on the PR. Only reply to the inlined comments.

--- a/.github/scripts/slash-resolve-comments/resolve-review-comments.js
+++ b/.github/scripts/slash-resolve-comments/resolve-review-comments.js
@@ -33,17 +33,7 @@ if (selected.length === 0) {
 const commentUrls = selected.map((c) => c.html_url).join('\n');
 const commentIds = selected.map((c) => c.id);
 
-const prompt = `Resolve the following PR review comments that were just submitted in a single review.
-
-Comment URLs:
-${commentUrls}
-
-Instructions:
-  - Fetch the details of the PR and each comment with \`gh\` CLI.
-  - For each comment: when it asks for clarification, reply to the comment with a response (including "[resolved by agent]" at the end) OR push a code fix to the PR branch.
-  - Whenever applicable, create a fix commit and push it to the PR branch, reply to the relevant comment(s) with "[resolved by agent]" at the end and also mark the comment thread as resolved on github.
-  - After investigation and looking at the other code, if you find that a comment is invalid or irrelevant, skip resolving it and just reply to the comment with why that is invalid or irrelevant (add [resolved by agent] at the end).
-  - If you need clarification from the PR author for any comment, add the label "Human Help Needed 🧑🏻‍💻" to the PR instead of guessing.`;
+const prompt = `Resolve the review comments on PR #${prNumber} using the /resolve-comments skill from the blade repo. COMMENT_URLS:\n${commentUrls}\n\nStrictly use the resolve-comments skill from the blade repo only. Do not use any other skill.`;
 
 const responseOutput = execSync(`node .github/scripts/run-slash.js ${JSON.stringify(prompt)}`, {
   encoding: 'utf8',


### PR DESCRIPTION
## Summary
- Adds a new `.agents/skills/resolve-comments/SKILL.md` skill with structured instructions for resolving PR review comments — matching the pattern used by the `heal-pr` skill
- Updates `resolve-review-comments.js` to invoke the skill via `/resolve-comments` instead of embedding the prompt inline

## Test plan
- [ ] Trigger a PR review that mentions `@rzp-slash-public` and verify Slash picks up the skill correctly
- [ ] Confirm the skill file appears in `.claude/skills/resolve-comments/SKILL.md` via the symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)