### PR TITLE
fix(native): fixed left padding in phone input's country selector

### DIFF
--- a/.changeset/good-flowers-chew.md
+++ b/.changeset/good-flowers-chew.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(native) :- fixed left padding in phone input's country selector

--- a/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.native.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.native.tsx
@@ -85,6 +85,7 @@ const CountrySelector = ({
           alignItems: 'center',
           alignSelf: 'stretch',
           justifyContent: 'center',
+          paddingLeft: 8,
         }}
       >
         <BaseBox display="flex" flexDirection="row" alignItems="center" gap="spacing.2">


### PR DESCRIPTION
## Description

fixed left padding in phone input's country selector

## Changes

fixed left padding in phone input's country selector in native

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [x] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset
