### PR TITLE
fix(SankeyChart): remove horizontal scroll wrapper so card wraps chart naturally

### DIFF
--- a/.changeset/fix-sankey-scroll-wrapper.md
+++ b/.changeset/fix-sankey-scroll-wrapper.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(SankeyChart): remove horizontal scroll wrapper so card wraps chart naturally

--- a/packages/blade/src/components/Charts/SankeyChart/SankeyChart.web.tsx
+++ b/packages/blade/src/components/Charts/SankeyChart/SankeyChart.web.tsx
@@ -34,7 +34,6 @@ import {
   CHIP_VALUE_BUDGET,
   NODE_MIN_HEIGHT,
   TOOLTIP_Z_INDEX,
-  MIN_CHART_WIDTH,
 } from './tokens';
 import { getComponentId } from '~utils/isValidAllowedChildren';
 import { throwBladeError } from '~utils/logger';
@@ -196,14 +195,9 @@ const _ChartSankeyWrapper = ({
           {...restProps}
           position="relative"
         >
-          {/* Scroll wrapper — ensures minimum width on narrow viewports */}
-          <BaseBox width="100%" height="100%" overflowX="auto">
-            <BaseBox height="100%" minWidth={`${MIN_CHART_WIDTH}px`}>
-              <ResponsiveContainer width="100%" height="100%">
-                {children}
-              </ResponsiveContainer>
-            </BaseBox>
-          </BaseBox>
+          <ResponsiveContainer width="100%" height="100%">
+            {children}
+          </ResponsiveContainer>
         </BaseBox>
       </SankeyChartContext.Provider>
     </CommonChartComponentsContext.Provider>

--- a/packages/blade/src/components/Charts/SankeyChart/__tests__/SankeyChart.web.test.tsx
+++ b/packages/blade/src/components/Charts/SankeyChart/__tests__/SankeyChart.web.test.tsx
@@ -263,16 +263,15 @@ describe('SankeyChart — color token resolution', () => {
 // ── Layout ─────────────────────────────────────────────────────────────────────
 
 describe('SankeyChart — layout', () => {
-  it('renders scroll wrapper with minWidth constraint via styled-component class', () => {
+  it('renders ResponsiveContainer without a scroll wrapper', () => {
     const { container } = renderSankey();
-    // BaseBox applies minWidth as a CSS class (styled-components), not inline style.
-    // We verify it is present in the computed styles of one of the wrapper divs.
+    // No overflowX scroll wrapper — chart fills available width directly.
     const divs = Array.from(container.querySelectorAll('div'));
-    const hasMinWidth = divs.some((div) => {
-      const computed = window.getComputedStyle(div).minWidth;
-      return computed && computed !== '0px' && computed !== '';
+    const hasOverflowScroll = divs.some((div) => {
+      const computed = window.getComputedStyle(div).overflowX;
+      return computed === 'auto' || computed === 'scroll';
     });
-    expect(hasMinWidth).toBe(true);
+    expect(hasOverflowScroll).toBe(false);
   });
 });
 

--- a/packages/blade/src/components/Charts/SankeyChart/__tests__/__snapshots__/SankeyChart.web.test.tsx.snap
+++ b/packages/blade/src/components/Charts/SankeyChart/__tests__/__snapshots__/SankeyChart.web.test.tsx.snap
@@ -7,58 +7,39 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
   width: 100%;
 }
 
-.c1.c1.c1.c1.c1 {
-  overflow-x: auto;
-  height: 100%;
-  width: 100%;
-}
-
-.c2.c2.c2.c2.c2 {
-  height: 100%;
-  min-width: 560px;
-}
-
 <div>
   <div
     class="c0"
     data-blade-component="ChartSankeyWrapper"
   >
     <div
-      class="c1"
-      data-blade-component="base-box"
+      class="recharts-wrapper"
+      height="100%"
+      style="position: relative; cursor: default; width: 800px; height: 100%;"
+      width="800"
     >
       <div
-        class="c2"
-        data-blade-component="base-box"
+        class="recharts-tooltip-wrapper"
+        style="visibility: hidden; pointer-events: none; position: absolute; top: 0px; left: 0px;"
+        tabindex="-1"
+        xmlns="http://www.w3.org/1999/xhtml"
+      />
+      <svg
+        class="recharts-surface"
+        height="100"
+        viewBox="0 0 800 100"
+        width="800"
       >
-        <div
-          class="recharts-wrapper"
-          height="100%"
-          style="position: relative; cursor: default; width: 800px; height: 100%;"
-          width="800"
+        <title />
+        <desc />
+        <g
+          class="recharts-layer recharts-sankey-links"
         >
-          <div
-            class="recharts-tooltip-wrapper"
-            style="visibility: hidden; pointer-events: none; position: absolute; top: 0px; left: 0px;"
-            tabindex="-1"
-            xmlns="http://www.w3.org/1999/xhtml"
-          />
-          <svg
-            class="recharts-surface"
-            height="100"
-            viewBox="0 0 800 100"
-            width="800"
+          <g
+            class="recharts-layer"
           >
-            <title />
-            <desc />
-            <g
-              class="recharts-layer recharts-sankey-links"
-            >
-              <g
-                class="recharts-layer"
-              >
-                <path
-                  d="
+            <path
+              d="
         M22,50.54369962503995
         C165.5,50.54369962503995
           165.5,48
@@ -69,16 +50,16 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           22,10.543699625039949
         Z
       "
-                  fill="hsla(218, 100%, 92%, 1)"
-                  fill-opacity="0.55"
-                  style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                />
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <path
-                  d="
+              fill="hsla(218, 100%, 92%, 1)"
+              fill-opacity="0.55"
+              style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            />
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <path
+              d="
         M22,82.54369962503995
         C165.5,82.54369962503995
           165.5,92
@@ -89,16 +70,16 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           22,50.54369962503995
         Z
       "
-                  fill="hsla(218, 100%, 92%, 1)"
-                  fill-opacity="0.55"
-                  style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                />
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <path
-                  d="
+              fill="hsla(218, 100%, 92%, 1)"
+              fill-opacity="0.55"
+              style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            />
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <path
+              d="
         M323,43
         C466.5,43
           466.5,43
@@ -109,16 +90,16 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           323,8
         Z
       "
-                  fill="hsla(149, 38%, 86%, 1)"
-                  fill-opacity="0.55"
-                  style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                />
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <path
-                  d="
+              fill="hsla(149, 38%, 86%, 1)"
+              fill-opacity="0.55"
+              style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            />
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <path
+              d="
         M323,48
         C466.5,48
           466.5,88
@@ -129,16 +110,16 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           323,43
         Z
       "
-                  fill="hsla(149, 38%, 86%, 1)"
-                  fill-opacity="0.55"
-                  style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                />
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <path
-                  d="
+              fill="hsla(149, 38%, 86%, 1)"
+              fill-opacity="0.55"
+              style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            />
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <path
+              d="
         M323,88
         C466.5,88
           466.5,71
@@ -149,16 +130,16 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           323,60
         Z
       "
-                  fill="hsla(46, 86%, 83%, 1)"
-                  fill-opacity="0.55"
-                  style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                />
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <path
-                  d="
+              fill="hsla(46, 86%, 83%, 1)"
+              fill-opacity="0.55"
+              style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            />
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <path
+              d="
         M323,92
         C466.5,92
           466.5,92
@@ -169,279 +150,277 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           323,88
         Z
       "
-                  fill="hsla(46, 86%, 83%, 1)"
-                  fill-opacity="0.55"
-                  style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                />
-              </g>
-            </g>
+              fill="hsla(46, 86%, 83%, 1)"
+              fill-opacity="0.55"
+              style="cursor: pointer; transition: fill-opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            />
+          </g>
+        </g>
+        <g
+          class="recharts-layer recharts-sankey-nodes"
+        >
+          <g
+            class="recharts-layer"
+          >
             <g
-              class="recharts-layer recharts-sankey-nodes"
+              opacity="1"
+              style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
             >
+              <rect
+                fill="hsla(218, 100%, 92%, 1)"
+                height="72"
+                rx="0"
+                style="cursor: pointer;"
+                width="14"
+                x="8"
+                y="10.543699625039949"
+              />
               <g
-                class="recharts-layer"
+                style="pointer-events: none;"
               >
-                <g
-                  opacity="1"
-                  style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+                <rect
+                  fill="hsla(0, 0%, 100%, 1)"
+                  height="27"
+                  rx="8"
+                  stroke="hsla(206, 10%, 29%, 0.18)"
+                  stroke-width="1"
+                  width="79"
+                  x="30.5"
+                  y="33.04369962503995"
+                />
+                <text
+                  font-size="12"
+                  style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
+                  x="38"
+                  y="50.86369962503995"
                 >
-                  <rect
-                    fill="hsla(218, 100%, 92%, 1)"
-                    height="72"
-                    rx="0"
-                    style="cursor: pointer;"
-                    width="14"
-                    x="8"
-                    y="10.543699625039949"
-                  />
-                  <g
-                    style="pointer-events: none;"
+                  <tspan
+                    fill="hsla(0, 0%, 2%, 1)"
+                    font-weight="600"
                   >
-                    <rect
-                      fill="hsla(0, 0%, 100%, 1)"
-                      height="27"
-                      rx="8"
-                      stroke="hsla(206, 10%, 29%, 0.18)"
-                      stroke-width="1"
-                      width="79"
-                      x="30.5"
-                      y="33.04369962503995"
-                    />
-                    <text
-                      font-size="12"
-                      style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                      x="38"
-                      y="50.86369962503995"
-                    >
-                      <tspan
-                        fill="hsla(0, 0%, 2%, 1)"
-                        font-weight="600"
-                      >
-                        Total
-                      </tspan>
-                      <tspan
-                        dx="4"
-                        fill="hsla(204, 9%, 42%, 1)"
-                        font-weight="400"
-                      >
-                        7.2k
-                      </tspan>
-                    </text>
-                  </g>
-                </g>
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <g
-                  opacity="1"
-                  style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                >
-                  <rect
-                    fill="hsla(149, 38%, 86%, 1)"
-                    height="40"
-                    rx="0"
-                    style="cursor: pointer;"
-                    width="14"
-                    x="309"
-                    y="7.999999999999998"
-                  />
-                  <g
-                    style="pointer-events: none;"
+                    Total
+                  </tspan>
+                  <tspan
+                    dx="4"
+                    fill="hsla(204, 9%, 42%, 1)"
+                    font-weight="400"
                   >
-                    <rect
-                      fill="hsla(0, 0%, 100%, 1)"
-                      height="27"
-                      rx="8"
-                      stroke="hsla(206, 10%, 29%, 0.18)"
-                      stroke-width="1"
-                      width="90.35546875"
-                      x="331.5"
-                      y="14.5"
-                    />
-                    <text
-                      font-size="12"
-                      style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                      x="339"
-                      y="32.32"
-                    >
-                      <tspan
-                        fill="hsla(0, 0%, 2%, 1)"
-                        font-weight="600"
-                      >
-                        UPI
-                      </tspan>
-                      <tspan
-                        dx="4"
-                        fill="hsla(204, 9%, 42%, 1)"
-                        font-weight="400"
-                      >
-                        4k  (56%)
-                      </tspan>
-                    </text>
-                  </g>
-                </g>
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <g
-                  opacity="1"
-                  style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                >
-                  <rect
-                    fill="hsla(46, 86%, 83%, 1)"
-                    height="32"
-                    rx="0"
-                    style="cursor: pointer;"
-                    width="14"
-                    x="309"
-                    y="60"
-                  />
-                  <g
-                    style="pointer-events: none;"
-                  >
-                    <rect
-                      fill="hsla(0, 0%, 100%, 1)"
-                      height="27"
-                      rx="8"
-                      stroke="hsla(206, 10%, 29%, 0.18)"
-                      stroke-width="1"
-                      width="107.69921875"
-                      x="331.5"
-                      y="62.5"
-                    />
-                    <text
-                      font-size="12"
-                      style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                      x="339"
-                      y="80.32"
-                    >
-                      <tspan
-                        fill="hsla(0, 0%, 2%, 1)"
-                        font-weight="600"
-                      >
-                        Card
-                      </tspan>
-                      <tspan
-                        dx="4"
-                        fill="hsla(204, 9%, 42%, 1)"
-                        font-weight="400"
-                      >
-                        3.2k  (44%)
-                      </tspan>
-                    </text>
-                  </g>
-                </g>
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <g
-                  opacity="1"
-                  style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                >
-                  <rect
-                    fill="hsla(264, 100%, 89%, 1)"
-                    height="63"
-                    rx="0"
-                    style="cursor: pointer;"
-                    width="14"
-                    x="610"
-                    y="8.000000000000004"
-                  />
-                  <g
-                    style="pointer-events: none;"
-                  >
-                    <rect
-                      fill="hsla(0, 0%, 100%, 1)"
-                      height="27"
-                      rx="8"
-                      stroke="hsla(206, 10%, 29%, 0.18)"
-                      stroke-width="1"
-                      width="143.72265625"
-                      x="632.5"
-                      y="26"
-                    />
-                    <text
-                      font-size="12"
-                      style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                      x="640"
-                      y="43.82"
-                    >
-                      <tspan
-                        fill="hsla(0, 0%, 2%, 1)"
-                        font-weight="600"
-                      >
-                        Successful
-                      </tspan>
-                      <tspan
-                        dx="4"
-                        fill="hsla(204, 9%, 42%, 1)"
-                        font-weight="400"
-                      >
-                        6.3k  (88%)
-                      </tspan>
-                    </text>
-                  </g>
-                </g>
-              </g>
-              <g
-                class="recharts-layer"
-              >
-                <g
-                  opacity="1"
-                  style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
-                >
-                  <rect
-                    fill="hsla(24, 100%, 92%, 1)"
-                    height="9"
-                    rx="0"
-                    style="cursor: pointer;"
-                    width="14"
-                    x="610"
-                    y="83"
-                  />
-                  <g
-                    style="pointer-events: none;"
-                  >
-                    <rect
-                      fill="hsla(0, 0%, 100%, 1)"
-                      height="27"
-                      rx="8"
-                      stroke="hsla(206, 10%, 29%, 0.18)"
-                      stroke-width="1"
-                      width="112.375"
-                      x="632.5"
-                      y="74"
-                    />
-                    <text
-                      font-size="12"
-                      style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                      x="640"
-                      y="91.82"
-                    >
-                      <tspan
-                        fill="hsla(0, 0%, 2%, 1)"
-                        font-weight="600"
-                      >
-                        Failed
-                      </tspan>
-                      <tspan
-                        dx="4"
-                        fill="hsla(204, 9%, 42%, 1)"
-                        font-weight="400"
-                      >
-                        900  (13%)
-                      </tspan>
-                    </text>
-                  </g>
-                </g>
+                    7.2k
+                  </tspan>
+                </text>
               </g>
             </g>
-          </svg>
-        </div>
-      </div>
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <g
+              opacity="1"
+              style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            >
+              <rect
+                fill="hsla(149, 38%, 86%, 1)"
+                height="40"
+                rx="0"
+                style="cursor: pointer;"
+                width="14"
+                x="309"
+                y="7.999999999999998"
+              />
+              <g
+                style="pointer-events: none;"
+              >
+                <rect
+                  fill="hsla(0, 0%, 100%, 1)"
+                  height="27"
+                  rx="8"
+                  stroke="hsla(206, 10%, 29%, 0.18)"
+                  stroke-width="1"
+                  width="90.35546875"
+                  x="331.5"
+                  y="14.5"
+                />
+                <text
+                  font-size="12"
+                  style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
+                  x="339"
+                  y="32.32"
+                >
+                  <tspan
+                    fill="hsla(0, 0%, 2%, 1)"
+                    font-weight="600"
+                  >
+                    UPI
+                  </tspan>
+                  <tspan
+                    dx="4"
+                    fill="hsla(204, 9%, 42%, 1)"
+                    font-weight="400"
+                  >
+                    4k  (56%)
+                  </tspan>
+                </text>
+              </g>
+            </g>
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <g
+              opacity="1"
+              style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            >
+              <rect
+                fill="hsla(46, 86%, 83%, 1)"
+                height="32"
+                rx="0"
+                style="cursor: pointer;"
+                width="14"
+                x="309"
+                y="60"
+              />
+              <g
+                style="pointer-events: none;"
+              >
+                <rect
+                  fill="hsla(0, 0%, 100%, 1)"
+                  height="27"
+                  rx="8"
+                  stroke="hsla(206, 10%, 29%, 0.18)"
+                  stroke-width="1"
+                  width="107.69921875"
+                  x="331.5"
+                  y="62.5"
+                />
+                <text
+                  font-size="12"
+                  style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
+                  x="339"
+                  y="80.32"
+                >
+                  <tspan
+                    fill="hsla(0, 0%, 2%, 1)"
+                    font-weight="600"
+                  >
+                    Card
+                  </tspan>
+                  <tspan
+                    dx="4"
+                    fill="hsla(204, 9%, 42%, 1)"
+                    font-weight="400"
+                  >
+                    3.2k  (44%)
+                  </tspan>
+                </text>
+              </g>
+            </g>
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <g
+              opacity="1"
+              style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            >
+              <rect
+                fill="hsla(264, 100%, 89%, 1)"
+                height="63"
+                rx="0"
+                style="cursor: pointer;"
+                width="14"
+                x="610"
+                y="8.000000000000004"
+              />
+              <g
+                style="pointer-events: none;"
+              >
+                <rect
+                  fill="hsla(0, 0%, 100%, 1)"
+                  height="27"
+                  rx="8"
+                  stroke="hsla(206, 10%, 29%, 0.18)"
+                  stroke-width="1"
+                  width="143.72265625"
+                  x="632.5"
+                  y="26"
+                />
+                <text
+                  font-size="12"
+                  style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
+                  x="640"
+                  y="43.82"
+                >
+                  <tspan
+                    fill="hsla(0, 0%, 2%, 1)"
+                    font-weight="600"
+                  >
+                    Successful
+                  </tspan>
+                  <tspan
+                    dx="4"
+                    fill="hsla(204, 9%, 42%, 1)"
+                    font-weight="400"
+                  >
+                    6.3k  (88%)
+                  </tspan>
+                </text>
+              </g>
+            </g>
+          </g>
+          <g
+            class="recharts-layer"
+          >
+            <g
+              opacity="1"
+              style="transition: opacity 200ms cubic-bezier(0.3, 0, 0.2, 1);"
+            >
+              <rect
+                fill="hsla(24, 100%, 92%, 1)"
+                height="9"
+                rx="0"
+                style="cursor: pointer;"
+                width="14"
+                x="610"
+                y="83"
+              />
+              <g
+                style="pointer-events: none;"
+              >
+                <rect
+                  fill="hsla(0, 0%, 100%, 1)"
+                  height="27"
+                  rx="8"
+                  stroke="hsla(206, 10%, 29%, 0.18)"
+                  stroke-width="1"
+                  width="112.375"
+                  x="632.5"
+                  y="74"
+                />
+                <text
+                  font-size="12"
+                  style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
+                  x="640"
+                  y="91.82"
+                >
+                  <tspan
+                    fill="hsla(0, 0%, 2%, 1)"
+                    font-weight="600"
+                  >
+                    Failed
+                  </tspan>
+                  <tspan
+                    dx="4"
+                    fill="hsla(204, 9%, 42%, 1)"
+                    font-weight="400"
+                  >
+                    900  (13%)
+                  </tspan>
+                </text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
     </div>
   </div>
 </div>

--- a/packages/blade/src/components/Charts/SankeyChart/tokens.ts
+++ b/packages/blade/src/components/Charts/SankeyChart/tokens.ts
@@ -41,13 +41,6 @@ export const NODE_DIMMED_OPACITY = 0.3;
 export const TOOLTIP_Z_INDEX = 100;
 
 // ── Responsive layout ─────────────────────────────────────────────────────────
-/**
- * Minimum SVG render width in px. Sized for a 4-level chart with label chips
- * (~4 columns × ~120px column gap + NODE_WIDTH + chip margin).
- * Below this the Sankey layout collapses; the scroll wrapper kicks in instead.
- */
-export const MIN_CHART_WIDTH = 560;
-
 // ── Label vertical alignment ──────────────────────────────────────────────────
 /**
  * Cap-height ratio for the Inter font family.


### PR DESCRIPTION
## Problem

`ChartSankeyWrapper` wrapped its content in a `BaseBox` with `overflowX="auto"` and a `minWidth={560}` inner box. On viewports narrower than 560px this caused a horizontal scrollbar to appear inside the card, rather than the card wrapping the chart naturally.

## Fix

Remove the scroll wrapper entirely. `ResponsiveContainer` now sits directly inside the outer `BaseBox` with `width="100%" height="100%"`. The chart fills whatever space the consumer gives it — width is controlled by the outer `<Box>` (BoxProps), height is consumer-controlled the same way.

No risk of blank/white space: Recharts' Sankey always fills the given height.

## Changes

- `SankeyChart.web.tsx` — removed scroll wrapper, removed `MIN_CHART_WIDTH` import
- `tokens.ts` — removed dead `MIN_CHART_WIDTH` export
- `SankeyChart.web.test.tsx` — updated layout test to assert no overflow scroll wrapper
- `__snapshots__/SankeyChart.web.test.tsx.snap` — updated for flatter DOM
- `.changeset/fix-sankey-scroll-wrapper.md` — patch changeset

## Test plan

- [x] All 25 unit tests pass
- [x] Snapshot updated
- [x] No TypeScript or ESLint errors