### PR TITLE
fix(GenUI): add duplicate markdown table cleanup

### DIFF
--- a/.changeset/silver-tables-listen.md
+++ b/.changeset/silver-tables-listen.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(blade): add opt-in GenUI duplicate markdown table handling

--- a/packages/blade/src/components/GenUI/GenUI.stories.tsx
+++ b/packages/blade/src/components/GenUI/GenUI.stories.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useRef } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import type { StoryFn, Meta } from '@storybook/react-vite';
 import { jsonrepair } from 'jsonrepair';
 import { GenUIProvider } from './GenUIProvider';
 import { GenUISchemaRenderer } from './GenUISchemaRenderer';
+import type { GenUIComponent } from './GenUIComponents';
 import { Box } from '~components/Box';
 import type { BoxProps } from '~components/Box';
 import { getBoxArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
+import { ChevronUpDownIcon } from '~components/Icons';
 import { Text } from '~components/Typography';
 
 export default {
@@ -601,6 +603,399 @@ TextString.argTypes = {
     control: 'text',
   },
 };
+
+const merchantDuplicateMarkdownTableScenarios: Array<{
+  title: string;
+  components: GenUIComponent[];
+}> = [
+  {
+    title: 'Failed Payments',
+    components: [
+      {
+        component: 'TEXT',
+        content:
+          'You have 4 failed payments in total. Here they are:\n\n' +
+          '| # | Payment ID | Amount | Status | Contact | Date |\n' +
+          '|---|---|---|---|---|---|\n' +
+          '| 1 | pay_SOJ4XrMPRKtO4g | INR 5.00 | Failed | +917636802936 | 07 Mar, 04:12 PM |\n' +
+          '| 2 | pay_SMeXeyPnHOZbpE | INR 10.00 | Failed | +918806922557 | 03 Mar, 11:54 AM |\n\n' +
+          'All failures occurred in early March 2026.',
+      },
+      {
+        component: 'TABLE',
+        headers: ['Payment ID', 'Amount', 'Status', 'Contact', 'Date'],
+        rows: [
+          [
+            { component: 'LINK', text: 'pay_SOJ4XrMPRKtO4g' },
+            { component: 'TEXT', value: 'INR 5.00' },
+            { component: 'BADGE', value: 'Failed', color: 'negative' },
+            { component: 'TEXT', value: '+917636802936' },
+            { component: 'TEXT', value: '07 Mar, 04:12 PM' },
+          ],
+          [
+            { component: 'LINK', text: 'pay_SMeXeyPnHOZbpE' },
+            { component: 'TEXT', value: 'INR 10.00' },
+            { component: 'BADGE', value: 'Failed', color: 'negative' },
+            { component: 'TEXT', value: '+918806922557' },
+            { component: 'TEXT', value: '03 Mar, 11:54 AM' },
+          ],
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Refund Fees',
+    components: [
+      {
+        component: 'TEXT',
+        content:
+          "Here's the fee breakdown for each of your last 10 refunds:\n\n" +
+          '| Refund ID | Payment ID | Refund Amount | Fee | Tax | Total Fee |\n' +
+          '|---|---|---|---|---|---|\n' +
+          '| rfnd_SpHOaENSuADPyV | pay_SpBSOTesHIlrPt | INR 1599.00 | INR 37.74 | INR 5.76 | INR 43.50 |\n' +
+          '| rfnd_So4XV4d9LYZoVB | pay_SnzmL9T5y8xc25 | INR 10.00 | INR 0.12 | INR 0.02 | INR 0.14 |\n\n' +
+          'Total fees across all 10 refunds: INR 46.95.',
+      },
+      {
+        component: 'TABLE',
+        headers: ['Refund ID', 'Payment ID', 'Refund Amount', 'Fee', 'Tax', 'Total Fee'],
+        rows: [
+          [
+            { component: 'LINK', text: 'rfnd_SpHOaENSuADPyV' },
+            { component: 'LINK', text: 'pay_SpBSOTesHIlrPt' },
+            { component: 'TEXT', value: 'INR 1599.00' },
+            { component: 'TEXT', value: 'INR 37.74' },
+            { component: 'TEXT', value: 'INR 5.76' },
+            { component: 'TEXT', value: 'INR 43.50' },
+          ],
+          [
+            { component: 'LINK', text: 'rfnd_So4XV4d9LYZoVB' },
+            { component: 'LINK', text: 'pay_SnzmL9T5y8xc25' },
+            { component: 'TEXT', value: 'INR 10.00' },
+            { component: 'TEXT', value: 'INR 0.12' },
+            { component: 'TEXT', value: 'INR 0.02' },
+            { component: 'TEXT', value: 'INR 0.14' },
+          ],
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Settlements by Year',
+    components: [
+      {
+        component: 'TEXT',
+        content:
+          'Settlements in 2026:\n\n' +
+          '| Settlement ID | Amount | Status | Date |\n' +
+          '|---|---|---|---|\n' +
+          '| setl_2026A1 | INR 12850.00 | Processed | 14 Mar 2026 |\n' +
+          '| setl_2026B2 | INR 9640.00 | Processed | 22 Apr 2026 |\n\n' +
+          'Settlements in 2025:\n\n' +
+          '| Settlement ID | Amount | Status | Date |\n' +
+          '|---|---|---|---|\n' +
+          '| setl_2025A1 | INR 11220.00 | Processed | 18 Mar 2025 |\n' +
+          '| setl_2025B2 | INR 8730.00 | Processed | 28 Apr 2025 |',
+      },
+      {
+        component: 'TABLE',
+        headers: ['Settlement ID', 'Amount', 'Status', 'Date'],
+        rows: [
+          [
+            { component: 'LINK', text: 'setl_2026A1' },
+            { component: 'TEXT', value: 'INR 12850.00' },
+            { component: 'BADGE', value: 'Processed', color: 'positive' },
+            { component: 'TEXT', value: '14 Mar 2026' },
+          ],
+          [
+            { component: 'LINK', text: 'setl_2026B2' },
+            { component: 'TEXT', value: 'INR 9640.00' },
+            { component: 'BADGE', value: 'Processed', color: 'positive' },
+            { component: 'TEXT', value: '22 Apr 2026' },
+          ],
+        ],
+      },
+      {
+        component: 'TABLE',
+        headers: ['Settlement ID', 'Amount', 'Status', 'Date'],
+        rows: [
+          [
+            { component: 'LINK', text: 'setl_2025A1' },
+            { component: 'TEXT', value: 'INR 11220.00' },
+            { component: 'BADGE', value: 'Processed', color: 'positive' },
+            { component: 'TEXT', value: '18 Mar 2025' },
+          ],
+          [
+            { component: 'LINK', text: 'setl_2025B2' },
+            { component: 'TEXT', value: 'INR 8730.00' },
+            { component: 'BADGE', value: 'Processed', color: 'positive' },
+            { component: 'TEXT', value: '28 Apr 2025' },
+          ],
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Payment Health',
+    components: [
+      {
+        component: 'TEXT',
+        content:
+          "Here's an analysis of your payment health:\n\n" +
+          '| Metric | Value |\n' +
+          '|---|---|\n' +
+          '| Total Successful Payments | 7 |\n' +
+          '| Total Volume Collected | INR 1835.00 |\n' +
+          '| Failed Payments | 4 |\n' +
+          '| Success Rate | 64% |\n\n' +
+          'Moderate concern: success rate is below the usual healthy range.',
+      },
+      {
+        component: 'TABLE',
+        headers: ['Metric', 'Value'],
+        rows: [
+          [
+            { component: 'TEXT', value: 'Total Successful Payments' },
+            { component: 'TEXT', value: '7' },
+          ],
+          [
+            { component: 'TEXT', value: 'Total Volume Collected' },
+            { component: 'TEXT', value: 'INR 1835.00' },
+          ],
+          [
+            { component: 'TEXT', value: 'Failed Payments' },
+            { component: 'TEXT', value: '4' },
+          ],
+          [
+            { component: 'TEXT', value: 'Success Rate' },
+            { component: 'TEXT', value: '64%' },
+          ],
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Standalone Markdown Table Preserved',
+    components: [
+      {
+        component: 'TEXT',
+        content:
+          'This reference table has no matching GenUI table and should remain visible:\n\n' +
+          '| Field | Meaning |\n' +
+          '|---|---|\n' +
+          '| id | Internal identifier |',
+      },
+    ],
+  },
+];
+
+const MerchantDuplicateMarkdownTableComparison = ({
+  title,
+  components,
+}: {
+  title: string;
+  components: GenUIComponent[];
+}): JSX.Element => {
+  const [sliderPosition, setSliderPosition] = useState(50);
+  const [isSliding, setIsSliding] = useState(false);
+  const [frameWidth, setFrameWidth] = useState<number | undefined>();
+  const frameRef = useRef<HTMLDivElement>(null);
+  const comparisonTransition =
+    'left 140ms cubic-bezier(0.2, 0, 0, 1), width 140ms cubic-bezier(0.2, 0, 0, 1)';
+
+  useEffect(() => {
+    const frame = frameRef.current;
+    if (!frame) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      setFrameWidth(entry.contentRect.width);
+    });
+    resizeObserver.observe(frame);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.4">
+      <Text size="large" weight="semibold">
+        {title}
+      </Text>
+      <div
+        ref={frameRef}
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          minHeight: '320px',
+          border: '1px solid #D7D9DD',
+          borderRadius: '8px',
+          backgroundColor: '#F9F9F7',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '12px',
+            left: '12px',
+            zIndex: 3,
+            padding: '6px 12px',
+            borderRadius: '8px',
+            backgroundColor: '#FFFFFF',
+          }}
+        >
+          <Text size="small" weight="semibold" color="surface.text.gray.subtle">
+            Before
+          </Text>
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            right: '12px',
+            bottom: '12px',
+            zIndex: 3,
+            padding: '6px 12px',
+            borderRadius: '8px',
+            backgroundColor: '#FFFFFF',
+          }}
+        >
+          <Text size="small" weight="semibold" color="surface.text.gray.subtle">
+            After
+          </Text>
+        </div>
+        <div style={{ padding: '20px', overflow: 'auto' }}>
+          <GenUIProvider>
+            <GenUISchemaRenderer
+              isAnimating={false}
+              components={components}
+              duplicateMarkdownTableHandling={{ isEnabled: true }}
+            />
+          </GenUIProvider>
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: 0,
+            width: `${sliderPosition}%`,
+            overflow: 'hidden',
+            backgroundColor: '#F9F9F7',
+            transition: comparisonTransition,
+          }}
+        >
+          <div
+            style={{
+              width: frameWidth ? `${frameWidth}px` : '100%',
+              padding: '20px',
+              overflow: 'auto',
+              boxSizing: 'border-box',
+            }}
+          >
+            <GenUIProvider>
+              <GenUISchemaRenderer isAnimating={false} components={components} />
+            </GenUIProvider>
+          </div>
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: `${sliderPosition}%`,
+            zIndex: 2,
+            width: '2px',
+            backgroundColor: '#0B72E7',
+            transform: 'translateX(-50%)',
+            transition: comparisonTransition,
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: `${sliderPosition}%`,
+            zIndex: 3,
+            display: 'flex',
+            width: '40px',
+            height: '40px',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: '1px solid #D7D9DD',
+            borderRadius: '10px',
+            backgroundColor: '#FFFFFF',
+            boxShadow: isSliding
+              ? '0 8px 20px rgba(15, 23, 42, 0.18)'
+              : '0 2px 8px rgba(15, 23, 42, 0.14)',
+            transform: `translate(-50%, -50%) scale(${isSliding ? 1.06 : 1})`,
+            transition: `${comparisonTransition}, box-shadow 140ms cubic-bezier(0.2, 0, 0, 1), transform 140ms cubic-bezier(0.2, 0, 0, 1)`,
+          }}
+        >
+          <div style={{ display: 'flex', transform: 'rotate(90deg)' }}>
+            <ChevronUpDownIcon size="large" color="surface.icon.gray.subtle" />
+          </div>
+        </div>
+        <input
+          aria-label={`${title} comparison slider`}
+          min="0"
+          max="100"
+          type="range"
+          value={sliderPosition}
+          onChange={(event) => setSliderPosition(Number(event.target.value))}
+          onPointerDown={() => setIsSliding(true)}
+          onPointerUp={() => setIsSliding(false)}
+          onPointerCancel={() => setIsSliding(false)}
+          onBlur={() => setIsSliding(false)}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            opacity: 0,
+            zIndex: 4,
+            width: '100%',
+            height: '100%',
+            cursor: 'ew-resize',
+          }}
+        />
+      </div>
+    </Box>
+  );
+};
+
+const MerchantDuplicateMarkdownTableTemplate: StoryFn<typeof GenUISchemaRenderer> = () => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap="spacing.9"
+      maxWidth="1200px"
+      padding="spacing.5"
+    >
+      <Box display="flex" flexDirection="column" gap="spacing.3">
+        <Text size="xlarge" weight="semibold">
+          Duplicate Markdown Table Regression
+        </Text>
+        <Text size="medium" color="surface.text.gray.subtle">
+          Use this story to compare today&apos;s raw pipe-table leak with the opt-in renderer safety
+          net.
+        </Text>
+        <Text size="medium" color="surface.text.gray.subtle">
+          Drag each slider to reveal before and after.
+        </Text>
+      </Box>
+      {merchantDuplicateMarkdownTableScenarios.map((scenario) => (
+        <MerchantDuplicateMarkdownTableComparison
+          key={scenario.title}
+          title={scenario.title}
+          components={scenario.components}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export const MerchantDuplicateMarkdownTableRegression = MerchantDuplicateMarkdownTableTemplate.bind(
+  {},
+);
 
 const defaultTableRowActions = [
   {

--- a/packages/blade/src/components/GenUI/GenUI.stories.tsx
+++ b/packages/blade/src/components/GenUI/GenUI.stories.tsx
@@ -806,7 +806,7 @@ const MerchantDuplicateMarkdownTableComparison = ({
   useEffect(() => {
     const frame = frameRef.current;
     if (!frame) {
-      return;
+      return undefined;
     }
 
     const resizeObserver = new ResizeObserver(([entry]) => {

--- a/packages/blade/src/components/GenUI/GenUI.stories.tsx
+++ b/packages/blade/src/components/GenUI/GenUI.stories.tsx
@@ -868,7 +868,7 @@ const MerchantDuplicateMarkdownTableComparison = ({
             <GenUISchemaRenderer
               isAnimating={false}
               components={components}
-              duplicateMarkdownTableHandling={{ isEnabled: true }}
+              isDuplicateMarkdownTableHandlingEnabled={true}
             />
           </GenUIProvider>
         </div>

--- a/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
+++ b/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import React, { memo, useState, useEffect, useRef, useCallback } from 'react';
+import React, { memo, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import styled, { createGlobalStyle, keyframes } from 'styled-components';
 import type { GenUIComponent } from './GenUIComponents';
 import { useGenUI, GenUIContext } from './GenUIContext';
 import { getGenUIComponentTopSpacing } from './GenUISpacing';
 import type { AnimateOptions } from './rehypeAnimate';
+import { applyDuplicateMarkdownTableHandling } from './duplicateMarkdownTableHandling';
+import type { GenUIDuplicateMarkdownTableEvent } from './duplicateMarkdownTableHandling';
 import { Box } from '~components/Box';
 import { useResize } from '~utils/useResize';
 
@@ -336,6 +338,11 @@ type GenUISchemaRendererProps = {
   isAnimating?: boolean;
   /** Animation options for text streaming */
   animateOptions?: AnimateOptions;
+  /** Removes duplicate markdown pipe tables from TEXT when a matching structured TABLE exists */
+  duplicateMarkdownTableHandling?: {
+    isEnabled?: boolean;
+    onEvent?: (event: GenUIDuplicateMarkdownTableEvent) => void;
+  };
 };
 
 /**
@@ -350,10 +357,50 @@ type GenUISchemaRendererProps = {
  * ```
  */
 const GenUISchemaRenderer = memo(
-  ({ components, isAnimating, animateOptions }: GenUISchemaRendererProps) => {
+  ({
+    components,
+    isAnimating,
+    animateOptions,
+    duplicateMarkdownTableHandling,
+  }: GenUISchemaRendererProps) => {
     const parentContext = useGenUI();
+    const emittedDuplicateMarkdownTableEventKeysRef = useRef(new Set<string>());
+    const duplicateMarkdownTableHandlingResult = useMemo(
+      () =>
+        applyDuplicateMarkdownTableHandling(
+          components,
+          duplicateMarkdownTableHandling?.isEnabled ?? false,
+        ),
+      [components, duplicateMarkdownTableHandling?.isEnabled],
+    );
+    const componentsToRender = duplicateMarkdownTableHandlingResult.components;
 
-    if (!components || components.length === 0) {
+    useEffect(() => {
+      emittedDuplicateMarkdownTableEventKeysRef.current.clear();
+    }, [components]);
+
+    useEffect(() => {
+      if (!duplicateMarkdownTableHandling?.isEnabled || !duplicateMarkdownTableHandling.onEvent) {
+        return;
+      }
+
+      duplicateMarkdownTableHandlingResult.events.forEach((event) => {
+        const eventKey = `${event.textComponentPath.join('.')}:${event.tableFingerprint}`;
+        if (emittedDuplicateMarkdownTableEventKeysRef.current.has(eventKey)) {
+          return;
+        }
+
+        emittedDuplicateMarkdownTableEventKeysRef.current.add(eventKey);
+        duplicateMarkdownTableHandling.onEvent?.(event);
+      });
+    }, [
+      duplicateMarkdownTableHandling,
+      duplicateMarkdownTableHandlingResult.events,
+      duplicateMarkdownTableHandling?.isEnabled,
+      duplicateMarkdownTableHandling?.onEvent,
+    ]);
+
+    if (!componentsToRender || componentsToRender.length === 0) {
       return null;
     }
 
@@ -367,8 +414,8 @@ const GenUISchemaRenderer = memo(
     return (
       <GenUIContext.Provider value={contextValue}>
         <>
-          {components.map((component, index) => {
-            const marginTop = getGenUIComponentTopSpacing(components[index - 1], component);
+          {componentsToRender.map((component, index) => {
+            const marginTop = getGenUIComponentTopSpacing(componentsToRender[index - 1], component);
 
             return (
               <Box key={getComponentKey(component, index)} marginTop={marginTop}>

--- a/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
+++ b/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
@@ -376,15 +376,23 @@ const GenUISchemaRenderer = memo(
     const componentsToRender = duplicateMarkdownTableHandlingResult.components;
 
     useEffect(() => {
-      emittedDuplicateMarkdownTableEventKeysRef.current.clear();
-    }, [components]);
-
-    useEffect(() => {
       if (
         !duplicateMarkdownTableHandling?.isEnabled ||
         !duplicateMarkdownTableHandling.onDuplicateMarkdownTableRemoved
       ) {
         return;
+      }
+
+      const currentEventKeys = new Set(
+        duplicateMarkdownTableHandlingResult.events.map(
+          (event) => `${event.textComponentPath.join('.')}:${event.tableFingerprint}`,
+        ),
+      );
+
+      for (const key of emittedDuplicateMarkdownTableEventKeysRef.current) {
+        if (!currentEventKeys.has(key)) {
+          emittedDuplicateMarkdownTableEventKeysRef.current.delete(key);
+        }
       }
 
       duplicateMarkdownTableHandlingResult.events.forEach((event) => {

--- a/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
+++ b/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
@@ -339,10 +339,9 @@ type GenUISchemaRendererProps = {
   /** Animation options for text streaming */
   animateOptions?: AnimateOptions;
   /** Removes duplicate markdown pipe tables from TEXT when a matching structured TABLE exists */
-  duplicateMarkdownTableHandling?: {
-    isEnabled?: boolean;
-    onDuplicateMarkdownTableRemoved?: (event: GenUIDuplicateMarkdownTableEvent) => void;
-  };
+  isDuplicateMarkdownTableHandlingEnabled?: boolean;
+  /** Callback fired when a duplicate markdown table is removed */
+  onDuplicateMarkdownTableRemoved?: (event: GenUIDuplicateMarkdownTableEvent) => void;
 };
 
 /**
@@ -361,7 +360,8 @@ const GenUISchemaRenderer = memo(
     components,
     isAnimating,
     animateOptions,
-    duplicateMarkdownTableHandling,
+    isDuplicateMarkdownTableHandlingEnabled,
+    onDuplicateMarkdownTableRemoved,
   }: GenUISchemaRendererProps) => {
     const parentContext = useGenUI();
     const emittedDuplicateMarkdownTableEventKeysRef = useRef(new Set<string>());
@@ -369,17 +369,14 @@ const GenUISchemaRenderer = memo(
       () =>
         applyDuplicateMarkdownTableHandling(
           components,
-          duplicateMarkdownTableHandling?.isEnabled ?? false,
+          isDuplicateMarkdownTableHandlingEnabled ?? false,
         ),
-      [components, duplicateMarkdownTableHandling?.isEnabled],
+      [components, isDuplicateMarkdownTableHandlingEnabled],
     );
     const componentsToRender = duplicateMarkdownTableHandlingResult.components;
 
     useEffect(() => {
-      if (
-        !duplicateMarkdownTableHandling?.isEnabled ||
-        !duplicateMarkdownTableHandling.onDuplicateMarkdownTableRemoved
-      ) {
+      if (!isDuplicateMarkdownTableHandlingEnabled || !onDuplicateMarkdownTableRemoved) {
         return;
       }
 
@@ -402,12 +399,12 @@ const GenUISchemaRenderer = memo(
         }
 
         emittedDuplicateMarkdownTableEventKeysRef.current.add(eventKey);
-        duplicateMarkdownTableHandling.onDuplicateMarkdownTableRemoved?.(event);
+        onDuplicateMarkdownTableRemoved(event);
       });
     }, [
       duplicateMarkdownTableHandlingResult.events,
-      duplicateMarkdownTableHandling?.isEnabled,
-      duplicateMarkdownTableHandling?.onDuplicateMarkdownTableRemoved,
+      isDuplicateMarkdownTableHandlingEnabled,
+      onDuplicateMarkdownTableRemoved,
     ]);
 
     if (!componentsToRender || componentsToRender.length === 0) {

--- a/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
+++ b/packages/blade/src/components/GenUI/GenUISchemaRenderer.web.tsx
@@ -341,7 +341,7 @@ type GenUISchemaRendererProps = {
   /** Removes duplicate markdown pipe tables from TEXT when a matching structured TABLE exists */
   duplicateMarkdownTableHandling?: {
     isEnabled?: boolean;
-    onEvent?: (event: GenUIDuplicateMarkdownTableEvent) => void;
+    onDuplicateMarkdownTableRemoved?: (event: GenUIDuplicateMarkdownTableEvent) => void;
   };
 };
 
@@ -380,7 +380,10 @@ const GenUISchemaRenderer = memo(
     }, [components]);
 
     useEffect(() => {
-      if (!duplicateMarkdownTableHandling?.isEnabled || !duplicateMarkdownTableHandling.onEvent) {
+      if (
+        !duplicateMarkdownTableHandling?.isEnabled ||
+        !duplicateMarkdownTableHandling.onDuplicateMarkdownTableRemoved
+      ) {
         return;
       }
 
@@ -391,13 +394,12 @@ const GenUISchemaRenderer = memo(
         }
 
         emittedDuplicateMarkdownTableEventKeysRef.current.add(eventKey);
-        duplicateMarkdownTableHandling.onEvent?.(event);
+        duplicateMarkdownTableHandling.onDuplicateMarkdownTableRemoved?.(event);
       });
     }, [
-      duplicateMarkdownTableHandling,
       duplicateMarkdownTableHandlingResult.events,
       duplicateMarkdownTableHandling?.isEnabled,
-      duplicateMarkdownTableHandling?.onEvent,
+      duplicateMarkdownTableHandling?.onDuplicateMarkdownTableRemoved,
     ]);
 
     if (!componentsToRender || componentsToRender.length === 0) {

--- a/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
+++ b/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
@@ -1155,19 +1155,22 @@ describe('<GenUI />', () => {
     });
 
     it('should emit duplicate markdown table removal events without merchant row data', () => {
-      const onEvent = jest.fn();
+      const onDuplicateMarkdownTableRemoved = jest.fn();
 
       renderWithTheme(
         <GenUIProvider>
           <GenUISchemaRenderer
             components={duplicatePaymentTableComponents}
-            duplicateMarkdownTableHandling={{ isEnabled: true, onEvent }}
+            duplicateMarkdownTableHandling={{
+              isEnabled: true,
+              onDuplicateMarkdownTableRemoved,
+            }}
           />
         </GenUIProvider>,
       );
 
-      expect(onEvent).toHaveBeenCalledTimes(1);
-      expect(onEvent).toHaveBeenCalledWith({
+      expect(onDuplicateMarkdownTableRemoved).toHaveBeenCalledTimes(1);
+      expect(onDuplicateMarkdownTableRemoved).toHaveBeenCalledWith({
         type: 'DUPLICATE_MARKDOWN_TABLE_REMOVED',
         textComponentPath: [0],
         tableComponentPath: [1],
@@ -1175,7 +1178,9 @@ describe('<GenUI />', () => {
         tableFingerprint: '1:paymentid|amount|status|contact|date',
         reason: 'MATCHED_STRUCTURED_TABLE',
       });
-      expect(JSON.stringify(onEvent.mock.calls[0][0])).not.toContain('pay_SOJ4XrMPRKtO4g');
+      expect(
+        JSON.stringify(onDuplicateMarkdownTableRemoved.mock.calls[0][0]),
+      ).not.toContain('pay_SOJ4XrMPRKtO4g');
     });
 
     it('should remove duplicate markdown table text even when TEXT appears after TABLE', () => {

--- a/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
+++ b/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
@@ -1138,7 +1138,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={duplicatePaymentTableComponents}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1161,10 +1161,8 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={duplicatePaymentTableComponents}
-            duplicateMarkdownTableHandling={{
-              isEnabled: true,
-              onDuplicateMarkdownTableRemoved,
-            }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
+            onDuplicateMarkdownTableRemoved={onDuplicateMarkdownTableRemoved}
           />
         </GenUIProvider>,
       );
@@ -1193,7 +1191,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1218,7 +1216,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1244,7 +1242,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1269,7 +1267,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1296,7 +1294,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1327,7 +1325,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1370,7 +1368,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1432,7 +1430,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1500,7 +1498,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );
@@ -1531,7 +1529,7 @@ describe('<GenUI />', () => {
         <GenUIProvider>
           <GenUISchemaRenderer
             components={components}
-            duplicateMarkdownTableHandling={{ isEnabled: true }}
+            isDuplicateMarkdownTableHandlingEnabled={true}
           />
         </GenUIProvider>,
       );

--- a/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
+++ b/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
@@ -1178,9 +1178,9 @@ describe('<GenUI />', () => {
         tableFingerprint: '1:paymentid|amount|status|contact|date',
         reason: 'MATCHED_STRUCTURED_TABLE',
       });
-      expect(
-        JSON.stringify(onDuplicateMarkdownTableRemoved.mock.calls[0][0]),
-      ).not.toContain('pay_SOJ4XrMPRKtO4g');
+      expect(JSON.stringify(onDuplicateMarkdownTableRemoved.mock.calls[0][0])).not.toContain(
+        'pay_SOJ4XrMPRKtO4g',
+      );
     });
 
     it('should remove duplicate markdown table text even when TEXT appears after TABLE', () => {

--- a/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
+++ b/packages/blade/src/components/GenUI/__tests__/GenUI.web.test.tsx
@@ -1086,6 +1086,456 @@ describe('<GenUI />', () => {
     });
   });
 
+  describe('duplicate markdown table handling', () => {
+    const duplicatePaymentTableComponents: GenUIComponent[] = [
+      {
+        component: 'TEXT',
+        content:
+          'You have 4 failed payments in total. Here they are:\n\n' +
+          '| # | Payment ID | Amount | Status | Contact | Date |\n' +
+          '|---|---|---|---|---|---|\n' +
+          '| 1 | pay_SOJ4XrMPRKtO4g | INR 5.00 | Failed | +917636802936 | 7 Mar 2026 |\n' +
+          '| 2 | pay_SMeXeyPnHOZbpE | INR 10.00 | Failed | +918806922557 | 3 Mar 2026 |\n\n' +
+          'All failures occurred in early March 2026.',
+      },
+      {
+        component: 'TABLE',
+        headers: ['Payment ID', 'Amount', 'Status', 'Contact', 'Date'],
+        rows: [
+          [
+            { component: 'LINK', text: 'pay_SOJ4XrMPRKtO4g' },
+            { component: 'TEXT', value: 'INR 5.00' },
+            { component: 'BADGE', value: 'Failed', color: 'negative' },
+            { component: 'TEXT', value: '+917636802936' },
+            { component: 'TEXT', value: '7 Mar 2026' },
+          ],
+          [
+            { component: 'LINK', text: 'pay_SMeXeyPnHOZbpE' },
+            { component: 'TEXT', value: 'INR 10.00' },
+            { component: 'BADGE', value: 'Failed', color: 'negative' },
+            { component: 'TEXT', value: '+918806922557' },
+            { component: 'TEXT', value: '3 Mar 2026' },
+          ],
+        ],
+      },
+    ];
+
+    it('should keep duplicate markdown table text by default', () => {
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer components={duplicatePaymentTableComponents} />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain(
+        '| # | Payment ID | Amount | Status | Contact | Date |',
+      );
+      expect(container.textContent).toContain('|---|---|---|---|---|---|');
+    });
+
+    it('should remove duplicate markdown table text when opt-in handling is enabled', () => {
+      const { container, getByText } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={duplicatePaymentTableComponents}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain(
+        'You have 4 failed payments in total. Here they are:',
+      );
+      expect(container.textContent).toContain('All failures occurred in early March 2026.');
+      expect(getByText('pay_SOJ4XrMPRKtO4g')).toBeInTheDocument();
+      expect(container.textContent).not.toContain(
+        '| # | Payment ID | Amount | Status | Contact | Date |',
+      );
+      expect(container.textContent).not.toContain('|---|---|---|---|---|---|');
+    });
+
+    it('should emit duplicate markdown table removal events without merchant row data', () => {
+      const onEvent = jest.fn();
+
+      renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={duplicatePaymentTableComponents}
+            duplicateMarkdownTableHandling={{ isEnabled: true, onEvent }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+      expect(onEvent).toHaveBeenCalledWith({
+        type: 'DUPLICATE_MARKDOWN_TABLE_REMOVED',
+        textComponentPath: [0],
+        tableComponentPath: [1],
+        removedBlockCount: 1,
+        tableFingerprint: '1:paymentid|amount|status|contact|date',
+        reason: 'MATCHED_STRUCTURED_TABLE',
+      });
+      expect(JSON.stringify(onEvent.mock.calls[0][0])).not.toContain('pay_SOJ4XrMPRKtO4g');
+    });
+
+    it('should remove duplicate markdown table text even when TEXT appears after TABLE', () => {
+      const components = [
+        duplicatePaymentTableComponents[1],
+        duplicatePaymentTableComponents[0],
+      ] as GenUIComponent[];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).not.toContain('|---|---|---|---|---|---|');
+      expect(container.textContent).toContain('All failures occurred in early March 2026.');
+    });
+
+    it('should preserve standalone markdown tables when no structured table exists', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            'Reference table:\n\n' +
+            '| Field | Meaning |\n' +
+            '|---|---|\n' +
+            '| id | Internal identifier |',
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain('| Field | Meaning |');
+      expect(container.textContent).toContain('| id | Internal identifier |');
+    });
+
+    it('should preserve markdown tables when headers do not match the structured table', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            'Reference table:\n\n' +
+            '| Field | Meaning |\n' +
+            '|---|---|\n' +
+            '| id | Internal identifier |',
+        },
+        duplicatePaymentTableComponents[1],
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain('| Field | Meaning |');
+      expect(container.textContent).toContain('| id | Internal identifier |');
+    });
+
+    it('should preserve incomplete markdown table fragments during streaming', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            '| Payment ID | Amount | Status |\n' +
+            '|---|---|---|\n' +
+            '| pay_SOJ4XrMPRKtO4g | INR 5.00',
+        },
+        duplicatePaymentTableComponents[1],
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain('| Payment ID | Amount | Status |');
+      expect(container.textContent).toContain('| pay_SOJ4XrMPRKtO4g | INR 5.00');
+    });
+
+    it('should preserve matching markdown tables inside fenced code blocks', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            '```md\n' +
+            '| Payment ID | Amount | Status |\n' +
+            '|---|---|---|\n' +
+            '| pay_SOJ4XrMPRKtO4g | INR 5.00 | Failed |\n' +
+            '```',
+        },
+        duplicatePaymentTableComponents[1],
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain('| Payment ID | Amount | Status |');
+      expect(container.textContent).toContain('| pay_SOJ4XrMPRKtO4g | INR 5.00 | Failed |');
+    });
+
+    it('should remove only the matching markdown table when a TEXT component has multiple tables', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            'Reference table:\n\n' +
+            '| Field | Meaning |\n' +
+            '|---|---|\n' +
+            '| id | Internal identifier |\n\n' +
+            'Payment table:\n\n' +
+            '| Payment ID | Amount | Status |\n' +
+            '|---|---|---|\n' +
+            '| pay_SOJ4XrMPRKtO4g | INR 5.00 | Failed |\n' +
+            '| pay_SMeXeyPnHOZbpE | INR 10.00 | Failed |',
+        },
+        duplicatePaymentTableComponents[1],
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain('| Field | Meaning |');
+      expect(container.textContent).not.toContain('| Payment ID | Amount | Status |');
+      expect(container.textContent).toContain('Payment table:');
+    });
+
+    it('should preserve same-header yearly markdown tables when row overlap is generic', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            'Payments from 2025:\n\n' +
+            '| Amount | Status | Date |\n' +
+            '|---|---|---|\n' +
+            '| INR 500.00 | Failed | 10 Jan 2025 |\n' +
+            '| INR 750.00 | Captured | 12 Feb 2025 |',
+        },
+        {
+          component: 'TABLE',
+          headers: ['Amount', 'Status', 'Date'],
+          rows: [
+            [
+              { component: 'TEXT', value: 'INR 500.00' },
+              { component: 'BADGE', value: 'Failed', color: 'negative' },
+              { component: 'TEXT', value: '10 Jan 2026' },
+            ],
+            [
+              { component: 'TEXT', value: 'INR 750.00' },
+              { component: 'BADGE', value: 'Captured', color: 'positive' },
+              { component: 'TEXT', value: '12 Feb 2026' },
+            ],
+          ],
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).toContain('| Amount | Status | Date |');
+      expect(container.textContent).toContain('| INR 500.00 | Failed | 10 Jan 2025 |');
+    });
+
+    it('should remove same-header yearly markdown tables when rows contain matching payment identifiers', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            'Payments from 2025:\n\n' +
+            '| Payment ID | Amount | Status | Date |\n' +
+            '|---|---|---|---|\n' +
+            '| pay_2025A1 | INR 500.00 | Failed | 10 Jan 2025 |\n' +
+            '| pay_2025B2 | INR 750.00 | Captured | 12 Feb 2025 |',
+        },
+        {
+          component: 'TABLE',
+          headers: ['Payment ID', 'Amount', 'Status', 'Date'],
+          rows: [
+            [
+              { component: 'LINK', text: 'pay_2026A1' },
+              { component: 'TEXT', value: 'INR 500.00' },
+              { component: 'BADGE', value: 'Failed', color: 'negative' },
+              { component: 'TEXT', value: '10 Jan 2026' },
+            ],
+            [
+              { component: 'LINK', text: 'pay_2026B2' },
+              { component: 'TEXT', value: 'INR 750.00' },
+              { component: 'BADGE', value: 'Captured', color: 'positive' },
+              { component: 'TEXT', value: '12 Feb 2026' },
+            ],
+          ],
+        },
+        {
+          component: 'TABLE',
+          headers: ['Payment ID', 'Amount', 'Status', 'Date'],
+          rows: [
+            [
+              { component: 'LINK', text: 'pay_2025A1' },
+              { component: 'TEXT', value: 'INR 500.00' },
+              { component: 'BADGE', value: 'Failed', color: 'negative' },
+              { component: 'TEXT', value: '10 Jan 2025' },
+            ],
+            [
+              { component: 'LINK', text: 'pay_2025B2' },
+              { component: 'TEXT', value: 'INR 750.00' },
+              { component: 'BADGE', value: 'Captured', color: 'positive' },
+              { component: 'TEXT', value: '12 Feb 2025' },
+            ],
+          ],
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).not.toContain('| Payment ID | Amount | Status | Date |');
+      expect(container.textContent).toContain('pay_2025A1');
+      expect(container.textContent).toContain('pay_2026A1');
+    });
+
+    it('should keep text labels next to each structured table when one text block has multiple duplicate tables', () => {
+      const components: GenUIComponent[] = [
+        {
+          component: 'TEXT',
+          content:
+            'Settlements in 2026:\n\n' +
+            '| Settlement ID | Amount | Status | Date |\n' +
+            '|---|---|---|---|\n' +
+            '| setl_2026A1 | INR 12850.00 | Processed | 14 Mar 2026 |\n' +
+            '| setl_2026B2 | INR 9640.00 | Processed | 22 Apr 2026 |\n\n' +
+            'Settlements in 2025:\n\n' +
+            '| Settlement ID | Amount | Status | Date |\n' +
+            '|---|---|---|---|\n' +
+            '| setl_2025A1 | INR 11220.00 | Processed | 18 Mar 2025 |\n' +
+            '| setl_2025B2 | INR 8730.00 | Processed | 28 Apr 2025 |',
+        },
+        {
+          component: 'TABLE',
+          headers: ['Settlement ID', 'Amount', 'Status', 'Date'],
+          rows: [
+            [
+              { component: 'LINK', text: 'setl_2026A1' },
+              { component: 'TEXT', value: 'INR 12850.00' },
+              { component: 'BADGE', value: 'Processed', color: 'positive' },
+              { component: 'TEXT', value: '14 Mar 2026' },
+            ],
+            [
+              { component: 'LINK', text: 'setl_2026B2' },
+              { component: 'TEXT', value: 'INR 9640.00' },
+              { component: 'BADGE', value: 'Processed', color: 'positive' },
+              { component: 'TEXT', value: '22 Apr 2026' },
+            ],
+          ],
+        },
+        {
+          component: 'TABLE',
+          headers: ['Settlement ID', 'Amount', 'Status', 'Date'],
+          rows: [
+            [
+              { component: 'LINK', text: 'setl_2025A1' },
+              { component: 'TEXT', value: 'INR 11220.00' },
+              { component: 'BADGE', value: 'Processed', color: 'positive' },
+              { component: 'TEXT', value: '18 Mar 2025' },
+            ],
+            [
+              { component: 'LINK', text: 'setl_2025B2' },
+              { component: 'TEXT', value: 'INR 8730.00' },
+              { component: 'BADGE', value: 'Processed', color: 'positive' },
+              { component: 'TEXT', value: '28 Apr 2025' },
+            ],
+          ],
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      const renderedText = container.textContent ?? '';
+      expect(renderedText).not.toContain('| Settlement ID | Amount | Status | Date |');
+      expect(renderedText.indexOf('Settlements in 2026:')).toBeLessThan(
+        renderedText.indexOf('setl_2026A1'),
+      );
+      expect(renderedText.indexOf('setl_2026A1')).toBeLessThan(
+        renderedText.indexOf('Settlements in 2025:'),
+      );
+      expect(renderedText.indexOf('Settlements in 2025:')).toBeLessThan(
+        renderedText.indexOf('setl_2025A1'),
+      );
+    });
+
+    it('should match structured tables nested inside GenUI children', () => {
+      const components: GenUIComponent[] = [
+        duplicatePaymentTableComponents[0],
+        {
+          component: 'CARD',
+          children: [duplicatePaymentTableComponents[1]],
+        },
+      ];
+
+      const { container } = renderWithTheme(
+        <GenUIProvider>
+          <GenUISchemaRenderer
+            components={components}
+            duplicateMarkdownTableHandling={{ isEnabled: true }}
+          />
+        </GenUIProvider>,
+      );
+
+      expect(container.textContent).not.toContain('|---|---|---|---|---|---|');
+      expect(container.textContent).toContain('pay_SOJ4XrMPRKtO4g');
+    });
+  });
+
   describe('ALERT Component', () => {
     it('should render alert with title and description', () => {
       const components: GenUIComponent[] = [

--- a/packages/blade/src/components/GenUI/duplicateMarkdownTableHandling.ts
+++ b/packages/blade/src/components/GenUI/duplicateMarkdownTableHandling.ts
@@ -1,0 +1,652 @@
+import type { GenUIComponent } from './GenUIComponents';
+
+type GenUIDuplicateMarkdownTableEvent = {
+  type: 'DUPLICATE_MARKDOWN_TABLE_REMOVED';
+  textComponentPath: number[];
+  tableComponentPath: number[];
+  removedBlockCount: number;
+  tableFingerprint: string;
+  reason: 'MATCHED_STRUCTURED_TABLE';
+};
+
+type DuplicateMarkdownTableResult = {
+  components?: GenUIComponent[];
+  events: GenUIDuplicateMarkdownTableEvent[];
+};
+
+type MarkdownTableBlock = {
+  startIndex: number;
+  endIndex: number;
+  headers: string[];
+  rows: string[][];
+};
+
+type MarkdownTableMatch = {
+  block: MarkdownTableBlock;
+  structuredTable: StructuredTable;
+};
+
+type StructuredTable = {
+  headers: string[];
+  rows: string[][];
+  path: number[];
+  fingerprint: string;
+};
+
+type TextGenUIComponent = GenUIComponent & {
+  component: 'TEXT';
+  content?: string;
+};
+
+const MIN_HEADER_OVERLAP = 2;
+const MIN_COLUMNS = 2;
+const STRONG_IDENTIFIER_PATTERN = /\b[a-z]{2,12}_[a-z0-9][a-z0-9_]*\b/i;
+const LOW_CONFIDENCE_CELL_VALUES = new Set([
+  'active',
+  'authorized',
+  'cancelled',
+  'captured',
+  'complete',
+  'completed',
+  'failed',
+  'failure',
+  'inactive',
+  'paid',
+  'pending',
+  'processed',
+  'refunded',
+  'success',
+  'successful',
+]);
+
+const normalizeCell = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/&nbsp;/g, ' ')
+    .replace(/[^a-z0-9]+/g, '')
+    .trim();
+
+const normalizeHeader = normalizeCell;
+
+const isGenUIComponent = (value: unknown): value is GenUIComponent => {
+  return Boolean(value && typeof value === 'object' && 'component' in value);
+};
+
+const getComponentChildren = (component: GenUIComponent): GenUIComponent[] => {
+  const children = (component as { children?: unknown }).children;
+
+  if (Array.isArray(children)) {
+    return children.filter(isGenUIComponent);
+  }
+
+  if (isGenUIComponent(children)) {
+    return [children];
+  }
+
+  return [];
+};
+
+const getCellDisplayValues = (cell: unknown): string[] => {
+  if (!cell || typeof cell !== 'object') {
+    return [];
+  }
+
+  const typedCell = cell as {
+    component?: string;
+    value?: string | number;
+    text?: string;
+  };
+
+  switch (typedCell.component) {
+    case 'TEXT':
+    case 'BADGE':
+    case 'INDICATOR':
+    case 'DATE':
+    case 'AMOUNT':
+      return typedCell.value === undefined || typedCell.value === null
+        ? []
+        : [String(typedCell.value)];
+    case 'LINK':
+      return typedCell.text ? [typedCell.text] : [];
+    default:
+      return [];
+  }
+};
+
+const getStructuredRows = (rows: unknown): string[][] | null => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return null;
+  }
+
+  const structuredRows = rows.map((row) => {
+    if (!Array.isArray(row)) {
+      return [];
+    }
+
+    return row.map((cell) => getCellDisplayValues(cell)[0] ?? '');
+  });
+
+  return structuredRows.every((row) => row.length >= MIN_COLUMNS) ? structuredRows : null;
+};
+
+const getStructuredTableFingerprint = (headers: string[], path: number[]): string => {
+  return `${path.join('.')}:${headers.map(normalizeHeader).join('|')}`;
+};
+
+const collectStructuredTables = (
+  components: GenUIComponent[] | undefined,
+  path: number[] = [],
+): StructuredTable[] => {
+  if (!components) {
+    return [];
+  }
+
+  return components.flatMap((component, index) => {
+    const componentPath = [...path, index];
+    const componentWithTableProps = component as { headers?: unknown; rows?: unknown };
+    const headers = Array.isArray(componentWithTableProps.headers)
+      ? componentWithTableProps.headers.filter(
+          (header): header is string => typeof header === 'string',
+        )
+      : [];
+    const rows = getStructuredRows(componentWithTableProps.rows);
+    const ownTable =
+      component?.component === 'TABLE' && headers.length >= MIN_COLUMNS && rows
+        ? [
+            {
+              headers,
+              rows,
+              path: componentPath,
+              fingerprint: getStructuredTableFingerprint(headers, componentPath),
+            },
+          ]
+        : [];
+
+    return [
+      ...ownTable,
+      ...collectStructuredTables(getComponentChildren(component), componentPath),
+    ];
+  });
+};
+
+const splitMarkdownTableRow = (line: string): string[] => {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => cell.trim());
+};
+
+const isMarkdownTableSeparatorLine = (line: string, columnCount: number): boolean => {
+  const cells = splitMarkdownTableRow(line);
+
+  return (
+    cells.length === columnCount &&
+    cells.every((cell) => /^:?-{3,}:?$/.test(cell.replace(/\s/g, '')))
+  );
+};
+
+const isMarkdownTableRowLine = (line: string): boolean => {
+  return (line.match(/\|/g) ?? []).length >= MIN_COLUMNS;
+};
+
+const findMarkdownTableBlocks = (content: string): MarkdownTableBlock[] => {
+  const lines = content.split('\n');
+  const blocks: MarkdownTableBlock[] = [];
+  let isInsideCodeFence = false;
+
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const line = lines[index];
+
+    if (/^\s*(```|~~~)/.test(line)) {
+      isInsideCodeFence = !isInsideCodeFence;
+      continue;
+    }
+
+    if (isInsideCodeFence || !isMarkdownTableRowLine(line)) {
+      continue;
+    }
+
+    const headers = splitMarkdownTableRow(line);
+    if (
+      headers.length < MIN_COLUMNS ||
+      !isMarkdownTableSeparatorLine(lines[index + 1], headers.length)
+    ) {
+      continue;
+    }
+
+    const rows: string[][] = [];
+    let endIndex = index + 1;
+
+    for (let rowIndex = index + 2; rowIndex < lines.length; rowIndex += 1) {
+      const rowLine = lines[rowIndex];
+
+      if (/^\s*(```|~~~)/.test(rowLine) || !isMarkdownTableRowLine(rowLine)) {
+        break;
+      }
+
+      const row = splitMarkdownTableRow(rowLine);
+      if (row.length !== headers.length) {
+        break;
+      }
+
+      rows.push(row);
+      endIndex = rowIndex;
+    }
+
+    if (rows.length > 0) {
+      blocks.push({
+        startIndex: index,
+        endIndex,
+        headers,
+        rows,
+      });
+      index = endIndex;
+    }
+  }
+
+  return blocks;
+};
+
+const getHeaderOverlapCount = (markdownHeaders: string[], structuredHeaders: string[]): number => {
+  const normalizedStructuredHeaders = new Set(structuredHeaders.map(normalizeHeader));
+
+  return markdownHeaders.reduce((count, header) => {
+    return normalizedStructuredHeaders.has(normalizeHeader(header)) ? count + 1 : count;
+  }, 0);
+};
+
+const getDistinctMarkdownValues = (row: string[]): Set<string> => {
+  return new Set(
+    row
+      .map(normalizeCell)
+      .filter(
+        (value) =>
+          value.length >= 4 && !/^\d+$/.test(value) && !LOW_CONFIDENCE_CELL_VALUES.has(value),
+      ),
+  );
+};
+
+const getStrongIdentifierValues = (row: string[]): Set<string> => {
+  return new Set(
+    row
+      .filter((value) => STRONG_IDENTIFIER_PATTERN.test(value))
+      .map(normalizeCell)
+      .filter(Boolean),
+  );
+};
+
+const hasSharedStrongIdentifier = (markdownRow: string[], structuredRow: string[]): boolean => {
+  const markdownIdentifiers = getStrongIdentifierValues(markdownRow);
+
+  if (markdownIdentifiers.size === 0) {
+    return false;
+  }
+
+  const structuredIdentifiers = getStrongIdentifierValues(structuredRow);
+  return [...markdownIdentifiers].some((value) => structuredIdentifiers.has(value));
+};
+
+const structuredRowsContainMarkdownRow = (
+  markdownRow: string[],
+  structuredRows: string[][],
+): boolean => {
+  const markdownValues = getDistinctMarkdownValues(markdownRow);
+
+  if (markdownValues.size === 0) {
+    return false;
+  }
+
+  return structuredRows.some((structuredRow) => {
+    if (hasSharedStrongIdentifier(markdownRow, structuredRow)) {
+      return true;
+    }
+
+    const structuredValues = new Set(structuredRow.map(normalizeCell).filter(Boolean));
+    const matchingValueCount = [...markdownValues].filter((value) => structuredValues.has(value))
+      .length;
+
+    return matchingValueCount >= 2;
+  });
+};
+
+const getMatchingStructuredTable = (
+  markdownTable: MarkdownTableBlock,
+  structuredTables: StructuredTable[],
+): StructuredTable | undefined => {
+  return structuredTables.find((structuredTable) => {
+    if (
+      getHeaderOverlapCount(markdownTable.headers, structuredTable.headers) < MIN_HEADER_OVERLAP
+    ) {
+      return false;
+    }
+
+    const matchingRowCount = markdownTable.rows.filter((row) =>
+      structuredRowsContainMarkdownRow(row, structuredTable.rows),
+    ).length;
+
+    return matchingRowCount >= Math.min(2, markdownTable.rows.length);
+  });
+};
+
+const getDuplicateMarkdownTableMatches = (
+  content: string,
+  structuredTables: StructuredTable[],
+): MarkdownTableMatch[] => {
+  return findMarkdownTableBlocks(content)
+    .map((block) => ({
+      block,
+      structuredTable: getMatchingStructuredTable(block, structuredTables),
+    }))
+    .filter((match): match is MarkdownTableMatch => Boolean(match.structuredTable));
+};
+
+const normalizeTextSegment = (content: string): string => {
+  return content.replace(/\n{3,}/g, '\n\n').trim();
+};
+
+const createTextComponent = (
+  sourceComponent: GenUIComponent,
+  content: string,
+): TextGenUIComponent | undefined => {
+  const normalizedContent = normalizeTextSegment(content);
+
+  if (!normalizedContent) {
+    return undefined;
+  }
+
+  return {
+    ...sourceComponent,
+    component: 'TEXT',
+    content: normalizedContent,
+  };
+};
+
+const getDirectFollowingSiblingTableIndex = (
+  structuredTablePath: number[],
+  textComponentPath: number[],
+): number | undefined => {
+  if (structuredTablePath.length !== textComponentPath.length) {
+    return undefined;
+  }
+
+  const tableIndex = structuredTablePath[structuredTablePath.length - 1];
+  const textIndex = textComponentPath[textComponentPath.length - 1];
+  const hasSameParentPath = structuredTablePath
+    .slice(0, -1)
+    .every((pathIndex, index) => pathIndex === textComponentPath[index]);
+
+  if (!hasSameParentPath || tableIndex <= textIndex) {
+    return undefined;
+  }
+
+  return tableIndex;
+};
+
+const stripDuplicateMarkdownTablesFromContent = (
+  content: string,
+  structuredTables: StructuredTable[],
+  textComponentPath: number[],
+): { content: string; events: GenUIDuplicateMarkdownTableEvent[] } => {
+  if (structuredTables.length === 0) {
+    return { content, events: [] };
+  }
+
+  const lines = content.split('\n');
+  const removableBlocks = getDuplicateMarkdownTableMatches(content, structuredTables);
+
+  if (removableBlocks.length === 0) {
+    return { content, events: [] };
+  }
+
+  const removableLineIndexes = new Set<number>();
+  const events = removableBlocks.map(({ block, structuredTable }) => {
+    for (let index = block.startIndex; index <= block.endIndex; index += 1) {
+      removableLineIndexes.add(index);
+    }
+
+    return {
+      type: 'DUPLICATE_MARKDOWN_TABLE_REMOVED' as const,
+      textComponentPath,
+      tableComponentPath: structuredTable.path,
+      removedBlockCount: 1,
+      tableFingerprint: structuredTable.fingerprint,
+      reason: 'MATCHED_STRUCTURED_TABLE' as const,
+    };
+  });
+
+  return {
+    content: lines
+      .filter((_, index) => !removableLineIndexes.has(index))
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+    events,
+  };
+};
+
+const buildDuplicateMarkdownTableEvents = (
+  matches: MarkdownTableMatch[],
+  textComponentPath: number[],
+): GenUIDuplicateMarkdownTableEvent[] => {
+  return matches.map(({ structuredTable }) => ({
+    type: 'DUPLICATE_MARKDOWN_TABLE_REMOVED',
+    textComponentPath,
+    tableComponentPath: structuredTable.path,
+    removedBlockCount: 1,
+    tableFingerprint: structuredTable.fingerprint,
+    reason: 'MATCHED_STRUCTURED_TABLE',
+  }));
+};
+
+const pushTextComponentIntoMap = (
+  textComponentsByIndex: Map<number, TextGenUIComponent[]>,
+  index: number,
+  textComponent: TextGenUIComponent,
+): void => {
+  const textComponents = textComponentsByIndex.get(index) ?? [];
+  textComponents.push(textComponent);
+  textComponentsByIndex.set(index, textComponents);
+};
+
+const getInterleavedTextPlacements = (
+  component: GenUIComponent,
+  content: string,
+  structuredTables: StructuredTable[],
+  componentPath: number[],
+): {
+  beforeComponentTextByIndex: Map<number, TextGenUIComponent[]>;
+  afterComponentTextByIndex: Map<number, TextGenUIComponent[]>;
+  events: GenUIDuplicateMarkdownTableEvent[];
+  shouldInterleave: boolean;
+} => {
+  const matches = getDuplicateMarkdownTableMatches(content, structuredTables);
+
+  if (matches.length < 2) {
+    return {
+      beforeComponentTextByIndex: new Map(),
+      afterComponentTextByIndex: new Map(),
+      events: [],
+      shouldInterleave: false,
+    };
+  }
+
+  const tableIndexes = matches.map(({ structuredTable }) =>
+    getDirectFollowingSiblingTableIndex(structuredTable.path, componentPath),
+  );
+
+  if (
+    tableIndexes.some((tableIndex): tableIndex is undefined => tableIndex === undefined) ||
+    new Set(tableIndexes).size !== tableIndexes.length
+  ) {
+    return {
+      beforeComponentTextByIndex: new Map(),
+      afterComponentTextByIndex: new Map(),
+      events: [],
+      shouldInterleave: false,
+    };
+  }
+
+  const lines = content.split('\n');
+  const beforeComponentTextByIndex = new Map<number, TextGenUIComponent[]>();
+  const afterComponentTextByIndex = new Map<number, TextGenUIComponent[]>();
+  let cursorIndex = 0;
+
+  matches.forEach(({ block }, matchIndex) => {
+    const segmentBeforeTable = createTextComponent(
+      component,
+      lines.slice(cursorIndex, block.startIndex).join('\n'),
+    );
+    const tableIndex = tableIndexes[matchIndex];
+
+    if (segmentBeforeTable && tableIndex !== undefined) {
+      pushTextComponentIntoMap(beforeComponentTextByIndex, tableIndex, segmentBeforeTable);
+    }
+
+    cursorIndex = block.endIndex + 1;
+  });
+
+  const lastTableIndex = tableIndexes[tableIndexes.length - 1];
+  const trailingSegment = createTextComponent(component, lines.slice(cursorIndex).join('\n'));
+
+  if (trailingSegment && lastTableIndex !== undefined) {
+    pushTextComponentIntoMap(afterComponentTextByIndex, lastTableIndex, trailingSegment);
+  }
+
+  return {
+    beforeComponentTextByIndex,
+    afterComponentTextByIndex,
+    events: buildDuplicateMarkdownTableEvents(matches, componentPath),
+    shouldInterleave: true,
+  };
+};
+
+const dedupeComponentTree = (
+  components: GenUIComponent[],
+  structuredTables: StructuredTable[],
+  path: number[] = [],
+): { components: GenUIComponent[]; events: GenUIDuplicateMarkdownTableEvent[] } => {
+  const events: GenUIDuplicateMarkdownTableEvent[] = [];
+  const dedupedComponents: GenUIComponent[] = [];
+  const skippedTextIndexes = new Set<number>();
+  const beforeComponentTextByIndex = new Map<number, TextGenUIComponent[]>();
+  const afterComponentTextByIndex = new Map<number, TextGenUIComponent[]>();
+
+  components.forEach((component, index) => {
+    const componentPath = [...path, index];
+
+    if (component?.component !== 'TEXT') {
+      return;
+    }
+
+    const content = (component as { content?: string }).content;
+    if (!content) {
+      return;
+    }
+
+    const interleavedTextPlacements = getInterleavedTextPlacements(
+      component,
+      content,
+      structuredTables,
+      componentPath,
+    );
+
+    if (!interleavedTextPlacements.shouldInterleave) {
+      return;
+    }
+
+    skippedTextIndexes.add(index);
+    events.push(...interleavedTextPlacements.events);
+    interleavedTextPlacements.beforeComponentTextByIndex.forEach((textComponents, tableIndex) => {
+      textComponents.forEach((textComponent) =>
+        pushTextComponentIntoMap(beforeComponentTextByIndex, tableIndex, textComponent),
+      );
+    });
+    interleavedTextPlacements.afterComponentTextByIndex.forEach((textComponents, tableIndex) => {
+      textComponents.forEach((textComponent) =>
+        pushTextComponentIntoMap(afterComponentTextByIndex, tableIndex, textComponent),
+      );
+    });
+  });
+
+  components.forEach((component, index) => {
+    const componentPath = [...path, index];
+
+    dedupedComponents.push(...(beforeComponentTextByIndex.get(index) ?? []));
+
+    if (skippedTextIndexes.has(index)) {
+      dedupedComponents.push(...(afterComponentTextByIndex.get(index) ?? []));
+      return;
+    }
+
+    if (component?.component === 'TEXT') {
+      const content = (component as { content?: string }).content;
+
+      if (content) {
+        const result = stripDuplicateMarkdownTablesFromContent(
+          content,
+          structuredTables,
+          componentPath,
+        );
+        events.push(...result.events);
+
+        if (result.content) {
+          const dedupedTextComponent: TextGenUIComponent = {
+            ...component,
+            component: 'TEXT',
+            content: result.content,
+          };
+          dedupedComponents.push(dedupedTextComponent);
+        }
+        return;
+      }
+    }
+
+    const children = (component as { children?: unknown }).children;
+    if (Array.isArray(children)) {
+      const childResult = dedupeComponentTree(
+        children.filter(isGenUIComponent),
+        structuredTables,
+        componentPath,
+      );
+      events.push(...childResult.events);
+      dedupedComponents.push({ ...component, children: childResult.components } as GenUIComponent);
+      return;
+    }
+
+    if (isGenUIComponent(children)) {
+      const childResult = dedupeComponentTree([children], structuredTables, componentPath);
+      events.push(...childResult.events);
+      dedupedComponents.push({
+        ...component,
+        children: childResult.components[0],
+      } as GenUIComponent);
+      return;
+    }
+
+    dedupedComponents.push(component);
+    dedupedComponents.push(...(afterComponentTextByIndex.get(index) ?? []));
+  });
+
+  return { components: dedupedComponents, events };
+};
+
+const applyDuplicateMarkdownTableHandling = (
+  components?: GenUIComponent[],
+  isEnabled = false,
+): DuplicateMarkdownTableResult => {
+  if (!isEnabled || !components || components.length === 0) {
+    return { components, events: [] };
+  }
+
+  const structuredTables = collectStructuredTables(components);
+  if (structuredTables.length === 0) {
+    return { components, events: [] };
+  }
+
+  return dedupeComponentTree(components, structuredTables);
+};
+
+export { applyDuplicateMarkdownTableHandling };
+export type { GenUIDuplicateMarkdownTableEvent };

--- a/packages/blade/src/components/GenUI/index.ts
+++ b/packages/blade/src/components/GenUI/index.ts
@@ -4,6 +4,7 @@ export { GenUISchemaRenderer } from './GenUISchemaRenderer';
 
 export type { GenUISchemaRendererProps } from './GenUISchemaRenderer';
 export type { GenUIComponent } from './GenUIComponents';
+export type { GenUIDuplicateMarkdownTableEvent } from './duplicateMarkdownTableHandling';
 
 export type {
   GenUIAction,


### PR DESCRIPTION
## Summary
- add opt-in GenUI duplicate markdown table cleanup for TEXT blocks when a matching structured TABLE exists
- preserve standalone, incomplete, and code-fenced markdown tables, plus same-header generic year-over-year tables
- keep labels adjacent to multi-table outputs and add a before/after Storybook regression story

## Testing Status
- `yarn typecheck`
- `FRAMEWORK=REACT yarn jest -c ./jest.web.config.js GenUI --runInBand --no-coverage --testNamePattern="duplicate markdown table handling"`
- Storybook regression coverage added in `Patterns/GenUI > Merchant Duplicate Markdown Table Regression`

## Related
- Investigated Ray/GenUI duplicate raw pipe-table rendering failures from Langfuse traces and dashboard EventStream payloads
