### PR TITLE
feat(TreeView): add TreeView component

### DIFF
--- a/.changeset/treeview-component.md
+++ b/.changeset/treeview-component.md
@@ -1,0 +1,24 @@
+---
+'@razorpay/blade': minor
+---
+
+feat(TreeView): add TreeView component
+
+Adds a new `TreeView` component for displaying hierarchical/nested data with:
+- Expand/collapse nodes
+- Single and multiple selection support
+- Controlled and uncontrolled modes for both selection and expansion
+- Keyboard navigation (Enter, Space, ArrowRight, ArrowLeft)
+- ARIA tree/treeitem roles for accessibility
+- Optional icon and trailing slot per node
+- Disabled state support
+
+**Usage:**
+```jsx
+<TreeView selectionType="single" onSelectionChange={({ selectedIds }) => console.log(selectedIds)}>
+  <TreeViewItem id="src" label="src" icon={FolderIcon}>
+    <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+  </TreeViewItem>
+  <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+</TreeView>
+```

--- a/packages/blade/src/components/Link/BaseLink/StyledBaseLink.native.tsx
+++ b/packages/blade/src/components/Link/BaseLink/StyledBaseLink.native.tsx
@@ -63,12 +63,6 @@ const _StyledLink: React.ForwardRefRenderFunction<
     }
 
     if (onClick) {
-      /*
-      React Native's Pressable's onClick returns a GestureResponderEvent but our types expect a SyntheticEvent.
-      Until we have a way to handle platform specific types, we will have to ignore this TS error.
-      */
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-expect-error
       onClick(event);
     }
   };

--- a/packages/blade/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.stories.tsx
@@ -9,12 +9,7 @@ import type { TreeViewProps } from './types';
 import { Sandbox } from '~utils/storybook/Sandbox';
 import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
 import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
-import {
-  FolderIcon,
-  FileTextIcon,
-  CodeSnippetIcon,
-  ImageIcon,
-} from '~components/Icons';
+import { FolderIcon, FileTextIcon, CodeSnippetIcon, ImageIcon } from '~components/Icons';
 import { Badge } from '~components/Badge';
 import { Box } from '~components/Box';
 import { Text } from '~components/Typography';
@@ -160,11 +155,33 @@ export const WithTrailingBadge = (): ReactElement => {
           id="src"
           label="src"
           icon={FolderIcon}
-          trailing={<Badge size="small" color="positive">3 files</Badge>}
+          trailing={
+            <Badge size="small" color="positive">
+              3 files
+            </Badge>
+          }
         >
-          <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} trailing={<Badge size="small" color="notice">Modified</Badge>} />
+          <TreeViewItem
+            id="button"
+            label="Button.tsx"
+            icon={FileTextIcon}
+            trailing={
+              <Badge size="small" color="notice">
+                Modified
+              </Badge>
+            }
+          />
           <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} />
-          <TreeViewItem id="badge" label="Badge.tsx" icon={FileTextIcon} trailing={<Badge size="small" color="information">New</Badge>} />
+          <TreeViewItem
+            id="badge"
+            label="Badge.tsx"
+            icon={FileTextIcon}
+            trailing={
+              <Badge size="small" color="information">
+                New
+              </Badge>
+            }
+          />
         </TreeViewItem>
         <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
       </TreeViewComponent>
@@ -190,10 +207,7 @@ export const WithDisabledItems = (): ReactElement => {
 export const DefaultExpanded = (): ReactElement => {
   return (
     <Box maxWidth="400px">
-      <TreeViewComponent
-        selectionType="none"
-        defaultExpandedIds={['src', 'components']}
-      >
+      <TreeViewComponent selectionType="none" defaultExpandedIds={['src', 'components']}>
         <TreeViewItem id="src" label="src" icon={FolderIcon}>
           <TreeViewItem id="components" label="components" icon={FolderIcon}>
             <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />

--- a/packages/blade/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.stories.tsx
@@ -126,7 +126,7 @@ export const Controlled = (): ReactElement => {
           selectedIds={selectedIds}
           expandedIds={expandedIds}
           onSelectionChange={({ selectedIds: ids }) => setSelectedIds(ids)}
-          onExpandChange={({ expandedIds: ids }) => setExpandedIds(ids)}
+          onExpandedIdsChange={({ expandedIds: ids }) => setExpandedIds(ids)}
         >
           <TreeViewItem id="src" label="src" icon={FolderIcon}>
             <TreeViewItem id="components" label="components" icon={FolderIcon}>

--- a/packages/blade/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.stories.tsx
@@ -1,0 +1,207 @@
+import type { StoryFn, Meta } from '@storybook/react-vite';
+import { Title } from '@storybook/addon-docs/blocks';
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+
+import { TreeView as TreeViewComponent } from './TreeView';
+import { TreeViewItem } from './TreeViewItem';
+import type { TreeViewProps } from './types';
+import { Sandbox } from '~utils/storybook/Sandbox';
+import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
+import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
+import {
+  FolderIcon,
+  FileTextIcon,
+  CodeSnippetIcon,
+  ImageIcon,
+} from '~components/Icons';
+import { Badge } from '~components/Badge';
+import { Box } from '~components/Box';
+import { Text } from '~components/Typography';
+
+const Page = (): ReactElement => {
+  return (
+    <StoryPageWrapper
+      componentName="TreeView"
+      componentDescription="A tree view displays hierarchical data in a nested structure with support for expand/collapse and selection."
+      figmaURL="https://www.figma.com/proto/jubmQL9Z8V7881ayUD95ps/Blade-DSL"
+    >
+      <Title>Usage</Title>
+      <Sandbox editorHeight={500}>
+        {`
+        import { TreeView, TreeViewItem } from '@razorpay/blade/components';
+        import { FolderIcon, FileTextIcon } from '@razorpay/blade/components';
+
+        function App() {
+          return (
+            <TreeView selectionType="single">
+              <TreeViewItem id="src" label="src" icon={FolderIcon}>
+                <TreeViewItem id="components" label="components" icon={FolderIcon}>
+                  <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+                  <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} />
+                </TreeViewItem>
+                <TreeViewItem id="utils" label="utils" icon={FolderIcon}>
+                  <TreeViewItem id="helpers" label="helpers.ts" icon={FileTextIcon} />
+                </TreeViewItem>
+              </TreeViewItem>
+              <TreeViewItem id="package" label="package.json" icon={FileTextIcon} />
+            </TreeView>
+          )
+        }
+
+        export default App;
+        `}
+      </Sandbox>
+    </StoryPageWrapper>
+  );
+};
+
+const meta: Meta<TreeViewProps> = {
+  title: 'Components/TreeView',
+  component: TreeViewComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    ...getStyledPropsArgTypes(),
+  },
+  parameters: {
+    docs: {
+      page: Page,
+    },
+  },
+};
+
+export default meta;
+
+const TreeViewTemplate: StoryFn<TreeViewProps> = (args): ReactElement => {
+  return (
+    <Box maxWidth="400px">
+      <TreeViewComponent {...args}>
+        <TreeViewItem id="src" label="src" icon={FolderIcon}>
+          <TreeViewItem id="components" label="components" icon={FolderIcon}>
+            <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+            <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} />
+            <TreeViewItem id="badge" label="Badge.tsx" icon={FileTextIcon} />
+          </TreeViewItem>
+          <TreeViewItem id="utils" label="utils" icon={FolderIcon}>
+            <TreeViewItem id="helpers" label="helpers.ts" icon={CodeSnippetIcon} />
+            <TreeViewItem id="types" label="types.ts" icon={CodeSnippetIcon} />
+          </TreeViewItem>
+        </TreeViewItem>
+        <TreeViewItem id="assets" label="assets" icon={FolderIcon}>
+          <TreeViewItem id="logo" label="logo.png" icon={ImageIcon} />
+        </TreeViewItem>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+      </TreeViewComponent>
+    </Box>
+  );
+};
+
+export const Default = TreeViewTemplate.bind({});
+Default.args = {
+  selectionType: 'none',
+};
+Default.storyName = 'Default';
+
+export const SingleSelection = TreeViewTemplate.bind({});
+SingleSelection.args = {
+  selectionType: 'single',
+};
+SingleSelection.storyName = 'Single Selection';
+
+export const MultipleSelection = TreeViewTemplate.bind({});
+MultipleSelection.args = {
+  selectionType: 'multiple',
+};
+MultipleSelection.storyName = 'Multiple Selection';
+
+export const Controlled = (): ReactElement => {
+  const [selectedIds, setSelectedIds] = useState<string[]>(['button']);
+  const [expandedIds, setExpandedIds] = useState<string[]>(['src', 'components']);
+
+  return (
+    <Box display="flex" gap="spacing.6">
+      <Box maxWidth="400px">
+        <TreeViewComponent
+          selectionType="single"
+          selectedIds={selectedIds}
+          expandedIds={expandedIds}
+          onSelectionChange={({ selectedIds: ids }) => setSelectedIds(ids)}
+          onExpandChange={({ expandedIds: ids }) => setExpandedIds(ids)}
+        >
+          <TreeViewItem id="src" label="src" icon={FolderIcon}>
+            <TreeViewItem id="components" label="components" icon={FolderIcon}>
+              <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+              <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} />
+            </TreeViewItem>
+            <TreeViewItem id="utils" label="utils" icon={FolderIcon}>
+              <TreeViewItem id="helpers" label="helpers.ts" icon={CodeSnippetIcon} />
+            </TreeViewItem>
+          </TreeViewItem>
+          <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+        </TreeViewComponent>
+      </Box>
+      <Box>
+        <Text size="small" color="surface.text.gray.muted">
+          Selected: {selectedIds.join(', ') || 'none'}
+        </Text>
+        <Text size="small" color="surface.text.gray.muted">
+          Expanded: {expandedIds.join(', ') || 'none'}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export const WithTrailingBadge = (): ReactElement => {
+  return (
+    <Box maxWidth="400px">
+      <TreeViewComponent selectionType="single">
+        <TreeViewItem
+          id="src"
+          label="src"
+          icon={FolderIcon}
+          trailing={<Badge size="small" color="positive">3 files</Badge>}
+        >
+          <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} trailing={<Badge size="small" color="notice">Modified</Badge>} />
+          <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} />
+          <TreeViewItem id="badge" label="Badge.tsx" icon={FileTextIcon} trailing={<Badge size="small" color="information">New</Badge>} />
+        </TreeViewItem>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+      </TreeViewComponent>
+    </Box>
+  );
+};
+
+export const WithDisabledItems = (): ReactElement => {
+  return (
+    <Box maxWidth="400px">
+      <TreeViewComponent selectionType="single">
+        <TreeViewItem id="src" label="src" icon={FolderIcon}>
+          <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+          <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} isDisabled />
+          <TreeViewItem id="secret" label="secret.ts" icon={FileTextIcon} isDisabled />
+        </TreeViewItem>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+      </TreeViewComponent>
+    </Box>
+  );
+};
+
+export const DefaultExpanded = (): ReactElement => {
+  return (
+    <Box maxWidth="400px">
+      <TreeViewComponent
+        selectionType="none"
+        defaultExpandedIds={['src', 'components']}
+      >
+        <TreeViewItem id="src" label="src" icon={FolderIcon}>
+          <TreeViewItem id="components" label="components" icon={FolderIcon}>
+            <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+            <TreeViewItem id="input" label="Input.tsx" icon={FileTextIcon} />
+          </TreeViewItem>
+        </TreeViewItem>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+      </TreeViewComponent>
+    </Box>
+  );
+};

--- a/packages/blade/src/components/TreeView/TreeView.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.tsx
@@ -9,10 +9,6 @@ import { makeAccessible } from '~utils/makeAccessible';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { componentIds } from './componentIds';
 
-const normalizeIds = (ids?: string | string[]): string[] => {
-  if (!ids) return [];
-  return Array.isArray(ids) ? ids : [ids];
-};
 
 /**
  * # TreeView
@@ -48,16 +44,14 @@ const _TreeView = ({
   ...rest
 }: TreeViewProps): ReactElement => {
   const [uncontrolledSelectedIds, setUncontrolledSelectedIds] = useState<string[]>(
-    normalizeIds(defaultSelectedIds),
+    defaultSelectedIds ?? [],
   );
   const [uncontrolledExpandedIds, setUncontrolledExpandedIds] = useState<string[]>(
     defaultExpandedIds ?? [],
   );
 
   const selectedIds =
-    controlledSelectedIds !== undefined
-      ? normalizeIds(controlledSelectedIds)
-      : uncontrolledSelectedIds;
+    controlledSelectedIds !== undefined ? controlledSelectedIds : uncontrolledSelectedIds;
 
   const expandedIds = controlledExpandedIds !== undefined ? controlledExpandedIds : uncontrolledExpandedIds;
 

--- a/packages/blade/src/components/TreeView/TreeView.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.tsx
@@ -1,0 +1,120 @@
+import type { ReactElement } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { TreeViewContext } from './TreeViewContext';
+import type { TreeViewProps } from './types';
+import { BaseBox } from '~components/Box/BaseBox';
+import { getStyledProps } from '~components/Box/styledProps';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { componentIds } from './componentIds';
+
+const normalizeIds = (ids?: string | string[]): string[] => {
+  if (!ids) return [];
+  return Array.isArray(ids) ? ids : [ids];
+};
+
+/**
+ * # TreeView
+ *
+ * A tree view component for displaying hierarchical data with support for expand/collapse and selection.
+ *
+ * ## Usage
+ *
+ * ```jsx
+ * <TreeView selectionType="single" onSelectionChange={({ selectedIds }) => console.log(selectedIds)}>
+ *   <TreeViewItem id="fruits" label="Fruits" icon={FolderOpenIcon}>
+ *     <TreeViewItem id="apple" label="Apple" icon={FileIcon} />
+ *     <TreeViewItem id="banana" label="Banana" icon={FileIcon} />
+ *   </TreeViewItem>
+ *   <TreeViewItem id="vegetables" label="Vegetables" icon={FolderOpenIcon}>
+ *     <TreeViewItem id="carrot" label="Carrot" icon={FileIcon} />
+ *   </TreeViewItem>
+ * </TreeView>
+ * ```
+ *
+ * Checkout https://blade.razorpay.com/?path=/docs/components-treeview--docs
+ */
+const _TreeView = ({
+  children,
+  selectionType = 'none',
+  selectedIds: controlledSelectedIds,
+  defaultSelectedIds,
+  onSelectionChange,
+  expandedIds: controlledExpandedIds,
+  defaultExpandedIds,
+  onExpandChange,
+  testID,
+  ...rest
+}: TreeViewProps): ReactElement => {
+  const [uncontrolledSelectedIds, setUncontrolledSelectedIds] = useState<string[]>(
+    normalizeIds(defaultSelectedIds),
+  );
+  const [uncontrolledExpandedIds, setUncontrolledExpandedIds] = useState<string[]>(
+    defaultExpandedIds ?? [],
+  );
+
+  const selectedIds =
+    controlledSelectedIds !== undefined
+      ? normalizeIds(controlledSelectedIds)
+      : uncontrolledSelectedIds;
+
+  const expandedIds = controlledExpandedIds !== undefined ? controlledExpandedIds : uncontrolledExpandedIds;
+
+  const onNodeSelect = useCallback(
+    (id: string) => {
+      if (selectionType === 'none') return;
+
+      let nextIds: string[];
+      if (selectionType === 'single') {
+        nextIds = selectedIds.includes(id) ? [] : [id];
+      } else {
+        nextIds = selectedIds.includes(id)
+          ? selectedIds.filter((s) => s !== id)
+          : [...selectedIds, id];
+      }
+
+      if (controlledSelectedIds === undefined) {
+        setUncontrolledSelectedIds(nextIds);
+      }
+      onSelectionChange?.({ selectedIds: nextIds });
+    },
+    [selectionType, selectedIds, controlledSelectedIds, onSelectionChange],
+  );
+
+  const onNodeToggle = useCallback(
+    (id: string) => {
+      const isExpanded = expandedIds.includes(id);
+      const nextIds = isExpanded ? expandedIds.filter((e) => e !== id) : [...expandedIds, id];
+
+      if (controlledExpandedIds === undefined) {
+        setUncontrolledExpandedIds(nextIds);
+      }
+      onExpandChange?.({ expandedIds: nextIds, nodeId: id, isExpanded: !isExpanded });
+    },
+    [expandedIds, controlledExpandedIds, onExpandChange],
+  );
+
+  const contextValue = useMemo(
+    () => ({ selectionType, selectedIds, expandedIds, onNodeSelect, onNodeToggle }),
+    [selectionType, selectedIds, expandedIds, onNodeSelect, onNodeToggle],
+  );
+
+  return (
+    <TreeViewContext.Provider value={contextValue}>
+      <BaseBox
+        {...makeAccessible({ role: 'tree' })}
+        {...metaAttribute({ name: MetaConstants.TreeView, testID })}
+        {...getStyledProps(rest)}
+      >
+        {children}
+      </BaseBox>
+    </TreeViewContext.Provider>
+  );
+};
+
+const TreeView = assignWithoutSideEffects(_TreeView, {
+  componentId: componentIds.TreeView,
+});
+
+export { TreeView };

--- a/packages/blade/src/components/TreeView/TreeView.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.tsx
@@ -40,6 +40,7 @@ const _TreeView = ({
   expandedIds: controlledExpandedIds,
   defaultExpandedIds,
   onExpandChange,
+  onExpandedIdsChange,
   testID,
   ...rest
 }: TreeViewProps): ReactElement => {
@@ -84,9 +85,10 @@ const _TreeView = ({
       if (controlledExpandedIds === undefined) {
         setUncontrolledExpandedIds(nextIds);
       }
-      onExpandChange?.({ expandedIds: nextIds, nodeId: id, isExpanded: !isExpanded });
+      onExpandChange?.({ nodeId: id, isExpanded: !isExpanded });
+      onExpandedIdsChange?.({ expandedIds: nextIds });
     },
-    [expandedIds, controlledExpandedIds, onExpandChange],
+    [expandedIds, controlledExpandedIds, onExpandChange, onExpandedIdsChange],
   );
 
   const contextValue = useMemo(

--- a/packages/blade/src/components/TreeView/TreeView.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.tsx
@@ -97,7 +97,7 @@ const _TreeView = ({
   return (
     <TreeViewContext.Provider value={contextValue}>
       <BaseBox
-        {...makeAccessible({ role: 'tree' })}
+        {...makeAccessible({ role: 'tree', multiSelectable: selectionType === 'multiple' })}
         {...metaAttribute({ name: MetaConstants.TreeView, testID })}
         {...getStyledProps(rest)}
       >

--- a/packages/blade/src/components/TreeView/TreeView.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.tsx
@@ -90,7 +90,7 @@ const _TreeView = ({
   );
 
   const contextValue = useMemo(
-    () => ({ selectionType, selectedIds, expandedIds, onNodeSelect, onNodeToggle }),
+    () => ({ selectionType, selectedIds, expandedIds, depth: 0, onNodeSelect, onNodeToggle }),
     [selectionType, selectedIds, expandedIds, onNodeSelect, onNodeToggle],
   );
 

--- a/packages/blade/src/components/TreeView/TreeView.tsx
+++ b/packages/blade/src/components/TreeView/TreeView.tsx
@@ -9,7 +9,6 @@ import { makeAccessible } from '~utils/makeAccessible';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { componentIds } from './componentIds';
 
-
 /**
  * # TreeView
  *
@@ -54,7 +53,8 @@ const _TreeView = ({
   const selectedIds =
     controlledSelectedIds !== undefined ? controlledSelectedIds : uncontrolledSelectedIds;
 
-  const expandedIds = controlledExpandedIds !== undefined ? controlledExpandedIds : uncontrolledExpandedIds;
+  const expandedIds =
+    controlledExpandedIds !== undefined ? controlledExpandedIds : uncontrolledExpandedIds;
 
   const onNodeSelect = useCallback(
     (id: string) => {

--- a/packages/blade/src/components/TreeView/TreeViewContext.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewContext.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+import type { TreeViewContextType } from './types';
+import { throwBladeError } from '~utils/logger';
+
+const TreeViewContext = createContext<TreeViewContextType | null>(null);
+
+const useTreeView = (): TreeViewContextType => {
+  const ctx = useContext(TreeViewContext);
+  if (__DEV__) {
+    if (!ctx) {
+      throwBladeError({
+        message: 'TreeViewItem must be used inside TreeView',
+        moduleName: 'TreeViewContext',
+      });
+    }
+  }
+  return ctx!;
+};
+
+export { TreeViewContext, useTreeView };

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -51,6 +51,20 @@ const _TreeViewItem = ({
     if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
       onNodeToggle(id);
     }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const tree = (e.currentTarget as HTMLElement).closest('[role="tree"]');
+      if (!tree) return;
+      const treeitems = Array.from(
+        tree.querySelectorAll<HTMLElement>('[role="treeitem"]:not([aria-disabled="true"])'),
+      );
+      const currentIndex = treeitems.indexOf(e.currentTarget as HTMLElement);
+      if (e.key === 'ArrowDown' && currentIndex < treeitems.length - 1) {
+        treeitems[currentIndex + 1].focus();
+      } else if (e.key === 'ArrowUp' && currentIndex > 0) {
+        treeitems[currentIndex - 1].focus();
+      }
+    }
   };
 
   const indentLeftPx = depth * INDENT_SIZE_PX;

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -78,7 +78,7 @@ const _TreeViewItem = ({
         borderRadius="medium"
         cursor={(isReactNative() ? undefined : isDisabled ? 'not-allowed' : 'pointer') as never}
         backgroundColor={isSelected ? 'interactive.background.primary.faded' : 'transparent'}
-        onClick={handlePress as never}
+        onClick={(isReactNative() ? undefined : handlePress) as never}
         opacity={isDisabled ? 0.4 : 1}
       >
         {/* Indentation spacer */}

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -1,0 +1,163 @@
+import type { ReactElement } from 'react';
+import React, { Children } from 'react';
+import { useTreeView } from './TreeViewContext';
+import type { TreeViewItemProps } from './types';
+import { componentIds } from './componentIds';
+import { BaseBox } from '~components/Box/BaseBox';
+import { Text } from '~components/Typography';
+import { ChevronDownIcon, ChevronRightIcon } from '~components/Icons';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+
+type TreeViewItemInternalProps = TreeViewItemProps & {
+  /** Internal: nesting depth used for indentation */
+  _depth?: number;
+};
+
+const INDENT_SIZE_PX = 24;
+
+const _TreeViewItem = ({
+  id,
+  label,
+  icon: Icon,
+  trailing,
+  isDisabled = false,
+  children,
+  testID,
+  _depth = 0,
+  ...rest
+}: TreeViewItemInternalProps): ReactElement => {
+  const { selectionType, selectedIds, expandedIds, onNodeSelect, onNodeToggle } = useTreeView();
+
+  const hasChildren = Children.count(children) > 0;
+  const isExpanded = expandedIds.includes(id);
+  const isSelected = selectionType !== 'none' && selectedIds.includes(id);
+
+  const handlePress = (): void => {
+    if (isDisabled) return;
+    if (hasChildren) {
+      onNodeToggle(id);
+    }
+    if (selectionType !== 'none') {
+      onNodeSelect(id);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
+    if (isDisabled) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handlePress();
+    }
+    if (e.key === 'ArrowRight' && hasChildren && !isExpanded) {
+      onNodeToggle(id);
+    }
+    if (e.key === 'ArrowLeft' && hasChildren && isExpanded) {
+      onNodeToggle(id);
+    }
+  };
+
+  const indentLeftPx = _depth * INDENT_SIZE_PX;
+
+  return (
+    <BaseBox
+      {...makeAccessible({ role: 'treeitem', expanded: hasChildren ? isExpanded : undefined, selected: isSelected })}
+      {...metaAttribute({ name: MetaConstants.TreeViewItem, testID })}
+      {...makeAnalyticsAttribute(rest)}
+    >
+      {/* Row */}
+      <BaseBox
+        display="flex"
+        alignItems="center"
+        paddingY="spacing.2"
+        paddingRight="spacing.4"
+        paddingLeft="spacing.2"
+        borderRadius="medium"
+        cursor={isDisabled ? 'not-allowed' : 'pointer'}
+        backgroundColor={
+          isSelected
+            ? 'interactive.background.primary.faded'
+            : 'transparent'
+        }
+        tabIndex={isDisabled ? -1 : 0}
+        onKeyDown={handleKeyDown as never}
+        onClick={handlePress as never}
+        opacity={isDisabled ? 0.4 : 1}
+      >
+        {/* Indentation spacer */}
+        {indentLeftPx > 0 && (
+          <span style={{ display: 'inline-block', flexShrink: 0, width: `${indentLeftPx}px` }} />
+        )}
+        {/* Expand/collapse chevron */}
+        <BaseBox
+          width="spacing.6"
+          height="spacing.6"
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          flexShrink={0}
+        >
+          {hasChildren ? (
+            isExpanded ? (
+              <ChevronDownIcon size="small" color="surface.icon.gray.muted" />
+            ) : (
+              <ChevronRightIcon size="small" color="surface.icon.gray.muted" />
+            )
+          ) : null}
+        </BaseBox>
+
+        {/* Optional icon */}
+        {Icon && (
+          <BaseBox marginRight="spacing.2" display="flex" alignItems="center">
+            <Icon
+              size="small"
+              color={isSelected ? 'interactive.icon.primary.normal' : 'surface.icon.gray.normal'}
+            />
+          </BaseBox>
+        )}
+
+        {/* Label */}
+        <Text
+          size="medium"
+          color={
+            isDisabled
+              ? 'surface.text.gray.disabled'
+              : isSelected
+              ? 'interactive.text.primary.normal'
+              : 'surface.text.gray.normal'
+          }
+          weight={isSelected ? 'semibold' : 'regular'}
+          truncateAfterLines={1}
+        >
+          {label}
+        </Text>
+
+        {/* Trailing slot */}
+        {trailing && <BaseBox marginLeft="spacing.2">{trailing}</BaseBox>}
+      </BaseBox>
+
+      {/* Children group */}
+      {hasChildren && isExpanded && (
+        <BaseBox
+          {...makeAccessible({ role: 'group' })}
+        >
+          {Children.map(children, (child) => {
+            if (!React.isValidElement(child)) return child;
+            return React.cloneElement(child as React.ReactElement<TreeViewItemInternalProps>, {
+              _depth: _depth + 1,
+            });
+          })}
+        </BaseBox>
+      )}
+    </BaseBox>
+  );
+};
+
+const TreeViewItem = assignWithoutSideEffects(_TreeViewItem, {
+  componentId: componentIds.TreeViewItem,
+});
+
+export type { TreeViewItemProps };
+export { TreeViewItem };

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -61,6 +61,7 @@ const _TreeViewItem = ({
         role: 'treeitem',
         expanded: hasChildren ? isExpanded : undefined,
         selected: selectionType !== 'none' ? isSelected : undefined,
+        disabled: isDisabled,
       })}
       {...metaAttribute({ name: MetaConstants.TreeViewItem, testID })}
       {...makeAnalyticsAttribute(rest)}

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import React, { Children } from 'react';
-import { useTreeView } from './TreeViewContext';
+import React from 'react';
+import { TreeViewContext, useTreeView } from './TreeViewContext';
 import type { TreeViewItemProps } from './types';
 import { componentIds } from './componentIds';
 import { BaseBox } from '~components/Box/BaseBox';
@@ -12,11 +12,6 @@ import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
 import { isReactNative } from '~utils';
 
-type TreeViewItemInternalProps = TreeViewItemProps & {
-  /** Internal: nesting depth used for indentation */
-  _depth?: number;
-};
-
 const INDENT_SIZE_PX = 24;
 
 const _TreeViewItem = ({
@@ -27,12 +22,11 @@ const _TreeViewItem = ({
   isDisabled = false,
   children,
   testID,
-  _depth = 0,
   ...rest
-}: TreeViewItemInternalProps): ReactElement => {
-  const { selectionType, selectedIds, expandedIds, onNodeSelect, onNodeToggle } = useTreeView();
+}: TreeViewItemProps): ReactElement => {
+  const { selectionType, selectedIds, expandedIds, depth, onNodeSelect, onNodeToggle } = useTreeView();
 
-  const hasChildren = Children.count(children) > 0;
+  const hasChildren = React.Children.count(children) > 0;
   const isExpanded = expandedIds.includes(id);
   const isSelected = selectionType !== 'none' && selectedIds.includes(id);
 
@@ -40,8 +34,7 @@ const _TreeViewItem = ({
     if (isDisabled) return;
     if (hasChildren) {
       onNodeToggle(id);
-    }
-    if (selectionType !== 'none') {
+    } else if (selectionType !== 'none') {
       onNodeSelect(id);
     }
   };
@@ -60,7 +53,7 @@ const _TreeViewItem = ({
     }
   };
 
-  const indentLeftPx = _depth * INDENT_SIZE_PX;
+  const indentLeftPx = depth * INDENT_SIZE_PX;
 
   return (
     <BaseBox
@@ -139,16 +132,17 @@ const _TreeViewItem = ({
         {trailing && <BaseBox marginLeft="spacing.2">{trailing}</BaseBox>}
       </BaseBox>
 
-      {/* Children group */}
+      {/* Children group — depth incremented via context so cloneElement is not needed */}
       {hasChildren && isExpanded && (
-        <BaseBox {...makeAccessible({ role: 'group' })}>
-          {Children.map(children, (child) => {
-            if (!React.isValidElement(child)) return child;
-            return React.cloneElement(child as React.ReactElement<TreeViewItemInternalProps>, {
-              _depth: _depth + 1,
-            });
-          })}
-        </BaseBox>
+        <TreeViewContext.Consumer>
+          {(ctx) => (
+            <TreeViewContext.Provider value={{ ...ctx!, depth: depth + 1 }}>
+              <BaseBox {...makeAccessible({ role: 'group' })}>
+                {children}
+              </BaseBox>
+            </TreeViewContext.Provider>
+          )}
+        </TreeViewContext.Consumer>
       )}
     </BaseBox>
   );

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -24,7 +24,8 @@ const _TreeViewItem = ({
   testID,
   ...rest
 }: TreeViewItemProps): ReactElement => {
-  const { selectionType, selectedIds, expandedIds, depth, onNodeSelect, onNodeToggle } = useTreeView();
+  const { selectionType, selectedIds, expandedIds, depth, onNodeSelect, onNodeToggle } =
+    useTreeView();
 
   const hasChildren = React.Children.count(children) > 0;
   const isExpanded = expandedIds.includes(id);
@@ -134,8 +135,8 @@ const _TreeViewItem = ({
             isDisabled
               ? 'surface.text.gray.disabled'
               : isSelected
-              ? 'interactive.text.primary.normal'
-              : 'surface.text.gray.normal'
+                ? 'interactive.text.primary.normal'
+                : 'surface.text.gray.normal'
           }
           weight={isSelected ? 'semibold' : 'regular'}
           truncateAfterLines={1}
@@ -152,9 +153,7 @@ const _TreeViewItem = ({
         <TreeViewContext.Consumer>
           {(ctx) => (
             <TreeViewContext.Provider value={{ ...ctx!, depth: depth + 1 }}>
-              <BaseBox {...makeAccessible({ role: 'group' })}>
-                {children}
-              </BaseBox>
+              <BaseBox {...makeAccessible({ role: 'group' })}>{children}</BaseBox>
             </TreeViewContext.Provider>
           )}
         </TreeViewContext.Consumer>

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -10,6 +10,7 @@ import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { makeAccessible } from '~utils/makeAccessible';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { isReactNative } from '~utils';
 
 type TreeViewItemInternalProps = TreeViewItemProps & {
   /** Internal: nesting depth used for indentation */
@@ -63,9 +64,15 @@ const _TreeViewItem = ({
 
   return (
     <BaseBox
-      {...makeAccessible({ role: 'treeitem', expanded: hasChildren ? isExpanded : undefined, selected: selectionType !== 'none' ? isSelected : undefined })}
+      {...makeAccessible({
+        role: 'treeitem',
+        expanded: hasChildren ? isExpanded : undefined,
+        selected: selectionType !== 'none' ? isSelected : undefined,
+      })}
       {...metaAttribute({ name: MetaConstants.TreeViewItem, testID })}
       {...makeAnalyticsAttribute(rest)}
+      tabIndex={isDisabled ? -1 : 0}
+      onKeyDown={handleKeyDown as never}
     >
       {/* Row */}
       <BaseBox
@@ -75,14 +82,8 @@ const _TreeViewItem = ({
         paddingRight="spacing.4"
         paddingLeft="spacing.2"
         borderRadius="medium"
-        cursor={isDisabled ? 'not-allowed' : 'pointer'}
-        backgroundColor={
-          isSelected
-            ? 'interactive.background.primary.faded'
-            : 'transparent'
-        }
-        tabIndex={isDisabled ? -1 : 0}
-        onKeyDown={handleKeyDown as never}
+        cursor={isReactNative() ? undefined : isDisabled ? 'not-allowed' : 'pointer'}
+        backgroundColor={isSelected ? 'interactive.background.primary.faded' : 'transparent'}
         onClick={handlePress as never}
         opacity={isDisabled ? 0.4 : 1}
       >
@@ -140,9 +141,7 @@ const _TreeViewItem = ({
 
       {/* Children group */}
       {hasChildren && isExpanded && (
-        <BaseBox
-          {...makeAccessible({ role: 'group' })}
-        >
+        <BaseBox {...makeAccessible({ role: 'group' })}>
           {Children.map(children, (child) => {
             if (!React.isValidElement(child)) return child;
             return React.cloneElement(child as React.ReactElement<TreeViewItemInternalProps>, {

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -63,7 +63,7 @@ const _TreeViewItem = ({
 
   return (
     <BaseBox
-      {...makeAccessible({ role: 'treeitem', expanded: hasChildren ? isExpanded : undefined, selected: isSelected })}
+      {...makeAccessible({ role: 'treeitem', expanded: hasChildren ? isExpanded : undefined, selected: selectionType !== 'none' ? isSelected : undefined })}
       {...metaAttribute({ name: MetaConstants.TreeViewItem, testID })}
       {...makeAnalyticsAttribute(rest)}
     >

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -24,8 +24,14 @@ const _TreeViewItem = ({
   testID,
   ...rest
 }: TreeViewItemProps): ReactElement => {
-  const { selectionType, selectedIds, expandedIds, depth, onNodeSelect, onNodeToggle } =
-    useTreeView();
+  const {
+    selectionType,
+    selectedIds,
+    expandedIds,
+    depth,
+    onNodeSelect,
+    onNodeToggle,
+  } = useTreeView();
 
   const hasChildren = React.Children.count(children) > 0;
   const isExpanded = expandedIds.includes(id);
@@ -135,8 +141,8 @@ const _TreeViewItem = ({
             isDisabled
               ? 'surface.text.gray.disabled'
               : isSelected
-                ? 'interactive.text.primary.normal'
-                : 'surface.text.gray.normal'
+              ? 'interactive.text.primary.normal'
+              : 'surface.text.gray.normal'
           }
           weight={isSelected ? 'semibold' : 'regular'}
           truncateAfterLines={1}

--- a/packages/blade/src/components/TreeView/TreeViewItem.tsx
+++ b/packages/blade/src/components/TreeView/TreeViewItem.tsx
@@ -65,7 +65,7 @@ const _TreeViewItem = ({
       {...metaAttribute({ name: MetaConstants.TreeViewItem, testID })}
       {...makeAnalyticsAttribute(rest)}
       tabIndex={isDisabled ? -1 : 0}
-      onKeyDown={handleKeyDown as never}
+      onKeyDown={handleKeyDown}
     >
       {/* Row */}
       <BaseBox
@@ -75,7 +75,7 @@ const _TreeViewItem = ({
         paddingRight="spacing.4"
         paddingLeft="spacing.2"
         borderRadius="medium"
-        cursor={isReactNative() ? undefined : isDisabled ? 'not-allowed' : 'pointer'}
+        cursor={(isReactNative() ? undefined : isDisabled ? 'not-allowed' : 'pointer') as never}
         backgroundColor={isSelected ? 'interactive.background.primary.faded' : 'transparent'}
         onClick={handlePress as never}
         opacity={isDisabled ? 0.4 : 1}

--- a/packages/blade/src/components/TreeView/__tests__/TreeView.web.test.tsx
+++ b/packages/blade/src/components/TreeView/__tests__/TreeView.web.test.tsx
@@ -205,7 +205,7 @@ describe('<TreeView />', () => {
 
   it('should support keyboard navigation — Enter expands a node', async () => {
     const user = userEvent.setup();
-    const { getByText, queryByText } = renderWithTheme(<SimpleTree />);
+    const { getByText } = renderWithTheme(<SimpleTree />);
 
     const srcItem = getByText('src').closest('[role="treeitem"]') as HTMLElement;
     srcItem.focus();

--- a/packages/blade/src/components/TreeView/__tests__/TreeView.web.test.tsx
+++ b/packages/blade/src/components/TreeView/__tests__/TreeView.web.test.tsx
@@ -1,0 +1,212 @@
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { TreeView, TreeViewItem } from '../index';
+import renderWithTheme from '~utils/testing/renderWithTheme.web';
+import assertAccessible from '~utils/testing/assertAccessible.web';
+import { FolderIcon, FileTextIcon } from '~components/Icons';
+
+const SimpleTree = (): JSX.Element => (
+  <TreeView>
+    <TreeViewItem id="src" label="src" icon={FolderIcon}>
+      <TreeViewItem id="components" label="components" icon={FolderIcon}>
+        <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
+      </TreeViewItem>
+    </TreeViewItem>
+    <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+  </TreeView>
+);
+
+describe('<TreeView />', () => {
+  it('should render', () => {
+    const { container } = renderWithTheme(<SimpleTree />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should have correct aria roles', () => {
+    const { getByRole, getAllByRole } = renderWithTheme(<SimpleTree />);
+    expect(getByRole('tree')).toBeInTheDocument();
+    const treeItems = getAllByRole('treeitem');
+    expect(treeItems.length).toBeGreaterThan(0);
+  });
+
+  it('should expand a node on click', async () => {
+    const user = userEvent.setup();
+    const { getByText, queryByText } = renderWithTheme(<SimpleTree />);
+
+    // "components" child "Button.tsx" should not be visible until "src" is expanded
+    expect(queryByText('Button.tsx')).toBeNull();
+
+    await user.click(getByText('src'));
+
+    expect(getByText('components')).toBeInTheDocument();
+  });
+
+  it('should expand nested node on click', async () => {
+    const user = userEvent.setup();
+    const { getByText, queryByText } = renderWithTheme(<SimpleTree />);
+
+    await user.click(getByText('src'));
+    expect(getByText('components')).toBeInTheDocument();
+    expect(queryByText('Button.tsx')).toBeNull();
+
+    await user.click(getByText('components'));
+    expect(getByText('Button.tsx')).toBeInTheDocument();
+  });
+
+  it('should collapse an expanded node on click', async () => {
+    const user = userEvent.setup();
+    const { getByText, queryByText } = renderWithTheme(<SimpleTree />);
+
+    await user.click(getByText('src'));
+    expect(getByText('components')).toBeInTheDocument();
+
+    await user.click(getByText('src'));
+    expect(queryByText('components')).toBeNull();
+  });
+
+  it('should render with defaultExpandedIds', () => {
+    const { getByText } = renderWithTheme(
+      <TreeView defaultExpandedIds={['src']}>
+        <TreeViewItem id="src" label="src" icon={FolderIcon}>
+          <TreeViewItem id="components" label="components" icon={FolderIcon} />
+        </TreeViewItem>
+      </TreeView>,
+    );
+
+    expect(getByText('components')).toBeInTheDocument();
+  });
+
+  it('should call onExpandChange callback', async () => {
+    const onExpandChange = jest.fn();
+    const user = userEvent.setup();
+
+    const { getByText } = renderWithTheme(
+      <TreeView onExpandChange={onExpandChange}>
+        <TreeViewItem id="src" label="src" icon={FolderIcon}>
+          <TreeViewItem id="btn" label="Button.tsx" icon={FileTextIcon} />
+        </TreeViewItem>
+      </TreeView>,
+    );
+
+    await user.click(getByText('src'));
+    expect(onExpandChange).toHaveBeenCalledWith({
+      expandedIds: ['src'],
+      nodeId: 'src',
+      isExpanded: true,
+    });
+
+    await user.click(getByText('src'));
+    expect(onExpandChange).toHaveBeenCalledWith({
+      expandedIds: [],
+      nodeId: 'src',
+      isExpanded: false,
+    });
+  });
+
+  it('should support single selection', async () => {
+    const onSelectionChange = jest.fn();
+    const user = userEvent.setup();
+
+    const { getByText } = renderWithTheme(
+      <TreeView selectionType="single" onSelectionChange={onSelectionChange}>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+        <TreeViewItem id="package" label="package.json" icon={FileTextIcon} />
+      </TreeView>,
+    );
+
+    await user.click(getByText('README.md'));
+    expect(onSelectionChange).toHaveBeenCalledWith({ selectedIds: ['readme'] });
+
+    await user.click(getByText('package.json'));
+    expect(onSelectionChange).toHaveBeenCalledWith({ selectedIds: ['package'] });
+  });
+
+  it('should support multiple selection', async () => {
+    const onSelectionChange = jest.fn();
+    const user = userEvent.setup();
+
+    const { getByText } = renderWithTheme(
+      <TreeView selectionType="multiple" onSelectionChange={onSelectionChange}>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+        <TreeViewItem id="package" label="package.json" icon={FileTextIcon} />
+      </TreeView>,
+    );
+
+    await user.click(getByText('README.md'));
+    expect(onSelectionChange).toHaveBeenCalledWith({ selectedIds: ['readme'] });
+
+    await user.click(getByText('package.json'));
+    expect(onSelectionChange).toHaveBeenCalledWith({ selectedIds: ['readme', 'package'] });
+  });
+
+  it('should deselect on second click in single selection', async () => {
+    const onSelectionChange = jest.fn();
+    const user = userEvent.setup();
+
+    const { getByText } = renderWithTheme(
+      <TreeView selectionType="single" onSelectionChange={onSelectionChange}>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+      </TreeView>,
+    );
+
+    await user.click(getByText('README.md'));
+    expect(onSelectionChange).toHaveBeenCalledWith({ selectedIds: ['readme'] });
+
+    await user.click(getByText('README.md'));
+    expect(onSelectionChange).toHaveBeenCalledWith({ selectedIds: [] });
+  });
+
+  it('should support controlled expand', async () => {
+    const ControlledTree = (): JSX.Element => {
+      const [expandedIds, setExpandedIds] = useState<string[]>([]);
+      return (
+        <TreeView
+          expandedIds={expandedIds}
+          onExpandChange={({ expandedIds: ids }) => setExpandedIds(ids)}
+        >
+          <TreeViewItem id="src" label="src" icon={FolderIcon}>
+            <TreeViewItem id="btn" label="Button.tsx" icon={FileTextIcon} />
+          </TreeViewItem>
+        </TreeView>
+      );
+    };
+
+    const user = userEvent.setup();
+    const { getByText, queryByText } = renderWithTheme(<ControlledTree />);
+
+    expect(queryByText('Button.tsx')).toBeNull();
+
+    await user.click(getByText('src'));
+    expect(getByText('Button.tsx')).toBeInTheDocument();
+  });
+
+  it('should support keyboard navigation — Enter expands a node', async () => {
+    const user = userEvent.setup();
+    const { getByText, queryByText } = renderWithTheme(<SimpleTree />);
+
+    const srcItem = getByText('src').closest('[role="treeitem"]') as HTMLElement;
+    srcItem.focus();
+
+    await user.keyboard('{Enter}');
+    expect(getByText('components')).toBeInTheDocument();
+  });
+
+  it('should not interact when disabled', async () => {
+    const onSelectionChange = jest.fn();
+    const user = userEvent.setup();
+
+    const { getByText } = renderWithTheme(
+      <TreeView selectionType="single" onSelectionChange={onSelectionChange}>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} isDisabled />
+      </TreeView>,
+    );
+
+    await user.click(getByText('README.md'));
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  it('should be accessible', async () => {
+    const { container } = renderWithTheme(<SimpleTree />);
+    await assertAccessible(container);
+  });
+});

--- a/packages/blade/src/components/TreeView/__tests__/TreeView.web.test.tsx
+++ b/packages/blade/src/components/TreeView/__tests__/TreeView.web.test.tsx
@@ -90,14 +90,12 @@ describe('<TreeView />', () => {
 
     await user.click(getByText('src'));
     expect(onExpandChange).toHaveBeenCalledWith({
-      expandedIds: ['src'],
       nodeId: 'src',
       isExpanded: true,
     });
 
     await user.click(getByText('src'));
     expect(onExpandChange).toHaveBeenCalledWith({
-      expandedIds: [],
       nodeId: 'src',
       isExpanded: false,
     });
@@ -162,7 +160,7 @@ describe('<TreeView />', () => {
       return (
         <TreeView
           expandedIds={expandedIds}
-          onExpandChange={({ expandedIds: ids }) => setExpandedIds(ids)}
+          onExpandedIdsChange={({ expandedIds: ids }) => setExpandedIds(ids)}
         >
           <TreeViewItem id="src" label="src" icon={FolderIcon}>
             <TreeViewItem id="btn" label="Button.tsx" icon={FileTextIcon} />
@@ -178,6 +176,31 @@ describe('<TreeView />', () => {
 
     await user.click(getByText('src'));
     expect(getByText('Button.tsx')).toBeInTheDocument();
+  });
+
+  it('should support keyboard navigation — ArrowDown/ArrowUp moves focus between visible treeitems', async () => {
+    const user = userEvent.setup();
+    const { getByText } = renderWithTheme(
+      <TreeView>
+        <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
+        <TreeViewItem id="package" label="package.json" icon={FileTextIcon} />
+        <TreeViewItem id="tsconfig" label="tsconfig.json" icon={FileTextIcon} />
+      </TreeView>,
+    );
+
+    const first = getByText('README.md').closest('[role="treeitem"]') as HTMLElement;
+    const second = getByText('package.json').closest('[role="treeitem"]') as HTMLElement;
+    const third = getByText('tsconfig.json').closest('[role="treeitem"]') as HTMLElement;
+
+    first.focus();
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(second);
+
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(third);
+
+    await user.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(second);
   });
 
   it('should support keyboard navigation — Enter expands a node', async () => {

--- a/packages/blade/src/components/TreeView/__tests__/__snapshots__/TreeView.web.test.tsx.snap
+++ b/packages/blade/src/components/TreeView/__tests__/__snapshots__/TreeView.web.test.tsx.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TreeView /> should render 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-right: 12px;
+  padding-left: 4px;
+  background-color: hsla(0,0%,100%,0);
+  border-radius: 12px;
+  cursor: pointer;
+  opacity: 1;
+}
+
+.c1.c1.c1.c1.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 20px;
+  width: 20px;
+}
+
+.c2.c2.c2.c2.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-right: 4px;
+}
+
+.c3.c3.c3.c3.c3 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
+}
+
+<div>
+  <div
+    class=""
+    data-blade-component="tree-view"
+    role="tree"
+  >
+    <div
+      aria-expanded="false"
+      class=""
+      data-blade-component="tree-view-item"
+      role="treeitem"
+      tabindex="0"
+    >
+      <div
+        class="c0"
+        data-blade-component="base-box"
+        opacity="1"
+      >
+        <div
+          class="c1"
+          data-blade-component="base-box"
+        >
+          <svg
+            aria-hidden="true"
+            class="Svgweb__StyledSvg-vcmjs8-0"
+            data-blade-component="icon"
+            fill="none"
+            height="12px"
+            viewBox="0 0 24 24"
+            width="12px"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M8.29289 5.29289C8.68342 4.90237 9.31658 4.90237 9.70711 5.29289L15.7071 11.2929C16.0976 11.6834 16.0976 12.3166 15.7071 12.7071L9.70711 18.7071C9.31658 19.0976 8.68342 19.0976 8.29289 18.7071C7.90237 18.3166 7.90237 17.6834 8.29289 17.2929L13.5858 12L8.29289 6.70711C7.90237 6.31658 7.90237 5.68342 8.29289 5.29289Z"
+              data-blade-component="svg-path"
+              fill="hsla(204, 9%, 42%, 1)"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <div
+          class="c2"
+          data-blade-component="base-box"
+        >
+          <svg
+            aria-hidden="true"
+            class="Svgweb__StyledSvg-vcmjs8-0"
+            data-blade-component="icon"
+            fill="none"
+            height="12px"
+            viewBox="0 0 24 24"
+            width="12px"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M4 4C3.44772 4 3 4.44772 3 5V19C3 19.5523 3.44772 20 4 20H20C20.5523 20 21 19.5523 21 19V8C21 7.44772 20.5523 7 20 7H11C10.6656 7 10.3534 6.8329 10.1679 6.5547L8.46482 4H4ZM1 5C1 3.34315 2.34315 2 4 2H9C9.33435 2 9.64658 2.1671 9.83205 2.4453L11.5352 5H20C21.6569 5 23 6.34315 23 8V19C23 20.6569 21.6569 22 20 22H4C2.34315 22 1 20.6569 1 19V5Z"
+              data-blade-component="svg-path"
+              fill="hsla(0, 0%, 2%, 1)"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <p
+          class="c3"
+          data-blade-component="text"
+          letter-spacing="50"
+        >
+          src
+        </p>
+      </div>
+    </div>
+    <div
+      class=""
+      data-blade-component="tree-view-item"
+      role="treeitem"
+      tabindex="0"
+    >
+      <div
+        class="c0"
+        data-blade-component="base-box"
+        opacity="1"
+      >
+        <div
+          class="c1"
+          data-blade-component="base-box"
+        />
+        <div
+          class="c2"
+          data-blade-component="base-box"
+        >
+          <svg
+            aria-hidden="true"
+            class="Svgweb__StyledSvg-vcmjs8-0"
+            data-blade-component="icon"
+            fill="none"
+            height="12px"
+            viewBox="0 0 24 24"
+            width="12px"
+          >
+            <path
+              d="M8 12C7.44772 12 7 12.4477 7 13C7 13.5523 7.44772 14 8 14H16C16.5523 14 17 13.5523 17 13C17 12.4477 16.5523 12 16 12H8Z"
+              data-blade-component="svg-path"
+              fill="hsla(0, 0%, 2%, 1)"
+            />
+            <path
+              d="M7 17C7 16.4477 7.44772 16 8 16H16C16.5523 16 17 16.4477 17 17C17 17.5523 16.5523 18 16 18H8C7.44772 18 7 17.5523 7 17Z"
+              data-blade-component="svg-path"
+              fill="hsla(0, 0%, 2%, 1)"
+            />
+            <path
+              d="M8 8C7.44772 8 7 8.44772 7 9C7 9.55229 7.44772 10 8 10H10C10.5523 10 11 9.55229 11 9C11 8.44772 10.5523 8 10 8H8Z"
+              data-blade-component="svg-path"
+              fill="hsla(0, 0%, 2%, 1)"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M3 4C3 2.34315 4.34315 1 6 1H14C14.2652 1 14.5196 1.10536 14.7071 1.29289L20.7071 7.29289C20.8946 7.48043 21 7.73478 21 8V20C21 21.6569 19.6569 23 18 23H6C4.34315 23 3 21.6569 3 20V4ZM6 3C5.44772 3 5 3.44772 5 4V20C5 20.5523 5.44772 21 6 21H18C18.5523 21 19 20.5523 19 20V9H14C13.4477 9 13 8.55228 13 8V3H6ZM15 4.41421L17.5858 7H15V4.41421Z"
+              data-blade-component="svg-path"
+              fill="hsla(0, 0%, 2%, 1)"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <p
+          class="c3"
+          data-blade-component="text"
+          letter-spacing="50"
+        >
+          README.md
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/blade/src/components/TreeView/__tests__/__snapshots__/TreeView.web.test.tsx.snap
+++ b/packages/blade/src/components/TreeView/__tests__/__snapshots__/TreeView.web.test.tsx.snap
@@ -77,11 +77,13 @@ exports[`<TreeView /> should render 1`] = `
 
 <div>
   <div
+    aria-multiselectable="false"
     class=""
     data-blade-component="tree-view"
     role="tree"
   >
     <div
+      aria-disabled="false"
       aria-expanded="false"
       class=""
       data-blade-component="tree-view-item"
@@ -147,6 +149,7 @@ exports[`<TreeView /> should render 1`] = `
       </div>
     </div>
     <div
+      aria-disabled="false"
       class=""
       data-blade-component="tree-view-item"
       role="treeitem"

--- a/packages/blade/src/components/TreeView/componentIds.ts
+++ b/packages/blade/src/components/TreeView/componentIds.ts
@@ -1,0 +1,4 @@
+export const componentIds = {
+  TreeView: 'TreeView',
+  TreeViewItem: 'TreeViewItem',
+};

--- a/packages/blade/src/components/TreeView/index.ts
+++ b/packages/blade/src/components/TreeView/index.ts
@@ -1,0 +1,4 @@
+export { TreeView } from './TreeView';
+export type { TreeViewProps } from './types';
+export { TreeViewItem } from './TreeViewItem';
+export type { TreeViewItemProps } from './TreeViewItem';

--- a/packages/blade/src/components/TreeView/types.ts
+++ b/packages/blade/src/components/TreeView/types.ts
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
 import type { IconComponent } from '~components/Icons';
 import type { DataAnalyticsAttribute, TestID } from '~utils/types';
@@ -69,7 +69,7 @@ type TreeViewItemProps = {
   /**
    * Optional trailing content (e.g. badge, count)
    */
-  trailing?: ReactElement;
+  trailing?: ReactNode;
 
   /**
    * Whether the item is disabled
@@ -89,6 +89,7 @@ type TreeViewContextType = {
   selectionType: TreeViewSelectionType;
   selectedIds: string[];
   expandedIds: string[];
+  depth: number;
   onNodeSelect: (id: string) => void;
   onNodeToggle: (id: string) => void;
 };

--- a/packages/blade/src/components/TreeView/types.ts
+++ b/packages/blade/src/components/TreeView/types.ts
@@ -1,0 +1,96 @@
+import type { ReactElement, ReactNode } from 'react';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import type { IconComponent } from '~components/Icons';
+import type { DataAnalyticsAttribute, TestID } from '~utils/types';
+
+type TreeViewSelectionType = 'single' | 'multiple' | 'none';
+
+type TreeViewProps = {
+  /**
+   * Tree nodes — accepts `TreeViewItem` children
+   */
+  children: ReactNode;
+
+  /**
+   * Controls selection behavior
+   *
+   * @default 'none'
+   */
+  selectionType?: TreeViewSelectionType;
+
+  /**
+   * Selected node id(s) (controlled). Use string for `single`, string[] for `multiple`.
+   */
+  selectedIds?: string | string[];
+
+  /**
+   * Default selected node id(s) (uncontrolled). Use string for `single`, string[] for `multiple`.
+   */
+  defaultSelectedIds?: string | string[];
+
+  /**
+   * Callback when selection changes
+   */
+  onSelectionChange?: (params: { selectedIds: string[] }) => void;
+
+  /**
+   * Default expanded node ids. Nodes with matching ids will be expanded on initial render.
+   */
+  defaultExpandedIds?: string[];
+
+  /**
+   * Controlled expanded node ids
+   */
+  expandedIds?: string[];
+
+  /**
+   * Callback when a node is expanded or collapsed
+   */
+  onExpandChange?: (params: { expandedIds: string[]; nodeId: string; isExpanded: boolean }) => void;
+} & TestID &
+  StyledPropsBlade;
+
+type TreeViewItemProps = {
+  /**
+   * Unique identifier for the node (required for selection and expand callbacks)
+   */
+  id: string;
+
+  /**
+   * Label text displayed for the node
+   */
+  label: string;
+
+  /**
+   * Optional icon rendered before the label
+   */
+  icon?: IconComponent;
+
+  /**
+   * Optional trailing content (e.g. badge, count)
+   */
+  trailing?: ReactElement;
+
+  /**
+   * Whether the item is disabled
+   *
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Nested `TreeViewItem` children
+   */
+  children?: ReactNode;
+} & TestID &
+  DataAnalyticsAttribute;
+
+type TreeViewContextType = {
+  selectionType: TreeViewSelectionType;
+  selectedIds: string[];
+  expandedIds: string[];
+  onNodeSelect: (id: string) => void;
+  onNodeToggle: (id: string) => void;
+};
+
+export type { TreeViewProps, TreeViewItemProps, TreeViewContextType, TreeViewSelectionType };

--- a/packages/blade/src/components/TreeView/types.ts
+++ b/packages/blade/src/components/TreeView/types.ts
@@ -46,7 +46,12 @@ type TreeViewProps = {
   /**
    * Callback when a node is expanded or collapsed
    */
-  onExpandChange?: (params: { expandedIds: string[]; nodeId: string; isExpanded: boolean }) => void;
+  onExpandChange?: (params: { nodeId: string; isExpanded: boolean }) => void;
+
+  /**
+   * Callback when the set of expanded node ids changes
+   */
+  onExpandedIdsChange?: (params: { expandedIds: string[] }) => void;
 } & TestID &
   StyledPropsBlade;
 

--- a/packages/blade/src/components/TreeView/types.ts
+++ b/packages/blade/src/components/TreeView/types.ts
@@ -19,14 +19,14 @@ type TreeViewProps = {
   selectionType?: TreeViewSelectionType;
 
   /**
-   * Selected node id(s) (controlled). Use string for `single`, string[] for `multiple`.
+   * Selected node id(s) (controlled).
    */
-  selectedIds?: string | string[];
+  selectedIds?: string[];
 
   /**
-   * Default selected node id(s) (uncontrolled). Use string for `single`, string[] for `multiple`.
+   * Default selected node id(s) (uncontrolled).
    */
-  defaultSelectedIds?: string | string[];
+  defaultSelectedIds?: string[];
 
   /**
    * Callback when selection changes

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -80,3 +80,4 @@ export * from './ListView';
 export * from './Preview';
 export * from './GenUI';
 export * from './Spark';
+export * from './TreeView';

--- a/packages/blade/src/components/types.ts
+++ b/packages/blade/src/components/types.ts
@@ -34,6 +34,10 @@ type BladeCommonEvents = {
     web: React.KeyboardEventHandler;
     native: undefined | ((event: any) => void);
   }>;
+  onClick?: Platform.Select<{
+    web: React.MouseEventHandler;
+    native: undefined;
+  }>;
 };
 
 export type { BladeCommonEvents };

--- a/packages/blade/src/components/types.ts
+++ b/packages/blade/src/components/types.ts
@@ -36,7 +36,7 @@ type BladeCommonEvents = {
   }>;
   onClick?: Platform.Select<{
     web: React.MouseEventHandler;
-    native: undefined;
+    native: undefined | ((event: any) => void);
   }>;
 };
 

--- a/packages/blade/src/components/types.ts
+++ b/packages/blade/src/components/types.ts
@@ -30,6 +30,10 @@ type BladeCommonEvents = {
     native: undefined | ((event: any) => void);
     web: React.TouchEventHandler;
   }>;
+  onKeyDown?: Platform.Select<{
+    web: React.KeyboardEventHandler;
+    native: undefined | ((event: any) => void);
+  }>;
 };
 
 export type { BladeCommonEvents };

--- a/packages/blade/src/utils/metaAttribute/metaConstants.ts
+++ b/packages/blade/src/utils/metaAttribute/metaConstants.ts
@@ -159,4 +159,6 @@ export const MetaConstants = {
   PreviewFooter: 'preview-footer',
   Pagination: 'pagination',
   TimePicker: 'time-picker',
+  TreeView: 'tree-view',
+  TreeViewItem: 'tree-view-item',
 } as const;


### PR DESCRIPTION
## Summary

- Adds `TreeView` and `TreeViewItem` components for displaying hierarchical/nested data
- Supports expand/collapse with controlled and uncontrolled modes
- Supports `single` and `multiple` selection with controlled and uncontrolled modes
- Keyboard navigation: Enter/Space to toggle, ArrowRight/ArrowLeft to expand/collapse
- ARIA `tree`, `treeitem`, `group` roles for accessibility
- Optional `icon` prop and `trailing` slot per node
- `isDisabled` support per node

## Usage

```jsx
<TreeView selectionType="single" onSelectionChange={({ selectedIds }) => console.log(selectedIds)}>
  <TreeViewItem id="src" label="src" icon={FolderIcon}>
    <TreeViewItem id="components" label="components" icon={FolderIcon}>
      <TreeViewItem id="button" label="Button.tsx" icon={FileTextIcon} />
    </TreeViewItem>
  </TreeViewItem>
  <TreeViewItem id="readme" label="README.md" icon={FileTextIcon} />
</TreeView>
```

## Test plan

- [ ] TreeView renders correctly
- [ ] Nodes expand/collapse on click
- [ ] Nested nodes expand correctly
- [ ] Single selection works
- [ ] Multiple selection works
- [ ] Controlled expand/selection works
- [ ] Keyboard navigation works
- [ ] Disabled items don't respond to interactions
- [ ] Accessibility (ARIA roles) verified

> ⚠️ Note: There are a couple of known TypeScript issues (`cursor` prop type conflict on native) and 2 test failures (snapshot + disabled item test) to be fixed in follow-up. The component is functionally working on web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API in a minor release; pulse items use web-only keyboard DOM APIs and the PR acknowledges remaining native/type and test gaps.
> 
> **Overview**
> Adds a new **`TreeView`** / **`TreeViewItem`** API to `@razay/blade` for hierarchical data with expand/collapse, selection (none/single/multiple), and keyboard/ARIA tree roles, shipped as a **minor** release per the changeset.
> 
> **Supporting changes:** **`BladeCommonEvents`** gains **`onClick`** and **`onKeyDown`** for **`BaseBox`**-style interaction typing; **`MetaConstants`** and barrel export wire the component into the design system. Native **`BaseLink`** drops a **`@ts-expect-error`** on **`onClick`** now that types align.
> 
> The PR notes **known follow-ups**: native **`cursor`** typing and a couple of web tests may still need fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2abc877a117ecb6688d720cd2d044c83eee6d191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->