### PR TITLE
docs: add Cursor Cloud development environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,14 @@ fi
 ```
 
 When intent is `perform-task-end-to-end`, load `perform-task-end-to-end` skill in your context and do the task end-to-end as guided by the skill.
+
+## Cursor Cloud specific instructions
+
+Environment notes for future cloud agents (dependencies are already installed by the startup update script — `yarn install` from the repo root):
+
+- **Node:** `packages/blade` requires Node `>=20` (the strictest constraint in the monorepo). The VM ships Node 22, which works. Do not downgrade below 20.
+- **Package manager:** Yarn Classic (v1) with Lerna. The root `package.json` uses `"nohoist": ["**"]`, so dependencies are **not** hoisted — each workspace package keeps its own `node_modules`. Re-run `yarn install` from the repo root after pulling to refresh all packages; the root `postinstall` rebuilds `eslint-plugin-blade`.
+- **Primary product = `@razorpay/blade`** (React web + React Native components), developed/tested through Storybook. Standard lint/test/build/typecheck commands are documented in the root `package.json` scripts and `packages/blade/AGENTS.md` — use those rather than duplicating here.
+- **Running the web Storybook (main dev surface):** `cd packages/blade && yarn start:web` serves on http://localhost:9009. The first load triggers a Vite dependency pre-bundle that takes ~30–60s before stories render; wait for `Local: http://localhost:9009/` in the logs before hitting the server.
+- **Running tests directly:** prefer the documented `yarn test:react <Component>` form (e.g. `yarn test:react Button/Button`) from `packages/blade`, which works with or without the `SHARD` env var. Invoking `jest`/`cross-env` directly from a raw shell fails unless you use the package's local bin (`./node_modules/.bin/jest`) because `cross-env` is not on the global PATH.
+- **Optional services (only when working on those packages):** Svelte components — `cd packages/blade-svelte && yarn dev` (Storybook on port 6007, also builds `blade-core` in watch mode); MCP server — `cd packages/blade-mcp && yarn dev` (stdio-based, no HTTP port). Neither is needed to develop/test the core `blade` package.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the Blade monorepo for Cursor Cloud agents. Adds a `## Cursor Cloud specific instructions` section to the root `AGENTS.md` capturing durable, non-obvious startup/run caveats discovered while verifying the environment.

No application/library code was changed — only documentation.

## Environment verified

- **Install:** `yarn install --frozen-lockfile` (Yarn Classic + Lerna, `nohoist: ["**"]`, Node 22 — `blade` requires `>=20`).
- **Lint:** `yarn lint:blade` → 0 errors (warnings only).
- **Typecheck:** `yarn typecheck` (web + native) → pass.
- **Unit tests:** `yarn test:react Button/Button` → 37 passed.
- **Run:** `cd packages/blade && yarn start:web` → Storybook on http://localhost:9009 (HTTP 200). Interactive hello-world: typed text into the Blade `TextInput` story and verified focus/clear rendering.

## Notes captured in AGENTS.md

- Node `>=20` requirement; Yarn Classic with no hoisting.
- Web Storybook on port 9009 with first-load Vite pre-bundle delay.
- Direct `jest`/`cross-env` invocation gotcha (use `yarn test:react <Component>` or the local bin).
- Optional services: `blade-svelte` Storybook (6007) and `blade-mcp` (stdio).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b83b20d7-c4e4-4756-bca5-fc5920394f93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b83b20d7-c4e4-4756-bca5-fc5920394f93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

