### PR TITLE
fix: improve slash master healer error visibility and add workflow_dispatch

### DIFF
--- a/.github/workflows/slash-master-healer.yml
+++ b/.github/workflows/slash-master-healer.yml
@@ -8,6 +8,12 @@ name: Agentic Repo / Slash Master Healer
 #   workflow_run — fires when a monitored workflow completes on master
 
 on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Workflow run ID of the failing master check (optional)'
+        required: false
+        type: string
   workflow_run:
     workflows:
       - 'Blade Interaction Tests'
@@ -23,7 +29,7 @@ concurrency:
 jobs:
   heal-master:
     name: Heal Master Checks via Slash
-    if: github.event.workflow_run.conclusion == 'failure'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest # nosemgrep: non-self-hosted-runner
     steps:
       - name: Checkout repository
@@ -42,7 +48,7 @@ jobs:
           SLASH_API_PASSWORD: ${{ secrets.SLASH_API_PASSWORD }}
           SLASH_REPOSITORY_URL: https://github.com/${{ github.repository }}
           SLASH_BRANCH: master
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ github.event.inputs.run_id || github.event.workflow_run.id }}
           REPOSITORY: ${{ github.repository }}
         run: |
           WORKFLOW_RUN_URL="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
@@ -56,8 +62,15 @@ jobs:
           2. Before creating any fix PR, search for open PRs with the label 'Auto-Created PR' to check if a PR already exists for the same issue. If one exists, skip creating a new PR.
           3. If failures are real test or code issues and no existing fix PR is found, create a new branch off master and open a PR to fix them. Add the label 'Auto-Created PR' to the created PR."
 
+          set +e
           RESPONSE_OUTPUT=$(node .github/scripts/run-slash.js "$PROMPT")
+          NODE_EXIT=$?
+          set -e
           echo "$RESPONSE_OUTPUT"
+          if [ $NODE_EXIT -ne 0 ]; then
+            echo "ERROR: run-slash.js exited with code $NODE_EXIT (see response above)"
+            exit $NODE_EXIT
+          fi
 
           RESPONSE_JSON=$(echo "$RESPONSE_OUTPUT" | grep "^Response:" | sed 's/^Response: //')
           TASK_ID=$(echo "$RESPONSE_JSON" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d.get('task_id',''))" 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Wrap `node run-slash.js` call with `set +e` so the full API response body is printed before exiting on failure (previously `bash -e` aborted inside the subshell, swallowing the error)
- Add `workflow_dispatch` trigger with an optional `run_id` input so the workflow can be manually triggered for testing

## Test plan
- [ ] Trigger manually from Actions tab to verify the workflow runs and error output is visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; manual dispatch could target a wrong run_id if mis-specified, but no application code or secrets handling changes.
> 
> **Overview**
> Updates **Slash Master Healer** so operators can run it from the Actions tab and see why `run-slash.js` failed.
> 
> Adds **`workflow_dispatch`** with an optional **`run_id`** input. The heal job now runs on manual dispatch as well as on failed monitored **`workflow_run`** events, and **`RUN_ID`** uses the input when provided (otherwise the triggering run’s id).
> 
> Wraps the **`node .github/scripts/run-slash.js`** call with **`set +e`**, echoes the full script output, then re-exits with the captured Node exit code so API error messages aren’t hidden by **`bash -e`** inside the command substitution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a182a54ab3f18a7a3bae78acebe5b462fa383672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->