### PR TITLE
fix(blade-svelte): add Playground stories for working Storybook Controls

### DIFF
--- a/.changeset/blade-svelte-storybook-playground.md
+++ b/.changeset/blade-svelte-storybook-playground.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-svelte": patch
+---
+
+fix(blade-svelte): add Playground stories so Storybook Controls work

--- a/packages/blade-svelte/src/components/Accordion/Accordion.stories.svelte
+++ b/packages/blade-svelte/src/components/Accordion/Accordion.stories.svelte
@@ -6,7 +6,11 @@
     title: 'Components/Accordion',
     component: Accordion,
     tags: ['autodocs'],
-    args: {},
+    args: {
+      variant: 'transparent',
+      size: 'large',
+      showNumberPrefix: false,
+    },
     argTypes: {
       variant: {
         control: 'select',
@@ -50,6 +54,37 @@
   let controlledExpandedIndex = $state(-1);
   let customHeaderVisible = $state(true);
 </script>
+
+<Story name="Playground">
+  {#snippet template({ children: _children, ...args })}
+    <Accordion {...args}>
+      {#snippet children()}
+        <AccordionItem>
+          {#snippet children()}
+            <AccordionItemHeader title="How can I setup Route?" />
+            <AccordionItemBody>
+              <Text>
+                You can create Routes, Rules, and Processors to emulate your 3DS flow on Razorpay
+                Payments to accept international card payments.
+              </Text>
+            </AccordionItemBody>
+          {/snippet}
+        </AccordionItem>
+        <AccordionItem>
+          {#snippet children()}
+            <AccordionItemHeader title="How can I setup QR Code?" />
+            <AccordionItemBody>
+              <Text>
+                You can create Routes, Rules, and Processors to emulate your 3DS flow on Razorpay
+                Payments to accept international card payments.
+              </Text>
+            </AccordionItemBody>
+          {/snippet}
+        </AccordionItem>
+      {/snippet}
+    </Accordion>
+  {/snippet}
+</Story>
 
 <Story name="Basic Example" asChild>
   <Accordion>

--- a/packages/blade-svelte/src/components/Avatar/AvatarGroup.stories.svelte
+++ b/packages/blade-svelte/src/components/Avatar/AvatarGroup.stories.svelte
@@ -75,7 +75,8 @@
 
 <Story name="Playground">
   {#snippet template(args)}
-    <AvatarGroup {...args}>
+    {@const { children: _, ...rest } = args}
+    <AvatarGroup {...rest}>
       {#each names as name, index}
         <Avatar name={name} color={avatarColors[index]} />
       {/each}

--- a/packages/blade-svelte/src/components/Avatar/AvatarGroup.stories.svelte
+++ b/packages/blade-svelte/src/components/Avatar/AvatarGroup.stories.svelte
@@ -6,6 +6,10 @@
     title: 'Components/Avatar/AvatarGroup',
     component: AvatarGroup,
     tags: ['autodocs'],
+    args: {
+      size: 'medium',
+      density: 'normal',
+    },
     argTypes: {
       size: {
         control: 'select',
@@ -68,6 +72,16 @@
   const sizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'] as const;
   const densities = ['compact', 'normal', 'comfortable'] as const;
 </script>
+
+<Story name="Playground">
+  {#snippet template(args)}
+    <AvatarGroup {...args}>
+      {#each names as name, index}
+        <Avatar name={name} color={avatarColors[index]} />
+      {/each}
+    </AvatarGroup>
+  {/snippet}
+</Story>
 
 <!-- Story 1: Default -->
 <Story name="Default" asChild>

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -12,6 +12,10 @@
     args: {
       isOpen: undefined,
       snapPoints: undefined,
+      isDismissible: true,
+      title: 'Address Details',
+      subtitle: 'Saving addresses will improve your checkout experience',
+      showBackButton: false,
     },
     argTypes: {
       isOpen: { table: { disable: true } },
@@ -46,6 +50,9 @@
   import Badge from '../Badge/Badge.svelte';
   import Counter from '../Counter/Counter.svelte';
   import Link from '../Link/Link.svelte';
+
+  /* Playground story state — separate from product-demo stories. */
+  let isPlaygroundOpen = $state(false);
 
   /* Default story state (one bucket per story to keep them independent). */
   let isDefaultOpen = $state(false);
@@ -169,6 +176,33 @@
     {/each}
   </ul>
 {/snippet}
+
+<!-- Playground — controls drive BottomSheet + header props. -->
+<Story name="Playground">
+  {#snippet template(args: BottomSheetProps & { title?: string; subtitle?: string; showBackButton?: boolean })}
+    <div>
+      <Button onClick={() => (isPlaygroundOpen = true)}>Open</Button>
+      <BottomSheet
+        {...args}
+        isOpen={isPlaygroundOpen}
+        onDismiss={() => (isPlaygroundOpen = false)}
+      >
+        {#snippet children()}
+          <BottomSheetHeader
+            title={args.title ?? 'Address Details'}
+            subtitle={args.subtitle ?? 'Saving addresses will improve your checkout experience'}
+            showBackButton={args.showBackButton}
+          />
+          <BottomSheetBody>
+            {#snippet children()}
+              <Text>Use controls to tweak header props, isDismissible, and zIndex.</Text>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
 
 <!-- Story 1: Default — long Lorem Ipsum content + checkbox + Continue button. -->
 <Story name="Default">

--- a/packages/blade-svelte/src/components/Breadcrumb/Breadcrumb.stories.svelte
+++ b/packages/blade-svelte/src/components/Breadcrumb/Breadcrumb.stories.svelte
@@ -63,6 +63,25 @@
   });
 </script>
 
+<Story name="Playground">
+  {#snippet template({ children: _children, ...args })}
+    <div
+      style:padding="var(--spacing-4)"
+      style:background-color={args.color === 'white' ? 'var(--surface-background-primary-intense)' : undefined}
+    >
+      <Breadcrumb {...args}>
+        {#snippet children()}
+          <BreadcrumbItem accessibilityLabel="Home" icon={HomeIcon} href="/home" />
+          <BreadcrumbItem href="/dashboard">Dashboard</BreadcrumbItem>
+          <BreadcrumbItem isCurrentPage href="/settlements">
+            Settlements
+          </BreadcrumbItem>
+        {/snippet}
+      </Breadcrumb>
+    </div>
+  {/snippet}
+</Story>
+
 <!-- Story 1: Basic -->
 <Story name="Basic" asChild>
   <div style:padding="var(--spacing-4)">

--- a/packages/blade-svelte/src/components/Card/Card.stories.svelte
+++ b/packages/blade-svelte/src/components/Card/Card.stories.svelte
@@ -52,7 +52,8 @@
 
 <Story name="Playground">
   {#snippet template(args)}
-    <Card {...args} width="400px">
+    {@const { children: _, ...rest } = args}
+    <Card {...rest} width="400px">
       <CardBody>
         <Text>
           Card playground — tweak background, padding, and border radius via controls.

--- a/packages/blade-svelte/src/components/Card/Card.stories.svelte
+++ b/packages/blade-svelte/src/components/Card/Card.stories.svelte
@@ -50,6 +50,18 @@
   import { CreditCardIcon, InfoIcon, CloseIcon, CheckIcon, SearchIcon } from '../Icons';
 </script>
 
+<Story name="Playground">
+  {#snippet template(args)}
+    <Card {...args} width="400px">
+      <CardBody>
+        <Text>
+          Card playground — tweak background, padding, and border radius via controls.
+        </Text>
+      </CardBody>
+    </Card>
+  {/snippet}
+</Story>
+
 <!-- Story 1: Card Example
      React renders a split light+dark layout via a scoped <BladeProvider colorScheme="dark">.
      Svelte's BladeProvider isn't migrated yet and dark tokens are body-scoped in theme.css,

--- a/packages/blade-svelte/src/components/Card/CardInteractive.stories.svelte
+++ b/packages/blade-svelte/src/components/Card/CardInteractive.stories.svelte
@@ -171,6 +171,43 @@
   ];
 </script>
 
+<Story name="Playground">
+  {#snippet template(args)}
+    <Card {...args} width="400px" onHover={() => console.log('Hovered')}>
+      <CardHeader>
+        <CardHeaderLeading title="Payment Pages" subtitle="Card Header Subtitle">
+          {#snippet prefix()}
+            <CardHeaderIcon icon={CreditCardIcon} />
+          {/snippet}
+          {#snippet suffix()}
+            <CardHeaderCounter value={12} />
+          {/snippet}
+        </CardHeaderLeading>
+        <CardHeaderTrailing>
+          {#snippet visual()}
+            <CardHeaderBadge color="positive">NEW</CardHeaderBadge>
+          {/snippet}
+        </CardHeaderTrailing>
+      </CardHeader>
+      <CardBody>
+        <Text>
+          Share payment link via an email, SMS, messenger, chatbot etc. and get paid immediately.
+          Accepting payments from customers is now just a link away.
+        </Text>
+      </CardBody>
+      <CardFooter>
+        <CardFooterLeading title="Footer" subtitle="Footer Subtitle" />
+        <CardFooterTrailing
+          actions={{
+            primary: { text: 'Primary', onClick: () => console.log('Primary') },
+            secondary: { text: 'Secondary', onClick: () => console.log('Secondary') },
+          }}
+        />
+      </CardFooter>
+    </Card>
+  {/snippet}
+</Story>
+
 <!-- Story 1: Default -->
 <Story name="Default" asChild>
   <Card

--- a/packages/blade-svelte/src/components/Card/CardInteractive.stories.svelte
+++ b/packages/blade-svelte/src/components/Card/CardInteractive.stories.svelte
@@ -173,7 +173,8 @@
 
 <Story name="Playground">
   {#snippet template(args)}
-    <Card {...args} width="400px" onHover={() => console.log('Hovered')}>
+    {@const { children: _, ...rest } = args}
+    <Card {...rest} width="400px" onHover={() => console.log('Hovered')}>
       <CardHeader>
         <CardHeaderLeading title="Payment Pages" subtitle="Card Header Subtitle">
           {#snippet prefix()}

--- a/packages/blade-svelte/src/components/Chip/Chip.stories.svelte
+++ b/packages/blade-svelte/src/components/Chip/Chip.stories.svelte
@@ -9,6 +9,8 @@
     tags: ['autodocs'],
     args: {
       isDisabled: false,
+      value: 'Automated Payment Links',
+      color: 'primary',
     },
     argTypes: {
       isDisabled: {
@@ -38,6 +40,17 @@
     },
   });
 </script>
+
+<Story name="Playground">
+  {#snippet template(args)}
+    <ChipGroup
+      selectionType="multiple"
+      accessibilityLabel="Select other capabilities you are looking for from the options below"
+    >
+      <Chip {...args}>Automated Payment Links</Chip>
+    </ChipGroup>
+  {/snippet}
+</Story>
 
 <Story name="Default" asChild>
   <div>

--- a/packages/blade-svelte/src/components/Chip/ChipGroup.stories.svelte
+++ b/packages/blade-svelte/src/components/Chip/ChipGroup.stories.svelte
@@ -9,6 +9,10 @@
     args: {
       isDisabled: false,
       accessibilityLabel: 'Choose one business type from the options below',
+      label: 'Select Business type:',
+      selectionType: 'single',
+      size: 'small',
+      color: 'primary',
     },
     argTypes: {
       label: {
@@ -119,6 +123,16 @@
   let controlledMultiValues = $state(['Automated Payment Links']);
   let chipRefValue = $state('');
 </script>
+
+<Story name="Playground">
+  {#snippet template({ children: _children, ...args })}
+    <ChipGroup {...args}>
+      {#each singleChipValues as chipValue}
+        <Chip value={chipValue}>{chipValue}</Chip>
+      {/each}
+    </ChipGroup>
+  {/snippet}
+</Story>
 
 <!-- Story 1: Single Selection -->
 <Story name="Single Selection" asChild>


### PR DESCRIPTION
## Summary
- Adds an args-driven `Playground` story as the first story for 8 Svelte components whose Controls panel was non-functional
- Root cause: stories used `asChild` with hardcoded props and never spread `defineMeta` args into the component
- Static matrix/showcase stories are unchanged

## Components fixed
- Chip, ChipGroup
- Breadcrumb
- Card, Card Interactive
- Accordion
- AvatarGroup
- BottomSheet

## Test plan
- [ ] Open Storybook for each component above
- [ ] Select **Playground** (default autodocs story)
- [ ] Change Controls (`type`, `variant`, `size`, `color`, etc.) and confirm the rendered component updates
- [ ] Confirm static matrix stories still render as before

Made with [Cursor](https://cursor.com)