### PR TITLE
docs: add usage guidelines to MCP knowledgebase components

### DIFF
--- a/.changeset/easy-vans-hope.md
+++ b/.changeset/easy-vans-hope.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-mcp": patch
+---
+
+docs: add usage guidelines to MCP knowledgebase components

--- a/packages/blade-mcp/knowledgebase/components/Accordion.md
+++ b/packages/blade-mcp/knowledgebase/components/Accordion.md
@@ -120,6 +120,24 @@ type AccordionItemBodyProps = {
 } & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Accordion` for 3+ items that need expand/collapse behavior where only one is open at a time (FAQs, settings, documentation).
+- Compose with `AccordionItem` → `AccordionItemHeader` + `AccordionItemBody` (modern API).
+- Use `showNumberPrefix` for sequential/ordered items.
+- Use `leading` on `AccordionItemHeader` for category icons and `titleSuffix` for badges.
+- Use controlled mode (`expandedIndex` + `onExpandChange`) when you need programmatic control.
+
+**Don't**
+
+- Don't use `Accordion` when all items should be expandable simultaneously — use multiple `Collapsible` components instead.
+- Don't use the deprecated props API (`title`/`description` on AccordionItem) — use `AccordionItemHeader` + `AccordionItemBody`.
+- Don't nest Accordions — only single-level is supported.
+- Don't use `Accordion` when items are equal-weight and need quick access — use `Tabs` instead.
+- Don't combine `showNumberPrefix` with `leading` icon on the same item.
+
 ## Examples
 
 ### Basic Accordion

--- a/packages/blade-mcp/knowledgebase/components/ActionList.md
+++ b/packages/blade-mcp/knowledgebase/components/ActionList.md
@@ -119,6 +119,24 @@ type ActionListItemAssetProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `ActionList` inside `Dropdown` or `Menu` for presenting selectable or actionable item lists.
+- Use `ActionListSection` to group related items with automatic dividers and optional section titles.
+- Use `leading` prop with specific components: `ActionListItemIcon`, `ActionListItemAsset`, `ActionListItemAvatar`, `ActionListItemText`.
+- Use `intent="negative"` on `ActionListItem` for destructive actions (delete, remove, logout).
+- Use `isVirtualized` for lists with 100+ items to maintain performance.
+
+**Don't**
+
+- Don't use `ActionListItem` with `intent="negative"` when the parent Dropdown uses `SelectInput` as trigger.
+- Don't pass arbitrary components to `leading` or `trailing` — only specific ActionListItem sub-components are accepted.
+- Don't use `ActionList` for simple navigation — use `SideNav` or `Menu` with `MenuItem`.
+- Don't enable virtualization for small lists — it changes DOM structure unnecessarily.
+- Don't use `ActionList` standalone when `Menu` or `Dropdown` would provide better trigger/overlay behavior.
+
 ## Examples
 
 ### Basic ActionList

--- a/packages/blade-mcp/knowledgebase/components/Alert.md
+++ b/packages/blade-mcp/knowledgebase/components/Alert.md
@@ -100,6 +100,26 @@ type AlertProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Alert` for important, contextual messages that require user attention within a page section.
+- Use semantic `color` values to match intent: `negative` for errors, `notice` for warnings, `positive` for success confirmations, `information` for general info.
+- Provide a concise `title` and a descriptive `description` — the description can include `Link` components for related actions.
+- Use `isFullWidth` for page-level alerts that span the entire container width.
+- Provide a `primary` action when the user should take a specific next step; use `secondary` only alongside a primary action.
+- Use `emphasis="intense"` sparingly for critical alerts that need maximum visual prominence.
+
+**Don't**
+
+- Don't use `Alert` for transient feedback after user actions — use `Toast` instead.
+- Don't use `Alert` for page-level broadcast announcements — use `AnnouncementBanner` instead.
+- Don't pass complex components inside `description` — stick to plain text and `Link`.
+- Don't provide a `secondary` action without a `primary` action.
+- Don't override the default icon unless you have a strong reason — icons are automatically chosen based on `color` for consistent semantics.
+- Don't use `Alert` as a dismissible banner at the top of the page — it's designed for inline, contextual messaging.
+
 ## Examples
 
 ### Standard Alert with Title, Description, and Actions

--- a/packages/blade-mcp/knowledgebase/components/Amount.md
+++ b/packages/blade-mcp/knowledgebase/components/Amount.md
@@ -90,6 +90,25 @@ type AmountCommonProps = {
 type AmountProps = AmountTypeProps & AmountCommonProps;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Amount` for displaying currency values with locale-aware formatting (symbols, commas, decimals).
+- Use `suffix="humanize"` for large numbers that need compact notation (e.g., 1.2M, 123K).
+- Use semantic `color` values (`positive` for credits, `negative` for debits) to convey financial meaning.
+- Match `type` to context: `"body"` for inline amounts, `"heading"` for section-level, `"display"` for hero amounts.
+- Use `isStrikethrough` for original prices in discount contexts.
+- Set `fractionDigits="auto"` to respect currency-specific decimal conventions (JPY=0, INR=2, KWD=3).
+
+**Don't**
+
+- Don't pass values in paise/cents directly — convert to the primary unit (rupees/dollars) before passing to `value`.
+- Don't use invalid size combinations for the chosen `type` — each type has its own valid size range.
+- Don't use `color="neutral"` — it's not supported and throws an error.
+- Don't use `Amount` for arbitrary numbers that aren't currency — use `Text` for non-monetary values.
+- Don't omit `I18nProvider` in your app — proper locale formatting depends on it.
+
 ## Examples
 
 ### Display Variations

--- a/packages/blade-mcp/knowledgebase/components/AnimateInteractions.md
+++ b/packages/blade-mcp/knowledgebase/components/AnimateInteractions.md
@@ -41,6 +41,22 @@ type AnimateInteractionsProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `AnimateInteractions` to coordinate child animations based on parent-level interactions (hover, focus, tap).
+- Wrap the entire container that should trigger animations — child components use `motionTriggers={['on-animate-interactions']}` to respond.
+- Use for revealing actions on card hover, showing overlays on image hover, or scaling content on focus.
+- Combine with `Fade`, `Move`, `Scale`, or `Slide` on children for the actual animation effects.
+
+**Don't**
+
+- Don't use `AnimateInteractions` for individual element entry/exit — use `Fade`, `Move`, or `Slide` directly.
+- Don't pass multiple root children — wrap them in a single `Box` container.
+- Don't forget `motionTriggers={['on-animate-interactions']}` on child motion components — they must opt-in explicitly.
+- Don't use when simple CSS `:hover` would suffice — reserve for multi-element coordinated animations.
+
 ## Examples
 
 ### Basic Card with Animated Buttons

--- a/packages/blade-mcp/knowledgebase/components/AnnouncementBanner.md
+++ b/packages/blade-mcp/knowledgebase/components/AnnouncementBanner.md
@@ -43,6 +43,24 @@ type AnnouncementBannerProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `AnnouncementBanner` for brief, system-wide broadcast messages like feature announcements, promotions, or maintenance notices.
+- Keep the message to a single short line — text auto-truncates if it overflows.
+- Use a `Link` component inline for directing users to more details.
+- Place the banner at the top or bottom edge of the page for full-bleed positioning.
+- Provide a meaningful `accessibilityLabel` if the default "Announcement" doesn't describe the content well.
+
+**Don't**
+
+- Don't use `AnnouncementBanner` for contextual or section-specific messages — use `Alert` instead.
+- Don't use it for temporary feedback after user actions — use `Toast` instead.
+- Don't add multi-line content or complex JSX — the component only supports single-line text.
+- Don't try to control the color scheme via props — it automatically follows the app's `colorScheme` from `BladeProvider`.
+- Don't expect a dismiss button or action buttons — they are not supported; use `Alert` if you need dismissibility or actions.
+
 ## Examples
 
 ### Default AnnouncementBanner (centered, with icon)

--- a/packages/blade-mcp/knowledgebase/components/AreaChart.md
+++ b/packages/blade-mcp/knowledgebase/components/AreaChart.md
@@ -153,6 +153,24 @@ type ChartsCategoricalColorToken = `data.background.categorical.${ChartColorCate
 type colorTheme = 'categorical';
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `AreaChart` for showing trends over time with filled regions to emphasize volume or cumulative data.
+- Wrap in `ChartAreaWrapper` with `data` prop and compose with `ChartArea`, `ChartXAxis`, `ChartYAxis`, `ChartTooltip`, `ChartLegend`.
+- Use `stackId` on multiple `ChartArea` components to create stacked area visualizations showing cumulative proportions.
+- Use `connectNulls={true}` when your data has gaps that should be interpolated across.
+- Use `type="monotone"` (default) for smooth curves; `type="step"` for discrete step data.
+
+**Don't**
+
+- Don't use more than 10 `ChartArea` components per chart — this is the maximum enforced limit.
+- Don't use `AreaChart` for categorical comparisons — use `BarChart` instead.
+- Don't use `AreaChart` for showing parts of a whole — use `DonutChart` for proportional data.
+- Don't use sequential color tokens — only categorical color tokens are supported.
+- Don't try to customize chart margins — they are predefined internally.
+
 ## Examples
 
 ### Basic Area Chart with Single Data Series

--- a/packages/blade-mcp/knowledgebase/components/AutoComplete.md
+++ b/packages/blade-mcp/knowledgebase/components/AutoComplete.md
@@ -185,6 +185,24 @@ type AutoCompleteProps = {
 } & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `AutoComplete` for searchable dropdown selection with large option lists (10+ items).
+- Always wrap inside a `Dropdown` component with `DropdownOverlay` and `ActionList`.
+- Use `onInputValueChange` to implement custom filtering logic (client-side or server-side).
+- Use `filteredValues` for server-side/async filtering to control which options appear.
+- Use `ActionListSection` to organize large option lists by category.
+
+**Don't**
+
+- Don't use `AutoComplete` standalone without a `Dropdown` wrapper — it won't function.
+- Don't use `AutoComplete` for small fixed lists under 10 items — use `SelectInput` for simplicity.
+- Don't use React Fragments as children in the `Dropdown` wrapper.
+- Don't confuse with `SearchInput` — AutoComplete is for selection from a list, SearchInput is for triggering search operations.
+- Don't show all 10+ options at once without filtering — use controlled `filteredValues` to prevent layout shifts.
+
 ## Example
 
 ### Basic AutoComplete with Client-Side Filtering

--- a/packages/blade-mcp/knowledgebase/components/Avatar.md
+++ b/packages/blade-mcp/knowledgebase/components/Avatar.md
@@ -152,6 +152,24 @@ type AvatarGroupProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Avatar` to visually represent users or entities with photos, initials, or icons.
+- Use `variant="circle"` for people and `variant="square"` for organizations or entities.
+- Provide `name` or `alt` when using `src` for proper accessibility fallback and alt text.
+- Use `AvatarGroup` with `maxCount` to display multiple avatars in a compact overlapping layout.
+- Use `topAddon` with `Indicator` for online/offline status indicators.
+
+**Don't**
+
+- Don't pass anything other than `Indicator` to `topAddon` — it only accepts the Indicator component.
+- Don't pass anything other than icon components to `bottomAddon`.
+- Don't omit both `name` and `alt` when using `src` — accessibility requires one of them.
+- Don't use `Avatar` as a button — wrap with `onClick` or `href` for interactive behavior, or use `IconButton` for icon-only actions.
+- Don't put non-Avatar components inside `AvatarGroup` — only Avatar is accepted.
+
 ## Examples
 
 ### Avatar Component Usage

--- a/packages/blade-mcp/knowledgebase/components/Badge.md
+++ b/packages/blade-mcp/knowledgebase/components/Badge.md
@@ -55,6 +55,26 @@ type BadgeProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Badge` for non-interactive, color-coded metadata such as status labels, or category indicators.
+- Use semantic `color` values (`positive`, `negative`, `notice`, `information`, `neutral`) to convey meaning — e.g. `positive` for success states, `negative` for errors.
+- Use `emphasis="intense"` when the badge needs to stand out prominently (e.g. critical status); use `emphasis="subtle"` for secondary or supportive metadata.
+- Keep badge labels short (1–2 words) — the text auto-truncates with a tooltip on overflow.
+- Pair an `icon` with the label to reinforce meaning at a glance (e.g. `CheckCircleIcon` with a "Success" badge).
+- Use `size="small"` or `size="xsmall"` when embedding badges inside dense UI like table rows or list items; use `size="medium"` or `size="large"` for standalone callouts.
+
+**Don't**
+
+- Don't use `Badge` for interactive elements — use `Tag` (removable/selectable metadata) or `Chip` (user-driven filter/action) instead.
+- Don't use `Badge` as a clickable button or link — it is purely informational.
+- Don't use icon-only badges without text — `children` (text) is always required.
+- Don't use long sentences as badge labels — keep text concise and use title case or sentence case consistently.
+- Don't rely solely on `color` to convey meaning — always include a text label (and optionally an icon) for accessibility.
+- Don't mix `emphasis="intense"` badges alongside `emphasis="subtle"` for items of equal importance — keep emphasis consistent within the same visual group.
+
 ## Examples
 
 ### Badge Usage

--- a/packages/blade-mcp/knowledgebase/components/BarChart.md
+++ b/packages/blade-mcp/knowledgebase/components/BarChart.md
@@ -200,6 +200,23 @@ type ChartReferenceLineProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `BarChart` for comparing discrete categorical values across groups.
+- Wrap in `ChartBarWrapper` and compose with `ChartBar`, `ChartXAxis`, `ChartYAxis`, `ChartTooltip`, `ChartLegend`.
+- Use `stackId` on multiple `ChartBar` components to create stacked bars showing composition.
+- Use `layout="vertical"` for horizontal bars — remember to set `ChartXAxis type="number"` and `ChartYAxis type="category"`.
+- Use both categorical and sequential color tokens — BarChart supports both palettes unlike other charts.
+
+**Don't**
+
+- Don't use `BarChart` for time-series trends — use `LineChart` or `AreaChart` instead.
+- Don't use `BarChart` for proportional/percentage composition — use `DonutChart` instead.
+- Don't add `<Defs/>` elements — color and gradient handling is managed internally.
+- Don't forget to swap axis types when using `layout="vertical"`.
+
 ## Example
 
 ### Basic BarChart with Multiple Series

--- a/packages/blade-mcp/knowledgebase/components/BottomNav.md
+++ b/packages/blade-mcp/knowledgebase/components/BottomNav.md
@@ -93,6 +93,24 @@ type BottomNavItemProps = {
   DataAnalyticsAttribute;
 ````
 
+## Usage Guidelines
+
+**Do**
+
+- Use `BottomNav` for mobile-only navigation with 2–5 core app destinations.
+- Pair each `BottomNavItem` with a descriptive `title` and a meaningful `icon`.
+- Manage active state externally using React Router's `useLocation()` and `matchPath()`.
+- Use a "More" button (via `onClick`) to open a `SideNav` drawer for additional navigation items beyond the 2–5 limit.
+- Pass the `as` prop with your router's link component (e.g., `NavLink`) for proper navigation.
+
+**Don't**
+
+- Don't use `BottomNav` on desktop — it's designed exclusively for mobile touch interaction.
+- Don't exceed 5 items or go below 2 — the component validates this and throws errors in development.
+- Don't use `BottomNav` for deep or nested navigation — use `SideNav` for hierarchical structures.
+- Don't use `BottomNav` without icons — each item requires an icon displayed above the title.
+- Don't use `BottomNav` as a replacement for `Tabs` — Tabs switch content panels, BottomNav navigates between pages.
+
 ## Example
 
 This example demonstrates how to implement BottomNav with React Router for a mobile application, including active state management and integration with side navigation.

--- a/packages/blade-mcp/knowledgebase/components/BottomSheet.md
+++ b/packages/blade-mcp/knowledgebase/components/BottomSheet.md
@@ -129,6 +129,24 @@ type BottomSheetFooterProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `BottomSheet` as the mobile alternative to `Modal` — it slides from the bottom and supports snap points.
+- Use `snapPoints` array (values 0–1 representing viewport height %) to define multiple height states.
+- Compose with `BottomSheetHeader`, `BottomSheetBody`, and `BottomSheetFooter` for proper structure.
+- Use `showBackButton` on header for multi-step stacked flows with back navigation.
+- Ensure all stacked BottomSheets use the same `zIndex` value.
+
+**Don't**
+
+- Don't use `BottomSheet` on desktop when `Modal` would be more appropriate — BottomSheet is mobile-first.
+- Don't use snap point values outside 0–1 range — they represent percentages of viewport height.
+- Don't use `BottomSheetBody` padding values other than `"spacing.0"` or `"spacing.5"`.
+- Don't expect header/footer to scroll — only the body content scrolls.
+- Don't forget to set `isDismissible={false}` for mandatory flows where swiping down should be prevented.
+
 ## Example
 
 Here are several examples demonstrating different uses of the BottomSheet component:

--- a/packages/blade-mcp/knowledgebase/components/Box.md
+++ b/packages/blade-mcp/knowledgebase/components/Box.md
@@ -257,6 +257,24 @@ type BoxProps = {
 type BoxRefType = HTMLElement;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Box` as the foundational layout primitive for creating flex/grid layouts, spacing, and positioning.
+- Use the `as` prop for semantic HTML rendering (`section`, `article`, `nav`, `main`, `header`, `footer`, `aside`).
+- Use responsive value objects (e.g., `flexDirection={{ base: 'column', m: 'row' }}`) for mobile-first responsive design.
+- Use `elevation` prop for visual depth (`lowRaised`, `midRaised`, `highRaised`).
+- Use `backgroundColor` only with approved tokens: `transparent`, `surface.background.*`, or `overlay.*`.
+
+**Don't**
+
+- Don't use `Box` as a visual card surface with elevation — use `Card` component instead, which provides built-in header/body/footer structure.
+- Don't pass arbitrary color tokens to `backgroundColor` — only `surface.background.*` and `overlay.*` tokens are accepted.
+- Don't use `as` prop on React Native — it's only supported on web.
+- Don't add custom CSS classes — use Box's prop-based API for all styling.
+- Don't nest deeply for simple spacing — prefer `gap`, `padding`, and `margin` props.
+
 ## Example
 
 Here are comprehensive examples demonstrating the versatility of the Box component:

--- a/packages/blade-mcp/knowledgebase/components/Breadcrumb.md
+++ b/packages/blade-mcp/knowledgebase/components/Breadcrumb.md
@@ -94,6 +94,24 @@ type IconComponent = React.ComponentType<{
 }>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Breadcrumb` to show the user's current location within a multi-level application hierarchy.
+- Mark the last item with `isCurrentPage={true}` to set proper `aria-current="page"` semantics.
+- Provide `accessibilityLabel` on icon-only breadcrumb items (e.g., a home icon without text).
+- Use `color="white"` on dark backgrounds and `"primary"` or `"neutral"` on light backgrounds for contrast.
+- Use the `as` prop with your router's link component for SPA navigation.
+
+**Don't**
+
+- Don't manually add separator characters — they are automatically inserted between items.
+- Don't use `Breadcrumb` as primary navigation — it's supplementary wayfinding, not a primary nav pattern.
+- Don't create excessively deep breadcrumb trails — keep to a reasonable depth for usability.
+- Don't confuse with `Pagination` — Breadcrumbs show hierarchy location, Pagination navigates list pages.
+- Don't use `Breadcrumb` for switching between content views — use `Tabs` instead.
+
 ## Example
 
 The following examples demonstrate how to use the Breadcrumb component in various scenarios.

--- a/packages/blade-mcp/knowledgebase/components/Button.md
+++ b/packages/blade-mcp/knowledgebase/components/Button.md
@@ -125,6 +125,24 @@ type IconComponent = React.ComponentType<{
 }>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Button` for primary actions and calls-to-action that trigger operations (submit, save, create).
+- Use `variant` to establish visual hierarchy: `"primary"` for main actions, `"secondary"` for supporting, `"tertiary"` for de-emphasized.
+- Use `href` prop to render as an anchor element when the button navigates to a URL.
+- Use `isLoading` to show feedback during async operations.
+- Use `icon` with `iconPosition` for visual reinforcement of the action.
+
+**Don't**
+
+- Don't use `Button` for icon-only actions in tight spaces — use `IconButton` instead.
+- Don't use `Button` for navigation text that looks like a link — use `Link` instead.
+- Don't use `variant="tertiary"` with `color="positive"` or `color="negative"` — tertiary only supports `"primary"` and `"white"`.
+- Don't use `type="password"` on TextInput — but relevant here: don't pass `type="submit"` accidentally without a form context.
+- Don't use `Button` without text or `accessibilityLabel` when using icon-only mode.
+
 ## Example
 
 Here are comprehensive examples demonstrating various ways to use the Button component:

--- a/packages/blade-mcp/knowledgebase/components/ButtonGroup.md
+++ b/packages/blade-mcp/knowledgebase/components/ButtonGroup.md
@@ -46,6 +46,22 @@ type ButtonGroupProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `ButtonGroup` to visually associate related actions in toolbars or action areas.
+- Only pass `Button`, `Dropdown`, `Tooltip`, or `Popover` as children — other components are not allowed.
+- Use with `Dropdown` for split-button patterns (primary action + dropdown for alternatives).
+- Use consistent `variant` across the group — it's inherited via context.
+
+**Don't**
+
+- Don't pass non-allowed children (only Button, Dropdown, Tooltip, Popover are accepted).
+- Don't use `ButtonGroup` for unrelated actions — group only semantically related buttons.
+- Don't try to override individual button `variant`/`size`/`color` — they inherit from the group.
+- Don't use `ButtonGroup` for navigation — use `Tabs` or `BottomNav` instead.
+
 ## Examples
 
 ### ButtonGroup with Variants and State Management

--- a/packages/blade-mcp/knowledgebase/components/Card.md
+++ b/packages/blade-mcp/knowledgebase/components/Card.md
@@ -219,6 +219,25 @@ type CardFooterTrailingProps = {
 } & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Card` to group related content and actions on a single topic with a consistent elevated surface.
+- Compose using the prescribed structure: `CardHeader` + `CardBody` + `CardFooter` for the primary variant.
+- Use `CardHeaderIcon`, `CardHeaderCounter`, `CardHeaderBadge` for header visual elements — not raw components.
+- Use `onClick` or `href` to make cards interactive; provide `accessibilityLabel` for interactive cards.
+- Use `variant="secondary"` when you only need a body section without header/footer.
+
+**Don't**
+
+- Don't pass arbitrary children directly — only `CardHeader`, `CardBody`, and `CardFooter` are accepted (primary variant).
+- Don't use React Fragments as Card children — they are not allowed.
+- Don't use deprecated props (`backgroundColor`, `borderRadius`, `elevation`) — they are no-ops.
+- Don't use `Box` with elevation for card-like surfaces — use `Card` for content grouping with structure.
+- Don't put more than 2 actions (primary + secondary) in CardFooter.
+- Don't use raw `IconButton` in header trailing — only tertiary variant IconButton via `CardHeaderIconButton` is allowed.
+
 ## Example
 
 ### Basic Card with Header, Body, and Footer

--- a/packages/blade-mcp/knowledgebase/components/Carousel.md
+++ b/packages/blade-mcp/knowledgebase/components/Carousel.md
@@ -147,6 +147,24 @@ type ResponsiveValue<T> = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Carousel` for showcasing multiple items (testimonials, cards, images) in a horizontally scrollable container.
+- Use `visibleItems` (1/2/3) for fixed-count fluid layouts; use `visibleItems="autofit"` with `carouselItemWidth` for bleed/overflow effects.
+- Use `accessibilityLabel` to describe the carousel content for screen readers.
+- Use `navigationButtonPosition="side"` for desktop-optimized navigation; `"bottom"` for compact layouts.
+- Only pass `CarouselItem` components as children.
+
+**Don't**
+
+- Don't pass arbitrary numbers to `visibleItems` — only 1, 2, 3, or `"autofit"` are supported.
+- Don't expect `onChange` to fire during `autoPlay` — it only fires on user interaction.
+- Don't use `shouldAddStartEndSpacing` or `scrollOverlayColor` with fixed `visibleItems` (1/2/3) — they only work with `"autofit"`.
+- Don't use `Carousel` for navigation or step-completion flows — use `Tabs` or `StepGroup` instead.
+- Don't pass non-CarouselItem children — the component throws errors for invalid children.
+
 ## Examples
 
 ### Basic Responsive Carousel

--- a/packages/blade-mcp/knowledgebase/components/ChatInput.md
+++ b/packages/blade-mcp/knowledgebase/components/ChatInput.md
@@ -132,6 +132,23 @@ type ChatInputProps = {
   StyledPropsBlade;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `ChatInput` for AI chat interfaces and conversational UIs with file upload and ghost suggestions.
+- Use `isGenerating` to swap the submit button to a stop button during AI response generation.
+- Use `suggestions` with `onSuggestionAccept` to show cycling ghost suggestions that users accept with Tab.
+- Use `fileList` with `onFileChange`/`onFileRemove` for file attachment workflows.
+- Handle Enter for submit and Shift+Enter for newline in the textarea.
+
+**Don't**
+
+- Don't use `ChatInput` for simple forms or single-line input — use `TextInput` or `TextArea`.
+- Don't use `suggestions` without `onSuggestionAccept` — they must be used together.
+- Don't expect automatic file uploads — the consumer manages the upload lifecycle and status.
+- Don't forget that the submit button auto-disables when there's no text and no files, or when files are uploading/errored.
+
 ## Examples
 
 ### Basic Chat Input with File Upload

--- a/packages/blade-mcp/knowledgebase/components/ChatMessage.md
+++ b/packages/blade-mcp/knowledgebase/components/ChatMessage.md
@@ -106,6 +106,25 @@ type ChatMessageProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `ChatMessage` for building conversational interfaces with distinct sender/receiver messages.
+- Use `senderType="self"` for user messages (right-aligned) and `senderType="other"` for agent/system messages (left-aligned).
+- Use `leading` prop with an icon or avatar for agent messages to provide visual sender identification.
+- Use `isLoading` with `loadingText` (string array for rolling animation) during async AI responses.
+- Use `footerActions` for feedback controls (thumbs up/down, copy, share) on agent messages.
+- Pass complex JSX (Card, Table, RadioGroup) directly as children for rich message content.
+
+**Don't**
+
+- Don't use the deprecated `messageType` prop — it's non-functional.
+- Don't use `ChatMessage` for notification-style alerts — use `Toast` or `Alert` instead.
+- Don't pass more than 5 thumbnails — excess images show a "+n" badge.
+- Don't put `footerActions` on self-messages — they're designed for agent/other messages only.
+- Don't manually wrap string children in `Text` — ChatMessage auto-wraps string content.
+
 ## Examples
 
 ### Comprehensive Chat Interface

--- a/packages/blade-mcp/knowledgebase/components/Checkbox.md
+++ b/packages/blade-mcp/knowledgebase/components/Checkbox.md
@@ -173,6 +173,24 @@ type CheckboxGroupProps = {
   TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Checkbox` for selecting multiple independent options from a set (multiple selections allowed).
+- Use `CheckboxGroup` when grouping related checkboxes with shared validation, label, and state.
+- Use `isIndeterminate` for "select all" patterns when some (but not all) items are selected.
+- Inside `CheckboxGroup`, provide a unique `value` prop on each `Checkbox` — this is required.
+- Use standalone `Checkbox` (outside group) when you need a single toggle with its own validation.
+
+**Don't**
+
+- Don't use `Checkbox` when only one option can be selected — use `Radio`/`RadioGroup` instead.
+- Don't use `Checkbox` for immediate on/off actions without form submission — use `Switch` instead.
+- Don't set `validationState`, `name`, `isChecked`, or `onChange` on individual Checkboxes inside a `CheckboxGroup` — use these on the group.
+- Don't use React Fragments as children in `CheckboxGroup` — only `Checkbox` components are accepted.
+- Don't mix controlled (`isChecked`) and uncontrolled (`defaultChecked`) on the same Checkbox.
+
 ## Examples
 
 ### Payment Setup Form with Checkboxes

--- a/packages/blade-mcp/knowledgebase/components/Checkbox.md
+++ b/packages/blade-mcp/knowledgebase/components/Checkbox.md
@@ -175,18 +175,26 @@ type CheckboxGroupProps = {
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `Checkbox` in two scenarios:
+1. **Multi-select with longer/inconsistent labels** — when users can select multiple options and the labels are more than 1-2 words or inconsistent in length (use in a list item layout).
+2. **Single option requiring confirmation** — when there is exactly 1 binary option but it requires a separate action (like a submit button) to take effect (e.g., "I accept the terms"). If no confirmation is needed, use `Switch` instead.
+
 **Do**
 
 - Use `Checkbox` for selecting multiple independent options from a set (multiple selections allowed).
+- Use `Checkbox` (single, standalone) when a binary choice needs an explicit confirmation/submit action (e.g., "I agree to terms" inside a form).
+- Use `Checkbox` in list items when multi-select labels are long or inconsistent in length — prefer over `Chip` which works best with short 1-2 word labels.
 - Use `CheckboxGroup` when grouping related checkboxes with shared validation, label, and state.
 - Use `isIndeterminate` for "select all" patterns when some (but not all) items are selected.
 - Inside `CheckboxGroup`, provide a unique `value` prop on each `Checkbox` — this is required.
-- Use standalone `Checkbox` (outside group) when you need a single toggle with its own validation.
 
 **Don't**
 
-- Don't use `Checkbox` when only one option can be selected — use `Radio`/`RadioGroup` instead.
+- Don't use `Checkbox` when only one option can be selected from a set — use `Radio`/`RadioGroup` instead.
 - Don't use `Checkbox` for immediate on/off actions without form submission — use `Switch` instead.
+- Don't use `Checkbox` for multi-select with short (1-2 word), consistent labels — use `Chip` with `selectionType="multiple"` instead for a more compact UI.
 - Don't set `validationState`, `name`, `isChecked`, or `onChange` on individual Checkboxes inside a `CheckboxGroup` — use these on the group.
 - Don't use React Fragments as children in `CheckboxGroup` — only `Checkbox` components are accepted.
 - Don't mix controlled (`isChecked`) and uncontrolled (`defaultChecked`) on the same Checkbox.

--- a/packages/blade-mcp/knowledgebase/components/Chip.md
+++ b/packages/blade-mcp/knowledgebase/components/Chip.md
@@ -164,10 +164,19 @@ type IconComponent = React.ComponentType<IconProps>;
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `Chip` when options have **short (1-2 word), consistent labels**:
+- **Single select (`selectionType="single"`)** — acts as a segmented control. Use when you have 2–5 mutually exclusive options with short, uniform labels (e.g., "$0", "$1", "$2", "$5" or "Good", "Clean", "Fun").
+- **Multi-select (`selectionType="multiple"`)** — acts as toggle buttons. Use when users can select multiple options and labels are short and consistent.
+
+If labels are longer or inconsistent in length, use `Radio` (single select) or `Checkbox` in list items (multi-select) instead.
+
 **Do**
 
 - Use `Chip` inside `ChipGroup` for compact, inline selectable options (3–8 items typically).
-- Use `selectionType="single"` for radio-like behavior and `selectionType="multiple"` for checkbox-like behavior.
+- Use `selectionType="single"` when exactly one option must be selected (segmented control / radio-like behavior).
+- Use `selectionType="multiple"` when multiple options can be toggled on/off (toggle button / checkbox-like behavior).
 - Provide `accessibilityLabel` on `ChipGroup` to describe the filter/selection purpose.
 - Use `icon` prop on individual Chips for visual category indicators.
 - Use `color` prop to convey semantic meaning (`positive`, `negative`, `primary`).
@@ -175,6 +184,7 @@ type IconComponent = React.ComponentType<IconProps>;
 **Don't**
 
 - Don't use `Chip` outside `ChipGroup` — it must always be inside a group.
+- Don't use `Chip` when labels are long or inconsistent — use `Radio` (single select) or `Checkbox` in list items (multi-select) for better readability.
 - Don't use `Chip` for non-interactive display labels — use `Tag` (dismissible) or `Badge` (static) instead.
 - Don't use React Fragments as children in `ChipGroup` — only `Chip` components are accepted.
 - Don't use `Chip` for large option sets (10+) — use `AutoComplete` or `SelectInput` with a dropdown.

--- a/packages/blade-mcp/knowledgebase/components/Chip.md
+++ b/packages/blade-mcp/knowledgebase/components/Chip.md
@@ -162,6 +162,24 @@ type ChipGroupProps = {
 type IconComponent = React.ComponentType<IconProps>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Chip` inside `ChipGroup` for compact, inline selectable options (3–8 items typically).
+- Use `selectionType="single"` for radio-like behavior and `selectionType="multiple"` for checkbox-like behavior.
+- Provide `accessibilityLabel` on `ChipGroup` to describe the filter/selection purpose.
+- Use `icon` prop on individual Chips for visual category indicators.
+- Use `color` prop to convey semantic meaning (`positive`, `negative`, `primary`).
+
+**Don't**
+
+- Don't use `Chip` outside `ChipGroup` — it must always be inside a group.
+- Don't use `Chip` for non-interactive display labels — use `Tag` (dismissible) or `Badge` (static) instead.
+- Don't use React Fragments as children in `ChipGroup` — only `Chip` components are accepted.
+- Don't use `Chip` for large option sets (10+) — use `AutoComplete` or `SelectInput` with a dropdown.
+- Don't add custom children inside individual `Chip` elements — use `children` for the label text only.
+
 ## Examples
 
 ### Independent Chips for Product Information

--- a/packages/blade-mcp/knowledgebase/components/Code.md
+++ b/packages/blade-mcp/knowledgebase/components/Code.md
@@ -61,6 +61,22 @@ type CodeNonHighlightedProps = CodeCommonProps & {
 type CodeProps = CodeHighlightedProps | CodeNonHighlightedProps;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Code` for inline code snippets, variable names, API keys, or configuration values within text.
+- Use `isHighlighted={true}` (default) for standard inline code with a subtle background.
+- Use `isHighlighted={false}` with a custom `color` when you need code to match surrounding content color.
+- Embed `Code` inside `Text` components for proper inline rendering on web.
+
+**Don't**
+
+- Don't pass the `color` prop when `isHighlighted={true}` — this combination throws an error.
+- Don't use `Code` for large multi-line code blocks — it's designed for inline snippets only.
+- Don't pass React components or JSX as children — only strings are accepted.
+- Don't place `Code` directly adjacent to `Text` on React Native without wrapping both in a `Box` with `flexWrap="wrap"`.
+
 ## Example
 
 Here's a comprehensive example showcasing the Code component's various features and props:

--- a/packages/blade-mcp/knowledgebase/components/Collapsible.md
+++ b/packages/blade-mcp/knowledgebase/components/Collapsible.md
@@ -83,6 +83,23 @@ type CollapsibleBodyProps = {
   TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Collapsible` for single expand/collapse toggles like "Read more" patterns or detail disclosure.
+- Compose with exactly one trigger (`CollapsibleButton` or `CollapsibleLink`) and one `CollapsibleBody`.
+- Use `direction="top"` when the trigger is at the bottom and content should expand upward.
+- Use `onExpandChange` to track state or perform actions on toggle.
+
+**Don't**
+
+- Don't use `Collapsible` for 3+ items that need expand/collapse — use `Accordion` instead.
+- Don't add custom `onClick` handlers on the trigger — use `onExpandChange` on the parent instead.
+- Don't make the trigger full-width — this is a design constraint.
+- Don't use `Collapsible` for content that needs gallery/zoom features — use `LightBox` or `Preview`.
+- Don't expect the trigger to support all Button/Link props — only a subset is available.
+
 ## Examples
 
 ### Basic Usage: Uncontrolled Collapsible with Button Trigger

--- a/packages/blade-mcp/knowledgebase/components/Counter.md
+++ b/packages/blade-mcp/knowledgebase/components/Counter.md
@@ -48,6 +48,24 @@ type CounterProps = {
   TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Counter` for displaying numeric values like notification counts, item quantities, or status tallies.
+- Use the `max` prop to cap displayed values (e.g., `max={99}` shows "99+" for larger numbers).
+- Use semantic `color` values to convey meaning: `negative` for error counts, `positive` for success metrics.
+- Use `emphasis="intense"` to draw stronger attention to critical counts.
+- Pair with other components like `SideNavLink` trailing or `TabItem` trailing for contextual counts.
+
+**Don't**
+
+- Don't use `Counter` for interactive elements — it is purely display-only with no click handlers.
+- Don't pass non-numeric content — Counter only accepts a numeric `value` prop.
+- Don't use `Counter` for text-based metadata — use `Badge` instead.
+- Don't use `Counter` where a full `Badge` with descriptive text would be more informative.
+- Don't use decimal values or special number formats — Counter displays integers as-is.
+
 ## Example
 
 This example demonstrates different variants of the Counter component with various sizes, colors, emphasis levels, and a max value with overflow handling.

--- a/packages/blade-mcp/knowledgebase/components/CounterInput.md
+++ b/packages/blade-mcp/knowledgebase/components/CounterInput.md
@@ -9,6 +9,20 @@ CounterInput
 CounterInput is a specialized numerical input component that allows users to increment or decrement values using built-in plus/minus button controls alongside manual text input. It provides automatic value constraint enforcement with min/max limits, supports both controlled and uncontrolled usage patterns, and includes loading states with visual feedback. The component is designed for scenarios like quantity selection, subscription management, and any numerical value adjustment with clear boundaries.
 
 ## Usage Guidelines
+                                                                                                                                               
+  **Do**                                                                                                                                                      
+  
+  - Use `CounterInput` for small integer quantities under 100 (e.g., item counts, seats, retry attempts).                                                     
+  - Use `min` and `max` props to enforce sensible boundaries — buttons auto-disable at limits.                                                                
+  - Use `isLoading` to show a spinner during async updates (e.g., cart quantity changes).                                                                     
+  - Use `size="xsmall"` for compact inline controls and `size="large"` for prominent form fields.                                                             
+                                                                                                                                                              
+  **Don't**                                                                                                                                                   
+  
+  - Don't use `CounterInput` for large numbers (99+) — use `TextInput` with `type="number"` instead.                                                          
+  - Don't use `CounterInput` for decimal values — it only supports integers with step=1.                                                                      
+  - Don't use `CounterInput` for currency or complex numerical data — use `TextInput` or `Amount`.                                                            
+  - Don't use `CounterInput` without `min`/`max` boundaries — always define sensible limits.
 
 ### When to Use CounterInput
 

--- a/packages/blade-mcp/knowledgebase/components/CounterInput.md
+++ b/packages/blade-mcp/knowledgebase/components/CounterInput.md
@@ -9,35 +9,21 @@ CounterInput
 CounterInput is a specialized numerical input component that allows users to increment or decrement values using built-in plus/minus button controls alongside manual text input. It provides automatic value constraint enforcement with min/max limits, supports both controlled and uncontrolled usage patterns, and includes loading states with visual feedback. The component is designed for scenarios like quantity selection, subscription management, and any numerical value adjustment with clear boundaries.
 
 ## Usage Guidelines
-                                                                                                                                               
-  **Do**                                                                                                                                                      
-  
-  - Use `CounterInput` for small integer quantities under 100 (e.g., item counts, seats, retry attempts).                                                     
-  - Use `min` and `max` props to enforce sensible boundaries — buttons auto-disable at limits.                                                                
-  - Use `isLoading` to show a spinner during async updates (e.g., cart quantity changes).                                                                     
-  - Use `size="xsmall"` for compact inline controls and `size="large"` for prominent form fields.                                                             
-                                                                                                                                                              
-  **Don't**                                                                                                                                                   
-  
-  - Don't use `CounterInput` for large numbers (99+) — use `TextInput` with `type="number"` instead.                                                          
-  - Don't use `CounterInput` for decimal values — it only supports integers with step=1.                                                                      
-  - Don't use `CounterInput` for currency or complex numerical data — use `TextInput` or `Amount`.                                                            
-  - Don't use `CounterInput` without `min`/`max` boundaries — always define sensible limits.
 
-### When to Use CounterInput
+**Do**
 
-- **Small numerical values only** (typically 0-99)
-- Quantity selection (cart items, subscription seats, etc.)
-- Settings with clear boundaries (retry attempts, timeout values)
-- Any scenario where users need to adjust small numbers with clear min/max constraints
+- Use `CounterInput` for small integer quantities under 100 (e.g., item counts, subscription seats, retry attempts, timeout values).
+- Use `min` and `max` props to enforce sensible boundaries — buttons auto-disable at limits.
+- Use `isLoading` to show a spinner during async updates (e.g., cart quantity changes).
+- Use `size="xsmall"` for compact inline controls and `size="large"` for prominent form fields.
 
-### When NOT to Use CounterInput
+**Don't**
 
-- **Large numerical values (99+)** - Use a regular TextInput with `type="number"` instead
-- Complex numerical input (decimals, currency, percentages) - Use specialized input components
-- Values that don't benefit from increment/decrement buttons (IDs, phone numbers, etc.)
-
-**Important:** CounterInput is optimized for small numbers and provides the best user experience when used for values typically under 100. For larger values, the increment/decrement interaction becomes inefficient and a standard numerical text input should be used instead.
+- Don't use `CounterInput` for large numbers (99+) — use `TextInput` with `type="number"` instead. The increment/decrement interaction becomes inefficient for larger values.
+- Don't use `CounterInput` for decimal values — it only supports integers with step=1.
+- Don't use `CounterInput` for currency or complex numerical data — use `TextInput` or `Amount`.
+- Don't use `CounterInput` for values that don't benefit from increment/decrement buttons (IDs, phone numbers, etc.).
+- Don't use `CounterInput` without `min`/`max` boundaries — always define sensible limits.
 
 ## TypeScript Types
 

--- a/packages/blade-mcp/knowledgebase/components/DatePicker.md
+++ b/packages/blade-mcp/knowledgebase/components/DatePicker.md
@@ -367,6 +367,25 @@ type FilterChipDatePickerProps<T extends DatePickerSelectionType = 'single'> = O
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `DatePicker` for date selection with a calendar interface — supports single date and date range modes.
+- Use `presets` prop with range selection to offer quick options like "Last 7 days", "This month".
+- Use `minDate`/`maxDate` to constrain selectable dates to valid ranges.
+- Use `excludeDate` function to disable specific dates (holidays, unavailable slots).
+- Use object syntax for `label` and `name` in range mode: `label={{ start: 'From', end: 'To' }}`.
+- The component auto-converts to BottomSheet on mobile — no manual handling needed.
+
+**Don't**
+
+- Don't use `picker="month"` or `picker="year"` with `selectionType="range"` — range only supports day-level selection.
+- Don't combine date and time selection in one component — use `DatePicker` + `TimePicker` separately.
+- Don't use `presets` with single date selection — presets are designed for range mode only.
+- Don't forget to handle state updates in controlled mode — `onChange` won't auto-update the value.
+- Don't use a generic `TextInput` for date entry — `DatePicker` provides calendar UI, validation, and formatting.
+
 ## Examples
 
 ### Single Date Selection

--- a/packages/blade-mcp/knowledgebase/components/Display.md
+++ b/packages/blade-mcp/knowledgebase/components/Display.md
@@ -28,6 +28,22 @@ type DisplayProps = {
   StyledPropsBlade;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Display` for high-impact, eye-catching typography in hero sections, landing pages, and banners.
+- Use sparingly — typically once per page or section for maximum visual impact.
+- Use `as="span"` for inline color/weight variations within a Display heading.
+- Default renders as `h1` — override with `as` prop if the page already has an h1.
+
+**Don't**
+
+- Don't use `Display` for regular section headings — use `Heading` for page structure.
+- Don't use `Display` for body content or dense information — it's designed for attention-grabbing moments.
+- Don't use multiple `Display` components on the same page without overriding `as` — multiple h1 tags harm SEO and accessibility.
+- Don't use `Display` at small sizes when `Heading` with size `"2xlarge"` would suffice.
+
 ## Example
 
 Here's a comprehensive example showcasing the Display component's various features and props:

--- a/packages/blade-mcp/knowledgebase/components/Divider.md
+++ b/packages/blade-mcp/knowledgebase/components/Divider.md
@@ -52,6 +52,22 @@ type DividerProps = {
   TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Divider` to visually separate content sections or groups within a layout.
+- Use `orientation="horizontal"` (default) between vertically stacked content and `orientation="vertical"` between horizontally aligned items.
+- Place `Divider` inside flex containers for automatic stretch behavior.
+- Use `variant` to control prominence: `"muted"` (default) for subtle separation, `"normal"` for stronger emphasis.
+
+**Don't**
+
+- Don't use `height`/`width` props when the parent is a flex container — the Divider auto-stretches via flexGrow/alignSelf.
+- Don't use `Divider` for decorative borders on containers — use Box `borderWidth`/`borderColor` props instead.
+- Don't overuse Dividers — excessive use creates visual noise instead of clarity.
+- Don't use `Divider` as a spacing mechanism — use `Box` gap or margin for spacing.
+
 ## Examples
 
 ### Horizontal Divider

--- a/packages/blade-mcp/knowledgebase/components/DonutChart.md
+++ b/packages/blade-mcp/knowledgebase/components/DonutChart.md
@@ -91,6 +91,24 @@ type ChartSequentialColorToken = `data.background.sequential.${Exclude<
 >}.${keyof ChartSequentialEmphasis}`;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `DonutChart` for displaying proportional/percentage data showing parts of a whole.
+- Always wrap `ChartDonut` inside `ChartDonutWrapper` — standalone use is not supported.
+- Use the `content` prop on `ChartDonutWrapper` to display a summary value/label in the center hole.
+- Use `ChartDonutCell` components (one per data item) to customize segment colors.
+- Use `type="semicircle"` for half-donut displays when vertical space is constrained.
+
+**Don't**
+
+- Don't put multiple `ChartDonut` components inside one wrapper — only one is allowed.
+- Don't use `DonutChart` for time-series trends — use `LineChart` or `AreaChart` instead.
+- Don't use `DonutChart` for comparing absolute values across categories — use `BarChart` instead.
+- Don't use sequential color tokens — only categorical colors are supported.
+- Don't mismatch the number of `ChartDonutCell` components with data items.
+
 ## Example
 
 ### Basic Donut Chart with Custom Colors and Center Text

--- a/packages/blade-mcp/knowledgebase/components/Drawer.md
+++ b/packages/blade-mcp/knowledgebase/components/Drawer.md
@@ -150,6 +150,24 @@ type DrawerFooterProps = {
 } & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Drawer` for supplementary detail panels that slide from the right (e.g., transaction details, settings).
+- Compose with `DrawerHeader`, `DrawerBody`, and optionally `DrawerFooter`.
+- Use `onUnmount` (not `onDismiss`) for cleanup that should happen after the close animation completes.
+- Use `showOverlay` to control whether clicking outside dismisses the drawer.
+- Use stacking (max 2) for drill-down flows where the first drawer peeks behind.
+
+**Don't**
+
+- Don't use `Drawer` for critical interruptions requiring immediate action — use `Modal` instead.
+- Don't use `Drawer` on mobile — use `BottomSheet` for mobile-friendly slide-up panels.
+- Don't stack more than 2 drawers — this is the maximum supported.
+- Don't put non-Drawer sub-components as children — only `DrawerHeader`, `DrawerBody`, `DrawerFooter` are accepted.
+- Don't rely on `onDismiss` for post-animation cleanup — it fires immediately; use `onUnmount` instead.
+
 ## Example
 
 ### Basic Drawer

--- a/packages/blade-mcp/knowledgebase/components/Dropdown.md
+++ b/packages/blade-mcp/knowledgebase/components/Dropdown.md
@@ -260,9 +260,16 @@ type IconComponent = React.ComponentType<any>;
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `Dropdown` (with `SelectInput`) when users must select from **more than 5 options** in a single-select context. The dropdown pattern keeps the UI compact by hiding options behind a trigger.
+
+For fewer options (2–5), prefer visible selection controls: `Radio` (longer labels) or `Chip` with `selectionType="single"` (short labels) to keep choices visible without an extra click.
+
 **Do**
 
 - Use `Dropdown` for selection-based interactions — selecting one or multiple items from a list.
+- Use `Dropdown` with `SelectInput` when there are more than 5 options to choose from (single select).
 - Always pair with `DropdownOverlay` containing `ActionList` for the options display.
 - Use predefined triggers: `SelectInput`, `AutoComplete`, `DropdownButton`, `DropdownLink`, or `FilterChipSelectInput`.
 - Use `selectionType="multiple"` when users should select more than one option.
@@ -270,6 +277,7 @@ type IconComponent = React.ComponentType<any>;
 
 **Don't**
 
+- Don't use `Dropdown` for 5 or fewer options where choices can be shown inline — use `Radio`, `Chip`, or `Switch` instead to reduce interaction cost.
 - Don't use `Dropdown` for action menus (click-to-perform) — use `Menu` instead.
 - Don't pass arbitrary trigger components — only predefined Blade triggers are accepted.
 - Don't use `ActionListItem` with `intent="negative"` when using `SelectInput` as the trigger.

--- a/packages/blade-mcp/knowledgebase/components/Dropdown.md
+++ b/packages/blade-mcp/knowledgebase/components/Dropdown.md
@@ -258,6 +258,24 @@ type FilterChipGroupProps = {
 type IconComponent = React.ComponentType<any>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Dropdown` for selection-based interactions — selecting one or multiple items from a list.
+- Always pair with `DropdownOverlay` containing `ActionList` for the options display.
+- Use predefined triggers: `SelectInput`, `AutoComplete`, `DropdownButton`, `DropdownLink`, or `FilterChipSelectInput`.
+- Use `selectionType="multiple"` when users should select more than one option.
+- Use `DropdownHeader` and `DropdownFooter` for structuring complex selection overlays.
+
+**Don't**
+
+- Don't use `Dropdown` for action menus (click-to-perform) — use `Menu` instead.
+- Don't pass arbitrary trigger components — only predefined Blade triggers are accepted.
+- Don't use `ActionListItem` with `intent="negative"` when using `SelectInput` as the trigger.
+- Don't use `Dropdown` for nested submenus — use `Menu` which supports nested overlays.
+- Don't expect responsive behavior on mobile — manually switch to `BottomSheet` for mobile UX.
+
 ## Examples
 
 ### Basic Dropdown with Button Trigger

--- a/packages/blade-mcp/knowledgebase/components/Elevate.md
+++ b/packages/blade-mcp/knowledgebase/components/Elevate.md
@@ -40,6 +40,22 @@ type ElevateProps = {
 type MotionTrigger = 'hover' | 'focus' | 'press' | 'on-animate-interactions';
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Elevate` for interactive box-shadow feedback on block-level elements (cards, containers) on hover or focus.
+- Use default `motionTriggers={['hover']}` for standard hover elevation on clickable cards.
+- Use `isHighlighted` prop for programmatic elevation control (e.g., highlighting selected items).
+- Combine with `AnimateInteractions` using `motionTriggers={['on-animate-interactions']}` for coordinated effects.
+
+**Don't**
+
+- Don't use `Elevate` on text components or inline elements — it only works with block-level elements that support box-shadow.
+- Don't use `Elevate` for entry/exit animations — use `Fade`, `Move`, or `Slide` instead.
+- Don't expect customizable elevation levels — the animated shadow is fixed at `lowRaised`.
+- Don't use `Elevate` when `Scale` would be more appropriate — Elevate adds shadow depth, Scale changes size.
+
 ## Examples
 
 ### Multiple Triggers for Accessibility

--- a/packages/blade-mcp/knowledgebase/components/EmptyState.md
+++ b/packages/blade-mcp/knowledgebase/components/EmptyState.md
@@ -52,6 +52,24 @@ export type EmptyStateProps = {
 export type EmptyStateSize = 'small' | 'medium' | 'large' | 'xlarge';
 ````
 
+## Usage Guidelines
+
+**Do**
+
+- Use `EmptyState` when a list, table, or section has no data to display — provide context and actionable next steps.
+- Include a clear `title` explaining why content is empty, and a `description` with guidance.
+- Use `children` to render action buttons (e.g., "Create New", "Retry") or links (e.g., "Contact Support").
+- Match `size` to context: `"small"` for inline empty states in cards, `"medium"` for lists/tables, `"xlarge"` for full-page states.
+- Provide `alt` text on custom image assets for accessibility.
+
+**Don't**
+
+- Don't use `EmptyState` as a loading placeholder — use `Skeleton` or `Spinner` while data is being fetched.
+- Don't wrap `EmptyState` around other components — use conditional rendering to show either the empty state or the actual content.
+- Don't omit both `title` and `description` — users need context to understand what to do next.
+- Don't use `EmptyState` for transient error feedback — use `Toast` or `Alert` for operation-level errors.
+- Don't use complex nested layouts in `children` without wrapping in `Box` for proper structure.
+
 ## Examples
 
 ### Complete EmptyState with Interactive Functionality

--- a/packages/blade-mcp/knowledgebase/components/Fade.md
+++ b/packages/blade-mcp/knowledgebase/components/Fade.md
@@ -51,6 +51,22 @@ type FadeProps = {
 type MotionTrigger = 'hover' | 'focus' | 'press' | 'mount' | 'in-view' | 'on-animate-interactions';
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Fade` for opacity-only transitions: elements appearing/disappearing in-place without positional change.
+- Use `motionTriggers={['in-view']}` for scroll-triggered reveal animations.
+- Use `isVisible` prop for controlled show/hide without unmounting from the DOM.
+- Use `shouldUnmountWhenHidden` only when you need the element removed from DOM entirely.
+
+**Don't**
+
+- Don't use `Fade` when you also need positional movement — use `Move` (opacity + translate) or `Slide` (from viewport edge).
+- Don't pass multiple children — wrap in a single container element.
+- Don't use `Fade` for interactive feedback (hover/press) — use `Scale` or `Elevate` instead.
+- Don't forget to forward refs on custom components wrapped in Fade.
+
 ## Examples
 
 ### Controlled Fade Animation

--- a/packages/blade-mcp/knowledgebase/components/FileUpload.md
+++ b/packages/blade-mcp/knowledgebase/components/FileUpload.md
@@ -171,6 +171,25 @@ type BladeFile = File & {
 type BladeFileList = BladeFile[];
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `FileUpload` for file selection with drag-and-drop, progress tracking, and status display.
+- Use `accept` prop to restrict allowed file types (e.g., `".jpg,.png,.pdf"` or `"image/*"`).
+- Use `maxSize` and `maxCount` to enforce upload limits with clear validation feedback.
+- Use controlled mode (`fileList` prop) when you need to manage upload progress and status externally.
+- Use `uploadType="multiple"` when users need to attach several files at once.
+- Manage the actual file upload to your server — the component only handles selection and validation.
+
+**Don't**
+
+- Don't expect automatic server uploads — the component manages selection and UI, not network requests.
+- Don't use `actionButtonText`, `dropAreaText`, or custom `height`/`width` unless `size="variable"` — they only work with that size.
+- Don't use React Fragments as children.
+- Don't use `FileUpload` for simple single-file inputs in chat — use `ChatInput` which has integrated file handling.
+- Don't forget to handle `onRemove` and `onReupload` callbacks for proper file lifecycle management.
+
 ## Examples
 
 ### Single File Upload with Form

--- a/packages/blade-mcp/knowledgebase/components/Heading.md
+++ b/packages/blade-mcp/knowledgebase/components/Heading.md
@@ -28,6 +28,22 @@ type HeadingProps = {
   StyledPropsBlade;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Heading` for section titles and page hierarchy — it auto-maps sizes to semantic h-tags (small=h6, medium=h5, large=h4, xlarge=h3, 2xlarge=h2).
+- Use `as` prop to override the auto-mapped tag only when the visual size differs from the semantic level.
+- Use `as="span"` with nested Headings for inline color/weight variations within a heading.
+- Keep heading hierarchy consistent on the page for accessibility (don't skip levels).
+
+**Don't**
+
+- Don't use `Heading` for body content or paragraphs — use `Text` instead.
+- Don't use `Heading` for hero/landing page titles — use `Display` for maximum visual impact.
+- Don't override `as` without reason — the auto-mapping ensures proper semantic structure.
+- Don't use `weight="regular"` on headings unless specifically required — semibold (default) provides proper visual hierarchy.
+
 ## Example
 
 Here's a comprehensive example showcasing the Heading component's various features and props, demonstrating different sizes, colors, weights, and semantic variations to create page hierarchy:

--- a/packages/blade-mcp/knowledgebase/components/IconButton.md
+++ b/packages/blade-mcp/knowledgebase/components/IconButton.md
@@ -65,6 +65,22 @@ type IconComponent = React.ComponentType<{
 }>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `IconButton` for icon-only actions in space-constrained interfaces (close buttons, card actions, toolbars).
+- Always provide a meaningful `accessibilityLabel` (e.g., "Close dialog", "Edit profile") — it's required.
+- Use `emphasis="subtle"` for less prominent actions and `"intense"` (default) for primary icon actions.
+- Use appropriate size relative to surrounding content: `"small"` in dense UI, `"large"` for prominent actions.
+
+**Don't**
+
+- Don't use `IconButton` when text + icon would be clearer — use `Button` with an icon instead.
+- Don't use generic labels like "Button" for `accessibilityLabel` — describe the action specifically.
+- Don't combine `size="large"` with `isHighlighted={true}` — this combination is not supported.
+- Don't use `IconButton` for navigation — use `Link` with an icon instead.
+
 ## Examples
 
 ### Basic IconButton Usage

--- a/packages/blade-mcp/knowledgebase/components/Icons.md
+++ b/packages/blade-mcp/knowledgebase/components/Icons.md
@@ -30,6 +30,22 @@ type IconProps = {
   TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use Blade icon components primarily as props inside other components (Button `icon`, Badge `icon`, TextInput `icon`).
+- Use semantic color tokens for icon colors: `surface.icon.*`, `feedback.icon.*`, `action.icon.*`.
+- Choose between Filled and Stroked variants based on context (e.g., `StarIcon` for outlined, `StarFilledIcon` for filled).
+- Use appropriate sizes relative to context: `"small"` in dense UI, `"medium"` (default) in standard UI, `"xlarge"`/`"2xlarge"` standalone.
+
+**Don't**
+
+- Don't use Icons as standalone interactive elements — wrap in `IconButton` for clickable icon actions.
+- Don't use arbitrary hex/RGB colors — only Blade color tokens are supported.
+- Don't try to build custom SVGs using internal `_Svg` components — they are not exported.
+- Don't use Icons for illustrations or decorative graphics — they are designed for UI communication.
+
 ## Examples
 
 ### Icon Usage

--- a/packages/blade-mcp/knowledgebase/components/Indicator.md
+++ b/packages/blade-mcp/knowledgebase/components/Indicator.md
@@ -57,6 +57,24 @@ Where:
 - `DataAnalyticsAttribute` adds data attributes for analytics tracking
 - `StyledPropsBlade` includes styled-system props for flexible styling
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Indicator` for showing the status or condition of an entity (e.g., "Online", "Pending", "Error").
+- Always provide `accessibilityLabel` when using Indicator without visible `children` text — color alone is not accessible.
+- Use `children` to display a visible text label alongside the dot for clarity.
+- Use `emphasis="intense"` when the indicator needs stronger visual prominence with a background circle.
+- Use absolute positioning with styled props to overlay an Indicator dot on another component (e.g., notification dot on a button).
+
+**Don't**
+
+- Don't rely solely on the dot color to convey meaning — always pair with text or `accessibilityLabel` for color-blind users.
+- Don't use `Indicator` for numeric counts — use `Counter` instead.
+- Don't use `Indicator` for descriptive metadata labels — use `Badge` instead.
+- Don't use `Indicator` as an interactive element — it is purely informational.
+- Don't omit `accessibilityLabel` on dot-only indicators — screen reader users cannot perceive color.
+
 ## Example
 
 This example demonstrates different variations of the Indicator component showing positive, negative, and notice states with different emphasis levels and text options.

--- a/packages/blade-mcp/knowledgebase/components/InfoGroup.md
+++ b/packages/blade-mcp/knowledgebase/components/InfoGroup.md
@@ -131,6 +131,24 @@ type TestID = {
 type StringChildrenType = React.ReactText | React.ReactText[];
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `InfoGroup` for displaying structured key-value pairs like transaction details, user information, or entity attributes.
+- Always include both `InfoItemKey` and `InfoItemValue` inside each `InfoItem`.
+- Use `leading` prop for icons or avatars on keys/values to add visual context.
+- Use `itemOrientation="vertical"` for compact layouts where key appears above value.
+- Insert `Divider` components between `InfoItem` groups to separate logical sections.
+
+**Don't**
+
+- Don't use `InfoGroup` for tabular data with many rows — use `Table` instead.
+- Don't omit `InfoItemKey` or `InfoItemValue` from an `InfoItem` — both must be present for proper layout.
+- Don't wrap icon components in additional elements when passing to `leading` — pass them directly (e.g., `leading={UserIcon}`).
+- Don't use `InfoGroup` for editable forms — it's for read-only data presentation.
+- Don't use excessively long key text in horizontal orientation — keys should be concise as they truncate first.
+
 ## Examples
 
 ### Basic InfoGroup with Horizontal Layout

--- a/packages/blade-mcp/knowledgebase/components/InputGroup.md
+++ b/packages/blade-mcp/knowledgebase/components/InputGroup.md
@@ -96,6 +96,23 @@ type InputGroupContextType = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `InputGroup` to organize multiple related input fields (e.g., address, payment info) with shared validation and layout.
+- Use `InputRow` with `gridTemplateColumns` to control column distribution (e.g., `"1fr 2fr"` for a 1:2 ratio).
+- Use group-level `validationState` and `errorText` for unified validation messaging.
+- Use `isDisabled` on the group to disable all nested inputs at once.
+- Use `useIsMobile()` hook to conditionally adjust `gridTemplateColumns` for responsive layouts.
+
+**Don't**
+
+- Don't use `InputGroup` for a single input field — use the input component directly.
+- Don't nest `InputGroup` inside another `InputGroup`.
+- Don't mix non-input children inside `InputRow` — it's designed for input components only.
+- Don't rely on `labelPosition="left"` working on mobile — it auto-switches to `"top"`.
+
 ## Examples
 
 ### Payment Form with Validation

--- a/packages/blade-mcp/knowledgebase/components/LightBox.md
+++ b/packages/blade-mcp/knowledgebase/components/LightBox.md
@@ -107,6 +107,24 @@ type LightBoxItemProps =
     };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `LightBox` for full-screen immersive media browsing (image galleries, document review, mixed media).
+- Compose with `LightBoxBody` containing `LightBoxItem` children.
+- Use image mode (`src` prop) for simple image viewing; use custom mode (`thumbnail` + `children`) for video/PDF.
+- Use controlled state (`activeIndex` + `onIndexChange`) for programmatic navigation.
+- Always provide `alt` text on `LightBoxItem` for accessibility.
+
+**Don't**
+
+- Don't use `LightBox` for single-item viewing — use `Preview` component instead.
+- Don't mix image mode and custom mode on the same `LightBoxItem` — they are mutually exclusive.
+- Don't forget to provide `thumbnail` when using custom mode — the thumbnail strip needs an image.
+- Don't use `LightBox` for simple show/hide content — use `Collapsible` or `Modal`.
+- Don't expect wrap-around navigation — Prev is disabled at first item, Next at last.
+
 ## Example
 
 ### Controlled Image Gallery

--- a/packages/blade-mcp/knowledgebase/components/LineChart.md
+++ b/packages/blade-mcp/knowledgebase/components/LineChart.md
@@ -194,6 +194,23 @@ type ChartsCategoricalColorToken = `data.background.categorical.${ChartColorCate
 type colorTheme = 'categorical';
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `LineChart` for displaying time-series trends and comparing multiple data series over time.
+- Wrap in `ChartLineWrapper` and compose with `ChartLine`, `ChartXAxis`, `ChartYAxis`, `ChartTooltip`, `ChartLegend`.
+- Use `strokeStyle="dashed"` for forecast or projected data to visually distinguish from actual data.
+- Use `connectNulls={true}` for datasets with missing values that should show continuous lines.
+- Use `ChartReferenceLine` to add target/threshold lines for context.
+
+**Don't**
+
+- Don't use `LineChart` when you want to emphasize volume or cumulative data — use `AreaChart` (same as LineChart but with filled region).
+- Don't use `LineChart` for categorical comparisons — use `BarChart` instead.
+- Don't use sequential color tokens — only categorical colors are supported.
+- Don't use `LineChart` for proportional data — use `DonutChart` for parts-of-a-whole visualization.
+
 ## Examples
 
 ### Basic Line Chart with Multiple Series

--- a/packages/blade-mcp/knowledgebase/components/Link.md
+++ b/packages/blade-mcp/knowledgebase/components/Link.md
@@ -99,6 +99,23 @@ type IconProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Link` with `variant="anchor"` for navigation to other pages (renders as `<a>` tag with proper semantics).
+- Use `variant="button"` for inline actions within text that are styled as links but behave as buttons.
+- Use inline within `Text` components for contextual navigation links.
+- Provide `href` for anchor variant — it enables proper link semantics and right-click behavior.
+
+**Don't**
+
+- Don't use `Link` for primary actions — use `Button` instead.
+- Don't use `isDisabled` with `variant="anchor"` — disabled state only works on button variant.
+- Don't use `href`, `target`, or `rel` with `variant="button"` — those are anchor-only props.
+- Don't omit both `icon` and text children — at least one is required.
+- Don't use `Link` when you need a button with link styling — that's exactly what `variant="button"` is for.
+
 ## Examples
 
 ### Standard Link Usage

--- a/packages/blade-mcp/knowledgebase/components/List.md
+++ b/packages/blade-mcp/knowledgebase/components/List.md
@@ -134,6 +134,24 @@ type IconProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `List` for presenting ordered or unordered sequences of items with proper semantic HTML (`<ul>`, `<ol>`, `<li>`).
+- Use `variant="ordered-filled"` for numbered lists with filled background circles (step-by-step instructions).
+- Use custom `icon` and `iconColor` props with `variant="unordered"` for branded bullet points.
+- Use `ListItemLink`, `ListItemCode`, and `ListItemText` for inline rich content within items.
+- Nest `List` components inside `ListItem` for hierarchical content (up to 3 levels).
+
+**Don't**
+
+- Don't use `icon` prop with `variant="ordered"` or `variant="ordered-filled"` — icons are only for unordered lists.
+- Don't nest lists deeper than 3 levels — this is the design-imposed maximum.
+- Don't nest lists within `variant="ordered-filled"` — nesting is not supported for this variant.
+- Don't use React Fragments as List children — only `ListItem` components are accepted.
+- Don't use `List` for interactive navigation — use `SideNav` or `BottomNav` instead.
+
 ## Examples
 
 ### Ordered Filled List with Links

--- a/packages/blade-mcp/knowledgebase/components/ListView.md
+++ b/packages/blade-mcp/knowledgebase/components/ListView.md
@@ -107,6 +107,23 @@ type ListViewFiltersContextType = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `ListView` when you need a complete data display pattern with search, quick filters, advanced filters, and a table combined.
+- Compose with `ListViewFilters` (containing `QuickFilterGroup`) and `Table` as children.
+- Use `FilterChipGroup` inside `ListViewFilters` for advanced filter dropdowns and date pickers.
+- Omit `onSearchChange` entirely to hide the search feature — don't pass an empty handler.
+- Use the `actions` slot for custom action elements like export buttons or search with dropdown.
+
+**Don't**
+
+- Don't use `ListView` for simple tables without filtering needs — use `Table` standalone instead.
+- Don't try to customize the internal layout or search position — the layout is controlled by design for consistency.
+- Don't use `FilterChip` standalone outside of a `Dropdown` or `Menu` trigger — it's designed as a trigger component only.
+- Don't manually compose `Box` + `QuickFilterGroup` + `Table` when `ListView` provides the same pattern with consistent spacing and responsive behavior.
+
 ## Example
 
 Below is a comprehensive example demonstrating how to use the ListView component with various filtering options, search functionality, and table display:

--- a/packages/blade-mcp/knowledgebase/components/Menu.md
+++ b/packages/blade-mcp/knowledgebase/components/Menu.md
@@ -227,6 +227,24 @@ type MenuFooterProps = {
 type MenuDividerProps = TestID & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Menu` for action-based overlays — clickable items that perform operations (not selections).
+- Use any interactive component as a trigger (Button, Avatar, IconButton) — it must forward refs and expose proper event handlers.
+- Use `MenuItem` for action items and `MenuDivider` for visual separation.
+- Use nested `Menu` inside `MenuItem` for submenu patterns.
+- Use `openInteraction="hover"` for hover-triggered menus on desktop.
+
+**Don't**
+
+- Don't use `Menu` for selectable items where state tracking is needed — use `Dropdown` with `ActionList` instead.
+- Don't use custom triggers that don't forward refs and expose required event handlers.
+- Don't expect `Menu` to be responsive by default — switch to `BottomSheet` or `Drawer` on mobile.
+- Don't use `Menu` for multi-select checkbox patterns — use `Dropdown` with `selectionType="multiple"`.
+- Don't confuse `MenuItem` with `ActionListItem` — they serve different overlay patterns.
+
 ## Example
 
 ### Comprehensive Profile Menu

--- a/packages/blade-mcp/knowledgebase/components/Modal.md
+++ b/packages/blade-mcp/knowledgebase/components/Modal.md
@@ -98,6 +98,24 @@ type ModalFooterProps = {
 } & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Modal` for critical information or decisions that require focused user attention on desktop.
+- Compose with `ModalHeader`, `ModalBody`, and `ModalFooter` sub-components for proper structure.
+- Use `size` to match content needs: `"small"` (400px) for confirmations, `"medium"` (760px) for forms, `"large"` (1024px) for complex content.
+- Use `initialFocusRef` to direct focus to the most relevant element on open.
+- Use `isDismissible={false}` only for flows that require explicit user action (e.g., forced confirmations).
+
+**Don't**
+
+- Don't use `Modal` on mobile/mWeb — use `BottomSheet` instead (Modal is desktop-first by design).
+- Don't use `Modal` for supplementary information that doesn't need to block interaction — use `Drawer` or `Popover`.
+- Don't expect auto-conversion to BottomSheet on small screens — consumers must implement responsive logic manually.
+- Don't put arbitrary components in `ModalHeader` trailing — only Button, IconButton, Badge, Link, Text, and Amount are allowed.
+- Don't use `ModalBody` padding values other than `"spacing.0"` or `"spacing.6"`.
+
 ## Example
 
 Below is a comprehensive example showcasing the Modal component with various configurations:

--- a/packages/blade-mcp/knowledgebase/components/Morph.md
+++ b/packages/blade-mcp/knowledgebase/components/Morph.md
@@ -26,6 +26,22 @@ type MorphProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Morph` for smooth layout transitions between different UI states (button → input, circle → square, state changes).
+- Always wrap in Framer Motion's `<AnimatePresence>` for proper mount/unmount coordination.
+- Use the same `layoutId` on both the source and target `Morph` wrappers so they animate between each other.
+- Use with simple, similarly-shaped components for best visual results.
+
+**Don't**
+
+- Don't use `Morph` for entry/exit animations — use `Fade`, `Move`, or `Slide` instead.
+- Don't morph between complex components with many internal nodes — it causes text distortion artifacts.
+- Don't have two `Morph` elements with the same `layoutId` mounted simultaneously — one should unmount as the other mounts.
+- Don't use without `<AnimatePresence>` — conditional rendering won't animate properly.
+
 ## Example
 
 ### Basic Transformation Example

--- a/packages/blade-mcp/knowledgebase/components/Move.md
+++ b/packages/blade-mcp/knowledgebase/components/Move.md
@@ -67,6 +67,22 @@ type MoveProps = {
 type MotionDelay = keyof Delay | { enter: keyof Delay; exit: keyof Delay };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Move` for combined opacity + subtle vertical translation animations (elements fading in while sliding up slightly).
+- Use for page/route transitions, conditional content reveals, and card entry animations.
+- Use `motionTriggers={['in-view']}` for scroll-triggered appearance.
+- Use `isVisible` for controlled show/hide with smooth animation.
+
+**Don't**
+
+- Don't use `Move` when you only need opacity change — use `Fade` (lighter, no position change).
+- Don't use `Move` for dramatic viewport-edge entrances — use `Slide` (which animates from 100vh/100vw).
+- Don't use `shouldUnmountWhenHidden` without setting `minHeight` on the container — it causes layout shift.
+- Don't pass plain text as children — only React elements (wrap in Box if needed).
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/OTPInput.md
+++ b/packages/blade-mcp/knowledgebase/components/OTPInput.md
@@ -100,6 +100,23 @@ type OTPInputPropsWithLabel = {
 type OTPInputProps = OTPInputPropsWithA11yLabel | OTPInputPropsWithLabel;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `OTPInput` for verification codes, 2FA tokens, and PIN entry flows.
+- Use `onOTPFilled` callback to trigger auto-verification when all fields are complete.
+- Use `isMasked` for secure PIN entry where characters should be hidden.
+- Use `otpLength={4}` for short PINs and `otpLength={6}` (default) for verification codes.
+- Always provide `accessibilityLabel` when `label` is not shown.
+
+**Don't**
+
+- Don't use `OTPInput` for general text, phone numbers, or other sequential data — use `TextInput` with `format` instead.
+- Don't use `OTPInput` for password entry — use `PasswordInput`.
+- Don't forget to handle paste behavior — pasted strings auto-distribute across fields.
+- Don't manually create multiple `TextInput` fields to replicate OTP behavior — use this purpose-built component.
+
 ## Example
 
 ### Basic OTP Input with Validation

--- a/packages/blade-mcp/knowledgebase/components/Pagination.md
+++ b/packages/blade-mcp/knowledgebase/components/Pagination.md
@@ -117,6 +117,24 @@ type PaginationProps = PaginationCommonProps & {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Pagination` for navigating through large datasets divided into pages.
+- Always provide `totalPages` — it is the only required prop for the component to function.
+- Use controlled mode (`selectedPage` + `onSelectedPageChange`) when page state needs to sync with URL or external state.
+- Enable `showPageNumbers` for better navigation when there are many pages.
+- Enable `showPageSizePicker` when users should control items per page.
+
+**Don't**
+
+- Don't use `Pagination` for switching between content views — use `Tabs` instead.
+- Don't use custom page size values — only 10, 25, and 50 are supported.
+- Don't rely on `showPageSizePicker`, `showPageNumbers`, or `showLabel` being visible on mobile — they are automatically hidden on small screens.
+- Don't use 0-based page indexing — pages are 1-indexed externally.
+- Don't use `Pagination` when infinite scroll would provide a better user experience for browsing content.
+
 ## Example
 
 ### Controlled Pagination with All Features

--- a/packages/blade-mcp/knowledgebase/components/PasswordInput.md
+++ b/packages/blade-mcp/knowledgebase/components/PasswordInput.md
@@ -137,6 +137,22 @@ type IconButtonProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `PasswordInput` for all password entry fields: login, registration, and password change flows.
+- Use `autoCompleteSuggestionType="newPassword"` for registration/change flows and `"password"` for login.
+- Use `showRevealButton` (default true) to let users verify their typed password.
+- Use `maxCharacters` with validation feedback (`errorText`/`successText`) for password strength guidance.
+
+**Don't**
+
+- Don't use `TextInput` with `type="password"` — always use `PasswordInput` for proper security handling.
+- Don't use `PasswordInput` for non-password fields — it's specifically designed for secure credential entry.
+- Don't use `necessityIndicator="optional"` — it only supports `"required"` or `"none"`.
+- Don't add leading icons, dropdowns, or prefix/suffix — PasswordInput has a simplified visual feature set.
+
 ## Example
 
 ### Comprehensive PasswordInput Usage

--- a/packages/blade-mcp/knowledgebase/components/PhoneNumberInput.md
+++ b/packages/blade-mcp/knowledgebase/components/PhoneNumberInput.md
@@ -113,6 +113,22 @@ type PhoneNumberInputProps = {
   StyledPropsBlade;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `PhoneNumberInput` for collecting international phone numbers with country code selection.
+- Use `allowedCountries` to restrict the country selector to relevant countries for your use case.
+- Use `showCountrySelector={false}` for single-country applications where only domestic numbers are accepted.
+- Use `onCountryChange` to react to country selection and adjust validation accordingly.
+
+**Don't**
+
+- Don't use `PhoneNumberInput` for non-phone numeric input — use `TextInput` with `type="number"` or `CounterInput`.
+- Don't assume the component validates phone numbers — validation is the consumer's responsibility.
+- Don't use `TextInput` with `format` for international phone numbers — `PhoneNumberInput` handles dial codes and country selection.
+- Don't rely on the placeholder format for auto-formatting during typing — formatting is shown as a hint only.
+
 ## Example
 
 ### Basic Phone Number Input

--- a/packages/blade-mcp/knowledgebase/components/Popover.md
+++ b/packages/blade-mcp/knowledgebase/components/Popover.md
@@ -103,6 +103,24 @@ type PopoverInteractiveWrapperProps = {
   DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Popover` for contextual information or actions triggered by click on a specific element.
+- Pass `content` as a React element (not a string) — it supports rich interactive content.
+- Use `PopoverInteractiveWrapper` when the trigger is a non-interactive element (icon, badge, etc.).
+- Use `placement` to position relative to the trigger — auto-flips at viewport edges.
+- Use `title` and `footer` props for structured popover layout with header and actions.
+
+**Don't**
+
+- Don't use `Popover` for brief, hover-only help text — use `Tooltip` instead.
+- Don't use `Popover` for critical decisions that block the entire page — use `Modal` instead.
+- Don't pass strings to `content` — it must be a React element.
+- Don't use non-interactive triggers without `PopoverInteractiveWrapper` — accessibility requires it.
+- Don't use `Popover` for large panels of content — use `Drawer` or `BottomSheet` instead.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Preview.md
+++ b/packages/blade-mcp/knowledgebase/components/Preview.md
@@ -70,6 +70,23 @@ type PreviewFooterProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Preview` for inline content viewing with zoom, pan, and pinch interactions (images, PDFs).
+- Compose with `PreviewHeader`, `PreviewBody`, and `PreviewFooter` for structured layout with controls.
+- Use `onZoomChange` and `onDragChange` callbacks for tracking user interactions.
+- Use `isDragAndZoomDisabled` for static preview mode without interactions.
+- Use inside `LightBox` (custom mode) for gallery items that need zoom/pan.
+
+**Don't**
+
+- Don't use `Preview` for multi-item gallery navigation — use `LightBox` instead.
+- Don't expect built-in zoom controls — compose custom buttons in `PreviewFooter` trailing slot.
+- Don't use `Preview` as a PDF renderer — it's a wrapper only; use libraries like `react-pdf` for rendering.
+- Don't use `Preview` for simple image display without interaction — a plain `<img>` suffices.
+
 ## Example
 
 Here are comprehensive examples showing different use cases of the Preview component:

--- a/packages/blade-mcp/knowledgebase/components/ProgressBar.md
+++ b/packages/blade-mcp/knowledgebase/components/ProgressBar.md
@@ -101,6 +101,25 @@ type ProgressBarMeterProps = ProgressBarCommonProps & {
 type ProgressBarProps = ProgressBarProgressProps | ProgressBarMeterProps;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `ProgressBar` with `type="progress"` for real-time progress tracking (uploads, downloads, processing).
+- Use `type="meter"` for static value displays like account balance, storage capacity, or quota usage.
+- Use `isIndeterminate` when the total duration is unknown but you want to show activity.
+- Provide a descriptive `label` and `accessibilityLabel` so users understand what is progressing.
+- Use `variant="circular"` for compact spaces where a linear bar won't fit.
+- Match `color` to semantic meaning: `positive` for healthy progress, `negative` for critical thresholds.
+
+**Don't**
+
+- Don't use `isIndeterminate` with `type="meter"` — meters always represent a known value.
+- Don't use `size="large"` with the linear variant — large is only supported for circular.
+- Don't use `ProgressBar` as a generic loading indicator when progress percentage is unknown — use `Spinner` instead.
+- Don't combine `isIndeterminate` with `variant="circular"` — this combination is not supported.
+- Don't omit `accessibilityLabel` when `label` is not provided — screen readers need context.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/QuickFilter.md
+++ b/packages/blade-mcp/knowledgebase/components/QuickFilter.md
@@ -73,6 +73,23 @@ type QuickFilterGroupContextType = Pick<QuickFilterGroupProps, 'selectionType'> 
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `QuickFilter` inside `QuickFilterGroup` for inline status/category filters with optional trailing metadata (counters, badges).
+- Use `trailing` prop with `Counter` component to show item counts per filter option.
+- Use `selectionType="single"` for exclusive filters and `selectionType="multiple"` for combined filters.
+- Use inside `ListView` component's `ListViewFilters` for table filtering patterns.
+
+**Don't**
+
+- Don't use `QuickFilter` outside `QuickFilterGroup` — it won't function standalone.
+- Don't use `QuickFilter` for more than 8–10 options — consider `SelectInput` or `AutoComplete` for larger lists.
+- Don't use React Fragments as children in `QuickFilterGroup`.
+- Don't confuse with `Chip` — QuickFilter has a built-in trailing slot for metadata; Chips are simpler tag-based selectors.
+- Don't put heavy/complex elements in `trailing` — keep it lightweight (Counter, small Badge, text).
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Radio.md
+++ b/packages/blade-mcp/knowledgebase/components/Radio.md
@@ -161,6 +161,24 @@ type RadioGroupContextType = Pick<
 > & { state?: State };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Radio` inside `RadioGroup` for selecting exactly one option from a set of mutually exclusive choices.
+- Always wrap `Radio` components in `RadioGroup` — Radio cannot be used standalone.
+- Provide a unique `value` prop on each `Radio` within the group.
+- Use `helpText` on individual Radio items to provide context for each option.
+- Use `necessityIndicator` on RadioGroup to indicate whether selection is required or optional.
+
+**Don't**
+
+- Don't use `Radio` outside `RadioGroup` — it throws an error in development.
+- Don't use `Radio` when multiple selections are allowed — use `Checkbox`/`CheckboxGroup` instead.
+- Don't use `Radio` for immediate binary on/off actions — use `Switch` instead.
+- Don't use React Fragments as children in `RadioGroup` — only `Radio` components are accepted.
+- Don't mix controlled (`value`) and uncontrolled (`defaultValue`) on the same RadioGroup.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Radio.md
+++ b/packages/blade-mcp/knowledgebase/components/Radio.md
@@ -163,9 +163,16 @@ type RadioGroupContextType = Pick<
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `Radio` when the user must select **exactly 1 option** from a set of **2–5 choices** where the labels are **longer than 1-2 words or inconsistent in length**. Radio buttons work best in list-item layouts where each option needs descriptive text or help text.
+
+If the labels are short (1-2 words) and consistent, use `Chip` with `selectionType="single"` instead for a more compact segmented-control style.
+
 **Do**
 
 - Use `Radio` inside `RadioGroup` for selecting exactly one option from a set of mutually exclusive choices.
+- Use `Radio` when you have 2–5 options with longer or descriptive labels that benefit from a list layout.
 - Always wrap `Radio` components in `RadioGroup` — Radio cannot be used standalone.
 - Provide a unique `value` prop on each `Radio` within the group.
 - Use `helpText` on individual Radio items to provide context for each option.
@@ -176,6 +183,8 @@ type RadioGroupContextType = Pick<
 - Don't use `Radio` outside `RadioGroup` — it throws an error in development.
 - Don't use `Radio` when multiple selections are allowed — use `Checkbox`/`CheckboxGroup` instead.
 - Don't use `Radio` for immediate binary on/off actions — use `Switch` instead.
+- Don't use `Radio` when options are short (1-2 words) and consistent — use `Chip` with `selectionType="single"` for a compact segmented-control style.
+- Don't use `Radio` for more than 5 options — use `Dropdown` with `SelectInput` instead.
 - Don't use React Fragments as children in `RadioGroup` — only `Radio` components are accepted.
 - Don't mix controlled (`value`) and uncontrolled (`defaultValue`) on the same RadioGroup.
 

--- a/packages/blade-mcp/knowledgebase/components/RazorSense.md
+++ b/packages/blade-mcp/knowledgebase/components/RazorSense.md
@@ -174,6 +174,25 @@ type RazorSenseProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `RazorSense` for immersive, branded visual moments: success screens, hero sections, login pages, and loading states.
+- Use presets (`'default'`, `'zoomed'`, `'bottomWave'`, `'rippleWave'`, `'circleSlideUp'`) for quick setup; customize with individual props as needed.
+- Call `preloadRazorSenseAssets(preset)` before mounting to avoid visible frame skipping on first render.
+- Use `edgeFeather` for vignetting when overlaying text or UI on top of the animation.
+- Layer `RazorSenseGradient` on top as a foreground icon overlay for the full Spark Animation pattern.
+
+**Don't**
+
+- Don't use `RazorSense` on React Native — it requires WebGL and is web-only.
+- Don't provide both `videoSrc` and `imageSrc` simultaneously — they are mutually exclusive.
+- Don't rapidly change `gradientMapSrc`/`gradientMap2Src` — these re-initialize WebGL and cause flicker.
+- Don't set extremely high `numSegments` — it causes performance degradation.
+- Don't use `RazorSense` for simple transitions or button feedback — use standard CSS/framer-motion animations for lightweight effects.
+- Don't pass hex/CSS colors to `backgroundColor` — it expects normalized RGB `[0-1, 0-1, 0-1]`.
+
 ## Example
 
 Here are examples demonstrating various ways to use the RazorSense component:

--- a/packages/blade-mcp/knowledgebase/components/RazorSenseGradient.md
+++ b/packages/blade-mcp/knowledgebase/components/RazorSenseGradient.md
@@ -53,6 +53,25 @@ type RazorSenseGradientProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `RazorSenseGradient` for animated gradient effects masked to SVG icon/logo shapes.
+- Pass SVG elements (`<path>`, `<circle>`, `<rect>`, `<g>`) as children with `fill="white"` for visibility.
+- Match the `viewBox` prop to your SVG path's native coordinate system (typically `"0 0 24 24"` for icons).
+- Use `origin` prop to control where the radial gradient emanates from.
+- Layer over `RazorSense` as a foreground icon overlay for the full Spark Animation pattern.
+- Combine with framer-motion SVG variants (`motion.path`, `motion.g`) for animated mask effects.
+
+**Don't**
+
+- Don't use `RazorSenseGradient` on React Native — it requires WebGL and is web-only.
+- Don't pass HTML elements or React components as children — only SVG elements are supported.
+- Don't use `fill` values other than `"white"` unless you specifically want gradient transparency.
+- Don't use extremely large `size` values for many simultaneous instances — it impacts performance.
+- Don't mismatch `viewBox` with your SVG coordinate system — it causes scaling issues.
+
 ## Example
 
 Here are examples demonstrating various ways to use the RazorSenseGradient component:

--- a/packages/blade-mcp/knowledgebase/components/Scale.md
+++ b/packages/blade-mcp/knowledgebase/components/Scale.md
@@ -59,6 +59,22 @@ type ScaleProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Scale` for interactive hover/focus feedback — cards, images, and buttons that need subtle size change on interaction.
+- Use uncontrolled mode (default `motionTriggers={['hover']}`) for standard hover affordances.
+- Use controlled mode (`isHighlighted` prop) for programmatic scale control.
+- Use `variant="scale-down"` (0.98x) for press feedback and `"scale-up"` (1.05x, default) for hover enlargement.
+
+**Don't**
+
+- Don't use `Scale` for entry/exit animations — use `Fade`, `Move`, or `Slide` instead.
+- Don't expect custom scale values — only 1.05x (up) and 0.98x (down) are available.
+- Don't mix controlled (`isHighlighted`) and uncontrolled (`motionTriggers`) modes on the same instance.
+- Don't use `Scale` on text-only elements — it's designed for block-level interactive components.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/SearchInput.md
+++ b/packages/blade-mcp/knowledgebase/components/SearchInput.md
@@ -51,6 +51,22 @@ type SearchInputPropsWithLabel = {
 type SearchInputProps = SearchInputPropsWithA11yLabel | SearchInputPropsWithLabel;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `SearchInput` for search and filtering scenarios: table filters, global search, product catalogs.
+- Use `trailing` prop with a `Dropdown` component to show search results below the input.
+- Use `isLoading` to indicate async search in progress — set to `false` when input is empty.
+- Provide `accessibilityLabel` when hiding the visible label for compact search bars.
+
+**Don't**
+
+- Don't use `SearchInput` for general text input — use `TextInput` instead.
+- Don't use `SearchInput` without a search context — it always shows a search icon and auto-clear behavior.
+- Don't add prefix/suffix, character counters, or formatting — these are not supported in SearchInput.
+- Don't try to move the search icon to the trailing position — it's fixed at the leading (left) side.
+
 ## Example
 
 ### Basic Search Input

--- a/packages/blade-mcp/knowledgebase/components/SelectInput.md
+++ b/packages/blade-mcp/knowledgebase/components/SelectInput.md
@@ -148,17 +148,24 @@ type SelectInputProps = {
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `SelectInput` (inside `Dropdown`) when you have a **fixed set of more than 5 predefined options** and the user needs to pick one (or multiple). It's the standard form-field dropdown pattern.
+
+For fewer options (2–5 choices), prefer visible selection controls: `Radio` for longer labels, `Chip` with `selectionType="single"` for short consistent labels. For 1 binary option, use `Switch` (immediate) or `Checkbox` (requires confirmation).
+
 **Do**
 
-- Use `SelectInput` for dropdown-based selection from a fixed set of predefined options.
+- Use `SelectInput` for dropdown-based selection from a fixed set of predefined options (typically >5 items).
 - Always wrap `SelectInput` inside a `Dropdown` component with `DropdownOverlay` and `ActionList`.
-- Use `SelectInput` for small lists where users don't need to search/filter options.
+- Use `SelectInput` for lists where users don't need to search/filter options.
 - Use `icon` prop for a leading visual icon that provides context about the field type.
 - Use `valueSuffix` for badges or indicators after the selected value display.
 
 **Don't**
 
 - Don't use `SelectInput` standalone without a `Dropdown` wrapper — it won't function.
+- Don't use `SelectInput` for 5 or fewer options — use `Radio` or `Chip` to show choices inline without extra interaction.
 - Don't use `SelectInput` for large lists (10+ items) where users need to search — use `AutoComplete` instead.
 - Don't use `SelectInput` for inline tag-based selection — use `Chip`/`ChipGroup` instead.
 - Don't use React Fragments as children in the `Dropdown` wrapper.

--- a/packages/blade-mcp/knowledgebase/components/SelectInput.md
+++ b/packages/blade-mcp/knowledgebase/components/SelectInput.md
@@ -146,6 +146,24 @@ type SelectInputProps = {
 } & DataAnalyticsAttribute;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `SelectInput` for dropdown-based selection from a fixed set of predefined options.
+- Always wrap `SelectInput` inside a `Dropdown` component with `DropdownOverlay` and `ActionList`.
+- Use `SelectInput` for small lists where users don't need to search/filter options.
+- Use `icon` prop for a leading visual icon that provides context about the field type.
+- Use `valueSuffix` for badges or indicators after the selected value display.
+
+**Don't**
+
+- Don't use `SelectInput` standalone without a `Dropdown` wrapper — it won't function.
+- Don't use `SelectInput` for large lists (10+ items) where users need to search — use `AutoComplete` instead.
+- Don't use `SelectInput` for inline tag-based selection — use `Chip`/`ChipGroup` instead.
+- Don't use React Fragments as children in the `Dropdown` wrapper.
+- Don't confuse with `SearchInput` — SelectInput has no text input capability.
+
 ## Example
 
 ### Basic SelectInput with Single Selection

--- a/packages/blade-mcp/knowledgebase/components/SideNav.md
+++ b/packages/blade-mcp/knowledgebase/components/SideNav.md
@@ -295,6 +295,26 @@ type SideNavLevelProps = {
 };
 ````
 
+## Usage Guidelines
+
+**Do**
+
+- Use `SideNav` for complex, hierarchical navigation with 5+ items and multi-level nesting (L1, L2, L3).
+- Pass the `as` prop on `SideNavLink` with your router's link component (e.g., React Router `Link`) — it's required.
+- Manage active state externally using `isActive` prop with `useLocation()` and `matchPath()`.
+- Use `SideNavSection` to group related links under collapsible headings.
+- Use `SideNavFooter` for utility items like Settings or Test Mode toggles.
+- Use the `banner` slot only for critical activation or onboarding UI, not promotions.
+- Pair with `SkipNav` for keyboard accessibility to let users skip past the navigation.
+
+**Don't**
+
+- Don't use `SideNav` for simple mobile-only navigation with 2–5 items — use `BottomNav` instead.
+- Don't use `SideNav` without a routing library integration — the `as` prop requires a router component.
+- Don't put promotional content in the `banner` slot — it's reserved for critical UI like activation cards.
+- Don't expect automatic active state detection — Blade is routing-library agnostic, so consumers manage it.
+- Don't use `SideNavItem` for navigable links — it's for static items with trailing interactions like switches.
+
 ## Example
 
 ### Comprehensive SideNav with React Router Integration

--- a/packages/blade-mcp/knowledgebase/components/Skeleton.md
+++ b/packages/blade-mcp/knowledgebase/components/Skeleton.md
@@ -62,6 +62,24 @@ type SkeletonProps = {
   Partial<FlexboxProps>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Skeleton` when the layout structure of loading content is known — mimic the final content's dimensions.
+- Manually specify `width`, `height`, and `borderRadius` to match the target content (e.g., circle for avatars, full-width rectangles for text lines).
+- Compose multiple `Skeleton` elements in a `Box` with flex layout to build realistic loading placeholders.
+- Add `aria-busy="true"` on the parent container to announce the loading state to screen readers.
+- Use `borderRadius="max"` for circular skeletons (avatars) and `borderRadius="medium"` for text or card placeholders.
+
+**Don't**
+
+- Don't use `Skeleton` when the content structure is unknown — use `Spinner` for generic loading.
+- Don't wrap `Skeleton` around actual components (e.g., `<Skeleton><Card /></Skeleton>`) — compose skeletons separately and conditionally render them vs. real content.
+- Don't mix `Skeleton` and `Spinner` in the same view for the same loading state — choose one approach.
+- Don't forget to set dimensions — Skeleton doesn't auto-infer size from parent content.
+- Don't use `Skeleton` for empty states where no data exists — use `EmptyState` instead.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/SkipNav.md
+++ b/packages/blade-mcp/knowledgebase/components/SkipNav.md
@@ -44,6 +44,23 @@ type SkipNavContentProps = {
 } & TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Place `SkipNavLink` as the first interactive element in the document — before any navigation.
+- Place `SkipNavContent` at the start of the main content area (inside `<main>`).
+- Ensure the `id` prop on `SkipNavLink` matches the `id` on `SkipNavContent` — they default to `"blade-skip-nav"`.
+- Use multiple skip nav pairs with unique custom IDs if your page has distinct content sections.
+- Pair `SkipNav` with `SideNav` for apps with complex navigation hierarchies.
+
+**Don't**
+
+- Don't use `SkipNav` on React Native — it's web-only and throws an error on native.
+- Don't nest `SkipNavLink` inside `SkipNavContent` or vice versa — they are independent components placed at separate DOM locations.
+- Don't use mismatched IDs between the link and content target — navigation won't work.
+- Don't style or position `SkipNavLink` manually — it's visually hidden by default and only appears on keyboard focus.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Slide.md
+++ b/packages/blade-mcp/knowledgebase/components/Slide.md
@@ -92,6 +92,22 @@ type SlideProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Slide` for dramatic entrances from viewport edges — page transitions, modal content, major section reveals.
+- Use `direction` prop to control entry/exit edges (e.g., `{ enter: 'bottom', exit: 'top' }` for page transitions).
+- Use `motionTriggers={['in-view']}` for scroll-triggered slide reveals.
+- Use `fromOffset` to customize the slide distance (defaults to `100vh`/`100vw`).
+
+**Don't**
+
+- Don't use `Slide` for subtle in-viewport movement — use `Move` instead (Slide animates from outside the viewport).
+- Don't use `Slide` for opacity-only changes — use `Fade` instead.
+- Don't pass multiple children — wrap in a single container.
+- Don't use `Slide` for interactive hover/press feedback — use `Scale` or `Elevate`.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Spinner.md
+++ b/packages/blade-mcp/knowledgebase/components/Spinner.md
@@ -58,6 +58,23 @@ type SpinnerMotion = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Spinner` for indeterminate loading states where you don't know the completion percentage.
+- Use `color="white"` when placing the spinner on dark backgrounds for proper contrast.
+- Override `accessibilityLabel` with context-specific text (e.g., "Loading transactions" instead of generic "Loading").
+- Use `size="medium"` for inline loading within buttons or small sections; use `size="large"` or `size="xlarge"` for prominent full-page loading states.
+- Use `label` prop to provide visible loading context alongside the animation.
+
+**Don't**
+
+- Don't use `Spinner` when you know the progress percentage — use `ProgressBar` instead.
+- Don't use `Spinner` when the loading area's layout structure is known — use `Skeleton` to show content placeholders instead.
+- Don't place multiple spinners in the same view for the same operation — use one appropriately-sized spinner.
+- Don't use `Spinner` inside a `Button` directly — use the Button's built-in `isLoading` prop instead.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/SpotlightPopoverTour.md
+++ b/packages/blade-mcp/knowledgebase/components/SpotlightPopoverTour.md
@@ -113,6 +113,24 @@ type SpotlightPopoverStepRenderProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `SpotlightPopoverTour` for multi-step guided onboarding that highlights specific UI elements.
+- Wrap the entire page/section content inside the tour component — not just the target elements.
+- Match `name` in `steps` array exactly with the `name` on `SpotlightPopoverTourStep` wrappers.
+- Use `SpotlightPopoverTourFooter` helper for consistent step navigation button layout.
+- Use render functions for `content` and `footer` to access step navigation props (`goToNext`, `stopTour`, etc.).
+
+**Don't**
+
+- Don't place multiple independent tour instances on the same page — React Context prevents it.
+- Don't use mismatched `name` values between steps config and `SpotlightPopoverTourStep` components.
+- Don't use `SpotlightPopoverTour` for simple contextual help — use `Popover` or `Tooltip` instead.
+- Don't pass static JSX to `content` or `footer` — they must be render functions receiving step props.
+- Don't forget `width: 100%; height: 100%` on body for iOS Safari compatibility.
+
 ## Example
 
 ### Basic Tour Example

--- a/packages/blade-mcp/knowledgebase/components/Stagger.md
+++ b/packages/blade-mcp/knowledgebase/components/Stagger.md
@@ -54,6 +54,22 @@ type BaseMotionEntryExitProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Stagger` to orchestrate sequential animations for lists or groups (cards appearing one after another).
+- Wrap each child in a motion preset (`Move`, `Fade`, `Slide`) — Stagger coordinates their timing.
+- Use Box props (`display`, `gap`, `flexDirection`) directly on Stagger since it renders as a Box.
+- Control the entire group's visibility with `isVisible` on the Stagger (not on individual children).
+
+**Don't**
+
+- Don't use `Stagger` when all items should animate simultaneously — use individual motion presets directly.
+- Don't set `isVisible` on child motion presets — control visibility at the Stagger level.
+- Don't expect `in-view` or `on-animate-interactions` triggers — Stagger only supports `mount`, `hover`, and `focus`.
+- Don't use Stagger for single elements — it's designed for coordinating multiple children.
+
 ## Example
 
 ### Basic Stagger Animation with Fade

--- a/packages/blade-mcp/knowledgebase/components/StepGroup.md
+++ b/packages/blade-mcp/knowledgebase/components/StepGroup.md
@@ -138,6 +138,24 @@ type StepItemProps = {
 } & DataAnalyticsAttribute;
 ````
 
+## Usage Guidelines
+
+**Do**
+
+- Use `StepGroup` to visualize sequential processes like onboarding flows, wizards, multi-step forms, or transaction timelines.
+- Use `StepItemIcon` or `StepItemIndicator` as the `marker` prop to convey step status with semantic colors.
+- Use `stepProgress` to visually show completion progress along the connecting line between steps.
+- Use `onClick` or `href` on `StepItem` to make steps interactive — interactivity is determined by the presence of these props.
+- Use vertical orientation (default) for detailed timelines with descriptions, timestamps, and trailing badges.
+
+**Don't**
+
+- Don't use `Collapsible`, `trailing`, or nested `StepGroup` in horizontal orientation — they are only supported vertically.
+- Don't nest StepGroups beyond 3 levels deep — this is the maximum supported depth.
+- Don't confuse with `Breadcrumb` — StepGroup is for showing sequential processes, Breadcrumb is for navigational hierarchy.
+- Don't confuse with `Tabs` — Tabs switch between alternative views, StepGroup shows progression through ordered stages.
+- Don't use `StepGroup` for simple page navigation — use `Pagination` or `BottomNav` instead.
+
 ## Example
 
 ### Basic Vertical StepGroup

--- a/packages/blade-mcp/knowledgebase/components/Switch.md
+++ b/packages/blade-mcp/knowledgebase/components/Switch.md
@@ -77,17 +77,22 @@ type SwitchProps = {
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `Switch` when you have a **single binary option** (on/off) where **selection is also execution** — the action takes effect immediately without a separate confirmation or submit step. Think: toggling a setting, enabling a feature, activating a preference.
+
 **Do**
 
 - Use `Switch` for immediate binary on/off actions that take effect instantly (settings, feature toggles, preferences).
+- Use `Switch` when there is only 1 option and no additional action (like a submit button) is needed to confirm the selection.
 - Always provide `accessibilityLabel` — Switch does NOT render a built-in label.
 - Create a custom visible label by wrapping `Switch` and `Text` in a `Box` with `as="label"`.
 - Use `size="small"` for settings lists and compact layouts; `size="medium"` for prominent toggles.
 
 **Don't**
 
-- Don't use `Switch` for form-based selections that require submission — use `Checkbox` instead.
-- Don't use `Switch` when selecting one from multiple options — use `Radio`/`RadioGroup` instead.
+- Don't use `Switch` for form-based selections that require a submit/confirm action — use `Checkbox` instead.
+- Don't use `Switch` when selecting one from multiple options — use `Radio`, `Chip`, or `Dropdown` instead.
 - Don't render `Switch` without an associated visible label element — it has no built-in label.
 - Don't use `Switch` in groups — it's designed for individual binary controls only.
 - Don't mix controlled (`isChecked`) and uncontrolled (`defaultChecked`).

--- a/packages/blade-mcp/knowledgebase/components/Switch.md
+++ b/packages/blade-mcp/knowledgebase/components/Switch.md
@@ -75,6 +75,23 @@ type SwitchProps = {
   MotionMetaProp;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Switch` for immediate binary on/off actions that take effect instantly (settings, feature toggles, preferences).
+- Always provide `accessibilityLabel` — Switch does NOT render a built-in label.
+- Create a custom visible label by wrapping `Switch` and `Text` in a `Box` with `as="label"`.
+- Use `size="small"` for settings lists and compact layouts; `size="medium"` for prominent toggles.
+
+**Don't**
+
+- Don't use `Switch` for form-based selections that require submission — use `Checkbox` instead.
+- Don't use `Switch` when selecting one from multiple options — use `Radio`/`RadioGroup` instead.
+- Don't render `Switch` without an associated visible label element — it has no built-in label.
+- Don't use `Switch` in groups — it's designed for individual binary controls only.
+- Don't mix controlled (`isChecked`) and uncontrolled (`defaultChecked`).
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Table.md
+++ b/packages/blade-mcp/knowledgebase/components/Table.md
@@ -387,6 +387,26 @@ type TablePaginationProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Table` for displaying structured, multi-column data that users need to scan, sort, compare, or act on.
+- Use the function-as-children pattern: `<Table>{(tableData) => (<>...</>)}</Table>`.
+- Ensure every row object in `data.nodes` has a unique `id` field.
+- Use `sortFunctions` with matching `headerKey` props on `TableHeaderCell` for sortable columns.
+- Use `isHeaderSticky` and `isFirstColumnSticky` for large datasets that need scroll anchoring.
+- Wrap in `ListView` when you need search and filter capabilities alongside the table.
+
+**Don't**
+
+- Don't use static JSX children — `Table` requires the function-as-children pattern.
+- Don't expect column reordering, resizing, or row expansion — these are out of scope.
+- Don't put arbitrary elements in the `toolbar` prop — only `TableToolbar` is accepted.
+- Don't use `Table` for key-value pair display — use `InfoGroup` instead.
+- Don't sort multiple columns simultaneously — only single-column sorting is supported.
+- Don't use `Table` on mobile for complex data — consider a list-based layout instead.
+
 ## Example
 
 ### Comprehensive Table with Advanced Features

--- a/packages/blade-mcp/knowledgebase/components/Tabs.md
+++ b/packages/blade-mcp/knowledgebase/components/Tabs.md
@@ -132,6 +132,25 @@ type TabPanelProps = {
 // TabList has no specific props other than children and common styling props
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Tabs` to switch between related content views within the same page context.
+- Structure as `<Tabs>` → `<TabList>` → `<TabItem>` + `<TabPanel>` (panels are siblings of `TabList`).
+- Give each `TabItem` and its corresponding `TabPanel` matching `value` props.
+- Use `isLazy` when tab panels contain heavy content to avoid mounting all panels at once.
+- Use `trailing` prop on `TabItem` for badges or counters showing tab-specific counts.
+- Use `variant="filled"` for visually distinct tab groups; `"bordered"` (default) for standard use.
+
+**Don't**
+
+- Don't use `Tabs` for page-level navigation between separate routes — use `SideNav`, `TopNav`, or `BottomNav` instead.
+- Don't use icon-only tabs without a text label — tabs must have readable text.
+- Don't nest `TabPanel` inside `TabList` — panels must be siblings of `TabList` within `Tabs`.
+- Don't use `Tabs` where an `Accordion` would be more appropriate (progressive disclosure of stacked content).
+- Don't forget `value` on both `TabItem` and `TabPanel` — mismatched values cause panels not to display.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Tabs.md
+++ b/packages/blade-mcp/knowledgebase/components/Tabs.md
@@ -134,9 +134,14 @@ type TabPanelProps = {
 
 ## Usage Guidelines
 
+**When to Use**
+
+Use `Tabs` when a **single selection filters or changes the visible page content**. The key decision: if selecting an option doesn't just store a value but actively changes what the user sees on the page, Tabs is the right component.
+
 **Do**
 
 - Use `Tabs` to switch between related content views within the same page context.
+- Use `Tabs` when selection immediately filters or changes visible content (not just stores a value for later submission).
 - Structure as `<Tabs>` → `<TabList>` → `<TabItem>` + `<TabPanel>` (panels are siblings of `TabList`).
 - Give each `TabItem` and its corresponding `TabPanel` matching `value` props.
 - Use `isLazy` when tab panels contain heavy content to avoid mounting all panels at once.
@@ -146,6 +151,7 @@ type TabPanelProps = {
 **Don't**
 
 - Don't use `Tabs` for page-level navigation between separate routes — use `SideNav`, `TopNav`, or `BottomNav` instead.
+- Don't use `Tabs` for selecting a value to be submitted in a form — use `Radio`, `Chip`, or `Dropdown` instead.
 - Don't use icon-only tabs without a text label — tabs must have readable text.
 - Don't nest `TabPanel` inside `TabList` — panels must be siblings of `TabList` within `Tabs`.
 - Don't use `Tabs` where an `Accordion` would be more appropriate (progressive disclosure of stacked content).

--- a/packages/blade-mcp/knowledgebase/components/Tag.md
+++ b/packages/blade-mcp/knowledgebase/components/Tag.md
@@ -66,6 +66,24 @@ type TagProps = {
   TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Tag` for dismissible keywords or selected items that users can remove (e.g., selected filters, applied categories).
+- Always implement the `onDismiss` callback to handle tag removal — it is required.
+- Use `icon` to add visual context when the tag represents a specific category or entity type.
+- Keep tag labels concise — long text auto-truncates with a tooltip on hover.
+- Group multiple tags in a flex container with appropriate gap spacing.
+
+**Don't**
+
+- Don't use `Tag` for non-interactive metadata labels — use `Badge` instead (Badge is non-interactive and non-dismissible).
+- Don't use `Tag` for toggle-able filter selections — use `Chip` instead (Chip supports checked/unchecked states).
+- Don't try to make tags non-dismissible — the dismiss button is always present by design.
+- Don't use tags for actions or navigation — they are purely for displaying removable selections.
+- Don't manage tag state without external state management — the consumer must handle visibility and removal.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Text.md
+++ b/packages/blade-mcp/knowledgebase/components/Text.md
@@ -60,6 +60,23 @@ type TextProps<T> = T extends { variant: infer Variant }
   : T;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Text` for body content, paragraphs, and auxiliary information on pages.
+- Use `variant="body"` for main content and `variant="caption"` for smaller supporting text.
+- Use `as` prop for semantic HTML rendering (`span` for inline, `label` for form labels, `abbr` for abbreviations).
+- Use `truncateAfterLines` to prevent text overflow in constrained layouts.
+- Use `textDecorationLine="dotted"` only on abbreviations paired with `Tooltip` or `Popover` for additional context.
+
+**Don't**
+
+- Don't use `Text` for page or section titles — use `Heading` or `Display` instead.
+- Don't use invalid sizes with `variant="caption"` — only `"small"` and `"medium"` are accepted.
+- Don't use `textDecorationLine="dotted"` purely for visual emphasis — it's reserved for abbreviations that reveal context on interaction.
+- Don't deeply nest `Text` components for formatting — keep nesting minimal for readability.
+
 ## Example
 
 Here's a comprehensive example showcasing the Text component's various features and props, demonstrating different text variants, sizes, weights, and styling options for creating properly formatted content:

--- a/packages/blade-mcp/knowledgebase/components/TextArea.md
+++ b/packages/blade-mcp/knowledgebase/components/TextArea.md
@@ -67,6 +67,22 @@ type TextAreaPropsWithLabel = {
 type TextAreaProps = TextAreaPropsWithA11yLabel | TextAreaPropsWithLabel;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `TextArea` for multi-line text input: comments, descriptions, feedback, and longer-form content.
+- Use `numberOfLines` (2–5) to set the visible height appropriate for the expected content length.
+- Use `maxCharacters` to enforce character limits with a visible counter below the field.
+- Use `onKeyDown` for custom keyboard handling (e.g., Shift+Enter to submit).
+
+**Don't**
+
+- Don't use `TextArea` for single-line input — use `TextInput` instead.
+- Don't expect `numberOfLines` to auto-grow — it sets a fixed height.
+- Don't use `TextArea` with leading/trailing icons, dropdowns, or prefix/suffix — these are only supported in `TextInput`.
+- Don't use `TextArea` for chat input — use `ChatInput` which has file upload, suggestions, and submit/stop behavior.
+
 ## Example
 
 ### Basic TextArea with Validation

--- a/packages/blade-mcp/knowledgebase/components/TextInput.md
+++ b/packages/blade-mcp/knowledgebase/components/TextInput.md
@@ -143,6 +143,25 @@ type TextInputPropsWithLabel = {
 type TextInputProps = TextInputPropsWithA11yLabel | TextInputPropsWithLabel;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `TextInput` for single-line text collection: names, emails, URLs, phone numbers, and general text.
+- Use the `type` prop to get the correct mobile keyboard (`email`, `tel`, `url`, `number`).
+- Use `format` prop with `#` patterns for structured inputs (card numbers, dates) — extract raw values from `onChange`.
+- Use `maxCharacters` to enforce hard limits with a visible character counter.
+- Use `leading`/`trailing` slots for icons, badges, or `Dropdown` components for contextual actions.
+- Use `showClearButton` for search-like inputs where users need to reset quickly.
+
+**Don't**
+
+- Don't use `TextInput` for passwords — use `PasswordInput` which handles masking and reveal.
+- Don't use `TextInput` for multi-line content — use `TextArea` instead.
+- Don't use `TextInput` for search — use `SearchInput` which has built-in search icon and Dropdown integration.
+- Don't use alphanumeric characters in `format` patterns — only `#` and special characters are allowed.
+- Don't mix `value` and `defaultValue` with `format` — it throws a conflict error.
+
 ## Example
 
 ### Basic Usage with Validation States

--- a/packages/blade-mcp/knowledgebase/components/TimePicker.md
+++ b/packages/blade-mcp/knowledgebase/components/TimePicker.md
@@ -245,6 +245,24 @@ type TimeSegmentProps = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `TimePicker` for time selection with scrollable spin wheels (hours, minutes, AM/PM).
+- Use `timeFormat="24h"` for business/technical contexts and `"12h"` (default) for consumer-facing UIs.
+- Use `minuteStep` (1, 5, 15, or 30) to control granularity based on your use case.
+- Use two separate `TimePicker` components for time range selection with custom validation between them.
+- The component auto-converts to BottomSheet on mobile — no manual handling needed.
+
+**Don't**
+
+- Don't use `TimePicker` for date selection — use `DatePicker` for dates.
+- Don't expect built-in time range support — use two TimePickers with validation logic.
+- Don't use arbitrary `minuteStep` values — only 1, 5, 15, and 30 are accepted.
+- Don't use generic `TextInput` for time entry — `TimePicker` provides a proper time selection UI.
+- Don't rely on `onApply` when `showFooterActions={false}` — in that mode, time applies immediately on blur/Enter.
+
 ## Example
 
 ### TimePicker Usage

--- a/packages/blade-mcp/knowledgebase/components/Toast.md
+++ b/packages/blade-mcp/knowledgebase/components/Toast.md
@@ -87,6 +87,27 @@ type UseToastReturn = {
 };
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Toast` for brief, non-critical feedback after user actions (e.g., "Item saved", "Payment successful").
+- Use the imperative `useToast()` hook API — call `toast.show()` and `toast.dismiss()`.
+- Place `<ToastContainer />` once at the root of your app, outside nested `BladeProvider` instances.
+- Use `type="informational"` (default) with auto-dismiss for transient confirmations.
+- Use `type="promotional"` for richer content that requires user acknowledgment.
+- Keep action labels short — a single verb like "Undo" or "Retry".
+- Use semantic `color` values to match the feedback intent (`positive` for success, `negative` for errors).
+
+**Don't**
+
+- Don't use `Toast` for critical errors that need explicit acknowledgment — use `Alert` instead.
+- Don't use `Toast` for persistent, inline status messages — use `Alert` for in-page context.
+- Don't stack multiple promotional toasts — only one can be active at a time.
+- Don't render `ToastContainer` inside `BladeProvider` children if you have nested providers — place it at the app root.
+- Don't rely on `onDismissButtonClick` for detecting auto-dismiss — it only fires on manual dismiss.
+- Don't use long sentences as toast content — keep messages concise and scannable.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/Tooltip.md
+++ b/packages/blade-mcp/knowledgebase/components/Tooltip.md
@@ -44,6 +44,23 @@ type TooltipProps = {
 type TooltipInteractiveWrapperProps = Omit<BaseBoxProps, 'as'>;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `Tooltip` for brief, supplementary hover help (icon explanations, abbreviations, feature hints).
+- Pass `content` as a string — Tooltip only accepts plain text, not React elements.
+- Use `TooltipInteractiveWrapper` when the trigger is a non-interactive element (icon, badge).
+- Use sparingly — too many tooltips create a noisy experience.
+
+**Don't**
+
+- Don't put interactive elements (buttons, links) inside Tooltip — it's read-only; use `Popover` for interactive content.
+- Don't use `Tooltip` for critical information — users may not hover to discover it.
+- Don't pass React elements to `content` — only strings are accepted (unlike Popover).
+- Don't use non-interactive triggers without `TooltipInteractiveWrapper`.
+- Don't use `Tooltip` when click-triggered contextual content is needed — use `Popover` instead.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/TopNav.md
+++ b/packages/blade-mcp/knowledgebase/components/TopNav.md
@@ -140,6 +140,24 @@ type MenuTriggerProps = {
 };
 ````
 
+## Usage Guidelines
+
+**Do**
+
+- Use `TopNav` for multi-product or multi-module applications that need a brand header with horizontal navigation, search, and user menu.
+- Structure content using `TopNavBrand`, `TopNavContent`, and `TopNavActions` as direct children.
+- Use `TabNav` inside `TopNavContent` with the render prop pattern to handle responsive overflow into a "More" menu.
+- Handle mobile layout with conditional rendering — hide `TabNav` on mobile and show a simplified menu button layout.
+- Manage active state externally via React Router's `useLocation()`.
+
+**Don't**
+
+- Don't try to override the dark theme — `TopNav` always renders in dark mode internally.
+- Don't skip the `TabNav` render prop pattern — the simple children API is not supported.
+- Don't use `TopNav` as the primary deep navigation — pair it with `SideNav` for hierarchical navigation.
+- Don't put complex or multi-line content inside `TopNav` — it's designed for single-line items.
+- Don't use `TopNav` for mobile bottom navigation — use `BottomNav` for mobile-first persistent nav.
+
 ## Example
 
 Below is a comprehensive example showing how to use the TopNav component with its subcomponents, including TabNav integration and responsive behavior:

--- a/packages/blade-mcp/knowledgebase/components/VisuallyHidden.md
+++ b/packages/blade-mcp/knowledgebase/components/VisuallyHidden.md
@@ -19,6 +19,21 @@ type VisuallyHiddenProps = {
 } & TestID;
 ```
 
+## Usage Guidelines
+
+**Do**
+
+- Use `VisuallyHidden` to provide accessible labels for screen readers when the visual label is absent or redundant (e.g., icon-only buttons, checkboxes without visible labels).
+- Wrap text content that adds context for assistive technology users but would be redundant for sighted users.
+- Use inside interactive components like `Checkbox`, `IconButton`, or custom controls that lack visible labels.
+
+**Don't**
+
+- Don't use `VisuallyHidden` to conditionally hide content for sighted users — it's an accessibility utility, not a display toggle.
+- Don't use it as a replacement for `aria-label` on components that already support the `accessibilityLabel` prop — prefer the prop-based approach.
+- Don't wrap complex interactive components inside `VisuallyHidden` — only use it for supplementary text content.
+- Don't use `display: none` or `visibility: hidden` instead — those remove content from the accessibility tree entirely.
+
 ## Example
 
 ### Basic Usage

--- a/packages/blade-mcp/knowledgebase/components/prompt.txt
+++ b/packages/blade-mcp/knowledgebase/components/prompt.txt
@@ -14,6 +14,39 @@ list of constraints on which the component throws error. Below is an example:
 
 ## TypeScript Types - Add short description that these types are the props that the component accepts so that the LLMs pick this up properly. Get all the types required for this component and its subcomponents. Imagine You're a consumer who's trying to use {ComponentName} component along with its subcomponent so in order for you to know what {ComponentName} accepts as props and what props its subcomponents accepts you need to have all the types to be in one place for reference. Do not generate or inference types yourself, it already exists under types.ts or {componentName}tokens.ts file. In addition, scan the types in {ComponentName}'s file and also subcomponents' file of {ComponentName} for types. Never pick types from `.stories` file. Preserve the declaration eg: if its declared as `type` preserve it, if its declared as `interface` preserve it. If there are union types don't skip them, they shall be included as well along with types for eg: if `type {ComponentName}Props` has `TestID`, `StyledPropsBlade` or `DataAnalyticsAttribute`. Do not pick types that start with `_typename` or part of components that start with `_ComponentName` those are private types/components not be exposed to consumer and meant for internal purposes. Do not add types to the markdown that start with `Base*` eg: `BaseSomeProps` or `BaseSomeComponentName` or `BaseSomeTypeName` these are again internal types and components not useful for end consumers.
 
+## Usage Guidelines - Add a list of do's and don'ts that steer correct usage of
+the component, written so an LLM/MCP client generates idiomatic, correct code and
+avoids common misuse. These are recommendations and anti-patterns, NOT hard
+errors (hard errors go in ## Important Constraints). Derive every item from the
+Storybook stories, the component's _decisions/decisions.md and docs, and source
+— do not invent guidance. Format as two short bullet lists under **Do** and
+**Don't** subheadings. Keep each item to one actionable line, and whenever you
+write a don't, point to the right alternative. Cover only the points that apply:
+
+- Component selection: when to use this component vs a similar/related one
+  (e.g. use IconButton for icon-only actions, not Button with only an icon).
+- Composition: which components it must be paired with or nested in, and
+  combinations to avoid.
+- Prop usage: which variants/sizes/props are meant for which cases, and props
+  that should not be combined.
+- Content: label length and casing, icon usage, item counts, truncation.
+- Accessibility: required labels, focus order, color/contrast usage.
+- Common UX mistakes that won't throw an error but produce a poor result.
+
+Do NOT restate what the component is (that is ## Description) and do NOT restate
+the hard error conditions (those are ## Important Constraints). Keep the heading
+spelling identical across all files.
+
+Example shape (illustrative — replace with the component's real guidance):
+
+**Do**
+- Use `Toast` for brief, non-critical feedback that auto-dismisses.
+- Keep the action label to a single short verb.
+
+**Don't**
+- Don't use `Toast` for critical errors that need acknowledgement — use `Alert`.
+- Don't stack multiple toasts for the same event.
+
 ## Example - Create usage examples by clubbing multiple use cases like prop variations with all the props for {ComponentName} component. Follow best coding practices. Create code that follows accessibility guidelines and uses the right accessibility props defined by components. Create ONE comprehensive example per distinct use case, with each example showing multiple props combined in practical ways. Don't create multiple examples showing similar functionality with minor variations. Focus on showing how different prop combinations work together in real-world scenario for example: default selection, disabled cases, prefix prop, suffix prop, type prop, sizes prop, formatting props, color prop, variant prop, accessibility props etc in single clubbed examples so we don't bloat examples. Put core features and props in one example component and not multiple components within one example component. Do not ever use comments `{/* some comment *}` or headings to merge variations in one example. Split examples whenever necessary in their own sections with heading and short description of what each example does. All the examples must show the import statements too required for creating that example. Use Box component only wherever its required and necessary. Focus on comprehensive usage rather than isolated prop demonstrations. Create examples that focuses more on this components use cases and use other components only as supporting components whenever required. This will be fed to LLMs in future when the user ask to build something that involves this component. This example will just act as the blueprint and then referring the types and prompt of user the LLMs will be able to create the required example prompted by a user. Do not pick components that start with `_something` those are private components and never exposed to consumer and meant for internal purposes. All the imports that start with `~/something` should be replaced with named exports of `@razorpay/blade/something` eg: `~components/*` shall be replaced with named absolute imports of `@razorpay/blade/components`. 
 
 Do this only for {ComponentName} component right now and save it under a directory packages/blade-mcp/knowledgebase/components/{ComponentName.md}. Do not touch any other file/directory in this project. 

--- a/packages/blade-mcp/src/tools/__tests__/__snapshots__/getBladeComponentDocs.test.ts.snap
+++ b/packages/blade-mcp/src/tools/__tests__/__snapshots__/getBladeComponentDocs.test.ts.snap
@@ -134,6 +134,24 @@ type IconComponent = React.ComponentType<{
 }>;
 \`\`\`
 
+## Usage Guidelines
+
+**Do**
+
+- Use \`Button\` for primary actions and calls-to-action that trigger operations (submit, save, create).
+- Use \`variant\` to establish visual hierarchy: \`"primary"\` for main actions, \`"secondary"\` for supporting, \`"tertiary"\` for de-emphasized.
+- Use \`href\` prop to render as an anchor element when the button navigates to a URL.
+- Use \`isLoading\` to show feedback during async operations.
+- Use \`icon\` with \`iconPosition\` for visual reinforcement of the action.
+
+**Don't**
+
+- Don't use \`Button\` for icon-only actions in tight spaces — use \`IconButton\` instead.
+- Don't use \`Button\` for navigation text that looks like a link — use \`Link\` instead.
+- Don't use \`variant="tertiary"\` with \`color="positive"\` or \`color="negative"\` — tertiary only supports \`"primary"\` and \`"white"\`.
+- Don't use \`type="password"\` on TextInput — but relevant here: don't pass \`type="submit"\` accidentally without a form context.
+- Don't use \`Button\` without text or \`accessibilityLabel\` when using icon-only mode.
+
 ## Example
 
 Here are comprehensive examples demonstrating various ways to use the Button component:
@@ -427,6 +445,24 @@ type AccordionItemBodyProps = {
   children?: React.ReactNode | StringChildrenType;
 } & DataAnalyticsAttribute;
 \`\`\`
+
+## Usage Guidelines
+
+**Do**
+
+- Use \`Accordion\` for 3+ items that need expand/collapse behavior where only one is open at a time (FAQs, settings, documentation).
+- Compose with \`AccordionItem\` → \`AccordionItemHeader\` + \`AccordionItemBody\` (modern API).
+- Use \`showNumberPrefix\` for sequential/ordered items.
+- Use \`leading\` on \`AccordionItemHeader\` for category icons and \`titleSuffix\` for badges.
+- Use controlled mode (\`expandedIndex\` + \`onExpandChange\`) when you need programmatic control.
+
+**Don't**
+
+- Don't use \`Accordion\` when all items should be expandable simultaneously — use multiple \`Collapsible\` components instead.
+- Don't use the deprecated props API (\`title\`/\`description\` on AccordionItem) — use \`AccordionItemHeader\` + \`AccordionItemBody\`.
+- Don't nest Accordions — only single-level is supported.
+- Don't use \`Accordion\` when items are equal-weight and need quick access — use \`Tabs\` instead.
+- Don't combine \`showNumberPrefix\` with \`leading\` icon on the same item.
 
 ## Examples
 
@@ -924,6 +960,24 @@ type IconComponent = React.ComponentType<{
 }>;
 \`\`\`
 
+## Usage Guidelines
+
+**Do**
+
+- Use \`Button\` for primary actions and calls-to-action that trigger operations (submit, save, create).
+- Use \`variant\` to establish visual hierarchy: \`"primary"\` for main actions, \`"secondary"\` for supporting, \`"tertiary"\` for de-emphasized.
+- Use \`href\` prop to render as an anchor element when the button navigates to a URL.
+- Use \`isLoading\` to show feedback during async operations.
+- Use \`icon\` with \`iconPosition\` for visual reinforcement of the action.
+
+**Don't**
+
+- Don't use \`Button\` for icon-only actions in tight spaces — use \`IconButton\` instead.
+- Don't use \`Button\` for navigation text that looks like a link — use \`Link\` instead.
+- Don't use \`variant="tertiary"\` with \`color="positive"\` or \`color="negative"\` — tertiary only supports \`"primary"\` and \`"white"\`.
+- Don't use \`type="password"\` on TextInput — but relevant here: don't pass \`type="submit"\` accidentally without a form context.
+- Don't use \`Button\` without text or \`accessibilityLabel\` when using icon-only mode.
+
 ## Example
 
 Here are comprehensive examples demonstrating various ways to use the Button component:
@@ -1217,6 +1271,24 @@ type AccordionItemBodyProps = {
   children?: React.ReactNode | StringChildrenType;
 } & DataAnalyticsAttribute;
 \`\`\`
+
+## Usage Guidelines
+
+**Do**
+
+- Use \`Accordion\` for 3+ items that need expand/collapse behavior where only one is open at a time (FAQs, settings, documentation).
+- Compose with \`AccordionItem\` → \`AccordionItemHeader\` + \`AccordionItemBody\` (modern API).
+- Use \`showNumberPrefix\` for sequential/ordered items.
+- Use \`leading\` on \`AccordionItemHeader\` for category icons and \`titleSuffix\` for badges.
+- Use controlled mode (\`expandedIndex\` + \`onExpandChange\`) when you need programmatic control.
+
+**Don't**
+
+- Don't use \`Accordion\` when all items should be expandable simultaneously — use multiple \`Collapsible\` components instead.
+- Don't use the deprecated props API (\`title\`/\`description\` on AccordionItem) — use \`AccordionItemHeader\` + \`AccordionItemBody\`.
+- Don't nest Accordions — only single-level is supported.
+- Don't use \`Accordion\` when items are equal-weight and need quick access — use \`Tabs\` instead.
+- Don't combine \`showNumberPrefix\` with \`leading\` icon on the same item.
 
 ## Examples
 
@@ -1714,6 +1786,24 @@ type IconComponent = React.ComponentType<{
 }>;
 \`\`\`
 
+## Usage Guidelines
+
+**Do**
+
+- Use \`Button\` for primary actions and calls-to-action that trigger operations (submit, save, create).
+- Use \`variant\` to establish visual hierarchy: \`"primary"\` for main actions, \`"secondary"\` for supporting, \`"tertiary"\` for de-emphasized.
+- Use \`href\` prop to render as an anchor element when the button navigates to a URL.
+- Use \`isLoading\` to show feedback during async operations.
+- Use \`icon\` with \`iconPosition\` for visual reinforcement of the action.
+
+**Don't**
+
+- Don't use \`Button\` for icon-only actions in tight spaces — use \`IconButton\` instead.
+- Don't use \`Button\` for navigation text that looks like a link — use \`Link\` instead.
+- Don't use \`variant="tertiary"\` with \`color="positive"\` or \`color="negative"\` — tertiary only supports \`"primary"\` and \`"white"\`.
+- Don't use \`type="password"\` on TextInput — but relevant here: don't pass \`type="submit"\` accidentally without a form context.
+- Don't use \`Button\` without text or \`accessibilityLabel\` when using icon-only mode.
+
 ## Example
 
 Here are comprehensive examples demonstrating various ways to use the Button component:
@@ -2007,6 +2097,24 @@ type AccordionItemBodyProps = {
   children?: React.ReactNode | StringChildrenType;
 } & DataAnalyticsAttribute;
 \`\`\`
+
+## Usage Guidelines
+
+**Do**
+
+- Use \`Accordion\` for 3+ items that need expand/collapse behavior where only one is open at a time (FAQs, settings, documentation).
+- Compose with \`AccordionItem\` → \`AccordionItemHeader\` + \`AccordionItemBody\` (modern API).
+- Use \`showNumberPrefix\` for sequential/ordered items.
+- Use \`leading\` on \`AccordionItemHeader\` for category icons and \`titleSuffix\` for badges.
+- Use controlled mode (\`expandedIndex\` + \`onExpandChange\`) when you need programmatic control.
+
+**Don't**
+
+- Don't use \`Accordion\` when all items should be expandable simultaneously — use multiple \`Collapsible\` components instead.
+- Don't use the deprecated props API (\`title\`/\`description\` on AccordionItem) — use \`AccordionItemHeader\` + \`AccordionItemBody\`.
+- Don't nest Accordions — only single-level is supported.
+- Don't use \`Accordion\` when items are equal-weight and need quick access — use \`Tabs\` instead.
+- Don't combine \`showNumberPrefix\` with \`leading\` icon on the same item.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Adds **Usage Guidelines** (Do/Don't) section to all 86 component docs in `packages/blade-mcp/knowledgebase/components/`
- Provides AI-consumable guidance on when to use each component, common misuse patterns, prop constraints, and alternatives

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test snapshot updates only; no changes to Blade component runtime behavior or public APIs outside MCP doc content.
> 
> **Overview**
> This PR extends the `@razorpay/blade-mcp` knowledgebase so MCP/LLM clients get explicit **when to use / when not to use** guidance alongside types and examples.
> 
> Each component markdown under `packages/blade-mcp/knowledgebase/components/` now includes a **Usage Guidelines** section (after TypeScript types, before examples) with **Do** and **Don't** bullets covering component choice vs alternatives (e.g. `Alert` vs `Toast`, `Radio` vs `Chip`), required composition, prop combinations, accessibility, and common UX mistakes. **`CounterInput.md`** is aligned to the same Do/Don't shape where it previously used separate “when to use” prose.
> 
> **`prompt.txt`** is updated so future generated docs must include this section with the same rules (distinct from **Important Constraints** hard errors). **`getBladeComponentDocs` snapshots** are updated so exported docs include the new sections. A **changeset** records a patch bump for `@razorpay/blade-mcp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8af57b554fe577d6014191dc31e3279e16f47b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->