### PR TITLE
feat(blade-svelte): ActionList component

### DIFF
--- a/.changeset/blade-svelte-actionlist-component.md
+++ b/.changeset/blade-svelte-actionlist-component.md
@@ -1,4 +1,5 @@
 ---
+'@razorpay/blade': patch
 '@razorpay/blade-core': patch
 '@razorpay/blade-svelte': patch
 ---

--- a/.changeset/blade-svelte-actionlist-component.md
+++ b/.changeset/blade-svelte-actionlist-component.md
@@ -1,0 +1,6 @@
+---
+'@razorpay/blade-core': patch
+'@razorpay/blade-svelte': patch
+---
+
+feat(blade-svelte): add ActionList component

--- a/.changeset/blade-svelte-actionlist-component.md
+++ b/.changeset/blade-svelte-actionlist-component.md
@@ -5,3 +5,5 @@
 ---
 
 feat(blade-svelte): add ActionList component
+
+Also fixes a React BaseMenu hover style: the hover background is now suppressed when `aria-selected=true` so a selected row's `fadedHighlighted` background is not overridden on pointer-enter. This intentional fix applies to all React `BaseMenu`-based consumers (ActionList, Select, etc.) and matches the expected selected-item UX.

--- a/packages/blade-core/src/styles/ActionList/actionList.module.css
+++ b/packages/blade-core/src/styles/ActionList/actionList.module.css
@@ -142,6 +142,31 @@
   margin-left: auto;
 }
 
+/*
+ * Multi-select leading indicator wrapper. Mirrors React `BaseMenuLeadingItem`:
+ * the Checkbox is purely a visual affordance (row `aria-selected` +
+ * container `aria-multiselectable` carry the semantics), so pointer events are
+ * disabled and the subtree is hidden from the a11y tree via `aria-hidden`.
+ */
+.itemSelector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--size-20, 20px);
+  pointer-events: none;
+}
+
+/*
+ * Badge group (ActionListItemBadgeGroup) — flex row, vertically centered.
+ * Mirrors React `_ActionListItemBadgeGroup` (`display:flex; align-items:center;
+ * flex-direction:row`).
+ */
+.itemBadgeGroup {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 /* ── Section ── */
 .section {
   display: block;

--- a/packages/blade-core/src/styles/ActionList/actionList.module.css
+++ b/packages/blade-core/src/styles/ActionList/actionList.module.css
@@ -66,7 +66,7 @@
   color: inherit;
   font-family: inherit;
 
-  &:hover:not([disabled]):not([aria-disabled='true']) {
+  &:hover:not([disabled]):not([aria-disabled='true']):not([aria-selected='true']) {
     background-color: var(--interactive-background-gray-default);
   }
 
@@ -94,7 +94,7 @@
 
 /* Negative intent row — negative faded hover (mirrors React `color==='negative'`). */
 .itemNegative {
-  &:hover:not([disabled]):not([aria-disabled='true']) {
+  &:hover:not([disabled]):not([aria-disabled='true']):not([aria-selected='true']) {
     background-color: var(--interactive-background-negative-faded);
   }
 }

--- a/packages/blade-core/src/styles/ActionList/actionList.module.css
+++ b/packages/blade-core/src/styles/ActionList/actionList.module.css
@@ -1,0 +1,158 @@
+/* ───────────────────────── ActionList ───────────────────────── */
+
+/*
+ * Outer StyledActionList box — rendered ONLY when the list is NOT inside a
+ * BottomSheet. Mirrors React `getBaseActionListStyles`: thin gray border,
+ * medium radius, mid-raised elevation. Inside a BottomSheet these are dropped
+ * (ActionList renders the wrapper directly) so BottomSheetBody owns the scroll.
+ */
+.box {
+  border-width: var(--border-width-thin);
+  border-style: solid;
+  border-color: var(--surface-border-gray-normal);
+  border-radius: var(--border-radius-medium);
+  box-shadow: var(--elevation-mid-raised);
+}
+
+/*
+ * ListBox scroll wrapper — standalone (not-in-sheet) branch.
+ * React `getBaseListBoxWrapperStyles`: max-height size[300]=300px, spacing.3
+ * padding, overflow-y auto.
+ */
+.wrapper {
+  max-height: var(--size-300, 300px);
+  padding: var(--spacing-3);
+  overflow-y: auto;
+}
+
+/*
+ * ListBox scroll wrapper — in-BottomSheet branch. BottomSheetBody owns padding
+ * and scroll bounds, so only overflow-y is set here.
+ */
+.wrapperInSheet {
+  overflow-y: auto;
+}
+
+/*
+ * Hide the trailing Divider of the last section so section lists don't render
+ * a dangling separator. React drops it via `_hideDivider`/AutoComplete logic;
+ * here a descendant selector targets the final section's separator.
+ */
+.wrapper [role='group']:last-child > [role='separator']:last-child,
+.wrapperInSheet [role='group']:last-child > [role='separator']:last-child {
+  display: none;
+}
+
+/* ── Row (inlined BaseMenuItem container) ── */
+/*
+ * Mirrors `getBaseMenuItemStyles` + `StyledMenuItemContainer`: transparent
+ * button/link, left-aligned text, small radius, full width, spacing.1 vertical
+ * margin, spacing.2 padding on mobile → spacing.3 on desktop (@media m).
+ */
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+  margin-top: var(--spacing-1);
+  margin-bottom: var(--spacing-1);
+  padding: var(--spacing-2);
+  border-width: 0;
+  border-radius: var(--border-radius-small);
+  background-color: transparent;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+
+  &:hover:not([disabled]):not([aria-disabled='true']) {
+    background-color: var(--interactive-background-gray-default);
+  }
+
+  &:focus-visible {
+    outline: 4px solid var(--surface-border-primary-muted);
+    outline-offset: 1px;
+  }
+
+  &[aria-selected='true'],
+  &[aria-selected='true']:hover {
+    background-color: var(--interactive-background-gray-faded-highlighted);
+  }
+
+  &[disabled],
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+  }
+}
+
+@media (min-width: 768px) {
+  .item {
+    padding: var(--spacing-3);
+  }
+}
+
+/* Negative intent row — negative faded hover (mirrors React `color==='negative'`). */
+.itemNegative {
+  &:hover:not([disabled]):not([aria-disabled='true']) {
+    background-color: var(--interactive-background-negative-faded);
+  }
+}
+
+/* Inner row layout — flex row, top-aligned, full width. */
+.itemInner {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+/* Leading slot — centers asset/icon within the first-row height (size[20]=20px). */
+.itemLeading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--size-20, 20px);
+}
+
+/* Title/description column. */
+.itemContent {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding-right: var(--spacing-3);
+}
+
+/* When a leading slot is present, offset the content column by spacing.3. */
+.itemContentWithLeading {
+  padding-left: var(--spacing-3);
+}
+
+/* Title row — centers the title text within the first-row height. */
+.itemTitleRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: var(--size-20, 20px);
+}
+
+/* Trailing slot — pushed to the far right. */
+.itemTrailing {
+  margin-left: auto;
+}
+
+/* ── Section ── */
+.section {
+  display: block;
+}
+
+/* Section title block — spacing.3 padding (mirrors StyledActionListSectionTitle). */
+.sectionTitle {
+  padding: var(--spacing-3);
+}
+
+/* Inner listbox that wraps a section's items (announces item count per group). */
+.sectionItems {
+  display: block;
+}

--- a/packages/blade-core/src/styles/ActionList/actionList.ts
+++ b/packages/blade-core/src/styles/ActionList/actionList.ts
@@ -89,10 +89,12 @@ export function getActionListTemplateClasses(): {
   itemNegative: string;
   itemInner: string;
   itemLeading: string;
+  itemSelector: string;
   itemContent: string;
   itemContentWithLeading: string;
   itemTitleRow: string;
   itemTrailing: string;
+  itemBadgeGroup: string;
   section: string;
   sectionTitle: string;
   sectionItems: string;
@@ -105,10 +107,12 @@ export function getActionListTemplateClasses(): {
     itemNegative: styles.itemNegative,
     itemInner: styles.itemInner,
     itemLeading: styles.itemLeading,
+    itemSelector: styles.itemSelector,
     itemContent: styles.itemContent,
     itemContentWithLeading: styles.itemContentWithLeading,
     itemTitleRow: styles.itemTitleRow,
     itemTrailing: styles.itemTrailing,
+    itemBadgeGroup: styles.itemBadgeGroup,
     section: styles.section,
     sectionTitle: styles.sectionTitle,
     sectionItems: styles.sectionItems,

--- a/packages/blade-core/src/styles/ActionList/actionList.ts
+++ b/packages/blade-core/src/styles/ActionList/actionList.ts
@@ -1,0 +1,116 @@
+import { cva } from 'class-variance-authority';
+// @ts-expect-error - CSS modules may not have type definitions in build
+import styles from './actionList.module.css';
+
+export type ActionListBoxVariants = {
+  isInBottomSheet?: boolean;
+};
+
+/**
+ * Outer StyledActionList box. Present ONLY when NOT inside a BottomSheet
+ * (border + radius + mid-raised shadow). Inside a sheet the ActionList renders
+ * the scroll wrapper directly, so no box class is emitted.
+ */
+export const actionListBoxCva = cva('', {
+  variants: {
+    isInBottomSheet: {
+      true: null,
+      false: styles.box,
+    },
+  },
+  defaultVariants: {
+    isInBottomSheet: false,
+  },
+});
+
+export function getActionListBoxClasses(props: ActionListBoxVariants): string {
+  return actionListBoxCva(props);
+}
+
+export type ActionListWrapperVariants = {
+  isInBottomSheet?: boolean;
+};
+
+/**
+ * ListBox scroll wrapper. Standalone → `.wrapper` (max-height 300px + spacing.3
+ * padding + overflow-y auto). In-sheet → `.wrapperInSheet` (overflow-y only;
+ * BottomSheetBody owns padding + scroll bounds).
+ */
+export const actionListWrapperCva = cva('', {
+  variants: {
+    isInBottomSheet: {
+      true: styles.wrapperInSheet,
+      false: styles.wrapper,
+    },
+  },
+  defaultVariants: {
+    isInBottomSheet: false,
+  },
+});
+
+export function getActionListWrapperClasses(props: ActionListWrapperVariants): string {
+  return actionListWrapperCva(props);
+}
+
+export type ActionListItemVariants = {
+  intent?: 'default' | 'negative';
+};
+
+/**
+ * Row container (inlined BaseMenuItem). `.item` carries layout + hover/selected/
+ * focus states; `.itemNegative` adds the negative-faded hover for
+ * `intent="negative"`.
+ */
+export const actionListItemCva = cva(styles.item, {
+  variants: {
+    intent: {
+      default: null,
+      negative: styles.itemNegative,
+    },
+  },
+  defaultVariants: {
+    intent: 'default',
+  },
+});
+
+export function getActionListItemClasses(props: ActionListItemVariants): string {
+  return actionListItemCva(props);
+}
+
+/**
+ * Structural/template classes. Call from the Svelte component so Svelte does
+ * not tree-shake CVA class references that only appear in compound selectors.
+ */
+export function getActionListTemplateClasses(): {
+  box: string;
+  wrapper: string;
+  wrapperInSheet: string;
+  item: string;
+  itemNegative: string;
+  itemInner: string;
+  itemLeading: string;
+  itemContent: string;
+  itemContentWithLeading: string;
+  itemTitleRow: string;
+  itemTrailing: string;
+  section: string;
+  sectionTitle: string;
+  sectionItems: string;
+} {
+  return {
+    box: styles.box,
+    wrapper: styles.wrapper,
+    wrapperInSheet: styles.wrapperInSheet,
+    item: styles.item,
+    itemNegative: styles.itemNegative,
+    itemInner: styles.itemInner,
+    itemLeading: styles.itemLeading,
+    itemContent: styles.itemContent,
+    itemContentWithLeading: styles.itemContentWithLeading,
+    itemTitleRow: styles.itemTitleRow,
+    itemTrailing: styles.itemTrailing,
+    section: styles.section,
+    sectionTitle: styles.sectionTitle,
+    sectionItems: styles.sectionItems,
+  };
+}

--- a/packages/blade-core/src/styles/ActionList/index.ts
+++ b/packages/blade-core/src/styles/ActionList/index.ts
@@ -1,0 +1,1 @@
+export * from './actionList';

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -221,6 +221,20 @@ export type {
   CheckboxGroupOptionsVariants,
 } from './Checkbox';
 export {
+  actionListBoxCva,
+  getActionListBoxClasses,
+  actionListWrapperCva,
+  getActionListWrapperClasses,
+  actionListItemCva,
+  getActionListItemClasses,
+  getActionListTemplateClasses,
+} from './ActionList';
+export type {
+  ActionListBoxVariants,
+  ActionListWrapperVariants,
+  ActionListItemVariants,
+} from './ActionList';
+export {
   alertStyles,
   getAlertClasses,
   getAlertTemplateClasses,

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -261,6 +261,28 @@
   {/snippet}
 </Story>
 
+<!-- Story 8: Standalone — no BottomSheet. Renders its own box (border/shadow/padding)
+     since `isInBottomSheet` is false. -->
+<Story name="Standalone (No BottomSheet)">
+  {#snippet template()}
+    <ActionList>
+      {#snippet children()}
+        <ActionListItem title="Home" value="home">
+          {#snippet leading()}
+            <HomeIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Payments" value="payments">
+          {#snippet leading()}
+            <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Settings" value="settings" />
+      {/snippet}
+    </ActionList>
+  {/snippet}
+</Story>
+
 <!-- Story 7: Disabled & Negative Items. -->
 <Story name="Disabled & Negative Items">
   {#snippet template()}

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -1,0 +1,290 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import ActionList from './ActionList.svelte';
+  import type { ActionListProps } from './types';
+
+  /* Title deviates from React's Dropdown-nested `Components/Dropdown/ActionList/Stories`
+   * (Dropdown is out of scope). Uses the blade-svelte top-level convention. */
+  const { Story } = defineMeta({
+    title: 'Components/ActionList',
+    component: ActionList,
+    tags: ['autodocs'],
+    args: {
+      selectionType: 'single',
+    },
+    argTypes: {
+      children: { table: { disable: true } },
+      onItemSelect: { table: { disable: true } },
+      isInBottomSheet: { table: { disable: true } },
+      selectionType: { control: 'select', options: ['single'] },
+      selectedValue: { control: 'text' },
+    } as Record<string, unknown>,
+  } as Parameters<typeof defineMeta>[0] & { argTypes: Record<string, unknown> });
+</script>
+
+<script lang="ts">
+  import ActionListItem from './ActionListItem.svelte';
+  import ActionListItemAsset from './ActionListItemAsset.svelte';
+  import ActionListItemText from './ActionListItemText.svelte';
+  import ActionListSection from './ActionListSection.svelte';
+  import BottomSheet from '../BottomSheet/BottomSheet.svelte';
+  import BottomSheetHeader from '../BottomSheet/BottomSheetHeader.svelte';
+  import BottomSheetBody from '../BottomSheet/BottomSheetBody.svelte';
+  import Button from '../Button/Button.svelte';
+  import { HomeIcon, CreditCardIcon, UserIcon, BuildingIcon, SearchIcon } from '../Icons';
+
+  /* One open-state bucket per story so they stay independent. */
+  let isPlaygroundOpen = $state(false);
+  let isDefaultOpen = $state(false);
+  let isLeadingOpen = $state(false);
+  let isTrailingOpen = $state(false);
+  let isSectionsOpen = $state(false);
+  let isCountryOpen = $state(false);
+  let isDisabledNegativeOpen = $state(false);
+
+  let selectedCountry = $state<string | undefined>('in');
+
+  const countries = [
+    { value: 'in', name: 'India', code: 'in', dialCode: '+91' },
+    { value: 'us', name: 'United States', code: 'us', dialCode: '+1' },
+    { value: 'gb', name: 'United Kingdom', code: 'gb', dialCode: '+44' },
+    { value: 'au', name: 'Australia', code: 'au', dialCode: '+61' },
+    { value: 'de', name: 'Germany', code: 'de', dialCode: '+49' },
+    { value: 'fr', name: 'France', code: 'fr', dialCode: '+33' },
+    { value: 'jp', name: 'Japan', code: 'jp', dialCode: '+81' },
+    { value: 'sg', name: 'Singapore', code: 'sg', dialCode: '+65' },
+    { value: 'ae', name: 'United Arab Emirates', code: 'ae', dialCode: '+971' },
+    { value: 'br', name: 'Brazil', code: 'br', dialCode: '+55' },
+  ];
+
+  function flagSrc(code: string): string {
+    return `https://flagcdn.com/w20/${code}.png`;
+  }
+</script>
+
+<!-- Story 1: Playground — args drive the ActionList; a trigger toggles the sheet. -->
+<Story name="Playground">
+  {#snippet template(args: ActionListProps)}
+    <div>
+      <Button onClick={() => (isPlaygroundOpen = true)}>Open ActionList</Button>
+      <BottomSheet isOpen={isPlaygroundOpen} onDismiss={() => (isPlaygroundOpen = false)}>
+        {#snippet children()}
+          <BottomSheetHeader title="Actions" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList {...args}>
+                {#snippet children()}
+                  <ActionListItem title="Home" value="home" />
+                  <ActionListItem title="Pricing" value="pricing" />
+                  <ActionListItem title="Settings" value="settings" />
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 2: Default — items only. -->
+<Story name="Default">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isDefaultOpen = true)}>Open</Button>
+      <BottomSheet isOpen={isDefaultOpen} onDismiss={() => (isDefaultOpen = false)}>
+        {#snippet children()}
+          <BottomSheetHeader title="Actions" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList>
+                {#snippet children()}
+                  <ActionListItem title="Item 1" value="item-1" />
+                  <ActionListItem title="Item 2" value="item-2" />
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 3: Leading Icons/Images on Items. -->
+<Story name="Leading Icons/Images on Items">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isLeadingOpen = true)}>Open</Button>
+      <BottomSheet isOpen={isLeadingOpen} onDismiss={() => (isLeadingOpen = false)}>
+        {#snippet children()}
+          <BottomSheetHeader title="Quick Actions" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList>
+                {#snippet children()}
+                  <ActionListItem title="Settings" value="settings">
+                    {#snippet leading()}
+                      <HomeIcon size="medium" color="interactive.icon.gray.normal" />
+                    {/snippet}
+                  </ActionListItem>
+                  <ActionListItem title="Payments" value="payments">
+                    {#snippet leading()}
+                      <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
+                    {/snippet}
+                  </ActionListItem>
+                  <ActionListItem title="Pricing" value="pricing">
+                    {#snippet leading()}
+                      <ActionListItemAsset src={flagSrc('in')} alt="India flag" />
+                    {/snippet}
+                  </ActionListItem>
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 4: Trailing Icons/Texts on Items. -->
+<Story name="Trailing Icons/Texts on Items">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isTrailingOpen = true)}>Open</Button>
+      <BottomSheet isOpen={isTrailingOpen} onDismiss={() => (isTrailingOpen = false)}>
+        {#snippet children()}
+          <BottomSheetHeader title="Help" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList>
+                {#snippet children()}
+                  <ActionListItem title="Bank Settings" value="bank-settings">
+                    {#snippet trailing()}
+                      <ActionListItemText>⌘ + B</ActionListItemText>
+                    {/snippet}
+                  </ActionListItem>
+                  <ActionListItem title="FAQs" value="faqs">
+                    {#snippet trailing()}
+                      <SearchIcon size="medium" color="interactive.icon.gray.normal" />
+                    {/snippet}
+                  </ActionListItem>
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 5: With Sections. -->
+<Story name="With Sections">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isSectionsOpen = true)}>Open</Button>
+      <BottomSheet isOpen={isSectionsOpen} onDismiss={() => (isSectionsOpen = false)}>
+        {#snippet children()}
+          <BottomSheetHeader title="Account" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList>
+                {#snippet children()}
+                  <ActionListSection title="Profile">
+                    {#snippet children()}
+                      <ActionListItem title="My Account" value="account">
+                        {#snippet leading()}
+                          <UserIcon size="medium" color="interactive.icon.gray.normal" />
+                        {/snippet}
+                      </ActionListItem>
+                      <ActionListItem title="Organization" value="organization">
+                        {#snippet leading()}
+                          <BuildingIcon size="medium" color="interactive.icon.gray.normal" />
+                        {/snippet}
+                      </ActionListItem>
+                    {/snippet}
+                  </ActionListSection>
+                  <ActionListSection title="Danger">
+                    {#snippet children()}
+                      <ActionListItem title="Logout" value="logout" intent="negative" />
+                    {/snippet}
+                  </ActionListSection>
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 6: Single Select Country List — the PhoneNumberInput CountrySelector parity target. -->
+<Story name="Single Select Country List">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isCountryOpen = true)}>
+        Select country{selectedCountry ? ` (${selectedCountry.toUpperCase()})` : ''}
+      </Button>
+      <BottomSheet isOpen={isCountryOpen} onDismiss={() => (isCountryOpen = false)}>
+        {#snippet children()}
+          <BottomSheetHeader title="Select country" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList
+                selectedValue={selectedCountry}
+                onItemSelect={({ value }) => {
+                  selectedCountry = value;
+                  isCountryOpen = false;
+                }}
+              >
+                {#snippet children()}
+                  {#each countries as country (country.value)}
+                    <ActionListItem title={country.name} value={country.value}>
+                      {#snippet leading()}
+                        <ActionListItemAsset src={flagSrc(country.code)} alt={`${country.name} flag`} />
+                      {/snippet}
+                      {#snippet trailing()}
+                        <ActionListItemText>{country.dialCode}</ActionListItemText>
+                      {/snippet}
+                    </ActionListItem>
+                  {/each}
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 7: Disabled & Negative Items. -->
+<Story name="Disabled & Negative Items">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isDisabledNegativeOpen = true)}>Open</Button>
+      <BottomSheet
+        isOpen={isDisabledNegativeOpen}
+        onDismiss={() => (isDisabledNegativeOpen = false)}
+      >
+        {#snippet children()}
+          <BottomSheetHeader title="Actions" />
+          <BottomSheetBody hasActionList>
+            {#snippet children()}
+              <ActionList>
+                {#snippet children()}
+                  <ActionListItem title="Available action" value="available" />
+                  <ActionListItem title="Disabled action" value="disabled" isDisabled />
+                  <ActionListItem title="Logout" value="logout" intent="negative" />
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </BottomSheetBody>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -15,7 +15,7 @@
     argTypes: {
       children: { table: { disable: true } },
       onAction: { table: { disable: true } },
-      selectionType: { control: 'select', options: ['single'] },
+      selectionType: { control: 'select', options: ['single', 'multiple'] },
       selectedValue: { control: 'text' },
     } as Record<string, unknown>,
   } as Parameters<typeof defineMeta>[0] & { argTypes: Record<string, unknown> });
@@ -25,23 +25,41 @@
   import ActionListItem from './ActionListItem.svelte';
   import ActionListItemAsset from './ActionListItemAsset.svelte';
   import ActionListItemText from './ActionListItemText.svelte';
+  import ActionListItemIcon from './ActionListItemIcon.svelte';
+  import ActionListItemAvatar from './ActionListItemAvatar.svelte';
+  import ActionListItemBadge from './ActionListItemBadge.svelte';
+  import ActionListItemBadgeGroup from './ActionListItemBadgeGroup.svelte';
   import ActionListSection from './ActionListSection.svelte';
   import BottomSheet from '../BottomSheet/BottomSheet.svelte';
   import BottomSheetHeader from '../BottomSheet/BottomSheetHeader.svelte';
   import BottomSheetBody from '../BottomSheet/BottomSheetBody.svelte';
   import Button from '../Button/Button.svelte';
-  import { HomeIcon, CreditCardIcon, UserIcon, BuildingIcon, SearchIcon } from '../Icons';
+  import {
+    HomeIcon,
+    CreditCardIcon,
+    UserIcon,
+    BuildingIcon,
+    SearchIcon,
+    InfoIcon,
+    CloseIcon,
+  } from '../Icons';
 
-  /* One open-state bucket per story so they stay independent. */
-  let isPlaygroundOpen = $state(false);
-  let isDefaultOpen = $state(false);
-  let isLeadingOpen = $state(false);
-  let isTrailingOpen = $state(false);
-  let isSectionsOpen = $state(false);
+  // Country List is the only BottomSheet story, so it owns the single open-state bucket.
   let isCountryOpen = $state(false);
-  let isDisabledNegativeOpen = $state(false);
-
   let selectedCountry = $state<string | undefined>('in');
+
+  // Drives the interactive standalone single-select story.
+  let selectedStandalone = $state<string | undefined>('transactions');
+
+  // Drives the interactive standalone multi-select story — the consumer owns the
+  // array; `onAction` toggles membership.
+  let selectedMulti = $state<string[]>(['payments', 'analytics']);
+
+  function toggleMulti(value: string): void {
+    selectedMulti = selectedMulti.includes(value)
+      ? selectedMulti.filter((v) => v !== value)
+      : [...selectedMulti, value];
+  }
 
   const countries = [
     { value: 'in', name: 'India', code: 'in', dialCode: '+91' },
@@ -61,167 +79,290 @@
   }
 </script>
 
-<!-- Story 1: Playground — args drive the ActionList; a trigger toggles the sheet. -->
+<!-- Playground — args drive the ActionList directly (standalone, no BottomSheet) so the
+     Controls panel can toggle props. Mirrors React, whose stories render ActionList standalone. -->
 <Story name="Playground">
   {#snippet template(args: ActionListProps)}
-    <div>
-      <Button onClick={() => (isPlaygroundOpen = true)}>Open ActionList</Button>
-      <BottomSheet isOpen={isPlaygroundOpen} onDismiss={() => (isPlaygroundOpen = false)}>
-        {#snippet children()}
-          <BottomSheetHeader title="Actions" />
-          <BottomSheetBody hasActionList>
-            {#snippet children()}
-              <ActionList {...args}>
-                {#snippet children()}
-                  <ActionListItem title="Home" value="home" />
-                  <ActionListItem title="Pricing" value="pricing" />
-                  <ActionListItem title="Settings" value="settings" />
-                {/snippet}
-              </ActionList>
-            {/snippet}
-          </BottomSheetBody>
-        {/snippet}
-      </BottomSheet>
-    </div>
+    <ActionList {...args}>
+      {#snippet children()}
+        <ActionListItem title="Home" value="home" />
+        <ActionListItem title="Pricing" value="pricing" />
+        <ActionListItem title="Settings" value="settings" />
+      {/snippet}
+    </ActionList>
   {/snippet}
 </Story>
 
-<!-- Story 2: Default — items only. -->
-<Story name="Default">
+<!-- Standalone 1: Default — items with leading icons + one plain item. -->
+<Story name="Standalone">
   {#snippet template()}
-    <div>
-      <Button onClick={() => (isDefaultOpen = true)}>Open</Button>
-      <BottomSheet isOpen={isDefaultOpen} onDismiss={() => (isDefaultOpen = false)}>
-        {#snippet children()}
-          <BottomSheetHeader title="Actions" />
-          <BottomSheetBody hasActionList>
-            {#snippet children()}
-              <ActionList>
-                {#snippet children()}
-                  <ActionListItem title="Item 1" value="item-1" />
-                  <ActionListItem title="Item 2" value="item-2" />
-                {/snippet}
-              </ActionList>
-            {/snippet}
-          </BottomSheetBody>
-        {/snippet}
-      </BottomSheet>
-    </div>
+    <ActionList>
+      {#snippet children()}
+        <ActionListItem title="Home" value="home">
+          {#snippet leading()}
+            <HomeIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Payments" value="payments">
+          {#snippet leading()}
+            <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Settings" value="settings" />
+      {/snippet}
+    </ActionList>
   {/snippet}
 </Story>
 
-<!-- Story 3: Leading Icons/Images on Items. -->
-<Story name="Leading Icons/Images on Items">
+<!-- Standalone 2: Interactive single-select — clicking a row updates `selectedValue`
+     via `onAction`, moving the selected highlight (aria-selected) live. -->
+<Story name="Standalone / Single Select (Interactive)">
   {#snippet template()}
-    <div>
-      <Button onClick={() => (isLeadingOpen = true)}>Open</Button>
-      <BottomSheet isOpen={isLeadingOpen} onDismiss={() => (isLeadingOpen = false)}>
-        {#snippet children()}
-          <BottomSheetHeader title="Quick Actions" />
-          <BottomSheetBody hasActionList>
-            {#snippet children()}
-              <ActionList>
-                {#snippet children()}
-                  <ActionListItem title="Settings" value="settings">
-                    {#snippet leading()}
-                      <HomeIcon size="medium" color="interactive.icon.gray.normal" />
-                    {/snippet}
-                  </ActionListItem>
-                  <ActionListItem title="Payments" value="payments">
-                    {#snippet leading()}
-                      <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
-                    {/snippet}
-                  </ActionListItem>
-                  <ActionListItem title="Pricing" value="pricing">
-                    {#snippet leading()}
-                      <ActionListItemAsset src={flagSrc('in')} alt="India flag" />
-                    {/snippet}
-                  </ActionListItem>
-                {/snippet}
-              </ActionList>
-            {/snippet}
-          </BottomSheetBody>
-        {/snippet}
-      </BottomSheet>
-    </div>
+    <ActionList
+      selectedValue={selectedStandalone}
+      onAction={({ value }) => (selectedStandalone = value)}
+    >
+      {#snippet children()}
+        <ActionListItem title="Overview" value="overview">
+          {#snippet leading()}
+            <HomeIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Transactions" value="transactions">
+          {#snippet leading()}
+            <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Team" value="team">
+          {#snippet leading()}
+            <UserIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Organization" value="organization">
+          {#snippet leading()}
+            <BuildingIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+      {/snippet}
+    </ActionList>
   {/snippet}
 </Story>
 
-<!-- Story 4: Trailing Icons/Texts on Items. -->
-<Story name="Trailing Icons/Texts on Items">
+<!-- Standalone 3: Item descriptions — secondary text rendered under the title. -->
+<Story name="Standalone / Item Descriptions">
   {#snippet template()}
-    <div>
-      <Button onClick={() => (isTrailingOpen = true)}>Open</Button>
-      <BottomSheet isOpen={isTrailingOpen} onDismiss={() => (isTrailingOpen = false)}>
-        {#snippet children()}
-          <BottomSheetHeader title="Help" />
-          <BottomSheetBody hasActionList>
-            {#snippet children()}
-              <ActionList>
-                {#snippet children()}
-                  <ActionListItem title="Bank Settings" value="bank-settings">
-                    {#snippet trailing()}
-                      <ActionListItemText>⌘ + B</ActionListItemText>
-                    {/snippet}
-                  </ActionListItem>
-                  <ActionListItem title="FAQs" value="faqs">
-                    {#snippet trailing()}
-                      <SearchIcon size="medium" color="interactive.icon.gray.normal" />
-                    {/snippet}
-                  </ActionListItem>
-                {/snippet}
-              </ActionList>
-            {/snippet}
-          </BottomSheetBody>
-        {/snippet}
-      </BottomSheet>
-    </div>
+    <ActionList>
+      {#snippet children()}
+        <ActionListItem
+          title="My Profile"
+          description="Manage your personal information"
+          value="profile"
+        >
+          {#snippet leading()}
+            <UserIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem
+          title="Billing"
+          description="View invoices and payment methods"
+          value="billing"
+        >
+          {#snippet leading()}
+            <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem
+          title="Security"
+          description="Password, 2FA, and active sessions"
+          value="security"
+        >
+          {#snippet leading()}
+            <InfoIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+      {/snippet}
+    </ActionList>
   {/snippet}
 </Story>
 
-<!-- Story 5: With Sections. -->
-<Story name="With Sections">
+<!-- Standalone 4: Link items — `href`/`target` render each row as an `<a>`. -->
+<Story name="Standalone / Link Items (href)">
   {#snippet template()}
-    <div>
-      <Button onClick={() => (isSectionsOpen = true)}>Open</Button>
-      <BottomSheet isOpen={isSectionsOpen} onDismiss={() => (isSectionsOpen = false)}>
-        {#snippet children()}
-          <BottomSheetHeader title="Account" />
-          <BottomSheetBody hasActionList>
-            {#snippet children()}
-              <ActionList>
-                {#snippet children()}
-                  <ActionListSection title="Profile">
-                    {#snippet children()}
-                      <ActionListItem title="My Account" value="account">
-                        {#snippet leading()}
-                          <UserIcon size="medium" color="interactive.icon.gray.normal" />
-                        {/snippet}
-                      </ActionListItem>
-                      <ActionListItem title="Organization" value="organization">
-                        {#snippet leading()}
-                          <BuildingIcon size="medium" color="interactive.icon.gray.normal" />
-                        {/snippet}
-                      </ActionListItem>
-                    {/snippet}
-                  </ActionListSection>
-                  <ActionListSection title="Danger">
-                    {#snippet children()}
-                      <ActionListItem title="Logout" value="logout" intent="negative" />
-                    {/snippet}
-                  </ActionListSection>
-                {/snippet}
-              </ActionList>
-            {/snippet}
-          </BottomSheetBody>
-        {/snippet}
-      </BottomSheet>
-    </div>
+    <ActionList>
+      {#snippet children()}
+        <ActionListItem
+          title="Documentation"
+          value="docs"
+          href="https://razorpay.com/docs"
+          target="_blank"
+        >
+          {#snippet leading()}
+            <InfoIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem
+          title="Dashboard"
+          value="dashboard"
+          href="https://dashboard.razorpay.com"
+          target="_blank"
+        >
+          {#snippet leading()}
+            <HomeIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem
+          title="API Reference"
+          value="api"
+          href="https://razorpay.com/docs/api"
+          target="_blank"
+        >
+          {#snippet leading()}
+            <SearchIcon size="medium" color="interactive.icon.gray.normal" />
+          {/snippet}
+        </ActionListItem>
+      {/snippet}
+    </ActionList>
   {/snippet}
 </Story>
 
-<!-- Story 6: Single Select Country List — the PhoneNumberInput CountrySelector parity target. -->
-<Story name="Single Select Country List">
+<!-- Standalone 5: Sections + trailing content + disabled + negative intent (kitchen sink). -->
+<Story name="Standalone / Sections, Disabled & Negative">
+  {#snippet template()}
+    <ActionList>
+      {#snippet children()}
+        <ActionListSection title="Account">
+          {#snippet children()}
+            <ActionListItem title="My Profile" value="profile">
+              {#snippet leading()}
+                <UserIcon size="medium" color="interactive.icon.gray.normal" />
+              {/snippet}
+              {#snippet trailing()}
+                <ActionListItemText>⌘ + P</ActionListItemText>
+              {/snippet}
+            </ActionListItem>
+            <ActionListItem title="Organization" value="organization">
+              {#snippet leading()}
+                <BuildingIcon size="medium" color="interactive.icon.gray.normal" />
+              {/snippet}
+            </ActionListItem>
+          {/snippet}
+        </ActionListSection>
+        <ActionListSection title="Preferences">
+          {#snippet children()}
+            <ActionListItem title="Search settings" value="search">
+              {#snippet leading()}
+                <SearchIcon size="medium" color="interactive.icon.gray.normal" />
+              {/snippet}
+              {#snippet trailing()}
+                <InfoIcon size="medium" color="interactive.icon.gray.normal" />
+              {/snippet}
+            </ActionListItem>
+            <ActionListItem title="Offline sync (unavailable)" value="sync" isDisabled />
+          {/snippet}
+        </ActionListSection>
+        <ActionListSection title="Danger">
+          {#snippet children()}
+            <ActionListItem title="Delete account" value="delete" intent="negative">
+              {#snippet leading()}
+                <CloseIcon size="medium" color="interactive.icon.gray.normal" />
+              {/snippet}
+            </ActionListItem>
+          {/snippet}
+        </ActionListSection>
+      {/snippet}
+    </ActionList>
+  {/snippet}
+</Story>
+
+<!-- Standalone 6: Custom Items — mirrors React's `Custom Items` story. Exercises the
+     new sub-components: ActionListItemAvatar + ActionListItemIcon leading, a description,
+     ActionListItemBadgeGroup/ActionListItemBadge in titleSuffix, href items, an onClick
+     item, and a negative logout. (Icon set differs from React — SettingsIcon/DownloadIcon/
+     LogOutIcon/ActivityIcon aren't migrated, so the nearest available icons are used.) -->
+<Story name="Standalone / Custom Items">
+  {#snippet template()}
+    <ActionList>
+      {#snippet children()}
+        <ActionListSection title="Account">
+          {#snippet children()}
+            <ActionListItem title="Profile" value="profile">
+              {#snippet leading()}
+                <ActionListItemAvatar icon={UserIcon} color="primary" name="Saurabh Daware" />
+              {/snippet}
+            </ActionListItem>
+            <ActionListItem title="Credit" value="credit" description="check your credit here!">
+              {#snippet leading()}
+                <ActionListItemIcon icon={CreditCardIcon} />
+              {/snippet}
+            </ActionListItem>
+            <ActionListItem title="Disabled" value="disabled" isDisabled />
+          {/snippet}
+        </ActionListSection>
+        <ActionListItem
+          title="Go to Home"
+          value="home"
+          href="https://razorpay.com"
+          target="_blank"
+        />
+        <ActionListItem
+          title="Alert user"
+          value="alert_user"
+          onClick={() => window.alert('Alert user is clicked!')}
+        />
+        <ActionListItem
+          title="Systems"
+          value="systems"
+          href="https://razorpay.com/careers"
+          target="_blank"
+        >
+          {#snippet titleSuffix()}
+            <ActionListItemBadgeGroup>
+              {#snippet children()}
+                <ActionListItemBadge icon={InfoIcon} color="information">unstable</ActionListItemBadge>
+                <ActionListItemBadge>last updated: 2hr ago</ActionListItemBadge>
+              {/snippet}
+            </ActionListItemBadgeGroup>
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="saurabhdaware.razorpay@gmail.com" value="email">
+          {#snippet leading()}
+            <ActionListItemIcon icon={UserIcon} />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="Log Out" value="logout" intent="negative">
+          {#snippet leading()}
+            <ActionListItemIcon icon={CloseIcon} />
+          {/snippet}
+        </ActionListItem>
+      {/snippet}
+    </ActionList>
+  {/snippet}
+</Story>
+
+<!-- Standalone 7: Multi Select (Interactive) — `selectionType="multiple"`, `selectedValue`
+     is a `string[]`. Each row renders the checkbox indicator (overriding `leading`);
+     clicking toggles membership via `onAction`. Consumer owns the array. -->
+<Story name="Standalone / Multi Select (Interactive)">
+  {#snippet template()}
+    <ActionList
+      selectionType="multiple"
+      selectedValue={selectedMulti}
+      onAction={({ value }) => toggleMulti(value)}
+    >
+      {#snippet children()}
+        <ActionListItem title="Payments" value="payments" description="Accept online payments" />
+        <ActionListItem title="Analytics" value="analytics" description="Track your revenue" />
+        <ActionListItem title="Settlements" value="settlements" description="Manage payouts" />
+        <ActionListItem title="Disputes" value="disputes" description="Handle chargebacks" />
+        <ActionListItem title="Archived (unavailable)" value="archived" isDisabled />
+      {/snippet}
+    </ActionList>
+  {/snippet}
+</Story>
+
+<!-- Single Select Country List — the PhoneNumberInput CountrySelector parity target and the
+     only in-BottomSheet story: exercises the `isInBottomSheet` render branch + close-on-select. -->
+<Story name="Single Select Country List (in BottomSheet)">
   {#snippet template()}
     <div>
       <Button onClick={() => (isCountryOpen = true)}>
@@ -250,56 +391,6 @@
                       {/snippet}
                     </ActionListItem>
                   {/each}
-                {/snippet}
-              </ActionList>
-            {/snippet}
-          </BottomSheetBody>
-        {/snippet}
-      </BottomSheet>
-    </div>
-  {/snippet}
-</Story>
-
-<!-- Story 8: Standalone — no BottomSheet. Renders its own box (border/shadow/padding)
-     since `isInBottomSheet` is false. -->
-<Story name="Standalone (No BottomSheet)">
-  {#snippet template()}
-    <ActionList>
-      {#snippet children()}
-        <ActionListItem title="Home" value="home">
-          {#snippet leading()}
-            <HomeIcon size="medium" color="interactive.icon.gray.normal" />
-          {/snippet}
-        </ActionListItem>
-        <ActionListItem title="Payments" value="payments">
-          {#snippet leading()}
-            <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
-          {/snippet}
-        </ActionListItem>
-        <ActionListItem title="Settings" value="settings" />
-      {/snippet}
-    </ActionList>
-  {/snippet}
-</Story>
-
-<!-- Story 7: Disabled & Negative Items. -->
-<Story name="Disabled & Negative Items">
-  {#snippet template()}
-    <div>
-      <Button onClick={() => (isDisabledNegativeOpen = true)}>Open</Button>
-      <BottomSheet
-        isOpen={isDisabledNegativeOpen}
-        onDismiss={() => (isDisabledNegativeOpen = false)}
-      >
-        {#snippet children()}
-          <BottomSheetHeader title="Actions" />
-          <BottomSheetBody hasActionList>
-            {#snippet children()}
-              <ActionList>
-                {#snippet children()}
-                  <ActionListItem title="Available action" value="available" />
-                  <ActionListItem title="Disabled action" value="disabled" isDisabled />
-                  <ActionListItem title="Logout" value="logout" intent="negative" />
                 {/snippet}
               </ActionList>
             {/snippet}

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -14,7 +14,7 @@
     },
     argTypes: {
       children: { table: { disable: true } },
-      onItemSelect: { table: { disable: true } },
+      onAction: { table: { disable: true } },
       isInBottomSheet: { table: { disable: true } },
       selectionType: { control: 'select', options: ['single'] },
       selectedValue: { control: 'text' },
@@ -235,7 +235,7 @@
             {#snippet children()}
               <ActionList
                 selectedValue={selectedCountry}
-                onItemSelect={({ value }) => {
+                onAction={({ value }) => {
                   selectedCountry = value;
                   isCountryOpen = false;
                 }}

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -79,44 +79,65 @@
   }
 </script>
 
-<!-- Playground — args drive the ActionList directly (standalone, no BottomSheet) so the
-     Controls panel can toggle props. Mirrors React, whose stories render ActionList standalone. -->
-<Story name="Playground">
+<!-- Mirrors React `Default`. Args drive Controls panel. -->
+<Story name="Default">
   {#snippet template(args: ActionListProps)}
     <ActionList {...args}>
       {#snippet children()}
-        <ActionListItem title="Home" value="home" />
-        <ActionListItem title="Pricing" value="pricing" />
-        <ActionListItem title="Settings" value="settings" />
+        <ActionListItem title="Item 1" value="item1" />
+        <ActionListItem title="Item 2" value="item2" />
       {/snippet}
     </ActionList>
   {/snippet}
 </Story>
 
-<!-- Standalone 1: Default — items with leading icons + one plain item. -->
-<Story name="Standalone">
+<!-- Mirrors React `Leading icons/images on Items`. -->
+<Story name="Leading icons/images on Items">
   {#snippet template()}
     <ActionList>
       {#snippet children()}
-        <ActionListItem title="Home" value="home">
+        <ActionListItem title="Settings" value="settings">
           {#snippet leading()}
-            <HomeIcon size="medium" color="interactive.icon.gray.normal" />
+            <ActionListItemIcon icon={SearchIcon} />
           {/snippet}
         </ActionListItem>
-        <ActionListItem title="Payments" value="payments">
+        <ActionListItem title="Download" value="download">
           {#snippet leading()}
-            <CreditCardIcon size="medium" color="interactive.icon.gray.normal" />
+            <ActionListItemIcon icon={HomeIcon} />
           {/snippet}
         </ActionListItem>
-        <ActionListItem title="Settings" value="settings" />
+        <ActionListItem title="Pricing" value="pricing">
+          {#snippet leading()}
+            <ActionListItemAsset src="https://flagcdn.com/w20/in.png" alt="india" />
+          {/snippet}
+        </ActionListItem>
       {/snippet}
     </ActionList>
   {/snippet}
 </Story>
 
-<!-- Standalone 2: Interactive single-select — clicking a row updates `selectedValue`
-     via `onAction`, moving the selected highlight (aria-selected) live. -->
-<Story name="Standalone / Single Select (Interactive)">
+<!-- Mirrors React `Trailing icons/texts on Items`. -->
+<Story name="Trailing icons/texts on Items">
+  {#snippet template()}
+    <ActionList>
+      {#snippet children()}
+        <ActionListItem title="Bank Settings" value="bank_settings">
+          {#snippet trailing()}
+            <ActionListItemIcon icon={BuildingIcon} />
+          {/snippet}
+        </ActionListItem>
+        <ActionListItem title="FAQs, Live Chat" value="faqs">
+          {#snippet trailing()}
+            <ActionListItemText>⌘ + H</ActionListItemText>
+          {/snippet}
+        </ActionListItem>
+      {/snippet}
+    </ActionList>
+  {/snippet}
+</Story>
+
+<!-- Interactive single-select — clicking a row updates `selectedValue` via `onAction`. -->
+<Story name="Single Select (Interactive)">
   {#snippet template()}
     <ActionList
       selectedValue={selectedStandalone}
@@ -148,8 +169,8 @@
   {/snippet}
 </Story>
 
-<!-- Standalone 3: Item descriptions — secondary text rendered under the title. -->
-<Story name="Standalone / Item Descriptions">
+<!-- Item descriptions — secondary text rendered under the title. -->
+<Story name="Item Descriptions">
   {#snippet template()}
     <ActionList>
       {#snippet children()}
@@ -185,8 +206,8 @@
   {/snippet}
 </Story>
 
-<!-- Standalone 4: Link items — `href`/`target` render each row as an `<a>`. -->
-<Story name="Standalone / Link Items (href)">
+<!-- Link items — `href`/`target` render each row as an `<a>`. -->
+<Story name="Link Items (href)">
   {#snippet template()}
     <ActionList>
       {#snippet children()}
@@ -225,8 +246,8 @@
   {/snippet}
 </Story>
 
-<!-- Standalone 5: Sections + trailing content + disabled + negative intent (kitchen sink). -->
-<Story name="Standalone / Sections, Disabled & Negative">
+<!-- Mirrors React `With Sections`. -->
+<Story name="With Sections">
   {#snippet template()}
     <ActionList>
       {#snippet children()}
@@ -274,12 +295,8 @@
   {/snippet}
 </Story>
 
-<!-- Standalone 6: Custom Items — mirrors React's `Custom Items` story. Exercises the
-     new sub-components: ActionListItemAvatar + ActionListItemIcon leading, a description,
-     ActionListItemBadgeGroup/ActionListItemBadge in titleSuffix, href items, an onClick
-     item, and a negative logout. (Icon set differs from React — SettingsIcon/DownloadIcon/
-     LogOutIcon/ActivityIcon aren't migrated, so the nearest available icons are used.) -->
-<Story name="Standalone / Custom Items">
+<!-- Mirrors React `Custom Items`. Icon set differs from React — nearest available icons used. -->
+<Story name="Custom Items">
   {#snippet template()}
     <ActionList>
       {#snippet children()}
@@ -339,10 +356,8 @@
   {/snippet}
 </Story>
 
-<!-- Standalone 7: Multi Select (Interactive) — `selectionType="multiple"`, `selectedValue`
-     is a `string[]`. Each row renders the checkbox indicator (overriding `leading`);
-     clicking toggles membership via `onAction`. Consumer owns the array. -->
-<Story name="Standalone / Multi Select (Interactive)">
+<!-- Multi Select (Interactive) — `selectionType="multiple"`, consumer owns `selectedValue` array. -->
+<Story name="Multi Select (Interactive)">
   {#snippet template()}
     <ActionList
       selectionType="multiple"

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -15,7 +15,6 @@
     argTypes: {
       children: { table: { disable: true } },
       onAction: { table: { disable: true } },
-      isInBottomSheet: { table: { disable: true } },
       selectionType: { control: 'select', options: ['single'] },
       selectedValue: { control: 'text' },
     } as Record<string, unknown>,

--- a/packages/blade-svelte/src/components/ActionList/ActionList.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.svelte
@@ -64,12 +64,14 @@
 
   const outerClasses = $derived([boxClasses, styledClassString].filter(Boolean).join(' ') || undefined);
 
-  const metaAttrs = metaAttribute({ name: MetaConstants.ActionList, testID });
+  const isMultiSelectable = $derived(selectionType === 'multiple');
+
+  const metaAttrs = $derived(metaAttribute({ name: MetaConstants.ActionList, testID }));
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const a11yAttrs = $derived(
     makeAccessible({
       role: getActionListContainerRole(),
-      multiSelectable: false,
+      multiSelectable: isMultiSelectable,
     }),
   );
 </script>

--- a/packages/blade-svelte/src/components/ActionList/ActionList.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.svelte
@@ -24,14 +24,14 @@
     selectionType = 'single',
     selectedValue,
     onAction,
-    isInBottomSheet: isInBottomSheetProp,
     testID,
     ...rest
   }: ActionListProps = $props();
 
-  // Prefer the migrated BottomSheet context, fall back to the explicit prop.
+  // Rendering-context flag, resolved only from the migrated BottomSheet context
+  // (not a public prop) — mirrors React's `useBottomSheetContext()`.
   const bs = getBottomSheetContext();
-  const isInBottomSheet = $derived(isInBottomSheetProp ?? bs?.isInBottomSheet ?? false);
+  const isInBottomSheet = $derived(bs?.isInBottomSheet ?? false);
 
   // Reactive context for child items (getters keep `selectedValue` live).
   const contextValue: ActionListContextValue = {
@@ -77,7 +77,13 @@
 {#if isInBottomSheet}
   <!-- In a BottomSheet: render ONLY the scroll wrapper so BottomSheetBody owns
        scroll + padding (mirrors React's isInBottomSheet branch). -->
-  <div class={wrapperClasses} {...a11yAttrs} {...metaAttrs} {...analyticsAttrs}>
+  <div
+    class={[wrapperClasses, styledClassString].filter(Boolean).join(' ') || undefined}
+    style={styledStyleString}
+    {...a11yAttrs}
+    {...metaAttrs}
+    {...analyticsAttrs}
+  >
     {@render children()}
   </div>
 {:else}

--- a/packages/blade-svelte/src/components/ActionList/ActionList.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.svelte
@@ -23,7 +23,7 @@
     children,
     selectionType = 'single',
     selectedValue,
-    onItemSelect,
+    onAction,
     isInBottomSheet: isInBottomSheetProp,
     testID,
     ...rest
@@ -44,8 +44,8 @@
     get isInBottomSheet() {
       return isInBottomSheet;
     },
-    get onItemSelect() {
-      return onItemSelect;
+    get onAction() {
+      return onAction;
     },
     registerItem: () => {},
   };

--- a/packages/blade-svelte/src/components/ActionList/ActionList.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAccessible,
+    makeAnalyticsAttribute,
+    getStyledPropsClasses,
+  } from '@razorpay/blade-core/utils';
+  import {
+    getActionListBoxClasses,
+    getActionListWrapperClasses,
+    getActionListTemplateClasses,
+  } from '@razorpay/blade-core/styles';
+  import { getBottomSheetContext } from '../BottomSheet/bottomSheetContext';
+  import { setActionListContext } from './actionListContext';
+  import { getActionListContainerRole } from './getA11yRoles';
+  import type { ActionListContextValue, ActionListProps } from './types';
+
+  // Call template getter so CVA classes used in compound selectors aren't tree-shaken.
+  void getActionListTemplateClasses();
+
+  let {
+    children,
+    selectionType = 'single',
+    selectedValue,
+    onItemSelect,
+    isInBottomSheet: isInBottomSheetProp,
+    testID,
+    ...rest
+  }: ActionListProps = $props();
+
+  // Prefer the migrated BottomSheet context, fall back to the explicit prop.
+  const bs = getBottomSheetContext();
+  const isInBottomSheet = $derived(isInBottomSheetProp ?? bs?.isInBottomSheet ?? false);
+
+  // Reactive context for child items (getters keep `selectedValue` live).
+  const contextValue: ActionListContextValue = {
+    get selectionType() {
+      return selectionType;
+    },
+    get selectedValue() {
+      return selectedValue;
+    },
+    get isInBottomSheet() {
+      return isInBottomSheet;
+    },
+    get onItemSelect() {
+      return onItemSelect;
+    },
+    registerItem: () => {},
+  };
+  setActionListContext(() => contextValue);
+
+  const boxClasses = $derived(getActionListBoxClasses({ isInBottomSheet }));
+  const wrapperClasses = $derived(getActionListWrapperClasses({ isInBottomSheet }));
+
+  const styledProps = $derived(getStyledPropsClasses(rest));
+  const styledClassString = $derived((styledProps.classes || []).filter(Boolean).join(' '));
+  const styledStyleString = $derived(
+    Object.entries(styledProps.inlineStyles || {})
+      .map(([prop, val]) => `${prop}: ${val}`)
+      .join('; ') || undefined,
+  );
+
+  const outerClasses = $derived([boxClasses, styledClassString].filter(Boolean).join(' ') || undefined);
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.ActionList, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+  const a11yAttrs = $derived(
+    makeAccessible({
+      role: getActionListContainerRole(),
+      multiSelectable: false,
+    }),
+  );
+</script>
+
+{#if isInBottomSheet}
+  <!-- In a BottomSheet: render ONLY the scroll wrapper so BottomSheetBody owns
+       scroll + padding (mirrors React's isInBottomSheet branch). -->
+  <div class={wrapperClasses} {...a11yAttrs} {...metaAttrs} {...analyticsAttrs}>
+    {@render children()}
+  </div>
+{:else}
+  <div class={outerClasses} style={styledStyleString} {...a11yAttrs} {...metaAttrs} {...analyticsAttrs}>
+    <div class={wrapperClasses}>
+      {@render children()}
+    </div>
+  </div>
+{/if}

--- a/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
@@ -94,7 +94,14 @@
         .join(' ')}
     >
       <span class={templateClasses.itemTitleRow}>
-        <Text as="span" size="medium" weight="regular" color={titleColor} truncateAfterLines={1}>
+        <Text
+          as="span"
+          size="medium"
+          weight="regular"
+          color={titleColor}
+          truncateAfterLines={1}
+          wordBreak="break-all"
+        >
           {title}
         </Text>
       </span>

--- a/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
@@ -68,8 +68,8 @@
       event.stopPropagation();
       return;
     }
-    onClick?.({ name: value, value: isItemSelected, event });
-    ctx?.onItemSelect?.({ value });
+    onClick?.({ value, isSelected: isItemSelected, event });
+    ctx?.onAction?.({ value });
   }
 
   const metaAttrs = metaAttribute({ name: MetaConstants.ActionListItem, testID });

--- a/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
@@ -7,6 +7,7 @@
   } from '@razorpay/blade-core/utils';
   import { getActionListItemClasses, getActionListTemplateClasses } from '@razorpay/blade-core/styles';
   import Text from '../Typography/Text/Text.svelte';
+  import Checkbox from '../Checkbox/Checkbox.svelte';
   import { getActionListContext, setActionListItemContext } from './actionListContext';
   import { getActionListItemRole } from './getA11yRoles';
   import type { ActionListItemContextValue, ActionListItemProps } from './types';
@@ -22,6 +23,7 @@
     target,
     leading,
     trailing,
+    titleSuffix,
     onClick,
     isDisabled = false,
     isSelected,
@@ -32,8 +34,17 @@
 
   const ctx = getActionListContext();
 
+  const isMultiSelect = $derived(ctx?.selectionType === 'multiple');
+
   // Selection: explicit prop wins, else derive from ActionList `selectedValue`.
-  const isItemSelected = $derived(isSelected ?? ctx?.selectedValue === value);
+  // In multiple mode `selectedValue` is an array → membership check; in single
+  // mode it's a scalar → equality (mirrors React's array vs scalar handling).
+  const isItemSelected = $derived(
+    isSelected ??
+      (Array.isArray(ctx?.selectedValue)
+        ? ctx.selectedValue.includes(value)
+        : ctx?.selectedValue === value),
+  );
 
   // Provide row-local disabled/intent to ActionListItemText (React `useBaseMenuItem`).
   const itemContext: ActionListItemContextValue = {
@@ -72,7 +83,7 @@
     ctx?.onAction?.({ value });
   }
 
-  const metaAttrs = metaAttribute({ name: MetaConstants.ActionListItem, testID });
+  const metaAttrs = $derived(metaAttribute({ name: MetaConstants.ActionListItem, testID }));
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const a11yAttrs = $derived(
     makeAccessible({
@@ -84,12 +95,21 @@
 </script>
 
 {#snippet rowInner()}
+  {@const hasLeading = isMultiSelect || Boolean(leading)}
   <span class={templateClasses.itemInner}>
-    {#if leading}
+    {#if isMultiSelect}
+      <!-- Multi-select indicator overrides `leading` (mirrors React
+           `BaseMenuLeadingItem`): checkbox is visual only, so it's aria-hidden,
+           non-interactive (`tabindex=-1`, pointer-events none via .itemSelector)
+           and the row itself carries `aria-selected`. -->
+      <span class={templateClasses.itemSelector} aria-hidden="true">
+        <Checkbox isChecked={isItemSelected} isDisabled={isDisabled} tabIndex={-1} />
+      </span>
+    {:else if leading}
       <span class={templateClasses.itemLeading}>{@render leading()}</span>
     {/if}
     <span
-      class={[templateClasses.itemContent, leading ? templateClasses.itemContentWithLeading : '']
+      class={[templateClasses.itemContent, hasLeading ? templateClasses.itemContentWithLeading : '']
         .filter(Boolean)
         .join(' ')}
     >
@@ -104,6 +124,9 @@
         >
           {title}
         </Text>
+        {#if titleSuffix}
+          {@render titleSuffix()}
+        {/if}
       </span>
       {#if description}
         <span>

--- a/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAccessible,
+    makeAnalyticsAttribute,
+  } from '@razorpay/blade-core/utils';
+  import { getActionListItemClasses, getActionListTemplateClasses } from '@razorpay/blade-core/styles';
+  import Text from '../Typography/Text/Text.svelte';
+  import { getActionListContext, setActionListItemContext } from './actionListContext';
+  import { getActionListItemRole } from './getA11yRoles';
+  import type { ActionListItemContextValue, ActionListItemProps } from './types';
+
+  // Call template getter so CVA classes used in compound selectors aren't tree-shaken.
+  const templateClasses = getActionListTemplateClasses();
+
+  let {
+    title,
+    description,
+    value,
+    href,
+    target,
+    leading,
+    trailing,
+    onClick,
+    isDisabled = false,
+    isSelected,
+    intent,
+    testID,
+    ...rest
+  }: ActionListItemProps = $props();
+
+  const ctx = getActionListContext();
+
+  // Selection: explicit prop wins, else derive from ActionList `selectedValue`.
+  const isItemSelected = $derived(isSelected ?? ctx?.selectedValue === value);
+
+  // Provide row-local disabled/intent to ActionListItemText (React `useBaseMenuItem`).
+  const itemContext: ActionListItemContextValue = {
+    get isDisabled() {
+      return isDisabled;
+    },
+    get intent() {
+      return intent;
+    },
+  };
+  setActionListItemContext(() => itemContext);
+
+  const role = $derived(getActionListItemRole(href));
+
+  // Title/description colors mirror React BaseMenuItem `menuItemTitleColor` / `menuItemDescriptionColor`.
+  const titleColor = $derived(
+    isDisabled
+      ? 'interactive.text.gray.disabled'
+      : intent === 'negative'
+        ? 'feedback.text.negative.intense'
+        : 'interactive.text.gray.normal',
+  );
+  const descriptionColor = $derived(
+    isDisabled ? 'interactive.text.gray.disabled' : 'interactive.text.gray.muted',
+  );
+
+  const rowClasses = $derived(getActionListItemClasses({ intent: intent === 'negative' ? 'negative' : 'default' }));
+
+  function handleClick(event: MouseEvent): void {
+    if (isDisabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    onClick?.({ name: value, value: isItemSelected, event });
+    ctx?.onItemSelect?.({ value });
+  }
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.ActionListItem, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+  const a11yAttrs = $derived(
+    makeAccessible({
+      role,
+      selected: isItemSelected,
+      disabled: isDisabled,
+    }),
+  );
+</script>
+
+{#snippet rowInner()}
+  <span class={templateClasses.itemInner}>
+    {#if leading}
+      <span class={templateClasses.itemLeading}>{@render leading()}</span>
+    {/if}
+    <span
+      class={[templateClasses.itemContent, leading ? templateClasses.itemContentWithLeading : '']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <span class={templateClasses.itemTitleRow}>
+        <Text as="span" size="medium" weight="regular" color={titleColor} truncateAfterLines={1}>
+          {title}
+        </Text>
+      </span>
+      {#if description}
+        <span>
+          <Text size="small" color={descriptionColor}>{description}</Text>
+        </span>
+      {/if}
+    </span>
+    {#if trailing}
+      <span class={templateClasses.itemTrailing}>{@render trailing()}</span>
+    {/if}
+  </span>
+{/snippet}
+
+{#if href}
+  <a
+    class={rowClasses}
+    {href}
+    {target}
+    data-value={value}
+    onclick={handleClick}
+    {...a11yAttrs}
+    {...metaAttrs}
+    {...analyticsAttrs}
+  >
+    {@render rowInner()}
+  </a>
+{:else}
+  <button
+    class={rowClasses}
+    type="button"
+    data-value={value}
+    disabled={isDisabled || undefined}
+    onclick={handleClick}
+    {...a11yAttrs}
+    {...metaAttrs}
+    {...analyticsAttrs}
+  >
+    {@render rowInner()}
+  </button>
+{/if}

--- a/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
@@ -135,7 +135,6 @@
     class={rowClasses}
     type="button"
     data-value={value}
-    disabled={isDisabled || undefined}
     onclick={handleClick}
     {...a11yAttrs}
     {...metaAttrs}

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemAsset.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemAsset.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import type { ActionListItemAssetProps } from './types';
+
+  let { src, alt }: ActionListItemAssetProps = $props();
+</script>
+
+<img {src} {alt} width="16" height="12" />

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemAvatar.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemAvatar.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import Avatar from '../Avatar/Avatar.svelte';
+  import type { ActionListItemAvatarProps } from './types';
+
+  // `size` is forced to `xsmall` (mirrors React `_ActionListItemAvatar`); all
+  // other Avatar props flow through.
+  let { ...avatarProps }: ActionListItemAvatarProps = $props();
+</script>
+
+<Avatar size="xsmall" {...avatarProps} />

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemBadge.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemBadge.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import Badge from '../Badge/Badge.svelte';
+  import type { ActionListItemBadgeProps } from './types';
+
+  // `size` is forced to `medium` and a `spacing.3` left margin is applied
+  // (mirrors React `_ActionListItemBadge`); all other Badge props flow through.
+  let { ...badgeProps }: ActionListItemBadgeProps = $props();
+</script>
+
+<Badge size="medium" marginLeft="spacing.3" {...badgeProps} />

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemBadgeGroup.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemBadgeGroup.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { getActionListTemplateClasses } from '@razorpay/blade-core/styles';
+  import type { ActionListItemBadgeGroupProps } from './types';
+
+  // Call template getter so the CVA/template class isn't tree-shaken.
+  const templateClasses = getActionListTemplateClasses();
+
+  let { children }: ActionListItemBadgeGroupProps = $props();
+</script>
+
+<div class={templateClasses.itemBadgeGroup}>
+  {@render children()}
+</div>

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemIcon.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { getActionListItemContext } from './actionListContext';
+  import type { ActionListItemIconProps } from './types';
+
+  let { icon: Icon }: ActionListItemIconProps = $props();
+
+  // Row-local context (mirrors React `useBaseMenuItem()`): negative intent →
+  // negative icon; otherwise gray normal/disabled per the row's disabled state.
+  const itemContext = getActionListItemContext();
+  const color = $derived(
+    itemContext?.intent === 'negative'
+      ? 'feedback.icon.negative.intense'
+      : itemContext?.isDisabled
+        ? 'interactive.icon.gray.disabled'
+        : 'interactive.icon.gray.normal',
+  );
+</script>
+
+<Icon {color} size="medium" />

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemText.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemText.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { type Snippet } from 'svelte';
   import Text from '../Typography/Text/Text.svelte';
   import { getActionListItemContext } from './actionListContext';
   import type { ActionListItemTextProps } from './types';
@@ -12,15 +11,8 @@
   const color = $derived(
     itemContext?.isDisabled ? 'interactive.text.gray.disabled' : 'interactive.text.gray.muted',
   );
-
-  const isStringChildren = $derived(typeof children === 'string');
-  const snippetChildren = $derived(!isStringChildren ? (children as Snippet) : undefined);
 </script>
 
 <Text variant="caption" size="medium" {color}>
-  {#if isStringChildren}
-    {children}
-  {:else if snippetChildren}
-    {@render snippetChildren()}
-  {/if}
+  {@render children()}
 </Text>

--- a/packages/blade-svelte/src/components/ActionList/ActionListItemText.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItemText.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { type Snippet } from 'svelte';
+  import Text from '../Typography/Text/Text.svelte';
+  import { getActionListItemContext } from './actionListContext';
+  import type { ActionListItemTextProps } from './types';
+
+  let { children }: ActionListItemTextProps = $props();
+
+  // Row-local context (mirrors React `useBaseMenuItem()`): disabled → disabled
+  // token, else muted. No context (used standalone) → muted.
+  const itemContext = getActionListItemContext();
+  const color = $derived(
+    itemContext?.isDisabled ? 'interactive.text.gray.disabled' : 'interactive.text.gray.muted',
+  );
+
+  const isStringChildren = $derived(typeof children === 'string');
+  const snippetChildren = $derived(!isStringChildren ? (children as Snippet) : undefined);
+</script>
+
+<Text variant="caption" size="medium" {color}>
+  {#if isStringChildren}
+    {children}
+  {:else if snippetChildren}
+    {@render snippetChildren()}
+  {/if}
+</Text>

--- a/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
@@ -8,7 +8,7 @@
   import { getActionListTemplateClasses } from '@razorpay/blade-core/styles';
   import Text from '../Typography/Text/Text.svelte';
   import Divider from '../Divider/Divider.svelte';
-  import { getActionListSectionRole } from './getA11yRoles';
+  import { getActionListSectionRole, getActionListSectionItemsRole } from './getA11yRoles';
   import type { ActionListSectionProps } from './types';
 
   const templateClasses = getActionListTemplateClasses();
@@ -18,13 +18,15 @@
   const metaAttrs = metaAttribute({ name: MetaConstants.ActionListSection, testID });
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const a11yAttrs = $derived(makeAccessible({ role: getActionListSectionRole(), label: title }));
+  // Inner listbox mirrors React so SRs announce the per-group item count.
+  const itemsA11yAttrs = $derived(makeAccessible({ role: getActionListSectionItemsRole() }));
 </script>
 
 <div class={templateClasses.section} {...a11yAttrs} {...metaAttrs} {...analyticsAttrs}>
   <div class={templateClasses.sectionTitle}>
     <Text color="surface.text.gray.muted" size="small" weight="semibold">{title}</Text>
   </div>
-  <div class={templateClasses.sectionItems}>
+  <div class={templateClasses.sectionItems} {...itemsA11yAttrs}>
     {@render children()}
   </div>
   <Divider marginX="spacing.3" marginY="spacing.1" />

--- a/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAccessible,
+    makeAnalyticsAttribute,
+  } from '@razorpay/blade-core/utils';
+  import { getActionListTemplateClasses } from '@razorpay/blade-core/styles';
+  import Text from '../Typography/Text/Text.svelte';
+  import Divider from '../Divider/Divider.svelte';
+  import { getActionListSectionRole } from './getA11yRoles';
+  import type { ActionListSectionProps } from './types';
+
+  const templateClasses = getActionListTemplateClasses();
+
+  let { title, children, testID, ...rest }: ActionListSectionProps = $props();
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.ActionListSection, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+  const a11yAttrs = $derived(makeAccessible({ role: getActionListSectionRole(), label: title }));
+</script>
+
+<div class={templateClasses.section} {...a11yAttrs} {...metaAttrs} {...analyticsAttrs}>
+  <div class={templateClasses.sectionTitle}>
+    <Text color="surface.text.gray.muted" size="small" weight="semibold">{title}</Text>
+  </div>
+  <div class={templateClasses.sectionItems} role="listbox">
+    {@render children()}
+  </div>
+  <Divider marginX="spacing.3" marginY="spacing.1" />
+</div>

--- a/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
@@ -15,7 +15,7 @@
 
   let { title, children, testID, ...rest }: ActionListSectionProps = $props();
 
-  const metaAttrs = metaAttribute({ name: MetaConstants.ActionListSection, testID });
+  const metaAttrs = $derived(metaAttribute({ name: MetaConstants.ActionListSection, testID }));
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const a11yAttrs = $derived(makeAccessible({ role: getActionListSectionRole(), label: title }));
   // Inner listbox mirrors React so SRs announce the per-group item count.

--- a/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListSection.svelte
@@ -24,7 +24,7 @@
   <div class={templateClasses.sectionTitle}>
     <Text color="surface.text.gray.muted" size="small" weight="semibold">{title}</Text>
   </div>
-  <div class={templateClasses.sectionItems} role="listbox">
+  <div class={templateClasses.sectionItems}>
     {@render children()}
   </div>
   <Divider marginX="spacing.3" marginY="spacing.1" />

--- a/packages/blade-svelte/src/components/ActionList/actionListContext.ts
+++ b/packages/blade-svelte/src/components/ActionList/actionListContext.ts
@@ -1,0 +1,42 @@
+import { getContext, setContext } from 'svelte';
+import type { ActionListContextValue, ActionListItemContextValue } from './types';
+
+const ACTION_LIST_CONTEXT_KEY = Symbol('action-list-context');
+
+/**
+ * Reactive context provided by `ActionList` and read by each `ActionListItem`.
+ * Mirrors the slice of React's `useDropdown` that ActionList actually needs:
+ * `selectionType` (single-select only in this scope), the controlled
+ * `selectedValue`, the `onItemSelect` callback (consumer closes the sheet), and
+ * `isInBottomSheet` (resolved from `getBottomSheetContext()` or the prop).
+ *
+ * Uses the getter pattern (`setContext(KEY, () => value)`) so `selectedValue`
+ * stays reactive across the boundary.
+ */
+export function setActionListContext(getter: () => ActionListContextValue): void {
+  setContext(ACTION_LIST_CONTEXT_KEY, getter);
+}
+
+export function getActionListContext(): ActionListContextValue | undefined {
+  const getter = getContext<(() => ActionListContextValue) | undefined>(ACTION_LIST_CONTEXT_KEY);
+  return getter?.();
+}
+
+const ACTION_LIST_ITEM_CONTEXT_KEY = Symbol('action-list-item-context');
+
+/**
+ * Tiny row-local context carrying `isDisabled`/`intent` from `ActionListItem`
+ * down to `ActionListItemText` (mirrors React's `useBaseMenuItem()` read). Kept
+ * separate from `ActionListContext` so text/asset don't re-plumb the full menu
+ * context.
+ */
+export function setActionListItemContext(getter: () => ActionListItemContextValue): void {
+  setContext(ACTION_LIST_ITEM_CONTEXT_KEY, getter);
+}
+
+export function getActionListItemContext(): ActionListItemContextValue | undefined {
+  const getter = getContext<(() => ActionListItemContextValue) | undefined>(
+    ACTION_LIST_ITEM_CONTEXT_KEY,
+  );
+  return getter?.();
+}

--- a/packages/blade-svelte/src/components/ActionList/actionListContext.ts
+++ b/packages/blade-svelte/src/components/ActionList/actionListContext.ts
@@ -8,7 +8,7 @@ const ACTION_LIST_CONTEXT_KEY = Symbol('action-list-context');
  * Mirrors the slice of React's `useDropdown` that ActionList actually needs:
  * `selectionType` (single-select only in this scope), the controlled
  * `selectedValue`, the `onAction` callback (consumer closes the sheet), and
- * `isInBottomSheet` (resolved from `getBottomSheetContext()` or the prop).
+ * `isInBottomSheet` (resolved from `getBottomSheetContext()`).
  *
  * Uses the getter pattern (`setContext(KEY, () => value)`) so `selectedValue`
  * stays reactive across the boundary.

--- a/packages/blade-svelte/src/components/ActionList/actionListContext.ts
+++ b/packages/blade-svelte/src/components/ActionList/actionListContext.ts
@@ -7,7 +7,7 @@ const ACTION_LIST_CONTEXT_KEY = Symbol('action-list-context');
  * Reactive context provided by `ActionList` and read by each `ActionListItem`.
  * Mirrors the slice of React's `useDropdown` that ActionList actually needs:
  * `selectionType` (single-select only in this scope), the controlled
- * `selectedValue`, the `onItemSelect` callback (consumer closes the sheet), and
+ * `selectedValue`, the `onAction` callback (consumer closes the sheet), and
  * `isInBottomSheet` (resolved from `getBottomSheetContext()` or the prop).
  *
  * Uses the getter pattern (`setContext(KEY, () => value)`) so `selectedValue`

--- a/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
+++ b/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
@@ -19,3 +19,14 @@ export function getActionListItemRole(href?: string): 'link' | 'option' {
 export function getActionListSectionRole(): 'group' {
   return 'group';
 }
+
+/**
+ * Section items wrapper role — `listbox` on web. Mirrors React's deliberate
+ * inner listbox (ActionListItem.tsx `role: isReactNative() ? undefined : 'listbox'`)
+ * so screen readers announce the per-group item count. Yields
+ * `listbox > group > listbox > option`; the intervening `group` keeps the outer
+ * listbox's owned children valid.
+ */
+export function getActionListSectionItemsRole(): 'listbox' {
+  return 'listbox';
+}

--- a/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
+++ b/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
@@ -1,0 +1,21 @@
+/**
+ * Accessibility roles for the ActionList family. React's `getA11yRoles.ts`
+ * switches between `menu`/`listbox`/`dialog` based on the Dropdown trigger; that
+ * coupling is stripped here. This scope is single-select, BottomSheet-mode only,
+ * so it emits list/option roles exclusively.
+ */
+
+/** Container role — always `listbox` (no Dropdown/footer/menu branches). */
+export function getActionListContainerRole(): 'listbox' {
+  return 'listbox';
+}
+
+/** Row role — `link` when the item navigates (`href`), else `option`. */
+export function getActionListItemRole(href?: string): 'link' | 'option' {
+  return href ? 'link' : 'option';
+}
+
+/** Section wrapper role — `group` (announces the section title as its label). */
+export function getActionListSectionRole(): 'group' {
+  return 'group';
+}

--- a/packages/blade-svelte/src/components/ActionList/index.ts
+++ b/packages/blade-svelte/src/components/ActionList/index.ts
@@ -4,7 +4,7 @@
  * React's ActionList: Dropdown/AutoComplete/multiselect/virtualization are all
  * out of scope.
  *
- * Selection is controlled via `selectedValue` + `onItemSelect` (keyed on each
+ * Selection is controlled via `selectedValue` + `onAction` (keyed on each
  * item's `value`). When rendered inside a `BottomSheet`, `isInBottomSheet` is
  * auto-detected from the BottomSheet context, so the outer box (border/shadow/
  * padding) is dropped and `BottomSheetBody` owns scrolling.
@@ -41,7 +41,7 @@
  *       {#snippet children()}
  *         <ActionList
  *           selectedValue={selected}
- *           onItemSelect={({ value }) => {
+ *           onAction={({ value }) => {
  *             selected = value;
  *             isOpen = false;
  *           }}

--- a/packages/blade-svelte/src/components/ActionList/index.ts
+++ b/packages/blade-svelte/src/components/ActionList/index.ts
@@ -1,0 +1,80 @@
+/**
+ * ActionList — a list of selectable/actionable items, designed to render inside
+ * a `BottomSheet`. This is a scoped, single-select, BottomSheet-mode slice of
+ * React's ActionList: Dropdown/AutoComplete/multiselect/virtualization are all
+ * out of scope.
+ *
+ * Selection is controlled via `selectedValue` + `onItemSelect` (keyed on each
+ * item's `value`). When rendered inside a `BottomSheet`, `isInBottomSheet` is
+ * auto-detected from the BottomSheet context, so the outer box (border/shadow/
+ * padding) is dropped and `BottomSheetBody` owns scrolling.
+ *
+ * ### Deviations from React
+ * - **Story title:** stories use `Components/ActionList` (blade-svelte
+ *   convention), NOT React's Dropdown-nested `Components/Dropdown/ActionList/Stories`.
+ * - **`isVirtualized` removed:** virtualization is dropped entirely (not even a
+ *   noop); all items render in a plain `max-height` + `overflow-y: auto` scroll
+ *   container.
+ * - **`titleSuffix` removed:** Badge-in-item is out of scope.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import {
+ *     ActionList,
+ *     ActionListItem,
+ *     ActionListItemAsset,
+ *     ActionListItemText,
+ *     BottomSheet,
+ *     BottomSheetHeader,
+ *     BottomSheetBody,
+ *   } from '@razorpay/blade-svelte/components';
+ *
+ *   let isOpen = $state(false);
+ *   let selected = $state<string | undefined>('in');
+ * </script>
+ *
+ * <BottomSheet {isOpen} onDismiss={() => (isOpen = false)}>
+ *   {#snippet children()}
+ *     <BottomSheetHeader title="Select country" />
+ *     <BottomSheetBody hasActionList>
+ *       {#snippet children()}
+ *         <ActionList
+ *           selectedValue={selected}
+ *           onItemSelect={({ value }) => {
+ *             selected = value;
+ *             isOpen = false;
+ *           }}
+ *         >
+ *           {#snippet children()}
+ *             <ActionListItem title="India" value="in">
+ *               {#snippet leading()}
+ *                 <ActionListItemAsset src="https://flagcdn.com/w20/in.png" alt="India" />
+ *               {/snippet}
+ *               {#snippet trailing()}
+ *                 <ActionListItemText>+91</ActionListItemText>
+ *               {/snippet}
+ *             </ActionListItem>
+ *           {/snippet}
+ *         </ActionList>
+ *       {/snippet}
+ *     </BottomSheetBody>
+ *   {/snippet}
+ * </BottomSheet>
+ * ```
+ */
+export { default as ActionList } from './ActionList.svelte';
+export { default as ActionListItem } from './ActionListItem.svelte';
+export { default as ActionListItemAsset } from './ActionListItemAsset.svelte';
+export { default as ActionListItemText } from './ActionListItemText.svelte';
+export { default as ActionListSection } from './ActionListSection.svelte';
+export type {
+  ActionListProps,
+  ActionListItemProps,
+  ActionListItemAssetProps,
+  ActionListItemTextProps,
+  ActionListSectionProps,
+  ActionListSelectionType,
+  ActionListItemClickPayload,
+  ActionListItemSelectPayload,
+} from './types';

--- a/packages/blade-svelte/src/components/ActionList/index.ts
+++ b/packages/blade-svelte/src/components/ActionList/index.ts
@@ -1,13 +1,14 @@
 /**
  * ActionList — a list of selectable/actionable items, designed to render inside
- * a `BottomSheet`. This is a scoped, single-select, BottomSheet-mode slice of
- * React's ActionList: Dropdown/AutoComplete/multiselect/virtualization are all
- * out of scope.
+ * a `BottomSheet`. Supports both `single` and `multiple` selection. This is a
+ * scoped, BottomSheet-mode slice of React's ActionList: the Dropdown/AutoComplete
+ * couplings and virtualization are out of scope.
  *
  * Selection is controlled via `selectedValue` + `onAction` (keyed on each
- * item's `value`). When rendered inside a `BottomSheet`, `isInBottomSheet` is
- * auto-detected from the BottomSheet context, so the outer box (border/shadow/
- * padding) is dropped and `BottomSheetBody` owns scrolling.
+ * item's `value`) — a `string` in `single` mode, a `string[]` in `multiple`
+ * mode. When rendered inside a `BottomSheet`, `isInBottomSheet` is auto-detected
+ * from the BottomSheet context, so the outer box (border/shadow/padding) is
+ * dropped and `BottomSheetBody` owns scrolling.
  *
  * ### Deviations from React
  * - **Story title:** stories use `Components/ActionList` (blade-svelte
@@ -15,7 +16,9 @@
  * - **`isVirtualized` removed:** virtualization is dropped entirely (not even a
  *   noop); all items render in a plain `max-height` + `overflow-y: auto` scroll
  *   container.
- * - **`titleSuffix` removed:** Badge-in-item is out of scope.
+ * - **Dropdown / AutoComplete triggers out of scope:** roles are fixed to
+ *   list/option (no `menu`/`dialog`/`menuitemcheckbox` branches); there is no
+ *   filtering/`filteredValues` behavior.
  *
  * @example
  * ```svelte
@@ -67,12 +70,20 @@ export { default as ActionList } from './ActionList.svelte';
 export { default as ActionListItem } from './ActionListItem.svelte';
 export { default as ActionListItemAsset } from './ActionListItemAsset.svelte';
 export { default as ActionListItemText } from './ActionListItemText.svelte';
+export { default as ActionListItemIcon } from './ActionListItemIcon.svelte';
+export { default as ActionListItemAvatar } from './ActionListItemAvatar.svelte';
+export { default as ActionListItemBadge } from './ActionListItemBadge.svelte';
+export { default as ActionListItemBadgeGroup } from './ActionListItemBadgeGroup.svelte';
 export { default as ActionListSection } from './ActionListSection.svelte';
 export type {
   ActionListProps,
   ActionListItemProps,
   ActionListItemAssetProps,
   ActionListItemTextProps,
+  ActionListItemIconProps,
+  ActionListItemAvatarProps,
+  ActionListItemBadgeProps,
+  ActionListItemBadgeGroupProps,
   ActionListSectionProps,
   ActionListSelectionType,
   ActionListItemClickPayload,

--- a/packages/blade-svelte/src/components/ActionList/types.ts
+++ b/packages/blade-svelte/src/components/ActionList/types.ts
@@ -1,8 +1,11 @@
 import type { Snippet } from 'svelte';
 import type { StyledPropsBlade, DataAnalyticsAttribute } from '@razorpay/blade-core/utils';
+import type { IconComponent } from '../Icons';
+import type { AvatarProps } from '../Avatar/types';
+import type { BadgeProps } from '../Badge/types';
 
-/** Selection mode. Only single-select is supported in this scope. */
-export type ActionListSelectionType = 'single';
+/** Selection mode of the list — `single` (default) or `multiple`. */
+export type ActionListSelectionType = 'single' | 'multiple';
 
 /** Payload passed to `ActionList`'s `onAction` when a row is activated. */
 export type ActionListItemSelectPayload = { value: string };
@@ -23,18 +26,30 @@ export interface ActionListProps extends StyledPropsBlade, DataAnalyticsAttribut
    */
   children: Snippet;
   /**
-   * Selection mode of the list. Only `single` is supported.
+   * Selection mode of the list.
+   *
+   * - `single` — one item selected at a time; `selectedValue` is a `string`.
+   * - `multiple` — many items selectable; `selectedValue` is a `string[]` and
+   *   each row renders a (visual, `aria-hidden`) checkbox indicator in place of
+   *   its `leading` content. `aria-multiselectable` is set on the container.
    *
    * @default 'single'
    */
   selectionType?: ActionListSelectionType;
   /**
-   * Currently selected item `value` (controlled). Drives `aria-selected` on rows.
+   * Currently selected item value(s) (controlled). Drives `aria-selected` on rows.
+   *
+   * - `single` mode → pass a `string` (the selected item's `value`).
+   * - `multiple` mode → pass a `string[]` (all selected values).
    */
-  selectedValue?: string;
+  selectedValue?: string | string[];
   /**
-   * Fired when a row is activated. The consumer typically updates
-   * `selectedValue` and closes the surrounding BottomSheet.
+   * Fired when a row is activated, once per toggle, with the item's `value`.
+   *
+   * The consumer owns selection state: in `single` mode update `selectedValue`
+   * (and typically close the surrounding BottomSheet); in `multiple` mode
+   * toggle the `value` in/out of your `string[]`. This callback does not
+   * auto-manage the array.
    */
   onAction?: (payload: ActionListItemSelectPayload) => void;
   /**
@@ -66,13 +81,21 @@ export interface ActionListItemProps extends DataAnalyticsAttribute {
    */
   target?: string;
   /**
-   * Content on the left of the item. Holds `ActionListItemAsset` or an icon.
+   * Content on the left of the item. Holds `ActionListItemIcon`,
+   * `ActionListItemAsset`, or `ActionListItemAvatar`.
+   *
+   * Overridden by the checkbox indicator when the list is `selectionType="multiple"`.
    */
   leading?: Snippet;
   /**
    * Content on the right of the item. Holds `ActionListItemText` or an icon.
    */
   trailing?: Snippet;
+  /**
+   * Content rendered immediately next to the title (same row). Holds
+   * `ActionListItemBadge` or `ActionListItemBadgeGroup`.
+   */
+  titleSuffix?: Snippet;
   /**
    * Click handler (web-only). `value` is the item's string identifier,
    * `isSelected` is the current selected state.
@@ -117,6 +140,41 @@ export interface ActionListItemTextProps {
   children: Snippet | string;
 }
 
+/**
+ * Props for `ActionListItemIcon` — a leading/trailing icon whose color follows
+ * the row's disabled/negative state (mirrors React `useBaseMenuItem`).
+ */
+export interface ActionListItemIconProps {
+  /**
+   * Icon component to render (e.g. `HomeIcon`). Rendered at `size="medium"`;
+   * color is derived from the row context.
+   */
+  icon: IconComponent;
+}
+
+/**
+ * Props for `ActionListItemAvatar` — a leading avatar. Wraps `Avatar` and forces
+ * `size="xsmall"`; every other `Avatar` prop except `size` is accepted.
+ */
+export type ActionListItemAvatarProps = Omit<AvatarProps, 'size'>;
+
+/**
+ * Props for `ActionListItemBadge` — wraps `Badge` (forced `size="medium"` with a
+ * `spacing.3` left margin). Accepts all `Badge` props except `size`.
+ */
+export type ActionListItemBadgeProps = Omit<BadgeProps, 'size'>;
+
+/**
+ * Props for `ActionListItemBadgeGroup` — a flex-row container for one or more
+ * `ActionListItemBadge`, intended for the `titleSuffix` slot.
+ */
+export interface ActionListItemBadgeGroupProps {
+  /**
+   * `ActionListItemBadge` children laid out in a row.
+   */
+  children: Snippet;
+}
+
 export interface ActionListSectionProps extends DataAnalyticsAttribute {
   /**
    * Section title, announced as the group label.
@@ -137,7 +195,7 @@ export interface ActionListSectionProps extends DataAnalyticsAttribute {
  */
 export type ActionListContextValue = {
   selectionType: ActionListSelectionType;
-  selectedValue?: string;
+  selectedValue?: string | string[];
   isInBottomSheet: boolean;
   onAction?: (payload: ActionListItemSelectPayload) => void;
   /** No-op-safe hook reserved for future focus/index needs. */

--- a/packages/blade-svelte/src/components/ActionList/types.ts
+++ b/packages/blade-svelte/src/components/ActionList/types.ts
@@ -4,15 +4,15 @@ import type { StyledPropsBlade, DataAnalyticsAttribute } from '@razorpay/blade-c
 /** Selection mode. Only single-select is supported in this scope. */
 export type ActionListSelectionType = 'single';
 
-/** Payload passed to `ActionList`'s `onItemSelect` when a row is activated. */
+/** Payload passed to `ActionList`'s `onAction` when a row is activated. */
 export type ActionListItemSelectPayload = { value: string };
 
 /** Payload passed to `ActionListItem`'s `onClick` (web-only). */
 export type ActionListItemClickPayload = {
   /** The item's `value`. */
-  name: string;
+  value: string;
   /** The item's selected state at click time. */
-  value?: boolean;
+  isSelected?: boolean;
   /** Native click event. */
   event: MouseEvent;
 };
@@ -36,7 +36,7 @@ export interface ActionListProps extends StyledPropsBlade, DataAnalyticsAttribut
    * Fired when a row is activated. The consumer typically updates
    * `selectedValue` and closes the surrounding BottomSheet.
    */
-  onItemSelect?: (payload: ActionListItemSelectPayload) => void;
+  onAction?: (payload: ActionListItemSelectPayload) => void;
   /**
    * Whether the list is rendered inside a BottomSheet. When `true`, the outer
    * box (border/shadow/padding) is dropped so BottomSheetBody owns scrolling.
@@ -61,7 +61,7 @@ export interface ActionListItemProps extends DataAnalyticsAttribute {
    */
   description?: string;
   /**
-   * Identity of the item used for selection and returned via `onItemSelect` /
+   * Identity of the item used for selection and returned via `onAction` /
    * form submissions.
    */
   value: string;
@@ -82,8 +82,8 @@ export interface ActionListItemProps extends DataAnalyticsAttribute {
    */
   trailing?: Snippet;
   /**
-   * Click handler (web-only). `name` is the item `value`, `value` is the
-   * current selected state.
+   * Click handler (web-only). `value` is the item's string identifier,
+   * `isSelected` is the current selected state.
    */
   onClick?: (payload: ActionListItemClickPayload) => void;
   /**
@@ -147,7 +147,7 @@ export type ActionListContextValue = {
   selectionType: ActionListSelectionType;
   selectedValue?: string;
   isInBottomSheet: boolean;
-  onItemSelect?: (payload: ActionListItemSelectPayload) => void;
+  onAction?: (payload: ActionListItemSelectPayload) => void;
   /** No-op-safe hook reserved for future focus/index needs. */
   registerItem?: (value: string) => void;
 };

--- a/packages/blade-svelte/src/components/ActionList/types.ts
+++ b/packages/blade-svelte/src/components/ActionList/types.ts
@@ -38,14 +38,6 @@ export interface ActionListProps extends StyledPropsBlade, DataAnalyticsAttribut
    */
   onAction?: (payload: ActionListItemSelectPayload) => void;
   /**
-   * Whether the list is rendered inside a BottomSheet. When `true`, the outer
-   * box (border/shadow/padding) is dropped so BottomSheetBody owns scrolling.
-   *
-   * Resolved from `getBottomSheetContext()` when omitted, falling back to
-   * `false`.
-   */
-  isInBottomSheet?: boolean;
-  /**
    * Test ID for the container element.
    */
   testID?: string;

--- a/packages/blade-svelte/src/components/ActionList/types.ts
+++ b/packages/blade-svelte/src/components/ActionList/types.ts
@@ -1,0 +1,161 @@
+import type { Snippet } from 'svelte';
+import type { StyledPropsBlade, DataAnalyticsAttribute } from '@razorpay/blade-core/utils';
+
+/** Selection mode. Only single-select is supported in this scope. */
+export type ActionListSelectionType = 'single';
+
+/** Payload passed to `ActionList`'s `onItemSelect` when a row is activated. */
+export type ActionListItemSelectPayload = { value: string };
+
+/** Payload passed to `ActionListItem`'s `onClick` (web-only). */
+export type ActionListItemClickPayload = {
+  /** The item's `value`. */
+  name: string;
+  /** The item's selected state at click time. */
+  value?: boolean;
+  /** Native click event. */
+  event: MouseEvent;
+};
+
+export interface ActionListProps extends StyledPropsBlade, DataAnalyticsAttribute {
+  /**
+   * Accepts `ActionListItem` / `ActionListSection` children.
+   */
+  children: Snippet;
+  /**
+   * Selection mode of the list. Only `single` is supported.
+   *
+   * @default 'single'
+   */
+  selectionType?: ActionListSelectionType;
+  /**
+   * Currently selected item `value` (controlled). Drives `aria-selected` on rows.
+   */
+  selectedValue?: string;
+  /**
+   * Fired when a row is activated. The consumer typically updates
+   * `selectedValue` and closes the surrounding BottomSheet.
+   */
+  onItemSelect?: (payload: ActionListItemSelectPayload) => void;
+  /**
+   * Whether the list is rendered inside a BottomSheet. When `true`, the outer
+   * box (border/shadow/padding) is dropped so BottomSheetBody owns scrolling.
+   *
+   * Resolved from `getBottomSheetContext()` when omitted, falling back to
+   * `false`.
+   */
+  isInBottomSheet?: boolean;
+  /**
+   * Test ID for the container element.
+   */
+  testID?: string;
+}
+
+export interface ActionListItemProps extends DataAnalyticsAttribute {
+  /**
+   * Primary label of the item.
+   */
+  title: string;
+  /**
+   * Secondary description rendered under the title.
+   */
+  description?: string;
+  /**
+   * Identity of the item used for selection and returned via `onItemSelect` /
+   * form submissions.
+   */
+  value: string;
+  /**
+   * Link to open when the item is clicked. Renders the row as an `<a>`.
+   */
+  href?: string;
+  /**
+   * HTML `target` of the link (only relevant with `href`).
+   */
+  target?: string;
+  /**
+   * Content on the left of the item. Holds `ActionListItemAsset` or an icon.
+   */
+  leading?: Snippet;
+  /**
+   * Content on the right of the item. Holds `ActionListItemText` or an icon.
+   */
+  trailing?: Snippet;
+  /**
+   * Click handler (web-only). `name` is the item `value`, `value` is the
+   * current selected state.
+   */
+  onClick?: (payload: ActionListItemClickPayload) => void;
+  /**
+   * If `true`, the item is disabled — click is guarded and `aria-disabled` set.
+   *
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Explicitly marks the item selected. When omitted, selection is derived from
+   * the ActionList `selectedValue === value`.
+   */
+  isSelected?: boolean;
+  /**
+   * Negative intent — renders negative title text and hover background.
+   */
+  intent?: 'negative';
+  /**
+   * Test ID for the row element.
+   */
+  testID?: string;
+}
+
+export interface ActionListItemAssetProps {
+  /**
+   * Source of the image.
+   */
+  src: string;
+  /**
+   * Alt text for the image.
+   */
+  alt: string;
+}
+
+export interface ActionListItemTextProps {
+  /**
+   * Caption text. Color follows the row's disabled state.
+   */
+  children: Snippet | string;
+}
+
+export interface ActionListSectionProps extends DataAnalyticsAttribute {
+  /**
+   * Section title, announced as the group label.
+   */
+  title: string;
+  /**
+   * `ActionListItem` children belonging to this section.
+   */
+  children: Snippet;
+  /**
+   * Test ID for the section element.
+   */
+  testID?: string;
+}
+
+/**
+ * Reactive context shared from `ActionList` to its `ActionListItem` children.
+ */
+export type ActionListContextValue = {
+  selectionType: ActionListSelectionType;
+  selectedValue?: string;
+  isInBottomSheet: boolean;
+  onItemSelect?: (payload: ActionListItemSelectPayload) => void;
+  /** No-op-safe hook reserved for future focus/index needs. */
+  registerItem?: (value: string) => void;
+};
+
+/**
+ * Row-local context passed from `ActionListItem` to `ActionListItemText`.
+ */
+export type ActionListItemContextValue = {
+  isDisabled: boolean;
+  intent?: 'negative';
+};

--- a/packages/blade-svelte/src/components/ActionList/types.ts
+++ b/packages/blade-svelte/src/components/ActionList/types.ts
@@ -20,29 +20,11 @@ export type ActionListItemClickPayload = {
   event: MouseEvent;
 };
 
-export interface ActionListProps extends StyledPropsBlade, DataAnalyticsAttribute {
+interface ActionListBaseProps extends StyledPropsBlade, DataAnalyticsAttribute {
   /**
    * Accepts `ActionListItem` / `ActionListSection` children.
    */
   children: Snippet;
-  /**
-   * Selection mode of the list.
-   *
-   * - `single` — one item selected at a time; `selectedValue` is a `string`.
-   * - `multiple` — many items selectable; `selectedValue` is a `string[]` and
-   *   each row renders a (visual, `aria-hidden`) checkbox indicator in place of
-   *   its `leading` content. `aria-multiselectable` is set on the container.
-   *
-   * @default 'single'
-   */
-  selectionType?: ActionListSelectionType;
-  /**
-   * Currently selected item value(s) (controlled). Drives `aria-selected` on rows.
-   *
-   * - `single` mode → pass a `string` (the selected item's `value`).
-   * - `multiple` mode → pass a `string[]` (all selected values).
-   */
-  selectedValue?: string | string[];
   /**
    * Fired when a row is activated, once per toggle, with the item's `value`.
    *
@@ -57,6 +39,37 @@ export interface ActionListProps extends StyledPropsBlade, DataAnalyticsAttribut
    */
   testID?: string;
 }
+
+interface ActionListSingleProps extends ActionListBaseProps {
+  /**
+   * Selection mode: one item selected at a time.
+   *
+   * @default 'single'
+   */
+  selectionType?: 'single';
+  /**
+   * Currently selected item value (controlled). Pass the `value` of the
+   * selected `ActionListItem`. Drives `aria-selected` on rows.
+   */
+  selectedValue?: string;
+}
+
+interface ActionListMultipleProps extends ActionListBaseProps {
+  /**
+   * Selection mode: many items selectable. Each row renders a (visual,
+   * `aria-hidden`) checkbox indicator in place of its `leading` content.
+   * `aria-multiselectable` is set on the container.
+   */
+  selectionType: 'multiple';
+  /**
+   * Currently selected item values (controlled). Pass an array of `value`s
+   * for all selected `ActionListItem`s. Drives `aria-selected` on rows.
+   */
+  selectedValue?: string[];
+}
+
+/** Props for the `ActionList` container — `selectionType` discriminates `selectedValue`. */
+export type ActionListProps = ActionListSingleProps | ActionListMultipleProps;
 
 export interface ActionListItemProps extends DataAnalyticsAttribute {
   /**
@@ -137,7 +150,7 @@ export interface ActionListItemTextProps {
   /**
    * Caption text. Color follows the row's disabled state.
    */
-  children: Snippet | string;
+  children: Snippet;
 }
 
 /**

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -106,6 +106,10 @@ export {
   ActionListItem,
   ActionListItemAsset,
   ActionListItemText,
+  ActionListItemIcon,
+  ActionListItemAvatar,
+  ActionListItemBadge,
+  ActionListItemBadgeGroup,
   ActionListSection,
 } from './ActionList';
 export type {
@@ -113,6 +117,10 @@ export type {
   ActionListItemProps,
   ActionListItemAssetProps,
   ActionListItemTextProps,
+  ActionListItemIconProps,
+  ActionListItemAvatarProps,
+  ActionListItemBadgeProps,
+  ActionListItemBadgeGroupProps,
   ActionListSectionProps,
   ActionListSelectionType,
   ActionListItemClickPayload,

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -100,6 +100,25 @@ export type {
   CheckboxSize,
 } from './Checkbox/types';
 
+// ActionList
+export {
+  ActionList,
+  ActionListItem,
+  ActionListItemAsset,
+  ActionListItemText,
+  ActionListSection,
+} from './ActionList';
+export type {
+  ActionListProps,
+  ActionListItemProps,
+  ActionListItemAssetProps,
+  ActionListItemTextProps,
+  ActionListSectionProps,
+  ActionListSelectionType,
+  ActionListItemClickPayload,
+  ActionListItemSelectPayload,
+} from './ActionList';
+
 // Radio
 export { default as Radio } from './Radio/Radio.svelte';
 export { default as RadioGroup } from './Radio/RadioGroup.svelte';

--- a/packages/blade/src/components/BaseMenu/BaseMenuItem/StyledMenuItemContainer.web.tsx
+++ b/packages/blade/src/components/BaseMenu/BaseMenuItem/StyledMenuItemContainer.web.tsx
@@ -16,7 +16,7 @@ const StyledMenuItemContainer = styled(BaseBox)<StyledBaseMenuItemContainerProps
     [`@media ${getMediaQuery({ min: props.theme.breakpoints.m })}`]: {
       padding: makeSize(getItemPadding(props.theme).itemPaddingDesktop),
     },
-    '&:hover:not([aria-disabled=true]), &[aria-expanded="true"]': {
+    '&:hover:not([aria-disabled=true]):not([aria-selected=true]), &[aria-expanded="true"]': {
       backgroundColor:
         props.color === 'negative'
           ? props.theme.colors.interactive.background.negative.faded
@@ -27,10 +27,7 @@ const StyledMenuItemContainer = styled(BaseBox)<StyledBaseMenuItemContainerProps
       ? getFocusRingStyles({ theme: props.theme })
       : undefined,
     '&[aria-selected=true], &[aria-selected=true]:hover': {
-      backgroundColor:
-        props.selectionType === 'single'
-          ? props.theme.colors.interactive.background.gray.fadedHighlighted
-          : undefined,
+      backgroundColor: props.theme.colors.interactive.background.gray.fadedHighlighted,
     },
   };
 });

--- a/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.web.test.tsx.snap
+++ b/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.web.test.tsx.snap
@@ -482,7 +482,7 @@ exports[`<BottomSheet /> should compose with DropdownButton 1`] = `
   margin-bottom: 2px;
 }
 
-.c18.c18.c18.c18.c18:hover:not([aria-disabled=true]),
+.c18.c18.c18.c18.c18:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c18.c18.c18.c18.c18[aria-expanded="true"] {
   background-color: hsla(206,10%,29%,0.06);
 }
@@ -525,7 +525,7 @@ exports[`<BottomSheet /> should compose with DropdownButton 1`] = `
   margin-bottom: 2px;
 }
 
-.c25.c25.c25.c25.c25:hover:not([aria-disabled=true]),
+.c25.c25.c25.c25.c25:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c25.c25.c25.c25.c25[aria-expanded="true"] {
   background-color: hsla(4,85%,44%,0.09);
 }

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.web.test.tsx.snap
@@ -1799,7 +1799,7 @@ exports[`<BottomSheet /> & <Dropdown /> with <AutoComplete /> should render Bott
   margin-bottom: 2px;
 }
 
-.c45.c45.c45.c45.c45:hover:not([aria-disabled=true]),
+.c45.c45.c45.c45.c45:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c45.c45.c45.c45.c45[aria-expanded="true"] {
   background-color: hsla(206,10%,29%,0.06);
 }

--- a/packages/blade/src/components/Menu/__tests__/__snapshots__/Menu.web.test.tsx.snap
+++ b/packages/blade/src/components/Menu/__tests__/__snapshots__/Menu.web.test.tsx.snap
@@ -243,7 +243,7 @@ exports[`Menu renders a Menu 1`] = `
   margin-bottom: 2px;
 }
 
-.c22.c22.c22.c22.c22:hover:not([aria-disabled=true]),
+.c22.c22.c22.c22.c22:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c22.c22.c22.c22.c22[aria-expanded="true"] {
   background-color: hsla(206,10%,29%,0.06);
 }
@@ -286,7 +286,7 @@ exports[`Menu renders a Menu 1`] = `
   margin-bottom: 2px;
 }
 
-.c31.c31.c31.c31.c31:hover:not([aria-disabled=true]),
+.c31.c31.c31.c31.c31:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c31.c31.c31.c31.c31[aria-expanded="true"] {
   background-color: hsla(4,85%,44%,0.09);
 }
@@ -1314,7 +1314,7 @@ exports[`Menu should support data-analytics attribute 1`] = `
   margin-bottom: 2px;
 }
 
-.c22.c22.c22.c22.c22:hover:not([aria-disabled=true]),
+.c22.c22.c22.c22.c22:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c22.c22.c22.c22.c22[aria-expanded="true"] {
   background-color: hsla(206,10%,29%,0.06);
 }
@@ -1357,7 +1357,7 @@ exports[`Menu should support data-analytics attribute 1`] = `
   margin-bottom: 2px;
 }
 
-.c31.c31.c31.c31.c31:hover:not([aria-disabled=true]),
+.c31.c31.c31.c31.c31:hover:not([aria-disabled=true]):not([aria-selected=true]),
 .c31.c31.c31.c31.c31[aria-expanded="true"] {
   background-color: hsla(4,85%,44%,0.09);
 }


### PR DESCRIPTION
## Description

Migrates the React `ActionList` to **Svelte 5** as a scoped, **BottomSheet-mode, single-select** slice. This is unit 1 of the Input-family migration: it is consumed by `BottomSheetBody hasActionList` today and will back `PhoneNumberInput`'s `CountrySelector` in the follow-up Input PR (which branches off this one).

This is intentionally **not** a full port of React's ActionList surface.

## Changes

- Adds `packages/blade-svelte/src/components/ActionList/`
  - `ActionList.svelte`, `ActionListItem.svelte`, `ActionListItemAsset.svelte`, `ActionListItemText.svelte`, `ActionListSection.svelte`
  - `actionListContext.ts`, `getA11yRoles.ts`, `types.ts`, `index.ts`, `ActionList.stories.svelte`
- Adds `packages/blade-core/src/styles/ActionList/` (`actionList.module.css` + `actionList.ts` CVA + `index.ts`)
- Re-exports `ActionList`, `ActionListItem`, `ActionListItemAsset`, `ActionListItemText`, `ActionListSection` (+ `*Props`) from `packages/blade-svelte/src/components/index.ts`
- Registers ActionList styles in `packages/blade-core/src/styles/index.ts`
- Adds changeset (`@razorpay/blade-core`: patch, `@razorpay/blade-svelte`: patch)

## Key design decisions

- **Single-layer** — React has no `BaseActionList`; the `BaseMenuItem` row primitive is **inlined** into `ActionListItem.svelte`.
- **Standalone `ActionListContext`** (`selectionType: 'single'`, `selectedValue`, `onItemSelect`, `isInBottomSheet`) replaces React's `useDropdown` coupling. Selection is keyed on `value` (no `React.Children`; items are child components that read context).
- **`isInBottomSheet`** resolves from the migrated BottomSheet context (falls back to a prop). When inside a sheet, the outer box (border/shadow/padding) is dropped so `BottomSheetBody` owns scroll bounds — mirrors React's branch.
- **No virtualization** — rows render in a plain `max-height` + `overflow-y: auto` container. `react-window` is React-only and blade-svelte has no windowing dependency; ~200 country rows render fine. **The `isVirtualized` prop is dropped from the public API.**

## Out of scope (intentionally stripped — deferred to a later Dropdown batch if ever needed)

- `useDropdown` / `Dropdown` / `DropdownOverlay` / `SelectInput` / `FilterChip` / `DropdownFooter`
- AutoComplete filtering + `ActionListNoResults`, multiselect (Checkbox-in-row), keyboard roving / active-descendant
- React Native parity (`*.native` files), `titleSuffix` (Badge)

## Verification

- `svelte-check` + blade-core `build` clean for all new files.
- Computed-style parity vs React `BaseMenuItem`: row radius 8px, margin 2px, padding 8px, title 14px/400, 1-line truncate — exact match; disabled/negative/normal/selected token colors correct.
- Behavior: single-select round-trips + closes the sheet; disabled rows guarded; `href` rows render `<a role=link>`, others `<button role=option>`.
- A11y: container `role=listbox` (`aria-multiselectable=false`), items `role=option` + `aria-selected`/`aria-disabled`, sections `role=group` with last-divider hidden.
- Stories are BottomSheet-hosted (`Components/ActionList`), including a 10-country single-select list proving the CountrySelector usage.

## Component Checklist

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset


Made with [Cursor](https://cursor.com)