### PR TITLE
fix(blade-svelte): close gap between Tooltip arrow and bubble on left/right placements

### DIFF
--- a/.changeset/blade-svelte-tooltip-arrow-gap.md
+++ b/.changeset/blade-svelte-tooltip-arrow-gap.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade-svelte": patch
+---
+
+fix(blade-svelte): close gap between Tooltip arrow and bubble on left/right placements
+
+The arrow SVG was rendered non-square (14×8). Left/right placements rotate the arrow ±90° about its center, which shifted the flat base off the bubble edge by `(width - height) / 2` (3px), leaving a visible gap. The SVG box is now square (14×14), mirroring `@floating-ui/react`'s `FloatingArrow`, so the base stays flush on every side.

--- a/packages/blade-svelte/src/components/Tooltip/Tooltip.svelte
+++ b/packages/blade-svelte/src/components/Tooltip/Tooltip.svelte
@@ -302,13 +302,19 @@
         <p class={tooltipTitleClass}>{title}</p>
       {/if}
       <p class={tooltipContentClass}>{content}</p>
+      <!-- The SVG box is square (ARROW_WIDTH × ARROW_WIDTH), mirroring
+           @floating-ui/react's FloatingArrow (height={width}, viewBox 0 0 W W).
+           Left/right placements rotate the arrow ±90° about its center; a
+           non-square box would shift the flat base off the bubble edge by
+           (width - height) / 2, leaving a gap. The path apex still sits at
+           ARROW_HEIGHT within the taller viewBox. -->
       <svg
         bind:this={arrowEl}
         class={tooltipArrowClass}
         style={arrowStyle}
         width={ARROW_WIDTH}
-        height={ARROW_HEIGHT}
-        viewBox="0 0 {ARROW_WIDTH} {ARROW_HEIGHT}"
+        height={ARROW_WIDTH}
+        viewBox="0 0 {ARROW_WIDTH} {ARROW_WIDTH}"
         aria-hidden="true"
       >
         <path d={ARROW_PATH} />


### PR DESCRIPTION
## Description

On `left` / `right` placements the Svelte `Tooltip` rendered a visible gap between the arrow (triangle) and the tooltip bubble body. `top` / `bottom` were unaffected.

## Root cause

The arrow SVG was rendered **non-square** (`14×8`, `viewBox="0 0 14 8"`). Left/right placements rotate the arrow **±90° about its center**. Rotating a non-square box moves its bounding box, shifting the flat base off the bubble edge by `(width − height) / 2 = (14 − 8) / 2 = 3px`. Top/bottom use `0°`/`180°` rotation, so they stayed flush.

`@floating-ui/react`'s `FloatingArrow` (used by React Blade via `PopupArrow`) avoids this by rendering a **square** SVG — `height = width` with `viewBox="0 0 14 14"` — and only uses `height` for the path apex math. The Svelte port had dropped that detail.

## Fix

Make the arrow SVG box square (`ARROW_WIDTH × ARROW_WIDTH`), matching `FloatingArrow`. Rotating a square about its center does not move its bounding box, so the base stays flush on every side. The path (apex at `ARROW_HEIGHT`) is unchanged and sits inside the taller `viewBox`.

```diff
-        height={ARROW_HEIGHT}
-        viewBox="0 0 {ARROW_WIDTH} {ARROW_HEIGHT}"
+        height={ARROW_WIDTH}
+        viewBox="0 0 {ARROW_WIDTH} {ARROW_WIDTH}"
```

## Verification

Measured arrow-base → bubble-edge gap in Storybook (`Components/Tooltip → Placement`) via `getBoundingClientRect`:

| Placement    | Before | After |
| ------------ | ------ | ----- |
| top-start    | 0      | 0     |
| top          | 0      | 0     |
| top-end      | 0      | 0     |
| left         | 3px    | **0** |
| right        | 3px    | **0** |
| bottom-start | 0      | 0     |
| bottom       | 0      | 0     |
| bottom-end   | 0      | 0     |

Dark mode (1px arrow stroke): uniform `−1px` on all sides (stroked base tucks under the bubble edge — no seam, no side-specific shift).

`yarn svelte-check`: 0 errors.

## Component Checklist

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset

Made with [Cursor](https://cursor.com)