### PR TITLE
chore(blade-svelte): expose hasGrayBody on Accordion Storybook controls

### DIFF
--- a/packages/blade-svelte/src/components/Accordion/Accordion.stories.svelte
+++ b/packages/blade-svelte/src/components/Accordion/Accordion.stories.svelte
@@ -10,6 +10,7 @@
       variant: 'transparent',
       size: 'large',
       showNumberPrefix: false,
+      hasGrayBody: false,
     },
     argTypes: {
       variant: {
@@ -27,6 +28,12 @@
       showNumberPrefix: {
         control: 'boolean',
         description: 'Adds numeric index at the beginning of items',
+        table: { defaultValue: { summary: 'false' } },
+      },
+      hasGrayBody: {
+        control: 'boolean',
+        description:
+          'Renders expanded body on a recessed gray surface. Recommended with variant="filled" for checkout-style accordions.',
         table: { defaultValue: { summary: 'false' } },
       },
     },


### PR DESCRIPTION
## Summary
- Adds `hasGrayBody` to Accordion Playground `args` and `argTypes` so the recessed gray body surface can be toggled from Storybook Controls
- Playground already spreads `{...args}` onto `Accordion`, so no story template changes were needed

## Test plan
- [ ] Open blade-svelte Storybook → Components/Accordion → Playground
- [ ] Toggle `hasGrayBody` in Controls and confirm expanded body shows gray surface
- [ ] Set `variant` to `filled` + `hasGrayBody` true to verify checkout-style accordion


Made with [Cursor](https://cursor.com)