### PR TITLE
fix(blade-svelte): unique id per TextInput instance

### DIFF
--- a/.changeset/blade-svelte-textinput-unique-id.md
+++ b/.changeset/blade-svelte-textinput-unique-id.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade-svelte": patch
+---
+
+fix(blade-svelte): give each TextInput instance a unique id via useFormId
+
+TextInput hardcoded `id="textinput"`, so multiple instances emitted duplicate DOM ids and broke label / aria-labelledby / aria-describedby associations. It now uses `useFormId('textinput', id)` (matching SearchInput/OTPInput/PhoneNumberInput) and accepts an optional `id` prop.

--- a/packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte
+++ b/packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import { makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import { useFormId } from '../BaseInput/useFormId';
   import BaseInput from '../BaseInput/BaseInput.svelte';
   import CharacterCounter from '../_Form/CharacterCounter.svelte';
   import IconButton from '../../Button/IconButton/IconButton.svelte';
@@ -21,6 +22,7 @@
     defaultValue,
     value,
     name,
+    id,
     onChange,
     onFocus,
     onBlur,
@@ -55,6 +57,8 @@
     testID,
     ...rest
   }: TextInputProps = $props();
+
+  const ids = useFormId('textinput', id);
 
   let baseInput = $state<{ focus: () => void; getInput: () => HTMLInputElement | null } | null>(
     null,
@@ -147,7 +151,7 @@
 
 <BaseInput
   bind:this={baseInput}
-  id="textinput"
+  id={ids.baseId}
   {componentName}
   label={label ?? ''}
   hideLabelText={!label}

--- a/packages/blade-svelte/src/components/Input/TextInput/types.ts
+++ b/packages/blade-svelte/src/components/Input/TextInput/types.ts
@@ -131,6 +131,8 @@ interface TextInputCommonProps extends StyledPropsBlade, DataAnalyticsAttribute 
   componentName?: string;
   /** Test ID for the element. */
   testID?: string;
+  /** Optional stable HTML id for the underlying input. Auto-generated when omitted. */
+  id?: string;
 }
 
 export type TextInputProps = (TextInputPropsWithLabel | TextInputPropsWithA11yLabel) &


### PR DESCRIPTION
## Summary

The Svelte `TextInput` passed a hardcoded `id="textinput"` to `BaseInput`. Since `BaseInput` derives all sub-ids (`-input`, `-label`, `-helptext`, `-errortext`, `-successtext`) directly from that `id` without uniquification, **every `<TextInput>` on a page emitted identical DOM ids**. This produced duplicate HTML ids and broke `<label for>` / `aria-labelledby` / `aria-describedby` associations, causing screen-reader mis-association (a11y bug).

This is the localized fix that mirrors the pattern already used by the sibling leaves:
- `SearchInput` → `useFormId('searchinput')`
- `OTPInput` → `useFormId('otp')`
- `PhoneNumberInput` → `useFormId('phone-number-input', id)`

`TextInput` was the only input that forgot. It now:
- imports `useFormId` and computes `const ids = useFormId('textinput', id)`
- passes `id={ids.baseId}` to `BaseInput` (so each instance gets a unique, stable id)
- accepts an optional `id` prop (destructured out of `...rest` so it isn't double-applied)

`BaseInput` and the other leaves are intentionally left untouched (no larger "move `useFormId` into `BaseInput`" refactor).

Follow-up to the review of #3637 (blade-svelte Input family), which introduced `TextInput`.

> Note on base branch: #3637 has since merged into `master` (`TextInput.svelte` now lives on `master`), so this PR bases off `master` to keep the diff scoped to exactly the fix. Basing off the now-merged `feat/blade-svelte-input-v1` would drag in unrelated commits that landed on `master` afterward.

## Changes
- `packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte`
- `packages/blade-svelte/src/components/Input/TextInput/types.ts`
- `.changeset/blade-svelte-textinput-unique-id.md` (patch)

## Test plan
- [x] `yarn svelte-check` — 0 errors (7 pre-existing unrelated `context="module"` story warnings)
- [x] `yarn build` — types generation + rollup pass
- [x] `git diff` scoped to only the 3 files above
- [ ] Render two `<TextInput label="A" />` `<TextInput label="B" />` on one page and confirm each renders distinct `*-input` / `*-label` ids and correct `for` / `aria-*` wiring

Made with [Cursor](https://cursor.com)