### PR TITLE
feat(rn): add React Native support for TimePicker

### DIFF
--- a/.changeset/timepicker-react-native-support.md
+++ b/.changeset/timepicker-react-native-support.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+Add React Native support for TimePicker with spin-wheel picker inside BottomSheet

--- a/packages/blade/.storybook/react-native/preview.tsx
+++ b/packages/blade/.storybook/react-native/preview.tsx
@@ -2,11 +2,23 @@ import 'react-native-gesture-handler';
 import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
 import { StyleSheet } from 'react-native';
 import { View } from 'react-native';
+import { PortalHost } from '@gorhom/portal';
 
+// `@storybook/react-native-ui` wraps every story in `@gorhom/bottom-sheet`'s
+// `BottomSheetModalProvider`, which nests its OWN `PortalProvider` between the story
+// and the app-level `BladeBottomSheetPortal` host declared in `BladeProvider.native`.
+// `usePortal()` resolves to that nearest (Storybook) provider, so portal components
+// (Drawer, BottomSheet, Popover, Tooltip, Modal, …) target a provider that has no
+// `BladeBottomSheetPortal` host and their teleported content is silently dropped —
+// making them impossible to verify on-device. Registering the same-named host inside
+// the story decorator makes it resolvable on the nearest provider so portal content
+// renders within the story canvas. Production is unaffected (a real app has only the
+// single BladeProvider host).
 export const decorators = [
   (StoryFn) => (
     <View style={styles.container}>
       <StoryFn />
+      <PortalHost name="BladeBottomSheetPortal" />
     </View>
   ),
   withBackgrounds,
@@ -21,5 +33,9 @@ export const parameters = {
 };
 
 const styles = StyleSheet.create({
-  container: { padding: 16 },
+  // `flex: 1` lets the container fill the story canvas so absolutely-positioned
+  // portal content (e.g. the full-height BottomSheet) can size against a real
+  // viewport instead of collapsing to the intrinsic height of the story's inline
+  // content.
+  container: { flex: 1, padding: 16 },
 });

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -4,15 +4,16 @@
 import GorhomBottomSheet, {
   BottomSheetFooter as GorhomBottomSheetFooter,
 } from '@gorhom/bottom-sheet';
+import type { BottomSheetBackgroundProps } from '@gorhom/bottom-sheet';
 import React from 'react';
 import { Portal } from '@gorhom/portal';
-import styled from 'styled-components/native';
 import { Dimensions, AccessibilityInfo, findNodeHandle, View, Keyboard } from 'react-native';
 import { BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetGrabHandle } from './BottomSheetGrabHandle';
 import { BottomSheetBody } from './BottomSheetBody';
 import { BottomSheetFooter } from './BottomSheetFooter';
 import type { BottomSheetProps } from './types';
+import { computeMaxContent } from './utils';
 import { ComponentIds } from './componentIds';
 import type { BottomSheetContextProps } from './BottomSheetContext';
 import { BottomSheetContext, useBottomSheetAndDropdownGlue } from './BottomSheetContext';
@@ -20,6 +21,7 @@ import { BottomSheetBackdrop } from './BottomSheetBackdrop';
 import { useBottomSheetStack } from './BottomSheetStack';
 import { DropdownContext, useDropdown } from '~components/Dropdown/useDropdown';
 import BaseBox from '~components/Box/BaseBox';
+import { useTheme } from '~components/BladeProvider';
 import { useId } from '~utils/useId';
 import { useIsomorphicLayoutEffect } from '~utils/useIsomorphicLayoutEffect';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
@@ -27,17 +29,25 @@ import { makeSpace } from '~utils/makeSpace';
 import { getComponentId } from '~utils/isValidAllowedChildren';
 import { componentZIndices } from '~utils/componentZIndices';
 
-const BottomSheetSurface = styled(BaseBox)(({ theme }) => {
-  return {
-    // TODO: we do not have 16px radius token
-    borderTopLeftRadius: makeSpace(theme.spacing[5]),
-    borderTopRightRadius: makeSpace(theme.spacing[5]),
-    backgroundColor: theme.colors.popup.background.gray.subtle,
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'relative',
-  };
-});
+const BottomSheetBackground = ({
+  style,
+}: BottomSheetBackgroundProps): React.ReactElement => {
+  const { theme } = useTheme();
+
+  return (
+    <View
+      pointerEvents="none"
+      style={[
+        style,
+        {
+          borderTopLeftRadius: makeSpace(theme.spacing[5]),
+          borderTopRightRadius: makeSpace(theme.spacing[5]),
+          backgroundColor: theme.colors.popup.background.gray.subtle,
+        },
+      ]}
+    />
+  );
+};
 
 const focusOnElement = (element: React.Component<any, any>): void => {
   const reactTag = findNodeHandle(element);
@@ -52,6 +62,7 @@ const _BottomSheet = ({
   isOpen,
   onDismiss,
   isDismissible = true,
+  enableContentPanningGesture = true,
   initialFocusRef,
   zIndex = componentZIndices.bottomSheet,
 }: BottomSheetProps): React.ReactElement => {
@@ -68,6 +79,33 @@ const _BottomSheet = ({
   const [hasBodyPadding, setHasBodyPadding] = React.useState(true);
   const [isHeaderEmpty, setIsHeaderEmpty] = React.useState(false);
   const initialSnapPoint = React.useRef<number>(0);
+  const lastSnappedIndexRef = React.useRef<number | null>(null);
+  const isOpenRef = React.useRef(Boolean(_isOpen));
+  isOpenRef.current = Boolean(_isOpen);
+  // Gorhom emits `onClose` for programmatic snap/close as well as user dismiss.
+  // Suppress parent `onDismiss` during our own sheet animations.
+  const suppressDismissRef = React.useRef(false);
+  const suppressDismissTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const suppressDismiss = React.useCallback((duration = 600): void => {
+    if (suppressDismissTimeoutRef.current) {
+      clearTimeout(suppressDismissTimeoutRef.current);
+    }
+    suppressDismissRef.current = true;
+    suppressDismissTimeoutRef.current = setTimeout(() => {
+      suppressDismissRef.current = false;
+      suppressDismissTimeoutRef.current = null;
+    }, duration);
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (suppressDismissTimeoutRef.current) {
+        clearTimeout(suppressDismissTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const totalHeight = React.useMemo(() => {
     return headerHeight + footerHeight + contentHeight;
   }, [contentHeight, footerHeight, headerHeight]);
@@ -87,36 +125,70 @@ const _BottomSheet = ({
     if (bottomSheetAndDropdownGlue?.hasAutoCompleteInHeader) {
       // In AutoComplete, we want to open BottomSheet with max height so we set this to last index
       initialSnapPoint.current = 2;
+    } else if (totalHeight > 0) {
+      // Content-fitted snap at index 0 once heights are measured
+      initialSnapPoint.current = 0;
     } else {
       const height = Dimensions.get('window').height;
       const middleSnapPoint = snapPoints[1] * height;
       if (totalHeight > middleSnapPoint) {
         initialSnapPoint.current = 1;
+      } else {
+        initialSnapPoint.current = 0;
       }
     }
-  }, [snapPoints, totalHeight]);
+  }, [snapPoints, totalHeight, bottomSheetAndDropdownGlue?.hasAutoCompleteInHeader]);
 
-  const _snapPoints = React.useMemo(() => snapPoints.map((point) => `${point * 100}%`), [
-    snapPoints,
-  ]);
-
-  const close = React.useCallback(() => {
-    if (isDismissible) {
-      onDismiss?.();
-      bottomSheetAndDropdownGlue?.onBottomSheetDismiss?.();
+  const windowHeight = Dimensions.get('window').height;
+  const _snapPoints = React.useMemo(() => {
+    if (totalHeight > 0) {
+      const fittedHeight = computeMaxContent({
+        maxHeight: windowHeight * snapPoints[2],
+        headerHeight,
+        footerHeight,
+        contentHeight,
+      });
+      const fittedSnap = Math.min(
+        Math.max(fittedHeight / windowHeight, snapPoints[0]),
+        snapPoints[2],
+      );
+      return [
+        `${fittedSnap * 100}%`,
+        `${snapPoints[1] * 100}%`,
+        `${snapPoints[2] * 100}%`,
+      ];
     }
+    return snapPoints.map((point) => `${point * 100}%`);
+  }, [snapPoints, totalHeight, headerHeight, footerHeight, contentHeight, windowHeight]);
+
+  const dismissSheet = React.useCallback(() => {
+    if (!isDismissible) return;
+    onDismiss?.();
+    bottomSheetAndDropdownGlue?.onBottomSheetDismiss?.();
   }, [isDismissible, onDismiss, bottomSheetAndDropdownGlue]);
 
+  const handleSheetClosed = React.useCallback(() => {
+    if (!isDismissible) return;
+    if (suppressDismissRef.current) return;
+    // Ignore stale close events once React state is already closed.
+    if (!isOpenRef.current) return;
+    dismissSheet();
+  }, [dismissSheet, isDismissible]);
+
   const handleOnOpen = React.useCallback(() => {
-    sheetRef.current?.snapToIndex(initialSnapPoint.current);
-  }, []);
+    suppressDismiss();
+    const targetIndex = initialSnapPoint.current;
+    lastSnappedIndexRef.current = targetIndex;
+    sheetRef.current?.snapToIndex(targetIndex);
+  }, [suppressDismiss]);
 
   const handleOnClose = React.useCallback(() => {
+    suppressDismiss();
     sheetRef.current?.close();
     // We need this because if inside the BottomSheet there is a input which is focused
     // and user dragged down to close the sheet, even after closing the sheet the input will remain focused
     Keyboard.dismiss();
-  }, [sheetRef]);
+  }, [suppressDismiss]);
 
   // sync controlled state to our actions
   React.useEffect(() => {
@@ -130,9 +202,19 @@ const _BottomSheet = ({
         focusOnElement(initialFocusRef.current);
       }
     } else {
+      lastSnappedIndexRef.current = null;
       handleOnClose();
     }
   }, [_isOpen, handleOnClose, handleOnOpen, initialFocusRef]);
+
+  React.useEffect(() => {
+    if (!_isOpen || totalHeight === 0) return;
+    const targetIndex = initialSnapPoint.current;
+    if (lastSnappedIndexRef.current === targetIndex) return;
+    lastSnappedIndexRef.current = targetIndex;
+    suppressDismiss();
+    sheetRef.current?.snapToIndex(targetIndex);
+  }, [_isOpen, totalHeight, suppressDismiss]);
 
   // let the Dropdown component know that it's rendering a bottomsheet
   React.useEffect(() => {
@@ -175,9 +257,11 @@ const _BottomSheet = ({
 
   const renderBackdrop = React.useCallback(
     (props: any): React.ReactElement => {
-      return <BottomSheetBackdrop {...props} zIndex={bottomSheetZIndex} />;
+      return (
+        <BottomSheetBackdrop {...props} zIndex={bottomSheetZIndex} isDismissible={isDismissible} />
+      );
     },
-    [bottomSheetZIndex],
+    [bottomSheetZIndex, isDismissible],
   );
 
   const renderHandle = React.useCallback((): React.ReactElement => {
@@ -204,7 +288,7 @@ const _BottomSheet = ({
     () => ({
       isInBottomSheet: true,
       isOpen: Boolean(_isOpen),
-      close: handleOnClose,
+      close: dismissSheet,
       positionY: 0,
       headerHeight,
       contentHeight,
@@ -224,7 +308,7 @@ const _BottomSheet = ({
       _isOpen,
       contentHeight,
       footerHeight,
-      handleOnClose,
+      dismissSheet,
       headerHeight,
       isHeaderFloating,
       isDismissible,
@@ -272,7 +356,7 @@ const _BottomSheet = ({
             style={
               // only render shadow when the sheet is open,
               // otherwise there is visible shadow leak from the bottom edge of the screen
-              isOpen
+              _isOpen
                 ? {
                     // this is reverse top elevation of highRaised elevation token
                     shadowColor: 'hsla(217,56%,17%,0.64)',
@@ -289,18 +373,18 @@ const _BottomSheet = ({
             }
             enablePanDownToClose={isDismissible}
             enableOverDrag
-            enableContentPanningGesture
+            enableContentPanningGesture={enableContentPanningGesture}
             ref={sheetRef}
             // on initial render if _isOpen is true we want to render the sheet at initialSnapPoint
             // otherwise we want to render it at -1 so that it is not visible
             index={_isOpen ? initialSnapPoint.current : -1}
-            containerStyle={{ zIndex: bottomSheetZIndex }}
+            containerStyle={{ zIndex: bottomSheetZIndex, elevation: bottomSheetZIndex }}
             animateOnMount={true}
             handleComponent={renderHandle}
-            backgroundComponent={BottomSheetSurface}
+            backgroundComponent={BottomSheetBackground}
             footerComponent={renderFooter}
             backdropComponent={renderBackdrop}
-            onClose={close}
+            onClose={handleSheetClosed}
             snapPoints={_snapPoints}
           >
             {body}

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -28,9 +28,7 @@ import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { getComponentId } from '~utils/isValidAllowedChildren';
 import { componentZIndices } from '~utils/componentZIndices';
 
-const BottomSheetBackground = ({
-  style,
-}: BottomSheetBackgroundProps): React.ReactElement => {
+const BottomSheetBackground = ({ style }: BottomSheetBackgroundProps): React.ReactElement => {
   const { theme } = useTheme();
 
   return (
@@ -151,11 +149,7 @@ const _BottomSheet = ({
         Math.max(fittedHeight / windowHeight, snapPoints[0]),
         snapPoints[2],
       );
-      return [
-        `${fittedSnap * 100}%`,
-        `${snapPoints[1] * 100}%`,
-        `${snapPoints[2] * 100}%`,
-      ];
+      return [`${fittedSnap * 100}%`, `${snapPoints[1] * 100}%`, `${snapPoints[2] * 100}%`];
     }
     return snapPoints.map((point) => `${point * 100}%`);
   }, [snapPoints, totalHeight, headerHeight, footerHeight, contentHeight, windowHeight]);

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -59,7 +59,7 @@ const _BottomSheet = ({
   isOpen,
   onDismiss,
   isDismissible = true,
-  enableContentPanningGesture = true,
+  isContentPanningGestureEnabled = true,
   initialFocusRef,
   zIndex = componentZIndices.bottomSheet,
 }: BottomSheetProps): React.ReactElement => {
@@ -366,7 +366,7 @@ const _BottomSheet = ({
             }
             enablePanDownToClose={isDismissible}
             enableOverDrag
-            enableContentPanningGesture={enableContentPanningGesture}
+            enableContentPanningGesture={isContentPanningGestureEnabled}
             ref={sheetRef}
             // on initial render if _isOpen is true we want to render the sheet at initialSnapPoint
             // otherwise we want to render it at -1 so that it is not visible

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -76,31 +76,16 @@ const _BottomSheet = ({
   const [hasBodyPadding, setHasBodyPadding] = React.useState(true);
   const [isHeaderEmpty, setIsHeaderEmpty] = React.useState(false);
   const initialSnapPoint = React.useRef<number>(0);
-  const lastSnappedIndexRef = React.useRef<number | null>(null);
+  const lastSnappedSnapPointRef = React.useRef<string | null>(null);
   const isOpenRef = React.useRef(Boolean(_isOpen));
   isOpenRef.current = Boolean(_isOpen);
   // Gorhom emits `onClose` for programmatic snap/close as well as user dismiss.
-  // Suppress parent `onDismiss` during our own sheet animations.
-  const suppressDismissRef = React.useRef(false);
-  const suppressDismissTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Increment before our own animations; consume one count per `onClose` so we
+  // stay in sync with Gorhom instead of relying on a timeout.
+  const suppressDismissCountRef = React.useRef(0);
 
-  const suppressDismiss = React.useCallback((duration = 600): void => {
-    if (suppressDismissTimeoutRef.current) {
-      clearTimeout(suppressDismissTimeoutRef.current);
-    }
-    suppressDismissRef.current = true;
-    suppressDismissTimeoutRef.current = setTimeout(() => {
-      suppressDismissRef.current = false;
-      suppressDismissTimeoutRef.current = null;
-    }, duration);
-  }, []);
-
-  React.useEffect(() => {
-    return () => {
-      if (suppressDismissTimeoutRef.current) {
-        clearTimeout(suppressDismissTimeoutRef.current);
-      }
-    };
+  const suppressDismiss = React.useCallback((): void => {
+    suppressDismissCountRef.current += 1;
   }, []);
 
   const totalHeight = React.useMemo(() => {
@@ -162,7 +147,10 @@ const _BottomSheet = ({
 
   const handleSheetClosed = React.useCallback(() => {
     if (!isDismissible) return;
-    if (suppressDismissRef.current) return;
+    if (suppressDismissCountRef.current > 0) {
+      suppressDismissCountRef.current -= 1;
+      return;
+    }
     // Ignore stale close events once React state is already closed.
     if (!isOpenRef.current) return;
     dismissSheet();
@@ -170,9 +158,7 @@ const _BottomSheet = ({
 
   const handleOnOpen = React.useCallback(() => {
     suppressDismiss();
-    const targetIndex = initialSnapPoint.current;
-    lastSnappedIndexRef.current = targetIndex;
-    sheetRef.current?.snapToIndex(targetIndex);
+    sheetRef.current?.snapToIndex(initialSnapPoint.current);
   }, [suppressDismiss]);
 
   const handleOnClose = React.useCallback(() => {
@@ -195,7 +181,7 @@ const _BottomSheet = ({
         focusOnElement(initialFocusRef.current);
       }
     } else {
-      lastSnappedIndexRef.current = null;
+      lastSnappedSnapPointRef.current = null;
       handleOnClose();
     }
   }, [_isOpen, handleOnClose, handleOnOpen, initialFocusRef]);
@@ -203,11 +189,12 @@ const _BottomSheet = ({
   React.useEffect(() => {
     if (!_isOpen || totalHeight === 0) return;
     const targetIndex = initialSnapPoint.current;
-    if (lastSnappedIndexRef.current === targetIndex) return;
-    lastSnappedIndexRef.current = targetIndex;
+    const targetSnapPoint = _snapPoints[targetIndex];
+    if (lastSnappedSnapPointRef.current === targetSnapPoint) return;
+    lastSnappedSnapPointRef.current = targetSnapPoint;
     suppressDismiss();
     sheetRef.current?.snapToIndex(targetIndex);
-  }, [_isOpen, totalHeight, suppressDismiss]);
+  }, [_isOpen, totalHeight, _snapPoints, suppressDismiss]);
 
   // let the Dropdown component know that it's rendering a bottomsheet
   React.useEffect(() => {

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -25,7 +25,6 @@ import { useTheme } from '~components/BladeProvider';
 import { useId } from '~utils/useId';
 import { useIsomorphicLayoutEffect } from '~utils/useIsomorphicLayoutEffect';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
-import { makeSpace } from '~utils/makeSpace';
 import { getComponentId } from '~utils/isValidAllowedChildren';
 import { componentZIndices } from '~utils/componentZIndices';
 
@@ -40,8 +39,8 @@ const BottomSheetBackground = ({
       style={[
         style,
         {
-          borderTopLeftRadius: makeSpace(theme.spacing[5]),
-          borderTopRightRadius: makeSpace(theme.spacing[5]),
+          borderTopLeftRadius: theme.spacing[5],
+          borderTopRightRadius: theme.spacing[5],
           backgroundColor: theme.colors.popup.background.gray.subtle,
         },
       ]}

--- a/packages/blade/src/components/BottomSheet/BottomSheetBackdrop.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheetBackdrop.native.tsx
@@ -15,10 +15,7 @@ const BottomSheetBackdrop = (
       disappearsOnIndex={-1}
       pressBehavior={props.isDismissible ? 'close' : 'none'}
       opacity={1}
-      style={[
-        props.style,
-        { backgroundColor: theme.colors.overlay.background.subtle, zIndex: props.zIndex },
-      ]}
+      style={[props.style, { backgroundColor: theme.colors.overlay.background.subtle }]}
     />
   );
 };

--- a/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
+++ b/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
@@ -9,6 +9,15 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
   }
 >
   <View
+    accessibilityHint="Tap to close the Bottom Sheet"
+    accessibilityLabel="Bottom Sheet backdrop"
+    accessibilityRole="button"
+    accessible={true}
+    collapsable={false}
+    handlerTag={4}
+    handlerType="TapGestureHandler"
+    onGestureHandlerEvent={[Function]}
+    onGestureHandlerStateChange={[Function]}
     pointerEvents="auto"
     style={
       [
@@ -25,7 +34,6 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
           },
           {
             "backgroundColor": "hsla(0, 0%, 0%, 0.56)",
-            "zIndex": 100,
           },
         ],
         {
@@ -41,6 +49,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
     style={
       [
         {
+          "elevation": 100,
           "zIndex": 100,
         },
         {
@@ -89,37 +98,20 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
       }
     >
       <View
-        animatedIndex={
-          {
-            "value": -1,
-          }
-        }
-        animatedPosition={
-          {
-            "value": 1334,
-          }
-        }
-        data-blade-component="base-box"
         pointerEvents="none"
         style={
           [
-            {
-              "pointerEvents": "none",
-            },
-            {
-              "alignItems": "center",
-              "backgroundColor": "hsla(0, 0%, 100%, 1)",
-              "borderTopLeftRadius": 16,
-              "borderTopRightRadius": 16,
-              "justifyContent": "center",
-              "position": "relative",
-            },
             {
               "bottom": 0,
               "left": 0,
               "position": "absolute",
               "right": 0,
               "top": 0,
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 100%, 1)",
+              "borderTopLeftRadius": "16px",
+              "borderTopRightRadius": "16px",
             },
           ]
         }
@@ -139,7 +131,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
       >
         <View
           collapsable={false}
-          handlerTag={1}
+          handlerTag={2}
           handlerType="PanGestureHandler"
           onGestureHandlerEvent={[Function]}
           onGestureHandlerStateChange={[Function]}
@@ -612,7 +604,7 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
         accessibilityRole="adjustable"
         accessible={true}
         collapsable={false}
-        handlerTag={2}
+        handlerTag={3}
         handlerType="PanGestureHandler"
         onGestureHandlerEvent={[Function]}
         onGestureHandlerStateChange={[Function]}
@@ -1310,6 +1302,15 @@ exports[`<BottomSheet /> should render empty header 1`] = `
   }
 >
   <View
+    accessibilityHint="Tap to close the Bottom Sheet"
+    accessibilityLabel="Bottom Sheet backdrop"
+    accessibilityRole="button"
+    accessible={true}
+    collapsable={false}
+    handlerTag={8}
+    handlerType="TapGestureHandler"
+    onGestureHandlerEvent={[Function]}
+    onGestureHandlerStateChange={[Function]}
     pointerEvents="auto"
     style={
       [
@@ -1326,7 +1327,6 @@ exports[`<BottomSheet /> should render empty header 1`] = `
           },
           {
             "backgroundColor": "hsla(0, 0%, 0%, 0.56)",
-            "zIndex": 100,
           },
         ],
         {
@@ -1342,6 +1342,7 @@ exports[`<BottomSheet /> should render empty header 1`] = `
     style={
       [
         {
+          "elevation": 100,
           "zIndex": 100,
         },
         {
@@ -1390,37 +1391,20 @@ exports[`<BottomSheet /> should render empty header 1`] = `
       }
     >
       <View
-        animatedIndex={
-          {
-            "value": -1,
-          }
-        }
-        animatedPosition={
-          {
-            "value": 1334,
-          }
-        }
-        data-blade-component="base-box"
         pointerEvents="none"
         style={
           [
-            {
-              "pointerEvents": "none",
-            },
-            {
-              "alignItems": "center",
-              "backgroundColor": "hsla(0, 0%, 100%, 1)",
-              "borderTopLeftRadius": 16,
-              "borderTopRightRadius": 16,
-              "justifyContent": "center",
-              "position": "relative",
-            },
             {
               "bottom": 0,
               "left": 0,
               "position": "absolute",
               "right": 0,
               "top": 0,
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 100%, 1)",
+              "borderTopLeftRadius": "16px",
+              "borderTopRightRadius": "16px",
             },
           ]
         }
@@ -1440,7 +1424,7 @@ exports[`<BottomSheet /> should render empty header 1`] = `
       >
         <View
           collapsable={false}
-          handlerTag={3}
+          handlerTag={6}
           handlerType="PanGestureHandler"
           onGestureHandlerEvent={[Function]}
           onGestureHandlerStateChange={[Function]}
@@ -1913,7 +1897,7 @@ exports[`<BottomSheet /> should render empty header 1`] = `
         accessibilityRole="adjustable"
         accessible={true}
         collapsable={false}
-        handlerTag={4}
+        handlerTag={7}
         handlerType="PanGestureHandler"
         onGestureHandlerEvent={[Function]}
         onGestureHandlerStateChange={[Function]}

--- a/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
+++ b/packages/blade/src/components/BottomSheet/__tests__/__snapshots__/BottomSheet.native.test.tsx.snap
@@ -110,8 +110,8 @@ exports[`<BottomSheet /> should render Header/Footer/Body properly 1`] = `
             },
             {
               "backgroundColor": "hsla(0, 0%, 100%, 1)",
-              "borderTopLeftRadius": "16px",
-              "borderTopRightRadius": "16px",
+              "borderTopLeftRadius": 16,
+              "borderTopRightRadius": 16,
             },
           ]
         }
@@ -1403,8 +1403,8 @@ exports[`<BottomSheet /> should render empty header 1`] = `
             },
             {
               "backgroundColor": "hsla(0, 0%, 100%, 1)",
-              "borderTopLeftRadius": "16px",
-              "borderTopRightRadius": "16px",
+              "borderTopLeftRadius": 16,
+              "borderTopRightRadius": 16,
             },
           ]
         }

--- a/packages/blade/src/components/BottomSheet/types.ts
+++ b/packages/blade/src/components/BottomSheet/types.ts
@@ -27,6 +27,16 @@ type BottomSheetProps = {
    */
   isDismissible?: boolean;
   /**
+   * Whether dragging on the sheet's content pans/dismisses the sheet (native only).
+   *
+   * Disable this when the sheet contains its own interactive vertical scrollables
+   * (e.g. a picker wheel) so content drags scroll that content instead of fighting
+   * the sheet's pan-to-close gesture. The grab handle and backdrop still dismiss.
+   *
+   * @default true
+   */
+  enableContentPanningGesture?: boolean;
+  /**
    * Toggles bottom sheet state
    *
    * @default false

--- a/packages/blade/src/components/BottomSheet/types.ts
+++ b/packages/blade/src/components/BottomSheet/types.ts
@@ -35,7 +35,7 @@ type BottomSheetProps = {
    *
    * @default true
    */
-  enableContentPanningGesture?: boolean;
+  isContentPanningGestureEnabled?: boolean;
   /**
    * Toggles bottom sheet state
    *

--- a/packages/blade/src/components/TimePicker/SpinWheel.native.tsx
+++ b/packages/blade/src/components/TimePicker/SpinWheel.native.tsx
@@ -1,8 +1,180 @@
 import React from 'react';
-import { Text } from 'react-native';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+import { Pressable, ScrollView, View } from 'react-native';
+import { Text } from '~components/Typography';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import type { TestID } from '~utils/types';
 
-const SpinWheel = (_props: Record<string, unknown>): React.ReactElement => (
-  <Text>SpinWheel is not available on native</Text>
-);
+/**
+ * Wheel item geometry. `ITEM_HEIGHT` mirrors the web `StyledScrollItem` height,
+ * `VISIBLE_ITEMS` keeps the wheel roughly the same overall height as the web
+ * dropdown (~170px), and `SPACER` centers the first/last value under the
+ * highlight band.
+ */
+const ITEM_HEIGHT = 34;
+const VISIBLE_ITEMS = 5;
+const WHEEL_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS;
+const SPACER = (WHEEL_HEIGHT - ITEM_HEIGHT) / 2;
+const WHEEL_WIDTH = 72;
+
+export { ITEM_HEIGHT, VISIBLE_ITEMS, WHEEL_HEIGHT, SPACER, WHEEL_WIDTH };
+
+/**
+ * Native-only SpinWheel props.
+ *
+ * The shared `SpinWheelProps` in `types.ts` carries DOM-only members
+ * (`scrollContainerRef: React.Ref<HTMLDivElement>`, `tabIndex`) so it is NOT
+ * reused here. This local type keeps the value/selection contract while
+ * dropping the web-only ref plumbing.
+ */
+type SpinWheelNativeProps = {
+  values: (string | number)[];
+  selectedValue: string | number;
+  /**
+   * Optional display value for visual positioning when different from
+   * `selectedValue` (e.g. minute steps: typed "03" positions at "00" while the
+   * form value stays "03").
+   */
+  displayValue?: string | number;
+  onChange: (value: string | number, index: number) => void;
+  activeIndex?: number | null;
+  onActiveIndexChange?: (index: number | null) => void;
+  label?: string;
+} & TestID;
+
+/**
+ * Reusable native SpinWheel — a vertically scrollable column of values where
+ * the value under the center highlight band is the selected one. Replaces the
+ * web `scroll-snap` + `document.elementFromPoint` implementation with
+ * `ScrollView` momentum snapping and `contentOffset.y` → index math.
+ */
+const SpinWheel = ({
+  values,
+  selectedValue,
+  displayValue,
+  onChange,
+  activeIndex,
+  onActiveIndexChange,
+  label,
+  testID,
+}: SpinWheelNativeProps): React.ReactElement => {
+  const scrollRef = React.useRef<ScrollView>(null);
+  // Guards `onChange` from firing while we programmatically reposition the wheel
+  // (mirrors the web `isProgrammaticScroll` ref). Prevents a typed/selected
+  // value from being clobbered by the momentum handler after `scrollTo`.
+  const isProgrammaticScroll = React.useRef(false);
+  const programmaticTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasMounted = React.useRef(false);
+
+  // Visual positioning follows `displayValue` when present, otherwise the real
+  // selected value.
+  const positioningValue = displayValue ?? selectedValue;
+
+  const scrollToIndex = React.useCallback((index: number, animated: boolean): void => {
+    if (index < 0) return;
+    isProgrammaticScroll.current = true;
+    scrollRef.current?.scrollTo({ y: index * ITEM_HEIGHT, animated });
+    if (programmaticTimeoutRef.current) {
+      clearTimeout(programmaticTimeoutRef.current);
+    }
+    programmaticTimeoutRef.current = setTimeout(
+      () => {
+        isProgrammaticScroll.current = false;
+      },
+      animated ? 350 : 50,
+    );
+  }, []);
+
+  // Position the wheel whenever the positioning value (or the value set) changes.
+  React.useEffect(() => {
+    const positionIndex = values.findIndex((val) => String(val) === String(positioningValue));
+    if (positionIndex >= 0) {
+      scrollToIndex(positionIndex, hasMounted.current);
+    }
+    hasMounted.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [positioningValue, values]);
+
+  React.useEffect(() => {
+    return () => {
+      if (programmaticTimeoutRef.current) {
+        clearTimeout(programmaticTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleMomentumScrollEnd = (e: NativeSyntheticEvent<NativeScrollEvent>): void => {
+    const y = e.nativeEvent.contentOffset.y;
+    const index = Math.round(y / ITEM_HEIGHT);
+    const clamped = Math.max(0, Math.min(index, values.length - 1));
+    onActiveIndexChange?.(clamped);
+    if (isProgrammaticScroll.current) return;
+    const nextValue = values[clamped];
+    if (String(nextValue) === String(selectedValue)) return;
+    onChange(nextValue, clamped);
+  };
+
+  const handleItemPress = (value: string | number, index: number): void => {
+    scrollToIndex(index, true);
+    onChange(value, index);
+    onActiveIndexChange?.(index);
+  };
+
+  return (
+    <View
+      style={{
+        width: WHEEL_WIDTH,
+        height: WHEEL_HEIGHT,
+        overflow: 'hidden',
+      }}
+      {...metaAttribute({ name: MetaConstants.TimePicker, testID })}
+      {...makeAccessible({ label })}
+    >
+      <ScrollView
+        ref={scrollRef}
+        showsVerticalScrollIndicator={false}
+        snapToInterval={ITEM_HEIGHT}
+        decelerationRate="fast"
+        onMomentumScrollEnd={handleMomentumScrollEnd}
+      >
+        <View style={{ height: SPACER }} />
+        {values.map((value, index) => {
+          const isVisuallySelected =
+            activeIndex === index || String(value) === String(positioningValue);
+          return (
+            <Pressable
+              key={`${value}-${index}`}
+              onPress={() => handleItemPress(value, index)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isVisuallySelected }}
+              style={{
+                height: ITEM_HEIGHT,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Text
+                variant="body"
+                size={isVisuallySelected ? 'large' : 'medium'}
+                weight={isVisuallySelected ? 'semibold' : 'regular'}
+                color={
+                  isVisuallySelected
+                    ? 'interactive.text.gray.normal'
+                    : 'interactive.text.gray.muted'
+                }
+                textAlign="center"
+              >
+                {String(value).padStart(2, '0')}
+              </Text>
+            </Pressable>
+          );
+        })}
+        <View style={{ height: SPACER }} />
+      </ScrollView>
+    </View>
+  );
+};
 
 export { SpinWheel };
+export type { SpinWheelNativeProps };

--- a/packages/blade/src/components/TimePicker/TimePicker.native.tsx
+++ b/packages/blade/src/components/TimePicker/TimePicker.native.tsx
@@ -273,7 +273,7 @@ const TimePicker = ({
         <BottomSheet
           isOpen={isDropdownOpen}
           onDismiss={showFooterActions ? handleCancel : handleApply}
-          enableContentPanningGesture={false}
+          isContentPanningGestureEnabled={false}
         >
           <BottomSheetHeader title="Select Time" />
           <BottomSheetBody padding="spacing.0">

--- a/packages/blade/src/components/TimePicker/TimePicker.native.tsx
+++ b/packages/blade/src/components/TimePicker/TimePicker.native.tsx
@@ -175,15 +175,15 @@ const TimePicker = ({
     | 'surface.text.gray.muted' = isError
     ? 'feedback.text.negative.intense'
     : isSuccess
-      ? 'feedback.text.positive.intense'
-      : 'surface.text.gray.muted';
+    ? 'feedback.text.positive.intense'
+    : 'surface.text.gray.muted';
 
   const necessitySuffix =
     isRequired && necessityIndicator === 'required'
       ? ' *'
       : isRequired && necessityIndicator === 'optional'
-        ? ' (optional)'
-        : '';
+      ? ' (optional)'
+      : '';
 
   const displayValue = formatTriggerValue(timeValue, timeFormat);
   const triggerText = displayValue ?? placeholder ?? 'Select time';

--- a/packages/blade/src/components/TimePicker/TimePicker.native.tsx
+++ b/packages/blade/src/components/TimePicker/TimePicker.native.tsx
@@ -1,13 +1,359 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { throwBladeError } from '~utils/logger';
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import { SpinWheel, ITEM_HEIGHT, SPACER } from './SpinWheel.native';
+import { useTimePickerState } from './useTimePickerState';
+import {
+  createDateFromSelection,
+  getNearestStepValue,
+  getTimeComponents,
+} from './utils';
+import type { TimePickerProps, TimeFormat } from './types';
+import {
+  BottomSheet,
+  BottomSheetBody,
+  BottomSheetFooter,
+  BottomSheetHeader,
+} from '~components/BottomSheet';
+import { Button } from '~components/Button';
+import { Box } from '~components/Box';
+import { Divider } from '~components/Divider';
+import { Text } from '~components/Typography';
+import { ClockIcon } from '~components/Icons';
+import { useTheme } from '~components/BladeProvider';
+import { FocusRingWrapper } from '~utils/getFocusRingStyles/getFocusRingStyles';
+import getIn from '~utils/lodashButBetter/get';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import { getStyledProps } from '~components/Box/styledProps';
+import type { DataAnalyticsAttribute } from '~utils/types';
 
-const TimePicker = (_props: any): React.ReactElement => {
-  throwBladeError({
-    message: 'TimePicker is not yet implemented for native',
-    moduleName: 'TimePicker',
+/**
+ * Formats the selected `Date` into the trigger's display string, matching the
+ * web segmented input output: `hh:mm AM/PM` for 12h, `HH:mm` for 24h.
+ */
+const formatTriggerValue = (date: Date | null, timeFormat: TimeFormat): string | null => {
+  if (!date) return null;
+  const { selectedHour, selectedMinute, selectedPeriod } = getTimeComponents(date, timeFormat);
+  const mm = String(selectedMinute).padStart(2, '0');
+  const hh = String(selectedHour).padStart(2, '0');
+  return timeFormat === '12h' ? `${hh}:${mm} ${selectedPeriod}` : `${hh}:${mm}`;
+};
+
+/**
+ * TimePicker (native)
+ *
+ * Lets the user pick a time via scrollable spin wheels. On native the picker
+ * renders a tap-to-open trigger; the wheels open inside a `BottomSheet`.
+ *
+ * #### UX deviations from web
+ *
+ * - No segmented/keyboard-editable input — selection is wheel-only inside a
+ *   `BottomSheet` (this matches the web `isMobile` experience).
+ * - The decorative top/bottom fade gradient is omitted; only the center
+ *   highlight band is rendered.
+ *
+ * #### Usage
+ *
+ * ```tsx
+ * <TimePicker
+ *   label="Pick time"
+ *   timeFormat="12h"
+ *   minuteStep={15}
+ *   onApply={({ value }) => console.log(value)}
+ * />
+ * ```
+ */
+const TimePicker = ({
+  value,
+  defaultValue,
+  onChange,
+  onApply,
+  isOpen,
+  defaultIsOpen,
+  onOpenChange,
+  label,
+  labelPosition = 'top',
+  accessibilityLabel,
+  errorText,
+  helpText,
+  isDisabled,
+  isRequired,
+  successText,
+  validationState = 'none',
+  size = 'medium',
+  necessityIndicator = 'none',
+  placeholder,
+  showFooterActions = true,
+  timeFormat = '12h',
+  minuteStep = 1,
+  testID,
+  ...props
+}: TimePickerProps & StyledPropsBlade & DataAnalyticsAttribute): React.ReactElement => {
+  const { theme } = useTheme();
+
+  const {
+    timeValue,
+    setTimeValue,
+    selectedHour,
+    selectedMinute,
+    selectedPeriod,
+    isOpen: isDropdownOpen,
+    setIsOpen: setIsDropdownOpen,
+    onApply: handleApply,
+    onCancel: handleCancel,
+  } = useTimePickerState({
+    value,
+    defaultValue,
+    onChange,
+    isOpen,
+    defaultIsOpen,
+    onOpenChange,
+    timeFormat,
+    showFooterActions,
+    onApply,
   });
 
-  return <></>;
+  const is12HourFormat = timeFormat === '12h';
+
+  const open = (): void => {
+    if (isDisabled) return;
+    setIsDropdownOpen(true);
+  };
+
+  // Wheel value sets (mirrors TimePickerContent.web).
+  const hourValues = is12HourFormat
+    ? Array.from({ length: 12 }, (_, i) => String(i + 1).padStart(2, '0'))
+    : Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0'));
+  const minuteValues = Array.from({ length: 60 / minuteStep }, (_, i) =>
+    String(i * minuteStep).padStart(2, '0'),
+  );
+  const periodValues: ('AM' | 'PM')[] = ['AM', 'PM'];
+
+  // When minuteStep > 1 keep the typed/selected minute but visually align the
+  // wheel to the nearest valid step (mirrors web `displayValue`).
+  const displayMinute =
+    minuteStep > 1 ? getNearestStepValue(selectedMinute, minuteStep) : undefined;
+
+  const handleHourChange = (val: string | number): void => {
+    const hour = Number(val);
+    setTimeValue(
+      createDateFromSelection(selectedHour, selectedMinute, selectedPeriod, timeFormat, hour),
+    );
+  };
+
+  const handleMinuteChange = (val: string | number): void => {
+    const minute = Number(val);
+    setTimeValue(
+      createDateFromSelection(
+        selectedHour,
+        selectedMinute,
+        selectedPeriod,
+        timeFormat,
+        undefined,
+        minute,
+      ),
+    );
+  };
+
+  const handlePeriodChange = (val: string | number): void => {
+    const period = String(val);
+    setTimeValue(
+      createDateFromSelection(
+        selectedHour,
+        selectedMinute,
+        selectedPeriod,
+        timeFormat,
+        undefined,
+        undefined,
+        period,
+      ),
+    );
+  };
+
+  const isError = validationState === 'error';
+  const isSuccess = validationState === 'success';
+  const helperRenderText = isError ? errorText : isSuccess ? successText : helpText;
+  const helperRenderColor:
+    | 'feedback.text.negative.intense'
+    | 'feedback.text.positive.intense'
+    | 'surface.text.gray.muted' = isError
+    ? 'feedback.text.negative.intense'
+    : isSuccess
+    ? 'feedback.text.positive.intense'
+    : 'surface.text.gray.muted';
+
+  const necessitySuffix =
+    isRequired && necessityIndicator === 'required'
+      ? ' *'
+      : isRequired && necessityIndicator === 'optional'
+      ? ' (optional)'
+      : '';
+
+  const displayValue = formatTriggerValue(timeValue, timeFormat);
+  const triggerText = displayValue ?? placeholder ?? 'Select time';
+  const hasValue = displayValue !== null;
+
+  const labelNode = label ? (
+    <Text size="small" color="surface.text.gray.muted">
+      {`${label}${necessitySuffix}`}
+    </Text>
+  ) : null;
+
+  const triggerNode = (
+    <FocusRingWrapper
+      isFocused={isDropdownOpen}
+      borderRadius={theme.border.radius.medium}
+      disabled={isDisabled}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? label}
+        disabled={isDisabled}
+        onPress={open}
+      >
+        <Box
+          paddingX="spacing.4"
+          paddingY={size === 'large' ? 'spacing.4' : 'spacing.3'}
+          borderWidth={isDropdownOpen && !isDisabled ? 'thick' : 'thin'}
+          borderColor={
+            isDropdownOpen && !isDisabled
+              ? 'interactive.border.primary.default'
+              : 'surface.border.gray.muted'
+          }
+          borderRadius="medium"
+          backgroundColor={
+            isDisabled ? 'surface.background.gray.subtle' : 'surface.background.gray.intense'
+          }
+          display="flex"
+          flexDirection="row"
+          alignItems="center"
+        >
+          <Box marginRight="spacing.3">
+            <ClockIcon
+              size="medium"
+              color={isDisabled ? 'surface.icon.gray.disabled' : 'surface.icon.gray.muted'}
+            />
+          </Box>
+          <Text
+            size="medium"
+            color={hasValue ? 'surface.text.gray.normal' : 'surface.text.gray.muted'}
+          >
+            {triggerText}
+          </Text>
+        </Box>
+      </Pressable>
+    </FocusRingWrapper>
+  );
+
+  const highlightBandColor = getIn(theme.colors, 'interactive.background.gray.faded');
+
+  return (
+    <Box
+      width="100%"
+      {...getStyledProps(props)}
+      {...metaAttribute({ name: MetaConstants.TimePicker, testID })}
+    >
+      {labelPosition === 'left' && labelNode ? (
+        <Box display="flex" flexDirection="row" alignItems="center">
+          <Box paddingRight="spacing.3">{labelNode}</Box>
+          <Box flex={1}>{triggerNode}</Box>
+        </Box>
+      ) : (
+        <>
+          {labelNode ? <Box paddingBottom="spacing.2">{labelNode}</Box> : null}
+          {triggerNode}
+        </>
+      )}
+
+      {helperRenderText ? (
+        <Box paddingTop="spacing.2">
+          <Text size="small" color={helperRenderColor}>
+            {helperRenderText}
+          </Text>
+        </Box>
+      ) : null}
+
+      {!isDisabled && (
+        <BottomSheet
+          isOpen={isDropdownOpen}
+          onDismiss={showFooterActions ? handleCancel : handleApply}
+          enableContentPanningGesture={false}
+        >
+          <BottomSheetHeader title="Select Time" />
+          <BottomSheetBody padding="spacing.0">
+            <Box paddingX="spacing.5" paddingY="spacing.3">
+              <Box
+                display="flex"
+                flexDirection="row"
+                justifyContent="center"
+                alignItems="flex-start"
+                position="relative"
+              >
+                {/* Center highlight band. Sits behind the wheel values under the
+                    centered row. `overflow: hidden` + explicit borderRadius avoid
+                    Android white-bleed clipping. */}
+                <View
+                  pointerEvents="none"
+                  style={{
+                    position: 'absolute',
+                    top: SPACER,
+                    left: 0,
+                    right: 0,
+                    height: ITEM_HEIGHT,
+                    borderRadius: theme.border.radius.small,
+                    overflow: 'hidden',
+                    backgroundColor: highlightBandColor,
+                  }}
+                />
+
+                <SpinWheel
+                label="Hour"
+                values={hourValues}
+                selectedValue={String(selectedHour).padStart(2, '0')}
+                onChange={handleHourChange}
+              />
+              <Divider orientation="vertical" />
+              <SpinWheel
+                label="Minute"
+                values={minuteValues}
+                selectedValue={String(selectedMinute).padStart(2, '0')}
+                displayValue={displayMinute}
+                onChange={handleMinuteChange}
+              />
+              {is12HourFormat && (
+                <>
+                  <Divider orientation="vertical" />
+                  <SpinWheel
+                    label="Period"
+                    values={periodValues}
+                    selectedValue={selectedPeriod}
+                    onChange={handlePeriodChange}
+                  />
+                </>
+              )}
+              </Box>
+            </Box>
+          </BottomSheetBody>
+          {showFooterActions ? (
+            <BottomSheetFooter>
+              <Box display="flex" flexDirection="row">
+                <Box flex={1} marginRight="spacing.2">
+                  <Button variant="secondary" isFullWidth onClick={() => handleCancel()}>
+                    Cancel
+                  </Button>
+                </Box>
+                <Box flex={1}>
+                  <Button isFullWidth onClick={() => handleApply()}>
+                    Apply
+                  </Button>
+                </Box>
+              </Box>
+            </BottomSheetFooter>
+          ) : null}
+        </BottomSheet>
+      )}
+    </Box>
+  );
 };
 
 export { TimePicker };

--- a/packages/blade/src/components/TimePicker/TimePicker.native.tsx
+++ b/packages/blade/src/components/TimePicker/TimePicker.native.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { Pressable, View } from 'react-native';
 import { SpinWheel, ITEM_HEIGHT, SPACER } from './SpinWheel.native';
 import { useTimePickerState } from './useTimePickerState';
-import {
-  createDateFromSelection,
-  getNearestStepValue,
-  getTimeComponents,
-} from './utils';
+import { createDateFromSelection, getNearestStepValue, getTimeComponents } from './utils';
 import type { TimePickerProps, TimeFormat } from './types';
 import {
   BottomSheet,
@@ -179,15 +175,15 @@ const TimePicker = ({
     | 'surface.text.gray.muted' = isError
     ? 'feedback.text.negative.intense'
     : isSuccess
-    ? 'feedback.text.positive.intense'
-    : 'surface.text.gray.muted';
+      ? 'feedback.text.positive.intense'
+      : 'surface.text.gray.muted';
 
   const necessitySuffix =
     isRequired && necessityIndicator === 'required'
       ? ' *'
       : isRequired && necessityIndicator === 'optional'
-      ? ' (optional)'
-      : '';
+        ? ' (optional)'
+        : '';
 
   const displayValue = formatTriggerValue(timeValue, timeFormat);
   const triggerText = displayValue ?? placeholder ?? 'Select time';
@@ -307,30 +303,30 @@ const TimePicker = ({
                 />
 
                 <SpinWheel
-                label="Hour"
-                values={hourValues}
-                selectedValue={String(selectedHour).padStart(2, '0')}
-                onChange={handleHourChange}
-              />
-              <Divider orientation="vertical" />
-              <SpinWheel
-                label="Minute"
-                values={minuteValues}
-                selectedValue={String(selectedMinute).padStart(2, '0')}
-                displayValue={displayMinute}
-                onChange={handleMinuteChange}
-              />
-              {is12HourFormat && (
-                <>
-                  <Divider orientation="vertical" />
-                  <SpinWheel
-                    label="Period"
-                    values={periodValues}
-                    selectedValue={selectedPeriod}
-                    onChange={handlePeriodChange}
-                  />
-                </>
-              )}
+                  label="Hour"
+                  values={hourValues}
+                  selectedValue={String(selectedHour).padStart(2, '0')}
+                  onChange={handleHourChange}
+                />
+                <Divider orientation="vertical" />
+                <SpinWheel
+                  label="Minute"
+                  values={minuteValues}
+                  selectedValue={String(selectedMinute).padStart(2, '0')}
+                  displayValue={displayMinute}
+                  onChange={handleMinuteChange}
+                />
+                {is12HourFormat && (
+                  <>
+                    <Divider orientation="vertical" />
+                    <SpinWheel
+                      label="Period"
+                      values={periodValues}
+                      selectedValue={selectedPeriod}
+                      onChange={handlePeriodChange}
+                    />
+                  </>
+                )}
               </Box>
             </Box>
           </BottomSheetBody>

--- a/packages/blade/src/components/TimePicker/__tests__/SpinWheel.native.test.tsx
+++ b/packages/blade/src/components/TimePicker/__tests__/SpinWheel.native.test.tsx
@@ -53,12 +53,7 @@ describe('<SpinWheel /> (native)', () => {
   it('should visually position using displayValue when provided', () => {
     const minuteValues = Array.from({ length: 12 }, (_, i) => String(i * 5).padStart(2, '0'));
     const { toJSON } = renderWithTheme(
-      <SpinWheel
-        values={minuteValues}
-        selectedValue="03"
-        displayValue="05"
-        onChange={jest.fn()}
-      />,
+      <SpinWheel values={minuteValues} selectedValue="03" displayValue="05" onChange={jest.fn()} />,
     );
     expect(toJSON()).toMatchSnapshot();
   });

--- a/packages/blade/src/components/TimePicker/__tests__/SpinWheel.native.test.tsx
+++ b/packages/blade/src/components/TimePicker/__tests__/SpinWheel.native.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { SpinWheel } from '../SpinWheel.native';
+import renderWithTheme from '~utils/testing/renderWithTheme.native';
+
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
+afterAll(() => jest.restoreAllMocks());
+
+const hourValues = Array.from({ length: 12 }, (_, i) => String(i + 1).padStart(2, '0'));
+
+describe('<SpinWheel /> (native)', () => {
+  it('should render with default props', () => {
+    const { toJSON } = renderWithTheme(
+      <SpinWheel values={hourValues} selectedValue="03" onChange={jest.fn()} />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should render active styling for the selected value', () => {
+    const { toJSON } = renderWithTheme(
+      <SpinWheel values={hourValues} selectedValue="05" activeIndex={4} onChange={jest.fn()} />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should call onChange with value and index when an item is pressed', () => {
+    const onChange = jest.fn();
+    const { getByText } = renderWithTheme(
+      <SpinWheel values={hourValues} selectedValue="01" onChange={onChange} />,
+    );
+
+    fireEvent.press(getByText('07'));
+
+    expect(onChange).toHaveBeenCalledWith('07', 6);
+  });
+
+  it('should call onActiveIndexChange when an item is pressed', () => {
+    const onActiveIndexChange = jest.fn();
+    const { getByText } = renderWithTheme(
+      <SpinWheel
+        values={hourValues}
+        selectedValue="01"
+        onChange={jest.fn()}
+        onActiveIndexChange={onActiveIndexChange}
+      />,
+    );
+
+    fireEvent.press(getByText('09'));
+
+    expect(onActiveIndexChange).toHaveBeenCalledWith(8);
+  });
+
+  it('should visually position using displayValue when provided', () => {
+    const minuteValues = Array.from({ length: 12 }, (_, i) => String(i * 5).padStart(2, '0'));
+    const { toJSON } = renderWithTheme(
+      <SpinWheel
+        values={minuteValues}
+        selectedValue="03"
+        displayValue="05"
+        onChange={jest.fn()}
+      />,
+    );
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/packages/blade/src/components/TimePicker/__tests__/TimePicker.native.test.tsx
+++ b/packages/blade/src/components/TimePicker/__tests__/TimePicker.native.test.tsx
@@ -1,0 +1,19 @@
+// NOTE: rendering tests for the full <TimePicker /> aren't included here
+// because @gorhom/bottom-sheet's ScrollableComponent requires a native ref
+// (a `nativeTag`) at mount time, which react-test-renderer doesn't provide —
+// mounting the picker (which always mounts a closed BottomSheet) crashes.
+// The trigger view and wheel interactions are covered by the fully-testable
+// `SpinWheel.native.test.tsx` and by the storybook test stories
+// (`TimePicker.test.stories.tsx`) which run inside a real RN runtime.
+//
+// This mirrors `DatePicker.native.test.tsx` and serves as a sanity check that
+// the module imports without crashing.
+
+import { TimePicker } from '../TimePicker.native';
+
+describe('<TimePicker /> (native)', () => {
+  it('module exports the TimePicker component', () => {
+    expect(TimePicker).toBeDefined();
+    expect(typeof TimePicker).toBe('function');
+  });
+});

--- a/packages/blade/src/components/TimePicker/__tests__/__snapshots__/SpinWheel.native.test.tsx.snap
+++ b/packages/blade/src/components/TimePicker/__tests__/__snapshots__/SpinWheel.native.test.tsx.snap
@@ -1,0 +1,2911 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SpinWheel /> (native) should render active styling for the selected value 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    accessible={true}
+    data-blade-component="time-picker"
+    style={
+      {
+        "height": 170,
+        "overflow": "hidden",
+        "width": 72,
+      }
+    }
+  >
+    <RCTScrollView
+      decelerationRate="fast"
+      onMomentumScrollEnd={[Function]}
+      showsVerticalScrollIndicator={false}
+      snapToInterval={34}
+    >
+      <View>
+        <View
+          style={
+            {
+              "height": 68,
+            }
+          }
+        />
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            01
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            02
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            03
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            04
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": true,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.normal"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={200}
+            fontStyle="normal"
+            fontWeight="semibold"
+            letterSpacing={25}
+            lineHeight={200}
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 2%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontWeight": "600",
+                  "letterSpacing": -0.528,
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            05
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            06
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            07
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            08
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            09
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            10
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            11
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            12
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "height": 68,
+            }
+          }
+        />
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;
+
+exports[`<SpinWheel /> (native) should render with default props 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    accessible={true}
+    data-blade-component="time-picker"
+    style={
+      {
+        "height": 170,
+        "overflow": "hidden",
+        "width": 72,
+      }
+    }
+  >
+    <RCTScrollView
+      decelerationRate="fast"
+      onMomentumScrollEnd={[Function]}
+      showsVerticalScrollIndicator={false}
+      snapToInterval={34}
+    >
+      <View>
+        <View
+          style={
+            {
+              "height": 68,
+            }
+          }
+        />
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            01
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            02
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": true,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.normal"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={200}
+            fontStyle="normal"
+            fontWeight="semibold"
+            letterSpacing={25}
+            lineHeight={200}
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 2%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontWeight": "600",
+                  "letterSpacing": -0.528,
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            03
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            04
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            05
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            06
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            07
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            08
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            09
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            10
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            11
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            12
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "height": 68,
+            }
+          }
+        />
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;
+
+exports[`<SpinWheel /> (native) should visually position using displayValue when provided 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    accessible={true}
+    data-blade-component="time-picker"
+    style={
+      {
+        "height": 170,
+        "overflow": "hidden",
+        "width": 72,
+      }
+    }
+  >
+    <RCTScrollView
+      decelerationRate="fast"
+      onMomentumScrollEnd={[Function]}
+      showsVerticalScrollIndicator={false}
+      snapToInterval={34}
+    >
+      <View>
+        <View
+          style={
+            {
+              "height": 68,
+            }
+          }
+        />
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            00
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": true,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.normal"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={200}
+            fontStyle="normal"
+            fontWeight="semibold"
+            letterSpacing={25}
+            lineHeight={200}
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 2%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 16,
+                  "fontStyle": "normal",
+                  "fontWeight": "600",
+                  "letterSpacing": -0.528,
+                  "lineHeight": 24,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            05
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            10
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            15
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            20
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            25
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            30
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            35
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            40
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            45
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            50
+          </Text>
+        </View>
+        <View
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": false,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+              "height": 34,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            accessible={true}
+            color="interactive.text.gray.muted"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={100}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={100}
+            style={
+              [
+                {
+                  "color": "hsla(204, 9%, 42%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.18200000000000002,
+                  "lineHeight": 20,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textAlign": "center",
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+            textAlign="center"
+          >
+            55
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "height": 68,
+            }
+          }
+        />
+      </View>
+    </RCTScrollView>
+  </View>
+</View>
+`;

--- a/packages/blade/src/components/TimePicker/useTimePickerState.ts
+++ b/packages/blade/src/components/TimePicker/useTimePickerState.ts
@@ -81,9 +81,9 @@ export const useTimePickerState = ({
   });
 
   const handleApply = React.useCallback(() => {
+    onChange?.({ value: timeValue });
     setOldTimeValue(internalTimeValue);
     if (showFooterActions) {
-      onChange?.({ value: timeValue });
       onApply?.({ value: timeValue });
     }
     setControllableIsOpen(() => false);

--- a/packages/blade/src/components/TimePicker/useTimePickerState.ts
+++ b/packages/blade/src/components/TimePicker/useTimePickerState.ts
@@ -81,9 +81,9 @@ export const useTimePickerState = ({
   });
 
   const handleApply = React.useCallback(() => {
-    onChange?.({ value: timeValue });
     setOldTimeValue(internalTimeValue);
     if (showFooterActions) {
+      onChange?.({ value: timeValue });
       onApply?.({ value: timeValue });
     }
     setControllableIsOpen(() => false);

--- a/packages/blade/src/components/TimePicker/useTimePickerState.ts
+++ b/packages/blade/src/components/TimePicker/useTimePickerState.ts
@@ -71,20 +71,19 @@ export const useTimePickerState = ({
   const [controllableIsOpen, setControllableIsOpen] = useControllableState({
     value: isOpen,
     defaultValue: defaultIsOpen,
-    onChange: (isOpen: boolean) => {
-      onOpenChange?.({ isOpen });
-      // Update old value every time timepicker is opened or closed
-      setOldTimeValue(internalTimeValue);
+    onChange: (open: boolean) => {
+      onOpenChange?.({ isOpen: open });
+      // Snapshot the value when opening so Cancel can restore the pre-edit state.
+      if (open) {
+        setOldTimeValue(internalTimeValue);
+      }
     },
   });
 
   const handleApply = React.useCallback(() => {
+    onChange?.({ value: timeValue });
+    setOldTimeValue(internalTimeValue);
     if (showFooterActions) {
-      // Call onChange with current timeValue
-      onChange?.({ value: timeValue });
-      // Update oldTimeValue to current value
-      setOldTimeValue(internalTimeValue);
-      // Call onApply callback
       onApply?.({ value: timeValue });
     }
     setControllableIsOpen(() => false);


### PR DESCRIPTION
## Summary

- Adds native (`.native.tsx`) implementation for **TimePicker**, replacing the previous `throwBladeError` stub with a tap-to-open trigger and scrollable spin wheels inside `BottomSheet` (mirrors web mobile UX).
- Implements `SpinWheel.native.tsx` with momentum snapping, programmatic scroll guards, and minute-step `displayValue` positioning.
- Fixes native `BottomSheet` dismiss/sync issues needed for picker UX: backdrop tap, X button, swipe-down, suppress-dismiss guards, content-fitted snap sizing, and `enableContentPanningGesture` for wheel scrolling.

https://github.com/user-attachments/assets/a7f69641-e7ab-4ccf-b1e3-b9755ca03579



## Changes

- **Implemented:** `TimePicker.native.tsx`, `SpinWheel.native.tsx`
- **Updated:** `useTimePickerState.ts` — snapshot value on open only; apply (not cancel) on dismiss when `showFooterActions={false}`
- **BottomSheet fixes:** `BottomSheet.native.tsx`, `BottomSheetBackdrop.native.tsx`, `types.ts` (+ snapshot updates)
- **Storybook infra:** `.storybook/react-native/preview.tsx` — registers `BladeBottomSheetPortal` `PortalHost` in story decorator with `flex: 1` container so portal-based components render in RN Storybook
- **Tests:** `SpinWheel.native.test.tsx` (+ snapshots), `TimePicker.native.test.tsx` (module export sanity check)
- **Changeset:** minor bump for `@razorpay/blade`

## Test plan

- [x] Native unit tests pass (`FRAMEWORK=REACT_NATIVE jest` for TimePicker + BottomSheet)
- [x] Manual iOS simulator verification on TimePicker stories:
  - [x] Bottom sheet opens/closes via backdrop, X, and swipe-down
  - [x] Wheel selection updates trigger value (apply on dismiss for `showFooterActions={false}`)
  - [x] Cancel/Apply footer actions work when enabled
  - [x] Sheet height fits content (no large empty gap)
  - [x] Selected value centered in gray highlight band
- [ ] Android visual verification — not performed


Made with [Cursor](https://cursor.com)