### PR TITLE
ci: upgrade npm CLI to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
       - name: Setup Cache & Install Dependencies
         uses: ./.github/actions/install-dependencies
       - name: Build Blade Core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - name: Setup Cache & Install Dependencies
         uses: ./.github/actions/install-dependencies
       - name: Build Blade Core


### PR DESCRIPTION
## Summary

Follow-up to #3230. Since that PR merged, every release has failed at `publishToNpm.js` with `E404` on `PUT` to `registry.npmjs.org`.

**Root cause:** Node 22 ships with npm 10.x, but [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers/) requires npm CLI **11.5.1+**. The Trusted Publisher config on npmjs.com is correct — the npm CLI itself just can't perform the OIDC token exchange.

**Why the error is a 404 and not a 401:** with npm 10, no OIDC token is exchanged, so the CLI falls back to an unauthenticated (anonymous) publish request. The registry treats anonymous `PUT`s to a package namespace as if the package doesn't exist for that caller and returns `E404` instead of `401`. That's why the failure looks like "package missing" rather than "auth missing" — the misleading-error pattern is what made this take a bit to diagnose.

## Fix

Add a step right after `Use Node v22` in [.github/workflows/release.yml](.github/workflows/release.yml) to upgrade the global npm CLI before install:

```yaml
- name: Upgrade npm for OIDC trusted publishing
  run: npm install -g npm@latest
```

## Alternatives considered

- **Bump the runner to Node 24** (which ships with a newer npm). Rejected: larger blast radius — Node bumps touch every step in the workflow (install, build, publish, Chromatic) and any transient dep-graph or engines-field incompatibility would break the release path further. Upgrading only the npm CLI is the minimum-change fix to unblock publishing; a Node upgrade can be revisited separately.

## Test plan

- [ ] Merge and observe the next release run: `Upgrade npm for OIDC trusted publishing` step should print an npm 11.x version.
- [ ] Publish step should complete without `E404`.
- [ ] Confirm packages appear on npm with provenance attestation.

## Notes

No changeset intentionally — publishing after merge will be triggered separately (either via a fresh changeset or `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)