### PR TITLE
feat(rn): add React Native support for FilterChipSelectInput

### DIFF
--- a/.changeset/rn-filterchipselectinput-native-support.md
+++ b/.changeset/rn-filterchipselectinput-native-support.md
@@ -1,5 +1,5 @@
 ---
-"@razorpay/blade": patch
+"@razorpay/blade": minor
 ---
 
 feat(rn): add React Native support for FilterChipSelectInput

--- a/.changeset/rn-filterchipselectinput-native-support.md
+++ b/.changeset/rn-filterchipselectinput-native-support.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(rn): add React Native support for FilterChipSelectInput

--- a/packages/blade/src/components/BaseMenu/BaseMenuItem/StyledMenuItemContainer.native.tsx
+++ b/packages/blade/src/components/BaseMenu/BaseMenuItem/StyledMenuItemContainer.native.tsx
@@ -11,9 +11,11 @@ const StyledMenuItemContainer = styled(TouchableOpacity)<StyledBaseMenuItemConta
       padding: makeSize(props.theme.spacing[3]),
       display: props.isVisible ? 'flex' : 'none',
       // React Native specific styles
+      // Match web's selected-item highlight which uses a neutral gray token
+      // (see StyledMenuItemContainer.web.tsx aria-selected styles) instead of the primary/blue token.
       backgroundColor:
         props.isSelected && props.selectionType === 'single'
-          ? props.theme.colors.interactive.background.primary.faded
+          ? props.theme.colors.interactive.background.gray.fadedHighlighted
           : undefined,
     };
   },

--- a/packages/blade/src/components/Dropdown/DropdownOverlay.native.tsx
+++ b/packages/blade/src/components/Dropdown/DropdownOverlay.native.tsx
@@ -7,7 +7,7 @@ import type { DropdownOverlayProps } from './types';
 import { dropdownComponentIds } from './dropdownComponentIds';
 import BaseBox from '~components/Box/BaseBox';
 import { useTheme } from '~components/BladeProvider';
-import { makeSize } from '~utils';
+import { castNativeType, makeSize } from '~utils';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
 import { useBottomSheetAndDropdownGlue } from '~components/BottomSheet/BottomSheetContext';
@@ -32,8 +32,10 @@ const StyledCloseableArea = styled(Pressable)<{ display: 'flex' | 'none' }>((pro
  */
 const _DropdownOverlay = ({ children, testID }: DropdownOverlayProps): React.ReactElement => {
   const { isOpen, close } = useDropdown();
-  const { colorScheme } = useTheme();
+  const { theme, colorScheme } = useTheme();
   const bottomSheetAndDropdownGlue = useBottomSheetAndDropdownGlue();
+
+  const hasBottomSheet = bottomSheetAndDropdownGlue?.dropdownHasBottomSheet;
 
   return (
     <BaseBox position="relative">
@@ -45,13 +47,18 @@ const _DropdownOverlay = ({ children, testID }: DropdownOverlayProps): React.Rea
         testID="closeable-area"
       >
         <AnimatedDropdownOverlay
-          isInBottomSheet={bottomSheetAndDropdownGlue?.dropdownHasBottomSheet}
+          isInBottomSheet={hasBottomSheet}
           colorScheme={colorScheme}
           display={isOpen ? 'flex' : 'none'}
           position="absolute"
           width="100%"
           testID="dropdown-overlay"
-          elevation={bottomSheetAndDropdownGlue?.dropdownHasBottomSheet ? undefined : 'midRaised'}
+          elevation={hasBottomSheet ? undefined : 'midRaised'}
+          // Native shadow props (shadowColor/Opacity/Radius/Offset + Android elevation) must be
+          // applied via the raw style prop — styled-components mangles the shadowOffset object.
+          // Mirrors the Tooltip/Carousel native elevation pattern. The overlay already carries an
+          // opaque background and no overflow:hidden, so the iOS shadow isn't clipped.
+          style={hasBottomSheet ? undefined : castNativeType(theme.elevation.midRaised)}
           {...metaAttribute({ name: MetaConstants.DropdownOverlay, testID })}
         >
           {children}

--- a/packages/blade/src/components/Dropdown/FilterChipGroupContext.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipGroupContext.native.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import type { FilterChipGroupContextType } from './types';
+
+const FilterChipGroupContext = React.createContext<FilterChipGroupContextType>({
+  filterChipGroupSelectedFilters: [],
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setFilterChipGroupSelectedFilters: () => {},
+  clearFilterCallbackTriggerer: 0,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setClearFilterCallbackTriggerer: () => {},
+});
+const FilterChipGroupProvider = FilterChipGroupContext.Provider;
+
+const useFilterChipGroupContext = (): FilterChipGroupContextType => {
+  const context = React.useContext(FilterChipGroupContext);
+  return context;
+};
+
+export { useFilterChipGroupContext, FilterChipGroupProvider };

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -61,8 +61,10 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
 
   const isUnControlled = options.length > 0 && props.value === undefined;
   const { listViewSelectedFilters, setListViewSelectedFilters } = useListViewFilterContext();
-  const { clearFilterCallbackTriggerer, setFilterChipGroupSelectedFilters } =
-    useFilterChipGroupContext();
+  const {
+    clearFilterCallbackTriggerer,
+    setFilterChipGroupSelectedFilters,
+  } = useFilterChipGroupContext();
 
   const getValuesArrayFromIndices = (): string[] => {
     let indices: number[] = [];
@@ -95,7 +97,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
 
     if (isUnControlled) {
       if (listViewSelectedFilters[label]) {
-        const savedIndices = listViewSelectedFilters[label] as unknown as number[];
+        const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
         setSelectedIndices(savedIndices);
         const inputValue = savedIndices.map((selectionIndex) => options[selectionIndex].value);
         setUncontrolledInputValue(inputValue);
@@ -106,7 +108,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
         setSelectedIndices([]);
       }
     } else if (listViewSelectedFilters[label]) {
-      const savedIndices = listViewSelectedFilters[label] as unknown as number[];
+      const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
       setSelectedIndices(savedIndices);
     } else if (valueNotEmpty && !isValueAndSelectedIndicesSynced && options.length > 0) {
       const newSelectedIndices =

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -61,7 +61,9 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     changeCallbackTriggerer,
   } = useDropdown();
   const valueTitle =
-    typeof value === 'string' ? (options.find((option) => option.value === value)?.title ?? value) : undefined;
+    typeof value === 'string'
+      ? options.find((option) => option.value === value)?.title ?? value
+      : undefined;
 
   const isUnControlled = options.length > 0 && props.value === undefined;
   const { listViewSelectedFilters, setListViewSelectedFilters } = useListViewFilterContext();

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -16,7 +16,7 @@ import { useFirstRender } from '~utils/useFirstRender';
 
 type FilterChipSelectInputProps = Pick<
   BaseFilterChipProps,
-  'value' | 'label' | 'testID' | 'onClick' | 'selectionType'
+  'onKeyDown' | 'value' | 'label' | 'testID' | 'onClick' | 'selectionType' | 'onBlur'
 > & {
   accessibilityLabel?: string;
   onChange?: (props: { name: string; values: string[] }) => void;
@@ -29,6 +29,8 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
   const idBase = useId('filter-chip-select-input');
   const {
     onClick,
+    onBlur,
+    onKeyDown,
     accessibilityLabel,
     testID,
     value,
@@ -46,6 +48,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     options,
     selectedIndices,
     onTriggerClick,
+    onTriggerKeydown,
     dropdownBaseId,
     isOpen,
     activeIndex,
@@ -57,7 +60,8 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     controlledValueIndices,
     changeCallbackTriggerer,
   } = useDropdown();
-  const valueTitle = options.find((option) => option.value === value)?.title ?? value;
+  const valueTitle =
+    typeof value === 'string' ? (options.find((option) => option.value === value)?.title ?? value) : undefined;
 
   const isUnControlled = options.length > 0 && props.value === undefined;
   const { listViewSelectedFilters, setListViewSelectedFilters } = useListViewFilterContext();
@@ -74,7 +78,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       indices = selectedIndices;
     }
 
-    return indices.map((selectionIndex) => options[selectionIndex].value);
+    return indices.map((i) => options[i]?.value).filter((v): v is string => v !== undefined);
   };
 
   useEffect(() => {
@@ -99,7 +103,9 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       if (listViewSelectedFilters[label]) {
         const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
         setSelectedIndices(savedIndices);
-        const inputValue = savedIndices.map((selectionIndex) => options[selectionIndex].value);
+        const inputValue = savedIndices
+          .map((i) => options[i]?.value)
+          .filter((v): v is string => v !== undefined);
         setUncontrolledInputValue(inputValue);
         setFilterChipGroupSelectedFilters((prev) =>
           prev.includes(label) ? prev : [...prev, label],
@@ -120,7 +126,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       setSelectedIndices(newSelectedIndices);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUnControlled, options]);
+  }, [isUnControlled, options, value]);
 
   const getTitleFromValue = (value: string): string => {
     const option = options.find((option) => option.value === value);
@@ -138,8 +144,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
   };
 
   const handleClearButtonClick = (): void => {
-    const indices = isControlled ? controlledValueIndices : selectedIndices;
-    const currentValues = indices.map((selectionIndex) => options[selectionIndex].value);
+    const currentValues = getValuesArrayFromIndices();
     onClearButtonClick?.({ name: name ?? idBase, values: currentValues });
     onChange?.({ name: name ?? idBase, values: [] });
     setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
@@ -189,6 +194,22 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [changeCallbackTriggerer]);
 
+  const handleKeyDown = (e: React.KeyboardEvent<Element>): void => {
+    onKeyDown?.(e);
+    onTriggerKeydown?.({ event: e as React.KeyboardEvent<HTMLInputElement> });
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+
+    if ((e.key === 'Enter' || e.key === ' ') && !isOpen) {
+      e.preventDefault();
+      e.stopPropagation();
+      onTriggerClick();
+    }
+  };
+
   return (
     <BaseFilterChip
       label={label}
@@ -198,6 +219,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       {...rest}
       testID={testID}
       ref={triggererRef as any}
+      onKeyDown={handleKeyDown}
       accessibilityProps={{
         label: accessibilityLabel ?? label,
         hasPopup: getActionListContainerRole(hasFooterAction, 'FilterChipSelectInput'),
@@ -208,6 +230,9 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       onClick={(e) => {
         onTriggerClick();
         onClick?.(e);
+      }}
+      onBlur={(e) => {
+        onBlur?.(e);
       }}
       isDisabled={isDisabled}
     />

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -60,10 +60,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     controlledValueIndices,
     changeCallbackTriggerer,
   } = useDropdown();
-  const valueTitle =
-    typeof value === 'string'
-      ? options.find((option) => option.value === value)?.title ?? value
-      : undefined;
+  const valueTitle = options.find((option) => option.value === value)?.title ?? value;
 
   const isUnControlled = options.length > 0 && props.value === undefined;
   const { listViewSelectedFilters, setListViewSelectedFilters } = useListViewFilterContext();

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -61,10 +61,8 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
 
   const isUnControlled = options.length > 0 && props.value === undefined;
   const { listViewSelectedFilters, setListViewSelectedFilters } = useListViewFilterContext();
-  const {
-    clearFilterCallbackTriggerer,
-    setFilterChipGroupSelectedFilters,
-  } = useFilterChipGroupContext();
+  const { clearFilterCallbackTriggerer, setFilterChipGroupSelectedFilters } =
+    useFilterChipGroupContext();
 
   const getValuesArrayFromIndices = (): string[] => {
     let indices: number[] = [];
@@ -97,7 +95,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
 
     if (isUnControlled) {
       if (listViewSelectedFilters[label]) {
-        const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
+        const savedIndices = listViewSelectedFilters[label] as unknown as number[];
         setSelectedIndices(savedIndices);
         const inputValue = savedIndices.map((selectionIndex) => options[selectionIndex].value);
         setUncontrolledInputValue(inputValue);
@@ -108,7 +106,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
         setSelectedIndices([]);
       }
     } else if (listViewSelectedFilters[label]) {
-      const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
+      const savedIndices = listViewSelectedFilters[label] as unknown as number[];
       setSelectedIndices(savedIndices);
     } else if (valueNotEmpty && !isValueAndSelectedIndicesSynced && options.length > 0) {
       const newSelectedIndices =
@@ -149,7 +147,21 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     });
     setUncontrolledInputValue([]);
     setSelectedIndices([]);
-  }, [onClearButtonClick, onChange, name, idBase, label, isControlled, controlledValueIndices, selectedIndices, options, setFilterChipGroupSelectedFilters, setListViewSelectedFilters, setUncontrolledInputValue, setSelectedIndices]);
+  }, [
+    onClearButtonClick,
+    onChange,
+    name,
+    idBase,
+    label,
+    isControlled,
+    controlledValueIndices,
+    selectedIndices,
+    options,
+    setFilterChipGroupSelectedFilters,
+    setListViewSelectedFilters,
+    setUncontrolledInputValue,
+    setSelectedIndices,
+  ]);
 
   useEffect(() => {
     if (clearFilterCallbackTriggerer) {

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -1,13 +1,219 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { throwBladeError } from '~utils/logger';
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
-const BaseFilterChip = (_props: any): React.ReactElement => {
-  throwBladeError({
-    message: 'BaseFilterChip is not yet implemented for native',
-    moduleName: 'BaseFilterChip',
-  });
+import React, { useEffect } from 'react';
+import { useDropdown } from './useDropdown';
+import { dropdownComponentIds } from './dropdownComponentIds';
+import { useFilterChipGroupContext } from './FilterChipGroupContext';
+import type { DataAnalyticsAttribute } from '~utils/types';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { BaseFilterChip } from '~components/FilterChip/BaseFilterChip';
+import { getActionListContainerRole } from '~components/ActionList/getA11yRoles';
+import type { BaseFilterChipProps } from '~components/FilterChip/types';
+import { useId } from '~utils/useId';
+import { useListViewFilterContext } from '~components/ListView/ListViewFiltersContext';
+import { useFirstRender } from '~utils/useFirstRender';
 
-  return <></>;
+type FilterChipSelectInputProps = Pick<
+  BaseFilterChipProps,
+  'value' | 'label' | 'testID' | 'onClick' | 'selectionType'
+> & {
+  accessibilityLabel?: string;
+  onChange?: (props: { name: string; values: string[] }) => void;
+  name?: string;
+  onClearButtonClick?: (props: { name: string; values: string[] }) => void;
+  isDisabled?: boolean;
+} & DataAnalyticsAttribute;
+
+const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactElement => {
+  const idBase = useId('filter-chip-select-input');
+  const {
+    onClick,
+    accessibilityLabel,
+    testID,
+    value,
+    onClearButtonClick,
+    label,
+    onChange,
+    name,
+    isDisabled,
+    ...rest
+  } = props;
+  const [uncontrolledInputValue, setUncontrolledInputValue] = React.useState<string[]>([]);
+  const isFirstRender = useFirstRender();
+
+  const {
+    options,
+    selectedIndices,
+    onTriggerClick,
+    dropdownBaseId,
+    isOpen,
+    activeIndex,
+    hasFooterAction,
+    triggererRef,
+    selectionType,
+    isControlled,
+    setSelectedIndices,
+    controlledValueIndices,
+    changeCallbackTriggerer,
+  } = useDropdown();
+  const valueTitle = options.find((option) => option.value === value)?.title ?? value;
+
+  const isUnControlled = options.length > 0 && props.value === undefined;
+  const { listViewSelectedFilters, setListViewSelectedFilters } = useListViewFilterContext();
+  const {
+    clearFilterCallbackTriggerer,
+    setFilterChipGroupSelectedFilters,
+  } = useFilterChipGroupContext();
+
+  const getValuesArrayFromIndices = (): string[] => {
+    let indices: number[] = [];
+    if (isControlled) {
+      indices = controlledValueIndices;
+    } else {
+      indices = selectedIndices;
+    }
+
+    return indices.map((selectionIndex) => options[selectionIndex].value);
+  };
+
+  useEffect(() => {
+    const valueNotEmpty =
+      (typeof value === 'string' && value.trim() !== '') ||
+      (Array.isArray(value) && value.length > 0);
+
+    const currentSelectedValues = selectedIndices.map((i) => options[i]?.value);
+    const isSingleValueSynced =
+      typeof value === 'string' &&
+      currentSelectedValues.length === 1 &&
+      currentSelectedValues[0] === value;
+
+    const isMultiValueSynced =
+      Array.isArray(value) &&
+      value.length === currentSelectedValues.length &&
+      value.every((v) => currentSelectedValues.includes(v));
+
+    const isValueAndSelectedIndicesSynced = isSingleValueSynced || isMultiValueSynced;
+
+    if (isUnControlled) {
+      if (listViewSelectedFilters[label]) {
+        const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
+        setSelectedIndices(savedIndices);
+        const inputValue = savedIndices.map((selectionIndex) => options[selectionIndex].value);
+        setUncontrolledInputValue(inputValue);
+        setFilterChipGroupSelectedFilters((prev) =>
+          prev.includes(label) ? prev : [...prev, label],
+        );
+      } else {
+        setSelectedIndices([]);
+      }
+    } else if (listViewSelectedFilters[label]) {
+      const savedIndices = (listViewSelectedFilters[label] as unknown) as number[];
+      setSelectedIndices(savedIndices);
+    } else if (valueNotEmpty && !isValueAndSelectedIndicesSynced && options.length > 0) {
+      const newSelectedIndices =
+        typeof value === 'string'
+          ? [options.findIndex((option) => option.value === value)]
+          : options
+              .map((option, index) => (value.includes(option.value) ? index : -1))
+              .filter((index) => index !== -1);
+      setSelectedIndices(newSelectedIndices);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isUnControlled, options]);
+
+  const getTitleFromValue = (value: string): string => {
+    const option = options.find((option) => option.value === value);
+    return option ? option.title : '';
+  };
+
+  const getUnControlledFilterChipValue = (): string | string[] => {
+    if (selectionType === 'single') {
+      if (uncontrolledInputValue.length > 0) {
+        return getTitleFromValue(uncontrolledInputValue[0]);
+      }
+      return '';
+    }
+    return uncontrolledInputValue;
+  };
+
+  const handleClearButtonClick = (): void => {
+    props.onClearButtonClick?.({ name: name ?? idBase, values: getValuesArrayFromIndices() });
+    props.onChange?.({ name: name ?? idBase, values: [] });
+    setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
+    setListViewSelectedFilters((prev) => {
+      const { [label]: _, ...updatedFilters } = prev;
+      return updatedFilters;
+    });
+    setUncontrolledInputValue([]);
+    setSelectedIndices([]);
+  };
+
+  useEffect(() => {
+    if (clearFilterCallbackTriggerer) {
+      handleClearButtonClick();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clearFilterCallbackTriggerer]);
+
+  useEffect(() => {
+    if (!isFirstRender) {
+      props.onChange?.({
+        name: props.name || idBase,
+        values: getValuesArrayFromIndices(),
+      });
+      if (isUnControlled) {
+        setUncontrolledInputValue(getValuesArrayFromIndices());
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changeCallbackTriggerer]);
+
+  useEffect(() => {
+    const isValueEmpty = selectedIndices.length === 0;
+    if (!isFirstRender && !isValueEmpty) {
+      setFilterChipGroupSelectedFilters((prev) => (prev.includes(label) ? prev : [...prev, label]));
+      setListViewSelectedFilters((prev) => ({
+        ...prev,
+        [label]: selectedIndices as number[],
+      }));
+    } else if (!isFirstRender && isValueEmpty) {
+      setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
+      setListViewSelectedFilters((prev) => {
+        const { [label]: _, ...updatedFilters } = prev;
+        return updatedFilters;
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changeCallbackTriggerer]);
+
+  return (
+    <BaseFilterChip
+      label={label}
+      value={valueTitle ?? getUnControlledFilterChipValue()}
+      onClearButtonClick={handleClearButtonClick}
+      selectionType={selectionType}
+      {...rest}
+      testID={testID}
+      ref={triggererRef as any}
+      accessibilityProps={{
+        label: accessibilityLabel ?? label,
+        hasPopup: getActionListContainerRole(hasFooterAction, 'FilterChipSelectInput'),
+        expanded: isOpen,
+        controls: `${dropdownBaseId}-actionlist`,
+        activeDescendant: activeIndex >= 0 ? `${dropdownBaseId}-${activeIndex}` : undefined,
+      }}
+      onClick={(e) => {
+        onTriggerClick();
+        onClick?.(e);
+      }}
+      isDisabled={isDisabled}
+    />
+  );
 };
 
-export { BaseFilterChip };
+const FilterChipSelectInput = assignWithoutSideEffects(_FilterChipSelectInput, {
+  componentId: dropdownComponentIds.triggers.FilterChipSelectInput,
+});
+
+export { FilterChipSelectInput };

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDropdown } from './useDropdown';
 import { dropdownComponentIds } from './dropdownComponentIds';
 import { useFilterChipGroupContext } from './FilterChipGroupContext';
@@ -137,9 +137,11 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     return uncontrolledInputValue;
   };
 
-  const handleClearButtonClick = (): void => {
-    props.onClearButtonClick?.({ name: name ?? idBase, values: getValuesArrayFromIndices() });
-    props.onChange?.({ name: name ?? idBase, values: [] });
+  const handleClearButtonClick = useCallback((): void => {
+    const indices = isControlled ? controlledValueIndices : selectedIndices;
+    const currentValues = indices.map((selectionIndex) => options[selectionIndex].value);
+    onClearButtonClick?.({ name: name ?? idBase, values: currentValues });
+    onChange?.({ name: name ?? idBase, values: [] });
     setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
     setListViewSelectedFilters((prev) => {
       const { [label]: _, ...updatedFilters } = prev;
@@ -147,14 +149,13 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     });
     setUncontrolledInputValue([]);
     setSelectedIndices([]);
-  };
+  }, [onClearButtonClick, onChange, name, idBase, label, isControlled, controlledValueIndices, selectedIndices, options, setFilterChipGroupSelectedFilters, setListViewSelectedFilters, setUncontrolledInputValue, setSelectedIndices]);
 
   useEffect(() => {
     if (clearFilterCallbackTriggerer) {
       handleClearButtonClick();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clearFilterCallbackTriggerer]);
+  }, [clearFilterCallbackTriggerer, handleClearButtonClick]);
 
   useEffect(() => {
     if (!isFirstRender) {
@@ -165,24 +166,22 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       if (isUnControlled) {
         setUncontrolledInputValue(getValuesArrayFromIndices());
       }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [changeCallbackTriggerer]);
-
-  useEffect(() => {
-    const isValueEmpty = selectedIndices.length === 0;
-    if (!isFirstRender && !isValueEmpty) {
-      setFilterChipGroupSelectedFilters((prev) => (prev.includes(label) ? prev : [...prev, label]));
-      setListViewSelectedFilters((prev) => ({
-        ...prev,
-        [label]: selectedIndices as number[],
-      }));
-    } else if (!isFirstRender && isValueEmpty) {
-      setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
-      setListViewSelectedFilters((prev) => {
-        const { [label]: _, ...updatedFilters } = prev;
-        return updatedFilters;
-      });
+      const isValueEmpty = selectedIndices.length === 0;
+      if (!isValueEmpty) {
+        setFilterChipGroupSelectedFilters((prev) =>
+          prev.includes(label) ? prev : [...prev, label],
+        );
+        setListViewSelectedFilters((prev) => ({
+          ...prev,
+          [label]: selectedIndices as number[],
+        }));
+      } else {
+        setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
+        setListViewSelectedFilters((prev) => {
+          const { [label]: _, ...updatedFilters } = prev;
+          return updatedFilters;
+        });
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [changeCallbackTriggerer]);

--- a/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
+++ b/packages/blade/src/components/Dropdown/FilterChipSelectInput.native.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDropdown } from './useDropdown';
 import { dropdownComponentIds } from './dropdownComponentIds';
 import { useFilterChipGroupContext } from './FilterChipGroupContext';
@@ -137,7 +137,7 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     return uncontrolledInputValue;
   };
 
-  const handleClearButtonClick = useCallback((): void => {
+  const handleClearButtonClick = (): void => {
     const indices = isControlled ? controlledValueIndices : selectedIndices;
     const currentValues = indices.map((selectionIndex) => options[selectionIndex].value);
     onClearButtonClick?.({ name: name ?? idBase, values: currentValues });
@@ -149,27 +149,14 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
     });
     setUncontrolledInputValue([]);
     setSelectedIndices([]);
-  }, [
-    onClearButtonClick,
-    onChange,
-    name,
-    idBase,
-    label,
-    isControlled,
-    controlledValueIndices,
-    selectedIndices,
-    options,
-    setFilterChipGroupSelectedFilters,
-    setListViewSelectedFilters,
-    setUncontrolledInputValue,
-    setSelectedIndices,
-  ]);
+  };
 
   useEffect(() => {
     if (clearFilterCallbackTriggerer) {
       handleClearButtonClick();
     }
-  }, [clearFilterCallbackTriggerer, handleClearButtonClick]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clearFilterCallbackTriggerer]);
 
   useEffect(() => {
     if (!isFirstRender) {
@@ -180,22 +167,24 @@ const _FilterChipSelectInput = (props: FilterChipSelectInputProps): React.ReactE
       if (isUnControlled) {
         setUncontrolledInputValue(getValuesArrayFromIndices());
       }
-      const isValueEmpty = selectedIndices.length === 0;
-      if (!isValueEmpty) {
-        setFilterChipGroupSelectedFilters((prev) =>
-          prev.includes(label) ? prev : [...prev, label],
-        );
-        setListViewSelectedFilters((prev) => ({
-          ...prev,
-          [label]: selectedIndices as number[],
-        }));
-      } else {
-        setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
-        setListViewSelectedFilters((prev) => {
-          const { [label]: _, ...updatedFilters } = prev;
-          return updatedFilters;
-        });
-      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changeCallbackTriggerer]);
+
+  useEffect(() => {
+    const isValueEmpty = selectedIndices.length === 0;
+    if (!isFirstRender && !isValueEmpty) {
+      setFilterChipGroupSelectedFilters((prev) => (prev.includes(label) ? prev : [...prev, label]));
+      setListViewSelectedFilters((prev) => ({
+        ...prev,
+        [label]: selectedIndices as number[],
+      }));
+    } else if (!isFirstRender && isValueEmpty) {
+      setFilterChipGroupSelectedFilters((prev) => prev.filter((filter) => filter !== label));
+      setListViewSelectedFilters((prev) => {
+        const { [label]: _, ...updatedFilters } = prev;
+        return updatedFilters;
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [changeCallbackTriggerer]);

--- a/packages/blade/src/components/Dropdown/StyledDropdownOverlay.native.tsx
+++ b/packages/blade/src/components/Dropdown/StyledDropdownOverlay.native.tsx
@@ -1,10 +1,15 @@
 import styled from 'styled-components/native';
 import BaseBox from '~components/Box/BaseBox';
-import { makeSize } from '~utils';
+import { makeBorderSize, makeSize } from '~utils';
 import type { ColorSchemeNames } from '~tokens/theme';
 
-// Web-only CSS properties (borderWidth:'none', backdropFilter, borderTopStyle) are intentionally
+// Web-only CSS properties (backdropFilter, borderTopStyle) are intentionally
 // excluded here — they are invalid in React Native and crash Fabric/New Architecture.
+// On web the menu's defined edge comes from the elevation drop-shadow combined with an inset
+// border-shadow (see getPopupBoxShadowString). Native can't render inset box-shadows, and the web
+// popup border token (popup.border.gray.subtle) is a ~9% opacity color that reads as invisible on a
+// white surface. To make the native edge as clearly visible as web's perceived edge, we use a real
+// 1px border with the standard opaque neutral border token.
 const StyledDropdownOverlay = styled(BaseBox)<{
   isInBottomSheet?: boolean;
   colorScheme: ColorSchemeNames;
@@ -13,6 +18,9 @@ const StyledDropdownOverlay = styled(BaseBox)<{
   return {
     backgroundColor: theme.colors.popup.background.gray.moderate,
     borderRadius: makeSize(theme.border.radius.medium),
+    borderWidth: makeBorderSize(theme.border.width.thin),
+    borderStyle: 'solid',
+    borderColor: theme.colors.surface.border.gray.normal,
   };
 });
 

--- a/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
+++ b/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
@@ -170,4 +170,26 @@ describe('<FilterChipSelectInput /> (native)', () => {
     // A selected chip renders the clear button.
     expect(getByLabelText('Clear Status value')).toBeTruthy();
   });
+
+  it('should reflect a controlled multiple value with counter and clear button', () => {
+    const { getByText, getByLabelText } = renderWithTheme(
+      <Dropdown selectionType="multiple">
+        <FilterChipSelectInput
+          label="Status"
+          name="status"
+          value={['active', 'inactive']}
+        />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    // Controlled multi passes the array through as chip value → Counter shows selection count.
+    expect(getByText('2')).toBeTruthy();
+    expect(getByLabelText('Clear Status value')).toBeTruthy();
+  });
 });

--- a/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
+++ b/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
@@ -174,11 +174,7 @@ describe('<FilterChipSelectInput /> (native)', () => {
   it('should reflect a controlled multiple value with counter and clear button', () => {
     const { getByText, getByLabelText } = renderWithTheme(
       <Dropdown selectionType="multiple">
-        <FilterChipSelectInput
-          label="Status"
-          name="status"
-          value={['active', 'inactive']}
-        />
+        <FilterChipSelectInput label="Status" name="status" value={['active', 'inactive']} />
         <DropdownOverlay>
           <ActionList>
             <ActionListItem title="Active" value="active" />

--- a/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
+++ b/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
@@ -96,4 +96,78 @@ describe('<FilterChipSelectInput /> (native)', () => {
 
     expect(getByTestId('filter-chip-test')).toBeTruthy();
   });
+
+  it('should select multiple options and report all selected values', () => {
+    const onChange = jest.fn();
+    const { getByText, getAllByRole } = renderWithTheme(
+      <Dropdown selectionType="multiple">
+        <FilterChipSelectInput label="Status" name="status" onChange={onChange} />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    fireEvent.press(getByText('Status'));
+    const menuItems = getAllByRole('menuitem');
+    fireEvent.press(menuItems[0]);
+    fireEvent.press(menuItems[1]);
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      name: 'status',
+      values: ['active', 'inactive'],
+    });
+  });
+
+  it('should clear the selected value when the clear button is pressed', () => {
+    const onChange = jest.fn();
+    const onClearButtonClick = jest.fn();
+    const { getByText, getByLabelText, getAllByRole } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput
+          label="Status"
+          name="status"
+          onChange={onChange}
+          onClearButtonClick={onClearButtonClick}
+        />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    fireEvent.press(getByText('Status'));
+    fireEvent.press(getAllByRole('menuitem')[0]);
+    expect(onChange).toHaveBeenLastCalledWith({ name: 'status', values: ['active'] });
+
+    fireEvent.press(getByLabelText('Clear Status value'));
+
+    expect(onClearButtonClick).toHaveBeenCalledWith({ name: 'status', values: ['active'] });
+    expect(onChange).toHaveBeenLastCalledWith({ name: 'status', values: [] });
+  });
+
+  it('should reflect a controlled value as the selected chip value', () => {
+    const { getAllByText, getByLabelText } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput label="Status" name="status" value="active" />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    // "Active" is rendered both in the chip trigger (selected value) and in the ActionList item.
+    expect(getAllByText('Active').length).toBeGreaterThanOrEqual(2);
+    // A selected chip renders the clear button.
+    expect(getByLabelText('Clear Status value')).toBeTruthy();
+  });
 });

--- a/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
+++ b/packages/blade/src/components/Dropdown/__tests__/FilterChipSelectInput.native.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { Dropdown, DropdownOverlay } from '../index';
+import { FilterChipSelectInput } from '../FilterChipSelectInput';
+import renderWithTheme from '~utils/testing/renderWithTheme.native';
+import { ActionList, ActionListItem } from '~components/ActionList';
+
+beforeAll(() => jest.spyOn(console, 'error').mockImplementation());
+afterAll(() => jest.restoreAllMocks());
+
+describe('<FilterChipSelectInput /> (native)', () => {
+  it('should render with default props', () => {
+    const { toJSON } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput label="Status" />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should open dropdown on press', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput label="Status" />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    expect(getByTestId('dropdown-overlay').props.display).toBe('none');
+    fireEvent.press(getByText('Status'));
+    expect(getByTestId('dropdown-overlay').props.display).toBe('flex');
+  });
+
+  it('should select an option and display its value', () => {
+    const onChange = jest.fn();
+    const { getByText, getByTestId, getAllByRole } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput label="Status" name="status" onChange={onChange} />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    fireEvent.press(getByText('Status'));
+    expect(getByTestId('dropdown-overlay').props.display).toBe('flex');
+    fireEvent.press(getAllByRole('menuitem')[0]);
+    expect(onChange).toHaveBeenCalledWith({ name: 'status', values: ['active'] });
+  });
+
+  it('should not open dropdown when disabled', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput label="Status" isDisabled />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    expect(getByTestId('dropdown-overlay').props.display).toBe('none');
+    fireEvent.press(getByText('Status'));
+    expect(getByTestId('dropdown-overlay').props.display).toBe('none');
+  });
+
+  it('should accept testID', () => {
+    const { getByTestId } = renderWithTheme(
+      <Dropdown>
+        <FilterChipSelectInput label="Status" testID="filter-chip-test" />
+        <DropdownOverlay>
+          <ActionList>
+            <ActionListItem title="Active" value="active" />
+            <ActionListItem title="Inactive" value="inactive" />
+          </ActionList>
+        </DropdownOverlay>
+      </Dropdown>,
+    );
+
+    expect(getByTestId('filter-chip-test')).toBeTruthy();
+  });
+});

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/Dropdown.native.test.tsx.snap
@@ -862,12 +862,25 @@ exports[`<Dropdown /> should render dropdown 1`] = `
                 [
                   {
                     "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                    "borderColor": "hsla(203, 8%, 80%, 1)",
                     "borderRadius": 12,
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
                     "transform": [
                       {
                         "translateY": 8,
                       },
                     ],
+                  },
+                  {
+                    "elevation": 16,
+                    "shadowColor": "hsla(200, 10%, 18%, 1)",
+                    "shadowOffset": {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.06,
+                    "shadowRadius": 4,
                   },
                 ],
               ]

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
@@ -32,19 +32,20 @@ exports[`<FilterChipSelectInput /> (native) should render with default props 1`]
       textAlign="left"
     >
       <View
+        onLayout={[Function]}
         style={
           [
             {
               "alignSelf": "flex-start",
               "backgroundColor": "hsla(0, 0%, 100%, 1)",
-              "borderColor": "hsla(206, 10%, 29%, 0.18)",
+              "borderColor": "transparent",
               "borderRadius": 8,
-              "borderStyle": "dashed",
-              "borderWidth": 1,
+              "borderStyle": "solid",
+              "borderWidth": 0,
               "flexDirection": "row",
               "height": 28,
               "opacity": 1,
-              "overflow": "hidden",
+              "overflow": "visible",
             },
           ]
         }
@@ -311,12 +312,25 @@ exports[`<FilterChipSelectInput /> (native) should render with default props 1`]
                 [
                   {
                     "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                    "borderColor": "hsla(203, 8%, 80%, 1)",
                     "borderRadius": 12,
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
                     "transform": [
                       {
                         "translateY": 8,
                       },
                     ],
+                  },
+                  {
+                    "elevation": 16,
+                    "shadowColor": "hsla(200, 10%, 18%, 1)",
+                    "shadowOffset": {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.06,
+                    "shadowRadius": 4,
                   },
                 ],
               ]

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
@@ -44,7 +44,6 @@ exports[`<FilterChipSelectInput /> (native) should render with default props 1`]
               "borderWidth": 0,
               "flexDirection": "row",
               "height": 28,
-              "opacity": 1,
               "overflow": "visible",
             },
           ]

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`<FilterChipSelectInput /> (native) should render with default props 1`]
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
+          onKeyDown={[Function]}
           onResponderGrant={[Function]}
           onResponderMove={[Function]}
           onResponderRelease={[Function]}

--- a/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Dropdown/__tests__/__snapshots__/FilterChipSelectInput.native.test.tsx.snap
@@ -1,0 +1,768 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FilterChipSelectInput /> (native) should render with default props 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    data-blade-component="dropdown"
+    style={
+      [
+        {},
+      ]
+    }
+  >
+    <View
+      data-blade-component="base-box"
+      height="100%"
+      position="relative"
+      style={
+        [
+          {
+            "height": "100%",
+            "position": "relative",
+            "textAlign": "left",
+          },
+        ]
+      }
+      textAlign="left"
+    >
+      <View
+        style={
+          [
+            {
+              "alignSelf": "flex-start",
+              "backgroundColor": "hsla(0, 0%, 100%, 1)",
+              "borderColor": "hsla(206, 10%, 29%, 0.18)",
+              "borderRadius": 8,
+              "borderStyle": "dashed",
+              "borderWidth": 1,
+              "flexDirection": "row",
+              "height": 28,
+              "opacity": 1,
+              "overflow": "hidden",
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityControls="dropdown-2-actionlist"
+          accessibilityHasPopup="menu"
+          accessibilityLabel="Status"
+          accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": false,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          data-blade-component="filter-chip-trigger"
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "alignItems": "center",
+                "backgroundColor": "transparent",
+                "borderBottomLeftRadius": 8,
+                "borderRadius": 8,
+                "borderTopLeftRadius": 8,
+                "flexDirection": "row",
+                "gap": 4,
+                "height": "100%",
+                "paddingLeft": 12,
+                "paddingRight": 8,
+              },
+            ]
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="box"
+            flexDirection="row"
+            gap="spacing.2"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 4,
+                },
+              ]
+            }
+          >
+            <Text
+              accessible={true}
+              color="interactive.text.gray.subtle"
+              data-blade-component="text"
+              fontFamily="text"
+              fontSize={75}
+              fontStyle="normal"
+              fontWeight="medium"
+              letterSpacing={50}
+              lineHeight={75}
+              numberOfLines={1}
+              style={
+                [
+                  {
+                    "color": "hsla(200, 10%, 18%, 1)",
+                    "fontFamily": "Inter",
+                    "fontSize": 12,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": -0.15600000000000003,
+                    "lineHeight": 17,
+                    "marginBottom": 0,
+                    "marginLeft": 0,
+                    "marginRight": 0,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+            >
+              Status
+            </Text>
+          </View>
+          <View
+            alignItems="center"
+            data-blade-component="box"
+            flexDirection="row"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "paddingRight": 2,
+                },
+              ]
+            }
+          >
+            <RNSVGSvgView
+              accessibilityElementsHidden={true}
+              align="xMidYMid"
+              bbHeight="12px"
+              bbWidth="12px"
+              data-blade-component="icon"
+              fill="none"
+              focusable={false}
+              height="12px"
+              importantForAccessibility="no-hide-descendants"
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
+                [
+                  {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  [
+                    {},
+                  ],
+                  {
+                    "flex": 0,
+                    "height": 12,
+                    "width": 12,
+                  },
+                ]
+              }
+              vbHeight={24}
+              vbWidth={24}
+              width="12px"
+            >
+              <RNSVGGroup
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+              >
+                <RNSVGPath
+                  clipRule={0}
+                  d="M5.29289 8.29289C5.68342 7.90237 6.31658 7.90237 6.70711 8.29289L12 13.5858L17.2929 8.29289C17.6834 7.90237 18.3166 7.90237 18.7071 8.29289C19.0976 8.68342 19.0976 9.31658 18.7071 9.70711L12.7071 15.7071C12.3166 16.0976 11.6834 16.0976 11.2929 15.7071L5.29289 9.70711C4.90237 9.31658 4.90237 8.68342 5.29289 8.29289Z"
+                  fill={
+                    {
+                      "payload": 4284575093,
+                      "type": 0,
+                    }
+                  }
+                  fillRule={0}
+                  propList={
+                    [
+                      "fill",
+                      "fillRule",
+                    ]
+                  }
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
+        </View>
+      </View>
+      <View
+        data-blade-component="base-box"
+        position="relative"
+        style={
+          [
+            {
+              "position": "relative",
+            },
+          ]
+        }
+      >
+        <View
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
+          accessible={true}
+          collapsable={false}
+          display="none"
+          focusable={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            [
+              {
+                "display": "none",
+                "height": "100%",
+                "position": "static",
+                "width": "100%",
+              },
+            ]
+          }
+          testID="closeable-area"
+        >
+          <View
+            colorScheme="light"
+            data-blade-component="dropdown-overlay"
+            display="none"
+            elevation="midRaised"
+            isInBottomSheet={false}
+            position="absolute"
+            style={
+              [
+                {
+                  "display": "none",
+                  "position": "absolute",
+                  "width": "100%",
+                },
+                {
+                  "elevation": 16,
+                  "shadowColor": "hsla(200, 10%, 18%, 1)",
+                  "shadowOffset": {
+                    "height": 2,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.06,
+                  "shadowRadius": 4,
+                },
+                [
+                  {
+                    "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                    "borderRadius": 12,
+                    "transform": [
+                      {
+                        "translateY": 8,
+                      },
+                    ],
+                  },
+                ],
+              ]
+            }
+            testID="dropdown-overlay"
+            width="100%"
+          >
+            <View
+              accessibilityLabelledBy="dropdown-2-label"
+              accessibilityRole="menu"
+              accessible={true}
+              data-blade-component="action-list"
+              id="dropdown-2-actionlist"
+              style={
+                [
+                  {},
+                ]
+              }
+            >
+              <RCTScrollView
+                accessible={true}
+                data={
+                  [
+                    {
+                      "data": [
+                        {
+                          "_index": 0,
+                          "title": "Active",
+                          "value": "active",
+                        },
+                        {
+                          "_index": 1,
+                          "title": "Inactive",
+                          "value": "inactive",
+                        },
+                      ],
+                      "hideDivider": true,
+                      "title": null,
+                    },
+                  ]
+                }
+                getItem={[Function]}
+                getItemCount={[Function]}
+                isInBottomSheet={false}
+                keyExtractor={[Function]}
+                marginBottom={0}
+                onContentSizeChange={[Function]}
+                onLayout={[Function]}
+                onMomentumScrollBegin={[Function]}
+                onMomentumScrollEnd={[Function]}
+                onScroll={[Function]}
+                onScrollBeginDrag={[Function]}
+                onScrollEndDrag={[Function]}
+                renderItem={[Function]}
+                scrollEventThrottle={50}
+                stickyHeaderIndices={[]}
+                style={
+                  [
+                    {
+                      "marginBottom": 0,
+                      "maxHeight": 300,
+                      "paddingBottom": 8,
+                      "paddingLeft": 8,
+                      "paddingRight": 8,
+                      "paddingTop": 8,
+                    },
+                  ]
+                }
+                windowSize={5}
+              >
+                <View>
+                  <View
+                    onFocusCapture={[Function]}
+                    onLayout={[Function]}
+                    style={null}
+                  />
+                  <View
+                    onFocusCapture={[Function]}
+                    onLayout={[Function]}
+                    style={null}
+                  >
+                    <View
+                      accessibilityRole="menuitem"
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": false,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onClick={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        {
+                          "borderRadius": 8,
+                          "borderWidth": 0,
+                          "cursor": "pointer",
+                          "display": "flex",
+                          "flexDirection": "column",
+                          "opacity": 1,
+                          "paddingBottom": 8,
+                          "paddingLeft": 8,
+                          "paddingRight": 8,
+                          "paddingTop": 8,
+                          "textDecorationColor": "black",
+                          "textDecorationLine": "none",
+                          "textDecorationStyle": "solid",
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        alignItems="flex-start"
+                        data-blade-component="box"
+                        display="flex"
+                        flexDirection="row"
+                        justifyContent="flex-start"
+                        style={
+                          [
+                            {
+                              "alignItems": "flex-start",
+                              "display": "flex",
+                              "flexDirection": "row",
+                              "justifyContent": "flex-start",
+                              "width": "100%",
+                            },
+                          ]
+                        }
+                        width="100%"
+                      >
+                        <View
+                          alignItems="center"
+                          data-blade-component="box"
+                          display="flex"
+                          height="20px"
+                          justifyContent="center"
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "display": "flex",
+                                "height": 20,
+                                "justifyContent": "center",
+                              },
+                            ]
+                          }
+                        />
+                        <View
+                          data-blade-component="box"
+                          display="flex"
+                          flexDirection="column"
+                          style={
+                            [
+                              {
+                                "display": "flex",
+                                "flexDirection": "column",
+                                "paddingLeft": 0,
+                                "paddingRight": 8,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            alignItems="center"
+                            data-blade-component="box"
+                            display="flex"
+                            flexDirection="row"
+                            height="20px"
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "height": 20,
+                                },
+                              ]
+                            }
+                          >
+                            <Text
+                              accessible={true}
+                              color="interactive.text.gray.normal"
+                              data-blade-component="text"
+                              fontFamily="text"
+                              fontSize={100}
+                              fontStyle="normal"
+                              fontWeight="regular"
+                              lineHeight={100}
+                              numberOfLines={1}
+                              style={
+                                [
+                                  {
+                                    "color": "hsla(0, 0%, 2%, 1)",
+                                    "fontFamily": "Inter",
+                                    "fontSize": 14,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "letterSpacing": 0,
+                                    "lineHeight": 20,
+                                    "marginBottom": 0,
+                                    "marginLeft": 0,
+                                    "marginRight": 0,
+                                    "marginTop": 0,
+                                    "paddingBottom": 0,
+                                    "paddingLeft": 0,
+                                    "paddingRight": 0,
+                                    "paddingTop": 0,
+                                    "textDecorationLine": "none",
+                                  },
+                                ]
+                              }
+                            >
+                              Active
+                            </Text>
+                          </View>
+                          <View
+                            data-blade-component="box"
+                            style={
+                              [
+                                {},
+                              ]
+                            }
+                          />
+                        </View>
+                        <View
+                          data-blade-component="box"
+                          style={
+                            [
+                              {
+                                "marginLeft": "auto",
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    onFocusCapture={[Function]}
+                    onLayout={[Function]}
+                    style={null}
+                  >
+                    <View
+                      accessibilityRole="menuitem"
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": undefined,
+                          "expanded": undefined,
+                          "selected": false,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onClick={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        {
+                          "borderRadius": 8,
+                          "borderWidth": 0,
+                          "cursor": "pointer",
+                          "display": "flex",
+                          "flexDirection": "column",
+                          "opacity": 1,
+                          "paddingBottom": 8,
+                          "paddingLeft": 8,
+                          "paddingRight": 8,
+                          "paddingTop": 8,
+                          "textDecorationColor": "black",
+                          "textDecorationLine": "none",
+                          "textDecorationStyle": "solid",
+                          "width": "100%",
+                        }
+                      }
+                    >
+                      <View
+                        alignItems="flex-start"
+                        data-blade-component="box"
+                        display="flex"
+                        flexDirection="row"
+                        justifyContent="flex-start"
+                        style={
+                          [
+                            {
+                              "alignItems": "flex-start",
+                              "display": "flex",
+                              "flexDirection": "row",
+                              "justifyContent": "flex-start",
+                              "width": "100%",
+                            },
+                          ]
+                        }
+                        width="100%"
+                      >
+                        <View
+                          alignItems="center"
+                          data-blade-component="box"
+                          display="flex"
+                          height="20px"
+                          justifyContent="center"
+                          style={
+                            [
+                              {
+                                "alignItems": "center",
+                                "display": "flex",
+                                "height": 20,
+                                "justifyContent": "center",
+                              },
+                            ]
+                          }
+                        />
+                        <View
+                          data-blade-component="box"
+                          display="flex"
+                          flexDirection="column"
+                          style={
+                            [
+                              {
+                                "display": "flex",
+                                "flexDirection": "column",
+                                "paddingLeft": 0,
+                                "paddingRight": 8,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            alignItems="center"
+                            data-blade-component="box"
+                            display="flex"
+                            flexDirection="row"
+                            height="20px"
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "display": "flex",
+                                  "flexDirection": "row",
+                                  "height": 20,
+                                },
+                              ]
+                            }
+                          >
+                            <Text
+                              accessible={true}
+                              color="interactive.text.gray.normal"
+                              data-blade-component="text"
+                              fontFamily="text"
+                              fontSize={100}
+                              fontStyle="normal"
+                              fontWeight="regular"
+                              lineHeight={100}
+                              numberOfLines={1}
+                              style={
+                                [
+                                  {
+                                    "color": "hsla(0, 0%, 2%, 1)",
+                                    "fontFamily": "Inter",
+                                    "fontSize": 14,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "letterSpacing": 0,
+                                    "lineHeight": 20,
+                                    "marginBottom": 0,
+                                    "marginLeft": 0,
+                                    "marginRight": 0,
+                                    "marginTop": 0,
+                                    "paddingBottom": 0,
+                                    "paddingLeft": 0,
+                                    "paddingRight": 0,
+                                    "paddingTop": 0,
+                                    "textDecorationLine": "none",
+                                  },
+                                ]
+                              }
+                            >
+                              Inactive
+                            </Text>
+                          </View>
+                          <View
+                            data-blade-component="box"
+                            style={
+                              [
+                                {},
+                              ]
+                            }
+                          />
+                        </View>
+                        <View
+                          data-blade-component="box"
+                          style={
+                            [
+                              {
+                                "marginLeft": "auto",
+                              },
+                            ]
+                          }
+                        />
+                      </View>
+                    </View>
+                  </View>
+                  <View
+                    onFocusCapture={[Function]}
+                    onLayout={[Function]}
+                    style={null}
+                  />
+                </View>
+              </RCTScrollView>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -1,13 +1,178 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import styled from 'styled-components/native';
 import type { BaseFilterChipProps } from './types';
-import { throwBladeError } from '~utils/logger';
+import { size } from '~tokens/global';
+import { makeBorderSize } from '~utils';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAccessible } from '~utils/makeAccessible';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { Box } from '~components/Box';
+import { Counter } from '~components/Counter';
+import { Divider } from '~components/Divider';
+import { ChevronDownIcon, CloseIcon } from '~components/Icons';
+import { Text } from '~components/Typography';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import type { Theme } from '~components/BladeProvider';
 
-const BaseFilterChip = (_props: BaseFilterChipProps): React.ReactElement => {
-  throwBladeError({
-    message: 'BaseFilterChip is not yet implemented for native',
-    moduleName: 'BaseFilterChip',
-  });
+const FILTER_CHIP_HEIGHT_NATIVE = size['28'];
 
-  return <></>;
+const StyledFilterChip = styled(View)<{
+  theme: Theme;
+  $isSelected?: boolean;
+  $isDisabled?: boolean;
+}>(({ theme, $isDisabled, $isSelected }) => {
+  return {
+    borderWidth: makeBorderSize(theme.border.width.thin) as unknown as number,
+    borderColor:
+      theme.colors.interactive.border.gray[$isDisabled ? 'disabled' : 'faded'],
+    height: FILTER_CHIP_HEIGHT_NATIVE,
+    borderRadius: theme.border.radius.small,
+    borderStyle: $isSelected ? 'solid' : 'dashed',
+    backgroundColor: theme.colors.surface.background.gray.intense,
+    flexDirection: 'row',
+    alignSelf: 'flex-start',
+    overflow: 'hidden',
+    opacity: $isDisabled ? 0.5 : 1,
+  };
+});
+
+const StyledFilterTrigger = styled(Pressable)<{
+  theme: Theme;
+  $isSelected?: boolean;
+}>(({ theme, $isSelected }) => {
+  const { spacing } = theme;
+  return {
+    backgroundColor: 'transparent',
+    borderRadius: $isSelected ? 0 : theme.border.radius.small,
+    borderTopLeftRadius: theme.border.radius.small,
+    borderBottomLeftRadius: theme.border.radius.small,
+    paddingLeft: spacing[4],
+    paddingRight: $isSelected ? spacing[2] : spacing[3],
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: '100%',
+    gap: spacing[2],
+  };
+});
+
+const StyledFilterCloseButton = styled(Pressable)<{ theme: Theme }>(({ theme }) => {
+  return {
+    backgroundColor: 'transparent',
+    borderTopRightRadius: theme.border.radius.small,
+    borderBottomRightRadius: theme.border.radius.small,
+    paddingLeft: theme.spacing[2] + theme.spacing[1],
+    paddingRight: theme.spacing[2] + theme.spacing[1],
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100%',
+  };
+});
+
+const renderValue = (
+  selectionType: BaseFilterChipProps['selectionType'],
+  value: BaseFilterChipProps['value'],
+  isDisabled?: boolean,
+): React.ReactElement => {
+  if (selectionType === 'multiple' && Array.isArray(value)) {
+    return (
+      <Box alignItems="center" flexDirection="row">
+        <Counter value={value.length} color="neutral" size="small" />
+      </Box>
+    );
+  }
+
+  return (
+    <Text
+      size="small"
+      weight="medium"
+      color={isDisabled ? 'interactive.text.gray.disabled' : 'interactive.text.gray.normal'}
+    >
+      {value as string}
+    </Text>
+  );
 };
+
+const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps> = (
+  {
+    value,
+    onClearButtonClick,
+    label,
+    isDisabled,
+    selectionType = 'single',
+    onClick,
+    accessibilityProps,
+    id,
+    ...rest
+  }: BaseFilterChipProps,
+  ref: React.Ref<View>,
+): React.ReactElement => {
+  const isSelected =
+    selectionType === 'multiple' ? Array.isArray(value) && value.length > 0 : !!value;
+
+  return (
+    <StyledFilterChip
+      $isDisabled={isDisabled}
+      $isSelected={isSelected}
+      ref={ref}
+    >
+      <StyledFilterTrigger
+        $isSelected={isSelected}
+        disabled={isDisabled}
+        onPress={
+          isDisabled
+            ? undefined
+            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (e: any) => {
+                onClick?.(e);
+              }
+        }
+        {...makeAccessible({
+          ...accessibilityProps,
+          role: accessibilityProps?.role ?? 'button',
+        })}
+        {...makeAnalyticsAttribute(rest)}
+        {...metaAttribute({ name: 'filter-chip-trigger', testID: rest.testID })}
+      >
+        <Box flexDirection="row" gap="spacing.2" alignItems="center">
+          <Text
+            size="small"
+            weight="medium"
+            color="interactive.text.gray.subtle"
+            truncateAfterLines={1}
+          >
+            {label}
+            {isSelected ? ':' : null}
+          </Text>
+          {isSelected ? renderValue(selectionType, value, isDisabled) : null}
+        </Box>
+        <Box flexDirection="row" alignItems="center" paddingRight="spacing.1">
+          <ChevronDownIcon size="small" color="interactive.icon.gray.muted" />
+        </Box>
+      </StyledFilterTrigger>
+      {isSelected ? (
+        <>
+          <Divider orientation="vertical" variant={isDisabled ? 'muted' : 'subtle'} />
+          <StyledFilterCloseButton
+            accessibilityLabel={`Clear ${label} value`}
+            onPress={
+              isDisabled
+                ? undefined
+                : () => onClearButtonClick?.({ value: value ?? '' })
+            }
+            disabled={isDisabled}
+            {...metaAttribute({ name: 'filter-chip-close-button' })}
+          >
+            <CloseIcon size="small" color="interactive.icon.gray.muted" />
+          </StyledFilterCloseButton>
+        </>
+      ) : null}
+    </StyledFilterChip>
+  );
+};
+
+const BaseFilterChip = assignWithoutSideEffects(React.forwardRef(_BaseFilterChip), {
+  componentId: MetaConstants.BaseFilterChip,
+});
 
 export { BaseFilterChip };

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -160,7 +160,7 @@ const renderValue = (
       weight="medium"
       color={isDisabled ? 'interactive.text.gray.disabled' : 'interactive.text.gray.normal'}
     >
-      {value as string}
+      {typeof value === 'string' ? value : ''}
     </Text>
   );
 };
@@ -173,6 +173,7 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
     isDisabled,
     selectionType = 'single',
     onClick,
+    onKeyDown,
     accessibilityProps,
     id,
     ...rest
@@ -209,6 +210,14 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
                 onClick?.(e);
               }
         }
+        {...({
+          onKeyDown: isDisabled
+            ? undefined
+            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (e: any) => {
+                onKeyDown?.(e);
+              },
+        } as any)}
         {...makeAccessible({
           ...accessibilityProps,
           role: accessibilityProps?.role ?? 'button',
@@ -237,7 +246,7 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
           <Divider orientation="vertical" variant={isDisabled ? 'muted' : 'subtle'} />
           <StyledFilterCloseButton
             {...makeAccessible({ label: `Clear ${label} value`, role: 'button' })}
-            onPress={isDisabled ? undefined : () => onClearButtonClick?.({ value: value ?? '' })}
+            onPress={isDisabled ? undefined : () => onClearButtonClick?.()}
             disabled={isDisabled}
             {...metaAttribute({ name: 'filter-chip-close-button' })}
           >

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Pressable, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
+import type { LayoutChangeEvent } from 'react-native';
 import styled from 'styled-components/native';
+import Svg, { Rect } from 'react-native-svg';
 import type { BaseFilterChipProps } from './types';
 import { size } from '~tokens/global';
 import { makeBorderSize } from '~utils';
@@ -13,9 +15,73 @@ import { Divider } from '~components/Divider';
 import { ChevronDownIcon, CloseIcon } from '~components/Icons';
 import { Text } from '~components/Typography';
 import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { useTheme } from '~components/BladeProvider';
 import type { Theme } from '~components/BladeProvider';
 
 const FILTER_CHIP_HEIGHT_NATIVE = size['28'];
+
+/**
+ * React Native's `borderStyle: 'dashed'` combined with `borderRadius` is buggy on iOS —
+ * dashes render inconsistently and produce a broken/overlapping artifact near the corners
+ * and the right edge. To match web's clean dashed pill, we draw the dashed border ourselves
+ * with `react-native-svg` as a rounded `Rect` whose dash pattern divides evenly around the
+ * perimeter (so there's no visible seam where the stroke path closes).
+ */
+const DashedBorder = ({
+  width,
+  height,
+  borderRadius,
+  strokeWidth,
+  color,
+}: {
+  width: number;
+  height: number;
+  borderRadius: number;
+  strokeWidth: number;
+  color: string;
+}): React.ReactElement | null => {
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+
+  // Inset the stroke by half its width so it sits fully inside the bounds and the
+  // right/bottom edges aren't clipped.
+  const inset = strokeWidth / 2;
+  const rectWidth = width - strokeWidth;
+  const rectHeight = height - strokeWidth;
+  const radius = Math.max(borderRadius - inset, 0);
+
+  // Perimeter of a rounded rectangle = straight edges + the four quarter-circle corners.
+  const straightWidth = Math.max(rectWidth - 2 * radius, 0);
+  const straightHeight = Math.max(rectHeight - 2 * radius, 0);
+  const perimeter = 2 * straightWidth + 2 * straightHeight + 2 * Math.PI * radius;
+
+  // Target a small dot-like dash+gap (~4pt) and round to an integer number of segments so
+  // the pattern lands exactly on the path's start/end point (no broken dash on the right edge).
+  const targetSegment = 4;
+  const segmentCount = Math.max(1, Math.round(perimeter / targetSegment));
+  const segmentLength = perimeter / segmentCount;
+  const dashLength = segmentLength / 2;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      <Svg width={width} height={height}>
+        <Rect
+          x={inset}
+          y={inset}
+          width={rectWidth}
+          height={rectHeight}
+          rx={radius}
+          ry={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={[dashLength, segmentLength - dashLength]}
+        />
+      </Svg>
+    </View>
+  );
+};
 
 const StyledFilterChip = styled(View)<{
   theme: Theme;
@@ -23,15 +89,22 @@ const StyledFilterChip = styled(View)<{
   $isDisabled?: boolean;
 }>(({ theme, $isDisabled, $isSelected }) => {
   return {
-    borderWidth: (makeBorderSize(theme.border.width.thin) as unknown) as number,
-    borderColor: theme.colors.interactive.border.gray[$isDisabled ? 'disabled' : 'faded'],
+    // When unselected the dashed border is drawn via an SVG overlay (see DashedBorder) so we
+    // rely on it entirely: the native border has zero width, keeping the overlay's coordinate
+    // space aligned with the border-box and avoiding iOS's buggy dashed+radius render.
+    borderWidth: $isSelected ? ((makeBorderSize(theme.border.width.thin) as unknown) as number) : 0,
+    borderColor: $isSelected
+      ? theme.colors.interactive.border.gray[$isDisabled ? 'disabled' : 'faded']
+      : 'transparent',
     height: FILTER_CHIP_HEIGHT_NATIVE,
     borderRadius: theme.border.radius.small,
-    borderStyle: $isSelected ? 'solid' : 'dashed',
+    borderStyle: 'solid',
     backgroundColor: theme.colors.surface.background.gray.intense,
     flexDirection: 'row',
     alignSelf: 'flex-start',
-    overflow: 'hidden',
+    // The SVG dashed border must not be clipped when unselected; the selected state clips its
+    // divider/close button to the rounded corners.
+    overflow: $isSelected ? 'hidden' : 'visible',
     opacity: $isDisabled ? 0.5 : 1,
   };
 });
@@ -106,11 +179,25 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
   }: BaseFilterChipProps,
   ref: React.Ref<View>,
 ): React.ReactElement => {
+  const { theme } = useTheme();
   const isSelected =
     selectionType === 'multiple' ? Array.isArray(value) && value.length > 0 : !!value;
 
+  const [chipSize, setChipSize] = React.useState({ width: 0, height: 0 });
+  const handleLayout = (event: LayoutChangeEvent): void => {
+    const { width, height } = event.nativeEvent.layout;
+    setChipSize((prev) =>
+      prev.width === width && prev.height === height ? prev : { width, height },
+    );
+  };
+
   return (
-    <StyledFilterChip $isDisabled={isDisabled} $isSelected={isSelected} ref={ref}>
+    <StyledFilterChip
+      $isDisabled={isDisabled}
+      $isSelected={isSelected}
+      ref={ref}
+      onLayout={isSelected ? undefined : handleLayout}
+    >
       <StyledFilterTrigger
         $isSelected={isSelected}
         disabled={isDisabled}
@@ -158,6 +245,15 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
           </StyledFilterCloseButton>
         </>
       ) : null}
+      {isSelected ? null : (
+        <DashedBorder
+          width={chipSize.width}
+          height={chipSize.height}
+          borderRadius={theme.border.radius.small}
+          strokeWidth={makeBorderSize(theme.border.width.thin)}
+          color={theme.colors.interactive.border.gray[isDisabled ? 'disabled' : 'faded']}
+        />
+      )}
     </StyledFilterChip>
   );
 };

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
-import type { LayoutChangeEvent } from 'react-native';
+import type { LayoutChangeEvent, GestureResponderEvent } from 'react-native';
 import styled from 'styled-components/native';
 import Svg, { Rect } from 'react-native-svg';
 import type { BaseFilterChipProps } from './types';
@@ -205,19 +205,17 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
         onPress={
           isDisabled
             ? undefined
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (e: any) => {
-                onClick?.(e);
+            : (e: GestureResponderEvent) => {
+                onClick?.((e as unknown) as React.MouseEventHandler);
               }
         }
-        {...({
+        {...(({
           onKeyDown: isDisabled
             ? undefined
-            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (e: any) => {
-                onKeyDown?.(e);
+            : (e: GestureResponderEvent) => {
+                onKeyDown?.((e as unknown) as React.KeyboardEvent<Element>);
               },
-        } as any)}
+        } as unknown) as Record<string, unknown>)}
         {...makeAccessible({
           ...accessibilityProps,
           role: accessibilityProps?.role ?? 'button',

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -105,7 +105,6 @@ const StyledFilterChip = styled(View)<{
     // The SVG dashed border must not be clipped when unselected; the selected state clips its
     // divider/close button to the rounded corners.
     overflow: $isSelected ? 'hidden' : 'visible',
-    opacity: $isDisabled ? 0.5 : 1,
   };
 });
 
@@ -202,6 +201,7 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
       <StyledFilterTrigger
         $isSelected={isSelected}
         disabled={isDisabled}
+        id={id}
         onPress={
           isDisabled
             ? undefined
@@ -244,7 +244,8 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
           <Divider orientation="vertical" variant={isDisabled ? 'muted' : 'subtle'} />
           <StyledFilterCloseButton
             {...makeAccessible({ label: `Clear ${label} value`, role: 'button' })}
-            onPress={isDisabled ? undefined : () => onClearButtonClick?.()}
+            // value can never be undefined because when it's undefined the button itself doesn't render
+            onPress={isDisabled ? undefined : () => onClearButtonClick?.({ value: value ?? '' })}
             disabled={isDisabled}
             {...metaAttribute({ name: 'filter-chip-close-button' })}
           >

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -23,9 +23,8 @@ const StyledFilterChip = styled(View)<{
   $isDisabled?: boolean;
 }>(({ theme, $isDisabled, $isSelected }) => {
   return {
-    borderWidth: makeBorderSize(theme.border.width.thin) as unknown as number,
-    borderColor:
-      theme.colors.interactive.border.gray[$isDisabled ? 'disabled' : 'faded'],
+    borderWidth: (makeBorderSize(theme.border.width.thin) as unknown) as number,
+    borderColor: theme.colors.interactive.border.gray[$isDisabled ? 'disabled' : 'faded'],
     height: FILTER_CHIP_HEIGHT_NATIVE,
     borderRadius: theme.border.radius.small,
     borderStyle: $isSelected ? 'solid' : 'dashed',
@@ -111,11 +110,7 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
     selectionType === 'multiple' ? Array.isArray(value) && value.length > 0 : !!value;
 
   return (
-    <StyledFilterChip
-      $isDisabled={isDisabled}
-      $isSelected={isSelected}
-      ref={ref}
-    >
+    <StyledFilterChip $isDisabled={isDisabled} $isSelected={isSelected} ref={ref}>
       <StyledFilterTrigger
         $isSelected={isSelected}
         disabled={isDisabled}
@@ -155,11 +150,7 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
           <Divider orientation="vertical" variant={isDisabled ? 'muted' : 'subtle'} />
           <StyledFilterCloseButton
             accessibilityLabel={`Clear ${label} value`}
-            onPress={
-              isDisabled
-                ? undefined
-                : () => onClearButtonClick?.({ value: value ?? '' })
-            }
+            onPress={isDisabled ? undefined : () => onClearButtonClick?.({ value: value ?? '' })}
             disabled={isDisabled}
             {...metaAttribute({ name: 'filter-chip-close-button' })}
           >

--- a/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
+++ b/packages/blade/src/components/FilterChip/BaseFilterChip.native.tsx
@@ -92,7 +92,7 @@ const StyledFilterChip = styled(View)<{
     // When unselected the dashed border is drawn via an SVG overlay (see DashedBorder) so we
     // rely on it entirely: the native border has zero width, keeping the overlay's coordinate
     // space aligned with the border-box and avoiding iOS's buggy dashed+radius render.
-    borderWidth: $isSelected ? ((makeBorderSize(theme.border.width.thin) as unknown) as number) : 0,
+    borderWidth: $isSelected ? makeBorderSize(theme.border.width.thin) : 0,
     borderColor: $isSelected
       ? theme.colors.interactive.border.gray[$isDisabled ? 'disabled' : 'faded']
       : 'transparent',
@@ -236,7 +236,7 @@ const _BaseFilterChip: React.ForwardRefRenderFunction<View, BaseFilterChipProps>
         <>
           <Divider orientation="vertical" variant={isDisabled ? 'muted' : 'subtle'} />
           <StyledFilterCloseButton
-            accessibilityLabel={`Clear ${label} value`}
+            {...makeAccessible({ label: `Clear ${label} value`, role: 'button' })}
             onPress={isDisabled ? undefined : () => onClearButtonClick?.({ value: value ?? '' })}
             disabled={isDisabled}
             {...metaAttribute({ name: 'filter-chip-close-button' })}

--- a/packages/blade/src/components/FilterChip/types.ts
+++ b/packages/blade/src/components/FilterChip/types.ts
@@ -12,7 +12,7 @@ type BaseFilterChipProps = {
   /**
    * Change handler when FilterChip's value is cleared
    */
-  onClearButtonClick?: ({ value }: { value: string | string[] }) => void;
+  onClearButtonClick?: (props?: { value: string | string[] }) => void;
 
   /**
    * Children. Title of the Chip

--- a/packages/blade/src/components/FilterChip/types.ts
+++ b/packages/blade/src/components/FilterChip/types.ts
@@ -12,7 +12,7 @@ type BaseFilterChipProps = {
   /**
    * Change handler when FilterChip's value is cleared
    */
-  onClearButtonClick?: (props?: { value: string | string[] }) => void;
+  onClearButtonClick?: ({ value }: { value: string | string[] }) => void;
 
   /**
    * Children. Title of the Chip

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
@@ -825,12 +825,25 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                 [
                   {
                     "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+                    "borderColor": "hsla(203, 8%, 80%, 1)",
                     "borderRadius": 12,
+                    "borderStyle": "solid",
+                    "borderWidth": 1,
                     "transform": [
                       {
                         "translateY": 8,
                       },
                     ],
+                  },
+                  {
+                    "elevation": 16,
+                    "shadowColor": "hsla(200, 10%, 18%, 1)",
+                    "shadowOffset": {
+                      "height": 2,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.06,
+                    "shadowRadius": 4,
                   },
                 ],
               ]

--- a/packages/blade/src/components/ListView/ListViewFiltersContext.native.tsx
+++ b/packages/blade/src/components/ListView/ListViewFiltersContext.native.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { ListViewContextType } from './types';
+
+const ListViewFiltersGroupContext = React.createContext<ListViewContextType>({
+  selectedFiltersCount: 0,
+  listViewSelectedFilters: {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setListViewSelectedFilters: () => {},
+});
+const ListViewFiltersProvider = ListViewFiltersGroupContext.Provider;
+
+const useListViewFilterContext = (): ListViewContextType => {
+  const context = React.useContext(ListViewFiltersGroupContext);
+  return context;
+};
+
+export { useListViewFilterContext, ListViewFiltersProvider };


### PR DESCRIPTION
## Summary

Adds React Native support for the `FilterChipSelectInput` component (previously web-only, rendered a "not yet implemented for native" stub).

- Adds native `FilterChipSelectInput.native.tsx` that renders inside a `Dropdown` on React Native and registers the `FilterChipSelectInput` `componentId` so `Dropdown`'s child validation passes (this was the cause of the "invalid Dropdown child" render error on native).
- Adds native `FilterChipGroupContext.native.tsx` and `ListViewFiltersContext.native.tsx`.
- Extends `BaseFilterChip.native.tsx` for the select-input trigger behaviour.
- Uses the BottomSheet-based selection flow on native (native has no dropdown menu).
- Adds native unit tests + snapshot.

https://github.com/user-attachments/assets/9c6d97df-5998-4f38-852e-2909ad60ab47



## Known limitations / out of scope

- `FilterChipGroup` is **not** implemented on native — `FilterChipGroup.native.tsx` still throws `"FilterChipGroup is not yet implemented for native"`. This PR only adds native support for a standalone `FilterChipSelectInput` inside a `Dropdown`; the grouped `FilterChipGroup` wrapper usecase remains unsupported on native and should be tracked as a separate follow-up.

## Test plan

- [x] `FilterChipSelectInput.native.test.tsx` — 8 tests + 1 snapshot passing (`jest -c jest.native.config.js`). Covers default render, open-on-press, single-select, multi-select, clear button flow, controlled value, disabled, and testID.
- [x] Verified on iPhone 17 Pro Max simulator: "Controlled Filter Chip Select Input – Single" story renders correctly (trigger + chevron + clear button), no render error.
- [ ] Reviewer: verify selection flow via BottomSheet on device/simulator.

Part of the RN migration batch alongside ButtonGroup (#3685) and StepGroup (#3686).

Made with [Cursor](https://cursor.com)
