### PR TITLE
fix(TrustBadge): Trust badge design update

### DIFF
--- a/.changeset/trust-badge-emphasis-removal.md
+++ b/.changeset/trust-badge-emphasis-removal.md
@@ -1,0 +1,13 @@
+---
+'@razorpay/blade': minor
+'@razorpay/blade-svelte': minor
+'@razorpay/blade-core': minor
+---
+
+fix(TrustBadge): remove `emphasis` prop and align with Blade DSL trust marker design
+
+The `emphasis` prop (`'subtle' | 'intense'`) and the `TrustBadgeEmphasis` type have been removed from TrustBadge. The new Blade DSL design uses a single sea-subtle pill treatment regardless of surface color. Migrate by removing any `emphasis` prop usage — the updated component renders correctly on all surfaces.
+
+- `@razorpay/blade`: `emphasis` prop removed from `TrustBadgeProps`
+- `@razorpay/blade-svelte`: `emphasis` prop removed from `TrustBadgeProps`
+- `@razorpay/blade-core`: `TrustBadgeEmphasis` type and `getTrustBadgePillEmphasisClass` removed; replaced by `getTrustBadgeVariantClass`

--- a/packages/blade-core/src/styles/TrustBadge/index.ts
+++ b/packages/blade-core/src/styles/TrustBadge/index.ts
@@ -1,7 +1,7 @@
 export {
   getTrustBadgeTextColorToken,
-  getTrustBadgePillEmphasisClass,
+  getTrustBadgeVariantClass,
   getTrustBadgeTemplateClasses,
 } from './trustBadge';
 
-export type { TrustBadgeVariant, TrustBadgeEmphasis } from './trustBadge';
+export type { TrustBadgeVariant } from './trustBadge';

--- a/packages/blade-core/src/styles/TrustBadge/trustBadge.module.css
+++ b/packages/blade-core/src/styles/TrustBadge/trustBadge.module.css
@@ -1,63 +1,33 @@
 /* ============================================
    TrustBadge Component Styles
-   A generic trust badge — a brand shield paired with a faded pill.
-   Mirrors Figma: shield icon (brand gradient) overlapping a faded pill that
-   reads a configurable trust label (default: "Razorpay Trusted Business").
-   Two emphasis treatments (intense=white text on dark/colored surfaces, subtle=dark
-   text on light surfaces) and an icon-only variant that drops the pill entirely.
+   Utility trust marker — brand shield with label in a sea-tinted pill,
+   or icon-only for compact surfaces.
+   Mirrors Figma Blade-DSL: [Utility] Trust Marker (node 123352:128035).
    ============================================ */
 
-/* --- Root ---
-   Isolation creates a new stacking context so the shield's z-index sits above the
-   pill regardless of surrounding content. Inline-flex keeps the badge shrink-wrapped. */
 .trustBadge {
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  isolation: isolate;
   flex-shrink: 0;
 }
 
-/* --- Shield icon wrapper ---
-   The 16px shield overlaps the pill's left edge by 12px (Figma `mr-[-12px]`) and is
-   raised above it. In default variant the shield is decorative (aria-hidden) because the
-   visible pill text is announced; in `icon-only` variant the wrapper carries the label. */
-.trustBadgeShield {
-  position: relative;
-  z-index: 2;
+/* Default variant — icon + label in a sea-subtle pill. */
+.trustBadgeWithPill {
+  gap: var(--spacing-2);
+  height: 24px;
+  padding: var(--spacing-2) var(--spacing-3);
+  border-radius: var(--border-radius-max);
+  background-color: var(--surface-background-sea-subtle);
+}
+
+/* Icon-only variant — shield with compact padding, no pill. */
+.trustBadgeIconOnly {
+  padding: var(--spacing-2);
+}
+
+.trustBadgeIcon {
   display: flex;
   align-items: center;
   flex-shrink: 0;
-}
-
-/* The overlap only applies when the pill is present. */
-.trustBadgeShieldOverlap {
-  margin-right: -12px;
-}
-
-/* --- Pill ---
-   Shared pill layout. Background is emphasis-specific:
-   - intense → 32% black (`surface.icon.staticBlack.disabled`) + white text on dark surfaces
-   - subtle  → 10% black (Checkout DS Figma) + black text on light surfaces */
-.trustBadgePill {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  padding-top: var(--spacing-1);
-  padding-bottom: var(--spacing-1);
-  padding-left: var(--spacing-5);
-  padding-right: var(--spacing-4);
-  border-radius: var(--border-radius-large);
-  flex-shrink: 0;
-}
-
-.trustBadgePillIntense {
-  background-color: var(--surface-icon-static-black-disabled);
-}
-
-.trustBadgePillSubtle {
-  background-color: hsla(0, 0%, 0%, 0.1);
 }

--- a/packages/blade-core/src/styles/TrustBadge/trustBadge.ts
+++ b/packages/blade-core/src/styles/TrustBadge/trustBadge.ts
@@ -2,26 +2,15 @@
 import styles from './trustBadge.module.css';
 
 export type TrustBadgeVariant = 'default' | 'icon-only';
-export type TrustBadgeEmphasis = 'subtle' | 'intense';
 
-/**
- * Resolves the text color token for the TrustBadge label.
- *
- * The shield keeps its fixed brand gradient regardless of emphasis. Pill styling splits by emphasis:
- * - `intense` → 32% black pill + static-white text (dark/colored surfaces)
- * - `subtle`  → 10% black pill + static-black text (light surfaces)
- */
-export const getTrustBadgeTextColorToken = (
-  emphasis: TrustBadgeEmphasis,
-): 'surface.text.staticWhite.normal' | 'surface.text.staticBlack.normal' => {
-  return emphasis === 'subtle'
-    ? 'surface.text.staticBlack.normal'
-    : 'surface.text.staticWhite.normal';
+/** Label text color token for the TrustBadge pill. */
+export const getTrustBadgeTextColorToken = (): 'surface.text.gray.subtle' => {
+  return 'surface.text.gray.subtle';
 };
 
-/** Pill surface class for the given TrustBadge emphasis. Pair with `trustBadgePill`. */
-export const getTrustBadgePillEmphasisClass = (emphasis: TrustBadgeEmphasis): string => {
-  return emphasis === 'subtle' ? styles.trustBadgePillSubtle : styles.trustBadgePillIntense;
+/** Variant-specific root class. Pair with `trustBadge`. */
+export const getTrustBadgeVariantClass = (variant: TrustBadgeVariant): string => {
+  return variant === 'icon-only' ? styles.trustBadgeIconOnly : styles.trustBadgeWithPill;
 };
 
 /**
@@ -31,10 +20,8 @@ export const getTrustBadgePillEmphasisClass = (emphasis: TrustBadgeEmphasis): st
 export function getTrustBadgeTemplateClasses(): Record<string, string> {
   return {
     trustBadge: styles.trustBadge,
-    trustBadgeShield: styles.trustBadgeShield,
-    trustBadgeShieldOverlap: styles.trustBadgeShieldOverlap,
-    trustBadgePill: styles.trustBadgePill,
-    trustBadgePillIntense: styles.trustBadgePillIntense,
-    trustBadgePillSubtle: styles.trustBadgePillSubtle,
+    trustBadgeWithPill: styles.trustBadgeWithPill,
+    trustBadgeIconOnly: styles.trustBadgeIconOnly,
+    trustBadgeIcon: styles.trustBadgeIcon,
   };
 }

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -166,10 +166,10 @@ export { appBarStyles, getAppBarClasses, getAppBarTemplateClasses } from './AppB
 export type { AppBarVariants } from './AppBar';
 export {
   getTrustBadgeTextColorToken,
-  getTrustBadgePillEmphasisClass,
+  getTrustBadgeVariantClass,
   getTrustBadgeTemplateClasses,
 } from './TrustBadge';
-export type { TrustBadgeVariant, TrustBadgeEmphasis } from './TrustBadge';
+export type { TrustBadgeVariant } from './TrustBadge';
 export {
   animatedChipCva,
   getAnimatedChipClasses,

--- a/packages/blade-svelte/src/components/AppBar/AppBarLeading.svelte
+++ b/packages/blade-svelte/src/components/AppBar/AppBarLeading.svelte
@@ -23,7 +23,6 @@
   }: AppBarLeadingProps = $props();
 
   const isNeutral = $derived(appBarContext.variant === 'neutral');
-  const trustBadgeEmphasis = $derived(isNeutral ? 'intense' : 'subtle');
 
   const titleColor = $derived(
     isNeutral ? 'surface.text.staticWhite.normal' : 'surface.text.gray.normal',
@@ -46,7 +45,7 @@
           {@render logo()}
         </div>
         <div class={templateClasses.appBarLeadingBadge}>
-          <TrustBadge variant="default" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+          <TrustBadge variant="default" label={trustBadgeLabel} />
         </div>
       </div>
     {:else}
@@ -70,17 +69,17 @@
             </Text>
           </div>
           {#if showIconBadge}
-            <TrustBadge variant="icon-only" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+            <TrustBadge variant="icon-only" label={trustBadgeLabel} />
           {/if}
         </div>
       {/if}
       {#if showFullBadge && !stackFullBadgeBelowLogo}
         <div class={templateClasses.appBarLeadingBadge}>
-          <TrustBadge variant="default" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+          <TrustBadge variant="default" label={trustBadgeLabel} />
         </div>
       {/if}
     </div>
   {:else if showIconBadge}
-    <TrustBadge variant="icon-only" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+    <TrustBadge variant="icon-only" label={trustBadgeLabel} />
   {/if}
 </div>

--- a/packages/blade-svelte/src/components/TrustBadge/TrustBadge.stories.svelte
+++ b/packages/blade-svelte/src/components/TrustBadge/TrustBadge.stories.svelte
@@ -11,60 +11,45 @@
         control: { type: 'select' },
         options: ['default', 'icon-only'],
       },
-      emphasis: {
-        control: { type: 'select' },
-        options: ['intense', 'subtle'],
-      },
       label: {
         control: { type: 'text' },
       },
     },
     args: {
       variant: 'default',
-      emphasis: 'subtle',
       label: 'Razorpay Trusted Business',
     },
   });
 </script>
 
-<!-- Playground - auto-renders TrustBadge driven by Storybook controls -->
 <Story name="Playground">
   {#snippet template(args)}
-    <!-- intense emphasis needs a colored/dark surface, subtle needs a light one -->
     <div
-      style="background-color: {args.emphasis === 'subtle'
-        ? 'var(--surface-background-gray-subtle)'
-        : '#3669ff'}; padding: var(--spacing-5); border-radius: var(--border-radius-medium); display: inline-block;"
+      style="background-color: var(--surface-background-gray-subtle); padding: var(--spacing-5); border-radius: var(--border-radius-medium); display: inline-block;"
     >
       <TrustBadge {...args} />
     </div>
   {/snippet}
 </Story>
 
-<!-- Intense (white text) — sits on a dark/colored surface -->
-<Story name="Intense" asChild>
-  <div style="background-color: #3669ff; padding: var(--spacing-5); border-radius: var(--border-radius-medium);">
-    <TrustBadge emphasis="intense" />
-  </div>
-</Story>
-
-<!-- Subtle (dark text) — sits on a light surface -->
-<Story name="Subtle" asChild>
+<Story name="Default" asChild>
   <div style="background-color: var(--surface-background-gray-subtle); padding: var(--spacing-5); border-radius: var(--border-radius-medium);">
-    <TrustBadge emphasis="subtle" />
+    <TrustBadge />
   </div>
 </Story>
 
-<!-- Icon only — shield without the pill/text -->
 <Story name="Icon Only" asChild>
-  <div style="background-color: #3669ff; padding: var(--spacing-5); border-radius: var(--border-radius-medium);">
+  <div style="background-color: var(--surface-background-gray-subtle); padding: var(--spacing-5); border-radius: var(--border-radius-medium);">
     <TrustBadge variant="icon-only" />
   </div>
 </Story>
 
-<!-- Custom label — demonstrates generic trust badge usage -->
-<Story name="CustomLabel" asChild>
-  <div style="background-color: var(--surface-background-gray-subtle); padding: var(--spacing-5); border-radius: var(--border-radius-medium);">
-    <TrustBadge label="Razorpay Verified" />
-  </div>
+<Story name="CustomLabel" args={{ label: 'Razorpay Verified' }}>
+  {#snippet template(args)}
+    <div
+      style="background-color: var(--surface-background-gray-subtle); padding: var(--spacing-5); border-radius: var(--border-radius-medium);"
+    >
+      <TrustBadge {...args} />
+    </div>
+  {/snippet}
 </Story>

--- a/packages/blade-svelte/src/components/TrustBadge/TrustBadge.svelte
+++ b/packages/blade-svelte/src/components/TrustBadge/TrustBadge.svelte
@@ -9,7 +9,7 @@
   import {
     getTrustBadgeTemplateClasses,
     getTrustBadgeTextColorToken,
-    getTrustBadgePillEmphasisClass,
+    getTrustBadgeVariantClass,
   } from '@razorpay/blade-core/styles';
   import Text from '../Typography/Text/Text.svelte';
   import { RazorpayTrustIcon } from '../Icons';
@@ -17,55 +17,44 @@
 
   const DEFAULT_LABEL = 'Razorpay Trusted Business';
 
-  // Prevent CSS-module tree-shaking of structural classes.
   const templateClasses = getTrustBadgeTemplateClasses();
 
   let {
     variant = 'default',
-    emphasis = 'subtle',
     label = DEFAULT_LABEL,
     testID,
     ...rest
   }: TrustBadgeProps = $props();
 
   const isIconOnly = $derived(variant === 'icon-only');
-  const textColor = $derived(getTrustBadgeTextColorToken(emphasis));
-  const pillClasses = $derived(
-    [templateClasses.trustBadgePill, getTrustBadgePillEmphasisClass(emphasis)].join(' '),
-  );
+  const textColor = $derived(getTrustBadgeTextColorToken());
 
   const metaAttrs = $derived(metaAttribute({ name: MetaConstants.TrustBadge, testID }));
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const styledProps = $derived(getStyledPropsClasses(rest));
 
   const rootClasses = $derived(
-    [templateClasses.trustBadge, ...(styledProps.classes ?? [])].filter(Boolean).join(' '),
-  );
-
-  // In the default variant the pill text announces the badge, so the shield is decorative.
-  // In the icon-only variant there is no visible text, so the shield wrapper carries the label.
-  const shieldClasses = $derived(
     [
-      templateClasses.trustBadgeShield,
-      isIconOnly ? '' : templateClasses.trustBadgeShieldOverlap,
+      templateClasses.trustBadge,
+      getTrustBadgeVariantClass(variant),
+      ...(styledProps.classes ?? []),
     ]
       .filter(Boolean)
       .join(' '),
   );
+
   const iconA11yAttrs = $derived(
     isIconOnly ? makeAccessible({ role: 'img', label }) : { 'aria-hidden': 'true' },
   );
 </script>
 
 <div class={rootClasses} {...metaAttrs} {...analyticsAttrs}>
-  <span class={shieldClasses} {...iconA11yAttrs}>
+  <span class={templateClasses.trustBadgeIcon} {...iconA11yAttrs}>
     <RazorpayTrustIcon size="medium" />
   </span>
   {#if !isIconOnly}
-    <div class={pillClasses}>
-      <Text size="xsmall" weight="regular" color={textColor}>
-        {label}
-      </Text>
-    </div>
+    <Text size="xsmall" weight="regular" color={textColor}>
+      {label}
+    </Text>
   {/if}
 </div>

--- a/packages/blade-svelte/src/components/TrustBadge/index.ts
+++ b/packages/blade-svelte/src/components/TrustBadge/index.ts
@@ -1,3 +1,3 @@
 export { default as TrustBadge } from './TrustBadge.svelte';
 
-export type { TrustBadgeProps, TrustBadgeVariant, TrustBadgeEmphasis } from './types';
+export type { TrustBadgeProps, TrustBadgeVariant } from './types';

--- a/packages/blade-svelte/src/components/TrustBadge/types.ts
+++ b/packages/blade-svelte/src/components/TrustBadge/types.ts
@@ -1,7 +1,7 @@
 import type { StyledPropsBlade } from '@razorpay/blade-core/utils';
-import type { TrustBadgeVariant, TrustBadgeEmphasis } from '@razorpay/blade-core/styles';
+import type { TrustBadgeVariant } from '@razorpay/blade-core/styles';
 
-export type { TrustBadgeVariant, TrustBadgeEmphasis };
+export type { TrustBadgeVariant };
 
 export type TrustBadgeProps = {
   /**
@@ -12,16 +12,6 @@ export type TrustBadgeProps = {
    * @default 'default'
    */
   variant?: TrustBadgeVariant;
-
-  /**
-   * Text/foreground treatment. Only affects `variant='default'` — the shield keeps its
-   * fixed brand gradient regardless of emphasis.
-   * - `'intense'`: static-white text — for dark/colored surfaces.
-   * - `'subtle'` (default): static-black text — for light surfaces.
-   *
-   * @default 'subtle'
-   */
-  emphasis?: TrustBadgeEmphasis;
 
   /**
    * Trust label displayed in the pill (only visible when `variant='default'`).

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -90,7 +90,7 @@ export type { AppBarProps, AppBarLeadingProps, AppBarActionsProps, AppBarVariant
 
 // TrustBadge
 export { TrustBadge } from './TrustBadge';
-export type { TrustBadgeProps, TrustBadgeVariant, TrustBadgeEmphasis } from './TrustBadge';
+export type { TrustBadgeProps, TrustBadgeVariant } from './TrustBadge';
 
 // Chip
 export { default as Chip } from './Chip/Chip.svelte';

--- a/packages/blade/src/components/AppBar/AppBar.web.tsx
+++ b/packages/blade/src/components/AppBar/AppBar.web.tsx
@@ -142,7 +142,6 @@ const _AppBarLeading = ({
   const appBarContext = useAppBarContext();
   const isNeutral = (appBarContext?.variant ?? 'neutral') === 'neutral';
   const titleColor = isNeutral ? 'surface.text.staticWhite.normal' : 'surface.text.gray.normal';
-  const trustBadgeEmphasis = isNeutral ? 'intense' : 'subtle';
   const showFullBadge = trustBadgeVariant === 'default';
   const showIconBadge = trustBadgeVariant === 'icon-only';
   const stackFullBadgeBelowLogo = showFullBadge && Boolean(logo) && !title;
@@ -179,7 +178,7 @@ const _AppBarLeading = ({
               minWidth="0px"
               maxWidth="100%"
             >
-              <TrustBadge variant="default" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+              <TrustBadge variant="default" label={trustBadgeLabel} />
             </BaseBox>
           </BaseBox>
         ) : (
@@ -195,13 +194,7 @@ const _AppBarLeading = ({
               <Text size="large" weight="semibold" color={titleColor} truncateAfterLines={1}>
                 {title}
               </Text>
-              {showIconBadge ? (
-                <TrustBadge
-                  variant="icon-only"
-                  emphasis={trustBadgeEmphasis}
-                  label={trustBadgeLabel}
-                />
-              ) : null}
+              {showIconBadge ? <TrustBadge variant="icon-only" label={trustBadgeLabel} /> : null}
             </BaseBox>
           ) : null}
           {showFullBadge && !stackFullBadgeBelowLogo ? (
@@ -212,12 +205,12 @@ const _AppBarLeading = ({
               minWidth="0px"
               maxWidth="100%"
             >
-              <TrustBadge variant="default" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+              <TrustBadge variant="default" label={trustBadgeLabel} />
             </BaseBox>
           ) : null}
         </BaseBox>
       ) : showIconBadge ? (
-        <TrustBadge variant="icon-only" emphasis={trustBadgeEmphasis} label={trustBadgeLabel} />
+        <TrustBadge variant="icon-only" label={trustBadgeLabel} />
       ) : null}
     </BaseBox>
   );

--- a/packages/blade/src/components/AppBar/__tests__/__snapshots__/AppBar.ssr.test.tsx.snap
+++ b/packages/blade/src/components/AppBar/__tests__/__snapshots__/AppBar.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<AppBar /> should render AppBar ssr 1`] = `"<div id="root"><div data-blade-component="app-bar" data-testid="appbar-demo" role="banner" aria-label="Mavenshop store header" data-analytics-appbar="demo" class="BaseBox-bksIuc iSfCPy"><div data-blade-component="base-box" class="BaseBox-bksIuc ehKhQS"><div data-blade-component="base-box" class="BaseBox-bksIuc hfiPvl"><button type="button" aria-label="Go back" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 eGmpvF"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M10.7071 6.70711C11.0976 6.31658 11.0976 5.68342 10.7071 5.29289C10.3166 4.90237 9.68342 4.90237 9.29289 5.29289L3.29289 11.2929C2.90237 11.6834 2.90237 12.3166 3.29289 12.7071L9.29289 18.7071C9.68342 19.0976 10.3166 19.0976 10.7071 18.7071C11.0976 18.3166 11.0976 17.6834 10.7071 17.2929L6.41421 13H20C20.5523 13 21 12.5523 21 12C21 11.4477 20.5523 11 20 11H6.41421L10.7071 6.70711Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button></div><div data-blade-component="app-bar-leading" class="BaseBox-bksIuc bXkDKZ"><div data-blade-component="base-box" class="BaseBox-bksIuc dWIhGQ"><svg aria-hidden="true" data-blade-component="icon" height="20px" viewBox="0 0 24 24" width="20px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M9.71749 12.3339L10.7149 8.66299L21 2L15.4844 22.5753L11.6926 22.5722L15.4262 8.64209L9.71749 12.3339ZM3 22.5756L4.57044 16.7193L13.9519 10.6624L10.7718 22.5756H3Z" clip-rule="evenodd" fill="hsla(0, 0%, 100%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></div><div data-blade-component="base-box" class="BaseBox-bksIuc hUHgKK"><div data-blade-component="base-box" class="BaseBox-bksIuc hlJngZ"><p letter-spacing="25" class="StyledBaseText-foUshD jGddiS" data-blade-component="text">Mavenshop</p></div><div data-blade-component="base-box" class="BaseBox-bksIuc gbzmNn"><div data-blade-component="trust-badge" class="BaseBox-bksIuc evlwHc"><div aria-hidden="true" data-blade-component="base-box" class="BaseBox-bksIuc escAoS"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M19.7981 3.96094V15.3838C19.798 16.163 19.4121 16.8915 18.7679 17.3301L12.1311 21.8467L5.49443 17.3301C4.85022 16.8915 4.46425 16.163 4.46415 15.3838V3.96094L12.1311 2.09277L19.7981 3.96094Z" fill="url(#razorpayTrustFill-:Rd6:)" stroke="url(#razorpayTrustStroke-:Rd6:)" stroke-width="0.666667"></path><g filter="url(#razorpayTrustShadow-:Rd6:)"><path d="M11.5244 8.82L11.0532 10.6936L13.7494 8.80947L11.9861 15.9179L13.7767 15.9196L16.3815 5.42041L11.5244 8.82Z" fill="white"></path><path d="M8.62275 12.9321L7.88147 15.9204H11.5517L13.0534 9.8411L8.62275 12.9321Z" fill="white"></path></g><defs><filter id="razorpayTrustShadow-:Rd6:" x="5.65925" y="3.19819" width="12.9444" height="14.9444" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"></feColorMatrix><feOffset></feOffset><feGaussianBlur stdDeviation="1.11111"></feGaussianBlur><feComposite in2="hardAlpha" operator="out"></feComposite><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.294097 0 0 0 0 0.152931 0 0 0 0.25 0"></feColorMatrix><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"></feBlend><feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"></feBlend></filter><linearGradient id="razorpayTrustFill-:Rd6:" x1="4.13115" y1="5.0249" x2="18.2093" y2="18.4295" gradientUnits="userSpaceOnUse"><stop stop-color="#00FD0A"></stop><stop offset="0.972213" stop-color="#00AD8E"></stop></linearGradient><linearGradient id="razorpayTrustStroke-:Rd6:" x1="6.35337" y1="4.55055" x2="17.5246" y2="17.4954" gradientUnits="userSpaceOnUse"><stop stop-color="#65FF4D"></stop><stop offset="0.302473" stop-color="white" stop-opacity="0.895"></stop><stop offset="0.452125" stop-color="#65FF4D" stop-opacity="0.805"></stop><stop offset="1" stop-color="#00C67F"></stop></linearGradient></defs></svg></div><div data-blade-component="base-box" class="BaseBox-bksIuc lePPWY"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text">Razorpay Trusted Business</p></div></div></div></div></div><div data-blade-component="app-bar-actions" class="BaseBox-bksIuc halUdx"><button type="button" aria-label="Profile" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 eGmpvF"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2ZM9 7C9 5.34315 10.3431 4 12 4C13.6569 4 15 5.34315 15 7C15 8.65685 13.6569 10 12 10C10.3431 10 9 8.65685 9 7Z" clip-rule="evenodd" fill="currentColor" fill-rule="evenodd" data-blade-component="svg-path"></path><path d="M8 14C5.23858 14 3 16.2386 3 19V21C3 21.5523 3.44772 22 4 22C4.55228 22 5 21.5523 5 21V19C5 17.3431 6.34315 16 8 16H16C17.6569 16 19 17.3431 19 19V21C19 21.5523 19.4477 22 20 22C20.5523 22 21 21.5523 21 21V19C21 16.2386 18.7614 14 16 14H8Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button><button type="button" aria-label="Notifications" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 eGmpvF"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 3C8.68629 3 6 5.68629 6 9V14C6 14.7286 5.80521 15.4117 5.46487 16H18.5351C18.1948 15.4117 18 14.7286 18 14V9C18 5.68629 15.3137 3 12 3ZM22 16C20.8954 16 20 15.1046 20 14V9C20 4.58172 16.4183 1 12 1C7.58172 1 4 4.58172 4 9V14C4 15.1046 3.10457 16 2 16C1.44772 16 1 16.4477 1 17C1 17.5523 1.44772 18 2 18H22C22.5523 18 23 17.5523 23 17C23 16.4477 22.5523 16 22 16ZM9.76823 20.135C10.246 19.8579 10.8579 20.0205 11.135 20.4982C11.3139 20.8066 11.6435 20.9965 12 20.9965C12.3565 20.9965 12.6861 20.8066 12.865 20.4982C13.1421 20.0205 13.754 19.8579 14.2318 20.135C14.7095 20.4121 14.8721 21.024 14.595 21.5018C14.0583 22.427 13.0696 22.9965 12 22.9965C10.9304 22.9965 9.9417 22.427 9.405 21.5018C9.12788 21.024 9.2905 20.4121 9.76823 20.135Z" clip-rule="evenodd" fill="currentColor" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></button></div></div></div></div>"`;
+exports[`<AppBar /> should render AppBar ssr 1`] = `"<div id="root"><div data-blade-component="app-bar" data-testid="appbar-demo" role="banner" aria-label="Mavenshop store header" data-analytics-appbar="demo" class="BaseBox-bksIuc iSfCPy"><div data-blade-component="base-box" class="BaseBox-bksIuc ehKhQS"><div data-blade-component="base-box" class="BaseBox-bksIuc hfiPvl"><button type="button" aria-label="Go back" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 eGmpvF"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M10.7071 6.70711C11.0976 6.31658 11.0976 5.68342 10.7071 5.29289C10.3166 4.90237 9.68342 4.90237 9.29289 5.29289L3.29289 11.2929C2.90237 11.6834 2.90237 12.3166 3.29289 12.7071L9.29289 18.7071C9.68342 19.0976 10.3166 19.0976 10.7071 18.7071C11.0976 18.3166 11.0976 17.6834 10.7071 17.2929L6.41421 13H20C20.5523 13 21 12.5523 21 12C21 11.4477 20.5523 11 20 11H6.41421L10.7071 6.70711Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button></div><div data-blade-component="app-bar-leading" class="BaseBox-bksIuc bXkDKZ"><div data-blade-component="base-box" class="BaseBox-bksIuc dWIhGQ"><svg aria-hidden="true" data-blade-component="icon" height="20px" viewBox="0 0 24 24" width="20px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M9.71749 12.3339L10.7149 8.66299L21 2L15.4844 22.5753L11.6926 22.5722L15.4262 8.64209L9.71749 12.3339ZM3 22.5756L4.57044 16.7193L13.9519 10.6624L10.7718 22.5756H3Z" clip-rule="evenodd" fill="hsla(0, 0%, 100%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></div><div data-blade-component="base-box" class="BaseBox-bksIuc hUHgKK"><div data-blade-component="base-box" class="BaseBox-bksIuc hlJngZ"><p letter-spacing="25" class="StyledBaseText-foUshD jGddiS" data-blade-component="text">Mavenshop</p></div><div data-blade-component="base-box" class="BaseBox-bksIuc gbzmNn"><div data-blade-component="trust-badge" class="BaseBox-bksIuc jIkmmx"><div aria-hidden="true" data-blade-component="base-box" class="BaseBox-bksIuc jVxAcE"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M19.7981 3.96094V15.3838C19.798 16.163 19.4121 16.8915 18.7679 17.3301L12.1311 21.8467L5.49443 17.3301C4.85022 16.8915 4.46425 16.163 4.46415 15.3838V3.96094L12.1311 2.09277L19.7981 3.96094Z" fill="url(#razorpayTrustFill-:Rd6:)" stroke="url(#razorpayTrustStroke-:Rd6:)" stroke-width="0.666667"></path><g filter="url(#razorpayTrustShadow-:Rd6:)"><path d="M11.5244 8.82L11.0532 10.6936L13.7494 8.80947L11.9861 15.9179L13.7767 15.9196L16.3815 5.42041L11.5244 8.82Z" fill="white"></path><path d="M8.62275 12.9321L7.88147 15.9204H11.5517L13.0534 9.8411L8.62275 12.9321Z" fill="white"></path></g><defs><filter id="razorpayTrustShadow-:Rd6:" x="5.65925" y="3.19819" width="12.9444" height="14.9444" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"></feColorMatrix><feOffset></feOffset><feGaussianBlur stdDeviation="1.11111"></feGaussianBlur><feComposite in2="hardAlpha" operator="out"></feComposite><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.294097 0 0 0 0 0.152931 0 0 0 0.25 0"></feColorMatrix><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"></feBlend><feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"></feBlend></filter><linearGradient id="razorpayTrustFill-:Rd6:" x1="4.13115" y1="5.0249" x2="18.2093" y2="18.4295" gradientUnits="userSpaceOnUse"><stop stop-color="#00FD0A"></stop><stop offset="0.972213" stop-color="#00AD8E"></stop></linearGradient><linearGradient id="razorpayTrustStroke-:Rd6:" x1="6.35337" y1="4.55055" x2="17.5246" y2="17.4954" gradientUnits="userSpaceOnUse"><stop stop-color="#65FF4D"></stop><stop offset="0.302473" stop-color="white" stop-opacity="0.895"></stop><stop offset="0.452125" stop-color="#65FF4D" stop-opacity="0.805"></stop><stop offset="1" stop-color="#00C67F"></stop></linearGradient></defs></svg></div><p letter-spacing="50" class="StyledBaseText-foUshD hgoSmo" data-blade-component="text">Razorpay Trusted Business</p></div></div></div></div><div data-blade-component="app-bar-actions" class="BaseBox-bksIuc halUdx"><button type="button" aria-label="Profile" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 eGmpvF"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2ZM9 7C9 5.34315 10.3431 4 12 4C13.6569 4 15 5.34315 15 7C15 8.65685 13.6569 10 12 10C10.3431 10 9 8.65685 9 7Z" clip-rule="evenodd" fill="currentColor" fill-rule="evenodd" data-blade-component="svg-path"></path><path d="M8 14C5.23858 14 3 16.2386 3 19V21C3 21.5523 3.44772 22 4 22C4.55228 22 5 21.5523 5 21V19C5 17.3431 6.34315 16 8 16H16C17.6569 16 19 17.3431 19 19V21C19 21.5523 19.4477 22 20 22C20.5523 22 21 21.5523 21 21V19C21 16.2386 18.7614 14 16 14H8Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button><button type="button" aria-label="Notifications" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 eGmpvF"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 3C8.68629 3 6 5.68629 6 9V14C6 14.7286 5.80521 15.4117 5.46487 16H18.5351C18.1948 15.4117 18 14.7286 18 14V9C18 5.68629 15.3137 3 12 3ZM22 16C20.8954 16 20 15.1046 20 14V9C20 4.58172 16.4183 1 12 1C7.58172 1 4 4.58172 4 9V14C4 15.1046 3.10457 16 2 16C1.44772 16 1 16.4477 1 17C1 17.5523 1.44772 18 2 18H22C22.5523 18 23 17.5523 23 17C23 16.4477 22.5523 16 22 16ZM9.76823 20.135C10.246 19.8579 10.8579 20.0205 11.135 20.4982C11.3139 20.8066 11.6435 20.9965 12 20.9965C12.3565 20.9965 12.6861 20.8066 12.865 20.4982C13.1421 20.0205 13.754 19.8579 14.2318 20.135C14.7095 20.4121 14.8721 21.024 14.595 21.5018C14.0583 22.427 13.0696 22.9965 12 22.9965C10.9304 22.9965 9.9417 22.427 9.405 21.5018C9.12788 21.024 9.2905 20.4121 9.76823 20.135Z" clip-rule="evenodd" fill="currentColor" fill-rule="evenodd" data-blade-component="svg-path"></path></svg></button></div></div></div></div>"`;
 
 exports[`<AppBar /> should render AppBar ssr 2`] = `
 .c0.c0.c0.c0.c0 {
@@ -143,6 +143,11 @@ exports[`<AppBar /> should render AppBar ssr 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px 8px;
+  height: 24px;
+  gap: 4px;
+  background-color: hsla(180,91%,13%,1);
+  border-radius: 9999px;
 }
 
 .c11.c11.c11.c11.c11 {
@@ -157,41 +162,9 @@ exports[`<AppBar /> should render AppBar ssr 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
 }
 
-.c12.c12.c12.c12.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: hsla(0,0%,0%,0.32);
-  border-radius: 16px;
-}
-
-.c14.c14.c14.c14.c14 {
+.c13.c13.c13.c13.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -283,8 +256,8 @@ exports[`<AppBar /> should render AppBar ssr 2`] = `
   overflow-wrap: break-word;
 }
 
-.c13.c13.c13.c13.c13 {
-  color: hsla(0,0%,100%,1);
+.c12.c12.c12.c12.c12 {
+  color: hsla(210,3%,69%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
   font-weight: 400;
@@ -520,24 +493,19 @@ exports[`<AppBar /> should render AppBar ssr 2`] = `
                   </defs>
                 </svg>
               </div>
-              <div
+              <p
                 class="c12"
-                data-blade-component="base-box"
+                data-blade-component="text"
+                letter-spacing="50"
               >
-                <p
-                  class="c13"
-                  data-blade-component="text"
-                  letter-spacing="50"
-                >
-                  Razorpay Trusted Business
-                </p>
-              </div>
+                Razorpay Trusted Business
+              </p>
             </div>
           </div>
         </div>
       </div>
       <div
-        class="c14"
+        class="c13"
         data-blade-component="app-bar-actions"
       >
         <button

--- a/packages/blade/src/components/AppBar/__tests__/__snapshots__/AppBar.web.test.tsx.snap
+++ b/packages/blade/src/components/AppBar/__tests__/__snapshots__/AppBar.web.test.tsx.snap
@@ -292,6 +292,11 @@ exports[`<AppBar /> should render 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px 8px;
+  height: 24px;
+  gap: 4px;
+  background-color: hsla(180,91%,13%,1);
+  border-radius: 9999px;
 }
 
 .c11.c11.c11.c11.c11 {
@@ -306,41 +311,9 @@ exports[`<AppBar /> should render 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
 }
 
-.c12.c12.c12.c12.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: hsla(0,0%,0%,0.32);
-  border-radius: 16px;
-}
-
-.c14.c14.c14.c14.c14 {
+.c13.c13.c13.c13.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -432,8 +405,8 @@ exports[`<AppBar /> should render 1`] = `
   overflow-wrap: break-word;
 }
 
-.c13.c13.c13.c13.c13 {
-  color: hsla(0,0%,100%,1);
+.c12.c12.c12.c12.c12 {
+  color: hsla(210,3%,69%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
   font-weight: 400;
@@ -667,24 +640,19 @@ exports[`<AppBar /> should render 1`] = `
                   </defs>
                 </svg>
               </div>
-              <div
+              <p
                 class="c12"
-                data-blade-component="base-box"
+                data-blade-component="text"
+                letter-spacing="50"
               >
-                <p
-                  class="c13"
-                  data-blade-component="text"
-                  letter-spacing="50"
-                >
-                  Razorpay Trusted Business
-                </p>
-              </div>
+                Razorpay Trusted Business
+              </p>
             </div>
           </div>
         </div>
       </div>
       <div
-        class="c14"
+        class="c13"
         data-blade-component="app-bar-actions"
       >
         <button
@@ -862,6 +830,11 @@ exports[`<AppBar /> should render AppBarLeading with logo and full trust badge 1
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px 8px;
+  height: 24px;
+  gap: 4px;
+  background-color: hsla(180,91%,13%,1);
+  border-radius: 9999px;
 }
 
 .c7.c7.c7.c7.c7 {
@@ -876,42 +849,10 @@ exports[`<AppBar /> should render AppBarLeading with logo and full trust badge 1
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
 }
 
 .c8.c8.c8.c8.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: hsla(0,0%,0%,0.32);
-  border-radius: 16px;
-}
-
-.c9.c9.c9.c9.c9 {
-  color: hsla(0,0%,100%,1);
+  color: hsla(210,3%,69%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
   font-weight: 400;
@@ -1103,18 +1044,13 @@ exports[`<AppBar /> should render AppBarLeading with logo and full trust badge 1
                   </defs>
                 </svg>
               </div>
-              <div
+              <p
                 class="c8"
-                data-blade-component="base-box"
+                data-blade-component="text"
+                letter-spacing="50"
               >
-                <p
-                  class="c9"
-                  data-blade-component="text"
-                  letter-spacing="50"
-                >
-                  Razorpay Trusted Business
-                </p>
-              </div>
+                Razorpay Trusted Business
+              </p>
             </div>
           </div>
         </div>
@@ -1237,6 +1173,11 @@ exports[`<AppBar /> should render AppBarLeading with title and full trust badge 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px 8px;
+  height: 24px;
+  gap: 4px;
+  background-color: hsla(180,91%,13%,1);
+  border-radius: 9999px;
 }
 
 .c8.c8.c8.c8.c8 {
@@ -1251,38 +1192,6 @@ exports[`<AppBar /> should render AppBarLeading with title and full trust badge 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
-}
-
-.c9.c9.c9.c9.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: hsla(0,0%,0%,0.32);
-  border-radius: 16px;
 }
 
 .c5.c5.c5.c5.c5 {
@@ -1308,8 +1217,8 @@ exports[`<AppBar /> should render AppBarLeading with title and full trust badge 
   overflow-wrap: break-word;
 }
 
-.c10.c10.c10.c10.c10 {
-  color: hsla(0,0%,100%,1);
+.c9.c9.c9.c9.c9 {
+  color: hsla(210,3%,69%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
   font-weight: 400;
@@ -1491,18 +1400,13 @@ exports[`<AppBar /> should render AppBarLeading with title and full trust badge 
                   </defs>
                 </svg>
               </div>
-              <div
+              <p
                 class="c9"
-                data-blade-component="base-box"
+                data-blade-component="text"
+                letter-spacing="50"
               >
-                <p
-                  class="c10"
-                  data-blade-component="text"
-                  letter-spacing="50"
-                >
-                  Razorpay Trusted Business
-                </p>
-              </div>
+                Razorpay Trusted Business
+              </p>
             </div>
           </div>
         </div>
@@ -1611,6 +1515,7 @@ exports[`<AppBar /> should render AppBarLeading with title and icon-only trust b
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px;
 }
 
 .c7.c7.c7.c7.c7 {
@@ -1625,8 +1530,6 @@ exports[`<AppBar /> should render AppBarLeading with title and icon-only trust b
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
 }
 
 .c5.c5.c5.c5.c5 {

--- a/packages/blade/src/components/TrustBadge/TrustBadge.stories.tsx
+++ b/packages/blade/src/components/TrustBadge/TrustBadge.stories.tsx
@@ -10,8 +10,8 @@ const Page = (): React.ReactElement => {
   return (
     <StoryPageWrapper
       componentName="TrustBadge"
-      componentDescription="A generic trust badge — a brand shield paired with a faded pill that displays a configurable trust label (default: 'Razorpay Trusted Business'). The component is designed to be generic so the label can evolve without a breaking API change."
-      figmaURL="https://www.figma.com/design/fc7NbN38dG7olgm9mzpVx4/Checkout-DS?node-id=340-10923&m=dev"
+      componentDescription="A generic trust badge — a brand shield paired with a sea-tinted pill that displays a configurable trust label (default: 'Razorpay Trusted Business'). The component is designed to be generic so the label can evolve without a breaking API change."
+      figmaURL="https://www.figma.com/design/jubmQL9Z8V7881ayUD95ps/Blade-DSL?node-id=123352-128035&m=dev"
     >
       <Title>Usage</Title>
       <BaseBox
@@ -34,10 +34,6 @@ export default {
       control: { type: 'select' },
       options: ['default', 'icon-only'],
     },
-    emphasis: {
-      control: { type: 'select' },
-      options: ['intense', 'subtle'],
-    },
     label: {
       control: { type: 'text' },
     },
@@ -45,7 +41,6 @@ export default {
   },
   args: {
     variant: 'default',
-    emphasis: 'subtle',
     label: 'Razorpay Trusted Business',
   },
   parameters: {
@@ -56,30 +51,6 @@ export default {
 } as Meta<TrustBadgeProps>;
 
 const TrustBadgeTemplate: StoryFn<typeof TrustBadgeComponent> = (args) => {
-  const isSubtle = args.emphasis !== 'intense';
-  return (
-    <BaseBox
-      backgroundColor={
-        isSubtle ? 'surface.background.gray.subtle' : 'surface.background.gray.intense'
-      }
-      padding="spacing.5"
-      borderRadius="medium"
-      display="inline-flex"
-    >
-      <TrustBadgeComponent {...args} />
-    </BaseBox>
-  );
-};
-
-export const Default = TrustBadgeTemplate.bind({});
-
-export const Intense = TrustBadgeTemplate.bind({});
-Intense.args = {
-  emphasis: 'intense',
-};
-
-export const Subtle: StoryFn<typeof TrustBadgeComponent> = (args) => {
-  // The subtle variant uses static-black text, so render it over a light surface for contrast.
   return (
     <BaseBox
       backgroundColor="surface.background.gray.subtle"
@@ -91,9 +62,8 @@ export const Subtle: StoryFn<typeof TrustBadgeComponent> = (args) => {
     </BaseBox>
   );
 };
-Subtle.args = {
-  emphasis: 'subtle',
-};
+
+export const Default = TrustBadgeTemplate.bind({});
 
 export const IconOnly = TrustBadgeTemplate.bind({});
 IconOnly.args = {

--- a/packages/blade/src/components/TrustBadge/TrustBadge.web.tsx
+++ b/packages/blade/src/components/TrustBadge/TrustBadge.web.tsx
@@ -14,7 +14,7 @@ const DEFAULT_LABEL = 'Razorpay Trusted Business';
 /**
  * ### TrustBadge
  *
- * A generic trust badge — a brand shield paired with a faded pill that displays
+ * A generic trust badge — a brand shield paired with a sea-tinted pill that displays
  * a configurable trust label (default: "Razorpay Trusted Business").
  *
  * The component is intentionally generic so the label and semantics can evolve
@@ -25,25 +25,18 @@ const DEFAULT_LABEL = 'Razorpay Trusted Business';
  * #### Usage
  *
  * ```jsx
- * <TrustBadge />                        // subtle (default) — dark text, for light surfaces
- * <TrustBadge emphasis="intense" />     // white text, for dark/colored surfaces
+ * <TrustBadge />                        // shield + label pill (default)
  * <TrustBadge variant="icon-only" />    // shield only, no pill/text
  * <TrustBadge label="Razorpay Verified" />  // custom trust label
  * ```
  */
 const _TrustBadge = ({
   variant = 'default',
-  emphasis = 'subtle',
   label = DEFAULT_LABEL,
   testID,
   ...rest
 }: TrustBadgeProps): React.ReactElement => {
   const isIconOnly = variant === 'icon-only';
-  const textColor =
-    emphasis === 'subtle' ? 'surface.text.staticBlack.normal' : 'surface.text.staticWhite.normal';
-  // Checkout DS: intense pill = 32% black; subtle pill = 10% black on light surfaces.
-  const pillBackgroundColor =
-    emphasis === 'subtle' ? 'rgba(0, 0, 0, 0.1)' : 'surface.icon.staticBlack.disabled';
 
   return (
     <BaseBox
@@ -51,6 +44,11 @@ const _TrustBadge = ({
       flexDirection="row"
       alignItems="center"
       flexShrink={0}
+      gap={isIconOnly ? undefined : 'spacing.2'}
+      height={isIconOnly ? undefined : '24px'}
+      padding={isIconOnly ? 'spacing.2' : ['spacing.2', 'spacing.3']}
+      borderRadius={isIconOnly ? undefined : 'max'}
+      backgroundColor={isIconOnly ? undefined : 'surface.background.sea.subtle'}
       {...metaAttribute({ name: MetaConstants.TrustBadge, testID })}
       {...getStyledProps(rest)}
       {...makeAnalyticsAttribute(rest)}
@@ -61,33 +59,14 @@ const _TrustBadge = ({
         display="flex"
         alignItems="center"
         flexShrink={0}
-        position="relative"
-        zIndex={2}
-        marginRight={isIconOnly ? undefined : '-12px'}
         {...(isIconOnly ? makeAccessible({ role: 'img', label }) : { 'aria-hidden': true })}
       >
         <RazorpayTrustIcon size="medium" />
       </BaseBox>
       {isIconOnly ? null : (
-        <BaseBox
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          justifyContent="center"
-          position="relative"
-          zIndex={1}
-          flexShrink={0}
-          paddingTop="spacing.1"
-          paddingBottom="spacing.1"
-          paddingLeft="spacing.5"
-          paddingRight="10px"
-          borderRadius="large"
-          backgroundColor={pillBackgroundColor}
-        >
-          <Text size="xsmall" weight="regular" color={textColor}>
-            {label}
-          </Text>
-        </BaseBox>
+        <Text size="xsmall" weight="regular" color="surface.text.gray.subtle">
+          {label}
+        </Text>
       )}
     </BaseBox>
   );

--- a/packages/blade/src/components/TrustBadge/__tests__/TrustBadge.ssr.test.tsx
+++ b/packages/blade/src/components/TrustBadge/__tests__/TrustBadge.ssr.test.tsx
@@ -4,7 +4,7 @@ import renderWithSSR from '~utils/testing/renderWithSSR.web';
 
 describe('<TrustBadge />', () => {
   it('should render TrustBadge ssr', () => {
-    const { container } = renderWithSSR(<TrustBadge emphasis="intense" />);
+    const { container } = renderWithSSR(<TrustBadge />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/blade/src/components/TrustBadge/__tests__/TrustBadge.web.test.tsx
+++ b/packages/blade/src/components/TrustBadge/__tests__/TrustBadge.web.test.tsx
@@ -4,13 +4,7 @@ import assertAccessible from '~utils/testing/assertAccessible';
 
 describe('<TrustBadge />', () => {
   it('should render the default badge with the default trust label', () => {
-    const { container, getByText } = renderWithTheme(<TrustBadge emphasis="intense" />);
-    expect(getByText('Razorpay Trusted Business')).toBeInTheDocument();
-    expect(container).toMatchSnapshot();
-  });
-
-  it('should render the subtle variant', () => {
-    const { container, getByText } = renderWithTheme(<TrustBadge emphasis="subtle" />);
+    const { container, getByText } = renderWithTheme(<TrustBadge />);
     expect(getByText('Razorpay Trusted Business')).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
@@ -38,7 +32,7 @@ describe('<TrustBadge />', () => {
   });
 
   it('should pass general a11y', async () => {
-    const { container } = renderWithTheme(<TrustBadge emphasis="intense" />);
+    const { container } = renderWithTheme(<TrustBadge />);
     await assertAccessible(container);
   });
 

--- a/packages/blade/src/components/TrustBadge/__tests__/__snapshots__/TrustBadge.ssr.test.tsx.snap
+++ b/packages/blade/src/components/TrustBadge/__tests__/__snapshots__/TrustBadge.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<TrustBadge /> should render TrustBadge ssr 1`] = `"<div id="root"><div data-blade-component="trust-badge" class="BaseBox-bksIuc evlwHc"><div aria-hidden="true" data-blade-component="base-box" class="BaseBox-bksIuc escAoS"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M19.7981 3.96094V15.3838C19.798 16.163 19.4121 16.8915 18.7679 17.3301L12.1311 21.8467L5.49443 17.3301C4.85022 16.8915 4.46425 16.163 4.46415 15.3838V3.96094L12.1311 2.09277L19.7981 3.96094Z" fill="url(#razorpayTrustFill-:R1:)" stroke="url(#razorpayTrustStroke-:R1:)" stroke-width="0.666667"></path><g filter="url(#razorpayTrustShadow-:R1:)"><path d="M11.5244 8.82L11.0532 10.6936L13.7494 8.80947L11.9861 15.9179L13.7767 15.9196L16.3815 5.42041L11.5244 8.82Z" fill="white"></path><path d="M8.62275 12.9321L7.88147 15.9204H11.5517L13.0534 9.8411L8.62275 12.9321Z" fill="white"></path></g><defs><filter id="razorpayTrustShadow-:R1:" x="5.65925" y="3.19819" width="12.9444" height="14.9444" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"></feColorMatrix><feOffset></feOffset><feGaussianBlur stdDeviation="1.11111"></feGaussianBlur><feComposite in2="hardAlpha" operator="out"></feComposite><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.294097 0 0 0 0 0.152931 0 0 0 0.25 0"></feColorMatrix><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"></feBlend><feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"></feBlend></filter><linearGradient id="razorpayTrustFill-:R1:" x1="4.13115" y1="5.0249" x2="18.2093" y2="18.4295" gradientUnits="userSpaceOnUse"><stop stop-color="#00FD0A"></stop><stop offset="0.972213" stop-color="#00AD8E"></stop></linearGradient><linearGradient id="razorpayTrustStroke-:R1:" x1="6.35337" y1="4.55055" x2="17.5246" y2="17.4954" gradientUnits="userSpaceOnUse"><stop stop-color="#65FF4D"></stop><stop offset="0.302473" stop-color="white" stop-opacity="0.895"></stop><stop offset="0.452125" stop-color="#65FF4D" stop-opacity="0.805"></stop><stop offset="1" stop-color="#00C67F"></stop></linearGradient></defs></svg></div><div data-blade-component="base-box" class="BaseBox-bksIuc lePPWY"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text">Razorpay Trusted Business</p></div></div></div>"`;
+exports[`<TrustBadge /> should render TrustBadge ssr 1`] = `"<div id="root"><div data-blade-component="trust-badge" class="BaseBox-bksIuc hHFnVV"><div aria-hidden="true" data-blade-component="base-box" class="BaseBox-bksIuc jVxAcE"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M19.7981 3.96094V15.3838C19.798 16.163 19.4121 16.8915 18.7679 17.3301L12.1311 21.8467L5.49443 17.3301C4.85022 16.8915 4.46425 16.163 4.46415 15.3838V3.96094L12.1311 2.09277L19.7981 3.96094Z" fill="url(#razorpayTrustFill-:R1:)" stroke="url(#razorpayTrustStroke-:R1:)" stroke-width="0.666667"></path><g filter="url(#razorpayTrustShadow-:R1:)"><path d="M11.5244 8.82L11.0532 10.6936L13.7494 8.80947L11.9861 15.9179L13.7767 15.9196L16.3815 5.42041L11.5244 8.82Z" fill="white"></path><path d="M8.62275 12.9321L7.88147 15.9204H11.5517L13.0534 9.8411L8.62275 12.9321Z" fill="white"></path></g><defs><filter id="razorpayTrustShadow-:R1:" x="5.65925" y="3.19819" width="12.9444" height="14.9444" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feFlood flood-opacity="0" result="BackgroundImageFix"></feFlood><feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"></feColorMatrix><feOffset></feOffset><feGaussianBlur stdDeviation="1.11111"></feGaussianBlur><feComposite in2="hardAlpha" operator="out"></feComposite><feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.294097 0 0 0 0 0.152931 0 0 0 0.25 0"></feColorMatrix><feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"></feBlend><feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"></feBlend></filter><linearGradient id="razorpayTrustFill-:R1:" x1="4.13115" y1="5.0249" x2="18.2093" y2="18.4295" gradientUnits="userSpaceOnUse"><stop stop-color="#00FD0A"></stop><stop offset="0.972213" stop-color="#00AD8E"></stop></linearGradient><linearGradient id="razorpayTrustStroke-:R1:" x1="6.35337" y1="4.55055" x2="17.5246" y2="17.4954" gradientUnits="userSpaceOnUse"><stop stop-color="#65FF4D"></stop><stop offset="0.302473" stop-color="white" stop-opacity="0.895"></stop><stop offset="0.452125" stop-color="#65FF4D" stop-opacity="0.805"></stop><stop offset="1" stop-color="#00C67F"></stop></linearGradient></defs></svg></div><p letter-spacing="50" class="StyledBaseText-foUshD eEJNgd" data-blade-component="text">Razorpay Trusted Business</p></div></div>"`;
 
 exports[`<TrustBadge /> should render TrustBadge ssr 2`] = `
 .c0.c0.c0.c0.c0 {
@@ -18,6 +18,11 @@ exports[`<TrustBadge /> should render TrustBadge ssr 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px 8px;
+  height: 24px;
+  gap: 4px;
+  background-color: hsla(180,39%,95%,1);
+  border-radius: 9999px;
 }
 
 .c1.c1.c1.c1.c1 {
@@ -32,42 +37,10 @@ exports[`<TrustBadge /> should render TrustBadge ssr 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
 }
 
 .c2.c2.c2.c2.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: hsla(0,0%,0%,0.32);
-  border-radius: 16px;
-}
-
-.c3.c3.c3.c3.c3 {
-  color: hsla(0,0%,100%,1);
+  color: hsla(200,10%,18%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
   font-weight: 400;
@@ -211,18 +184,13 @@ exports[`<TrustBadge /> should render TrustBadge ssr 2`] = `
         </defs>
       </svg>
     </div>
-    <div
+    <p
       class="c2"
-      data-blade-component="base-box"
+      data-blade-component="text"
+      letter-spacing="50"
     >
-      <p
-        class="c3"
-        data-blade-component="text"
-        letter-spacing="50"
-      >
-        Razorpay Trusted Business
-      </p>
-    </div>
+      Razorpay Trusted Business
+    </p>
   </div>
 </div>
 `;

--- a/packages/blade/src/components/TrustBadge/__tests__/__snapshots__/TrustBadge.web.test.tsx.snap
+++ b/packages/blade/src/components/TrustBadge/__tests__/__snapshots__/TrustBadge.web.test.tsx.snap
@@ -16,6 +16,11 @@ exports[`<TrustBadge /> should render the default badge with the default trust l
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px 8px;
+  height: 24px;
+  gap: 4px;
+  background-color: hsla(180,39%,95%,1);
+  border-radius: 9999px;
 }
 
 .c1.c1.c1.c1.c1 {
@@ -30,42 +35,10 @@ exports[`<TrustBadge /> should render the default badge with the default trust l
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
 }
 
 .c2.c2.c2.c2.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: hsla(0,0%,0%,0.32);
-  border-radius: 16px;
-}
-
-.c3.c3.c3.c3.c3 {
-  color: hsla(0,0%,100%,1);
+  color: hsla(200,10%,18%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
   font-weight: 400;
@@ -207,18 +180,13 @@ exports[`<TrustBadge /> should render the default badge with the default trust l
         </defs>
       </svg>
     </div>
-    <div
+    <p
       class="c2"
-      data-blade-component="base-box"
+      data-blade-component="text"
+      letter-spacing="50"
     >
-      <p
-        class="c3"
-        data-blade-component="text"
-        letter-spacing="50"
-      >
-        Razorpay Trusted Business
-      </p>
-    </div>
+      Razorpay Trusted Business
+    </p>
   </div>
 </div>
 `;
@@ -239,6 +207,7 @@ exports[`<TrustBadge /> should render the icon-only badge without the visible la
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 4px;
 }
 
 .c1.c1.c1.c1.c1 {
@@ -253,8 +222,6 @@ exports[`<TrustBadge /> should render the icon-only badge without the visible la
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
-  z-index: 2;
 }
 
 <div>
@@ -267,217 +234,6 @@ exports[`<TrustBadge /> should render the icon-only badge without the visible la
       class="c1"
       data-blade-component="base-box"
       role="img"
-    >
-      <svg
-        aria-hidden="true"
-        class="Svgweb__StyledSvg-vcmjs8-0"
-        data-blade-component="icon"
-        fill="none"
-        height="16px"
-        viewBox="0 0 24 24"
-        width="16px"
-      >
-        <path
-          d="M19.7981 3.96094V15.3838C19.798 16.163 19.4121 16.8915 18.7679 17.3301L12.1311 21.8467L5.49443 17.3301C4.85022 16.8915 4.46425 16.163 4.46415 15.3838V3.96094L12.1311 2.09277L19.7981 3.96094Z"
-          fill="url(#razorpayTrustFill-:r2:)"
-          stroke="url(#razorpayTrustStroke-:r2:)"
-          stroke-width="0.666667"
-        />
-        <g
-          filter="url(#razorpayTrustShadow-:r2:)"
-        >
-          <path
-            d="M11.5244 8.82L11.0532 10.6936L13.7494 8.80947L11.9861 15.9179L13.7767 15.9196L16.3815 5.42041L11.5244 8.82Z"
-            fill="white"
-          />
-          <path
-            d="M8.62275 12.9321L7.88147 15.9204H11.5517L13.0534 9.8411L8.62275 12.9321Z"
-            fill="white"
-          />
-        </g>
-        <defs>
-          <filter
-            color-interpolation-filters="sRGB"
-            filterUnits="userSpaceOnUse"
-            height="14.9444"
-            id="razorpayTrustShadow-:r2:"
-            width="12.9444"
-            x="5.65925"
-            y="3.19819"
-          >
-            <feflood
-              flood-opacity="0"
-              result="BackgroundImageFix"
-            />
-            <fecolormatrix
-              in="SourceAlpha"
-              result="hardAlpha"
-              type="matrix"
-              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-            />
-            <feoffset />
-            <fegaussianblur
-              stdDeviation="1.11111"
-            />
-            <fecomposite
-              in2="hardAlpha"
-              operator="out"
-            />
-            <fecolormatrix
-              type="matrix"
-              values="0 0 0 0 0 0 0 0 0 0.294097 0 0 0 0 0.152931 0 0 0 0.25 0"
-            />
-            <feblend
-              in2="BackgroundImageFix"
-              mode="normal"
-              result="effect1_dropShadow"
-            />
-            <feblend
-              in="SourceGraphic"
-              in2="effect1_dropShadow"
-              mode="normal"
-              result="shape"
-            />
-          </filter>
-          <lineargradient
-            gradientUnits="userSpaceOnUse"
-            id="razorpayTrustFill-:r2:"
-            x1="4.13115"
-            x2="18.2093"
-            y1="5.0249"
-            y2="18.4295"
-          >
-            <stop
-              stop-color="#00FD0A"
-            />
-            <stop
-              offset="0.972213"
-              stop-color="#00AD8E"
-            />
-          </lineargradient>
-          <lineargradient
-            gradientUnits="userSpaceOnUse"
-            id="razorpayTrustStroke-:r2:"
-            x1="6.35337"
-            x2="17.5246"
-            y1="4.55055"
-            y2="17.4954"
-          >
-            <stop
-              stop-color="#65FF4D"
-            />
-            <stop
-              offset="0.302473"
-              stop-color="white"
-              stop-opacity="0.895"
-            />
-            <stop
-              offset="0.452125"
-              stop-color="#65FF4D"
-              stop-opacity="0.805"
-            />
-            <stop
-              offset="1"
-              stop-color="#00C67F"
-            />
-          </lineargradient>
-        </defs>
-      </svg>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`<TrustBadge /> should render the subtle variant 1`] = `
-.c0.c0.c0.c0.c0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c1.c1.c1.c1.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  z-index: 2;
-  margin-right: -12px;
-}
-
-.c2.c2.c2.c2.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  position: relative;
-  z-index: 1;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: 10px;
-  padding-left: 16px;
-  background-color: rgba(0,0,0,0.1);
-  border-radius: 16px;
-}
-
-.c3.c3.c3.c3.c3 {
-  color: hsla(0,0%,0%,1);
-  font-family: "Inter","Inter Fallback Arial",Arial;
-  font-size: 0.625rem;
-  font-weight: 400;
-  font-style: normal;
-  -webkit-text-decoration-line: none;
-  text-decoration-line: none;
-  line-height: 0.8125rem;
-  -webkit-letter-spacing: -0.13px;
-  -moz-letter-spacing: -0.13px;
-  -ms-letter-spacing: -0.13px;
-  letter-spacing: -0.13px;
-  margin: 0;
-  padding: 0;
-}
-
-<div>
-  <div
-    class="c0"
-    data-blade-component="trust-badge"
-  >
-    <div
-      aria-hidden="true"
-      class="c1"
-      data-blade-component="base-box"
     >
       <svg
         aria-hidden="true"
@@ -594,18 +350,6 @@ exports[`<TrustBadge /> should render the subtle variant 1`] = `
           </lineargradient>
         </defs>
       </svg>
-    </div>
-    <div
-      class="c2"
-      data-blade-component="base-box"
-    >
-      <p
-        class="c3"
-        data-blade-component="text"
-        letter-spacing="50"
-      >
-        Razorpay Trusted Business
-      </p>
     </div>
   </div>
 </div>

--- a/packages/blade/src/components/TrustBadge/types.ts
+++ b/packages/blade/src/components/TrustBadge/types.ts
@@ -12,16 +12,6 @@ type TrustBadgeProps = {
   variant?: 'default' | 'icon-only';
 
   /**
-   * Text/foreground treatment. Only affects `variant='default'` — the shield keeps its
-   * fixed brand gradient regardless of emphasis.
-   * - `'intense'`: static-white text — for dark/colored surfaces.
-   * - `'subtle'` (default): static-black text — for light surfaces.
-   *
-   * @default 'subtle'
-   */
-  emphasis?: 'subtle' | 'intense';
-
-  /**
    * Trust label displayed in the pill (only visible when `variant='default'`).
    * Also used as the accessible label for the icon-only form.
    *


### PR DESCRIPTION
## Summary
- Update TrustBadge to match the new Blade DSL `[Utility] Trust Marker` design: sea-subtle pill with inline shield + label, and icon-only variant with compact padding
- Remove the `emphasis` prop (`intense`/`subtle`) since the new design has a single visual treatment
- Fix Svelte `CustomLabel` story so Controls panel updates the `label` prop via args-driven snippet template
- Update AppBar TrustBadge usage and refresh TrustBadge/AppBar snapshots

## Test plan
- [x] `yarn test:react TrustBadge` — 8 passed
- [x] `yarn test:react AppBar` — 14 passed, snapshots updated
- [x] `yarn typecheck` in `packages/blade` and `packages/blade-core`
- [ ] Verify TrustBadge in Svelte Storybook (`Components/TrustBadge`) — Default, Icon Only, CustomLabel with Controls
- [ ] Verify TrustBadge in React Storybook (`Components/TrustBadge`)
- [ ] Spot-check AppBar with trust badge on neutral and light variants


Made with [Cursor](https://cursor.com)