### PR TITLE
fix(DatePicker): collapse same-month ranges in compact display format

### DIFF
--- a/.changeset/compact-date-range-same-month.md
+++ b/.changeset/compact-date-range-same-month.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(DatePicker): collapse same-month ranges in compact display format
+
+`displayFormat="compact"` now shows same-month date ranges as `1-23 Jun 2026` instead of repeating the month, e.g. `1 Jun - 23 Jun 2026`. Ranges spanning different months or years keep their existing format (`7 Jun - 12 Jul 2026`, `28 Dec 2025 - 3 Jan 2026`).

--- a/packages/blade/src/components/DatePicker/__tests__/getHumanizedDate.test.ts
+++ b/packages/blade/src/components/DatePicker/__tests__/getHumanizedDate.test.ts
@@ -13,14 +13,24 @@ describe('getHumanizedDate', () => {
     expect(result).toBe('7 Jun 2026');
   });
 
-  it('should format a same-year range without repeating the year on the start date', () => {
+  it('should format a same-month range as a compact day range with a single month/year', () => {
     const result = getHumanizedDate({
-      date: [new Date(2026, 5, 7), new Date(2026, 5, 12)],
+      date: [new Date(2026, 5, 1), new Date(2026, 5, 23)],
       locale,
       selectionType: 'range',
     });
 
-    expect(result).toBe('7 Jun - 12 Jun 2026');
+    expect(result).toBe('1-23 Jun 2026');
+  });
+
+  it('should format a same-year, different-month range without repeating the year on the start date', () => {
+    const result = getHumanizedDate({
+      date: [new Date(2026, 5, 7), new Date(2026, 6, 12)],
+      locale,
+      selectionType: 'range',
+    });
+
+    expect(result).toBe('7 Jun - 12 Jul 2026');
   });
 
   it('should format a cross-year range with the year on both dates', () => {

--- a/packages/blade/src/components/DatePicker/utils.ts
+++ b/packages/blade/src/components/DatePicker/utils.ts
@@ -736,9 +736,11 @@ const stripDelimiters = (str?: string): string => str?.replace(/\//g, '') ?? '';
 
 /**
  * Formats a date / date-range into a humanised, easy-to-read format used by the
- * `displayFormat="compact"` mode (e.g. "7 Jun 2026" or "7 Jun - 12 Jun 2026").
+ * `displayFormat="compact"` mode (e.g. "7 Jun 2026", "1-23 Jun 2026", or "7 Jun - 12 Jul 2026").
  *
- * The year is only repeated on the start date when the range spans multiple years.
+ * - Same month & year: only the day is repeated on the start date, e.g. "1-23 Jun 2026".
+ * - Same year, different month: the year is only repeated on the end date, e.g. "7 Jun - 12 Jul 2026".
+ * - Different years: the year is repeated on both dates, e.g. "28 Dec 2025 - 3 Jan 2026".
  * This intentionally uses a fixed `D MMM YYYY` format (locale-aware) since it is only
  * used for the read-only compact display and not for editable input parsing.
  */
@@ -755,6 +757,8 @@ const getHumanizedDate = ({
 
   const withYear = (value: Date): string => dayjs(value).locale(locale).format('D MMM YYYY');
   const withoutYear = (value: Date): string => dayjs(value).locale(locale).format('D MMM');
+  const dayOnly = (value: Date): string => dayjs(value).locale(locale).format('D');
+  const monthYear = (value: Date): string => dayjs(value).locale(locale).format('MMM YYYY');
 
   if (selectionType === 'single' && date instanceof Date) {
     return withYear(date);
@@ -763,7 +767,15 @@ const getHumanizedDate = ({
   if (Array.isArray(date)) {
     const [startDate, endDate] = date;
     if (startDate && endDate) {
-      const isSameYear = dayjs(startDate).year() === dayjs(endDate).year();
+      const start = dayjs(startDate);
+      const end = dayjs(endDate);
+      const isSameYear = start.year() === end.year();
+      const isSameMonth = isSameYear && start.month() === end.month();
+
+      if (isSameMonth) {
+        return `${dayOnly(startDate)}-${dayOnly(endDate)} ${monthYear(endDate)}`;
+      }
+
       return `${isSameYear ? withoutYear(startDate) : withYear(startDate)} - ${withYear(endDate)}`;
     }
     if (startDate) {


### PR DESCRIPTION
## Description

Follow-up to #3679. In `displayFormat="compact"` mode, a same-month date range currently repeats the month name on both dates, e.g. `1 Jun - 23 Jun 2026`. This PR collapses that into a single month/year, e.g. `1-23 Jun 2026`, matching common calendar-app conventions for compact range display.

## Changes

- `getHumanizedDate` (`DatePicker/utils.ts`): when the start and end date fall in the same month **and** year, format as `D-D MMM YYYY` (e.g. `1-23 Jun 2026`) instead of `D MMM - D MMM YYYY`.
- Existing behavior is unchanged for:
  - Same year, different month → `7 Jun - 12 Jul 2026`
  - Different years → `28 Dec 2025 - 3 Jan 2026`
  - Single date → `7 Jun 2026`
- Updated/added unit tests in `getHumanizedDate.test.ts` covering the same-month case and the same-year/different-month case.
- Added changeset.

## Test plan

- [x] `yarn test:react getHumanizedDate` — 7/7 passing
- [x] `yarn test:react DatePicker` — all passing
- [x] `yarn typecheck` — clean