### PR TITLE
fix(blade-svelte): UI polish and checkbox icon flash

### DIFF
--- a/packages/blade-core/src/styles/Alert/alert.module.css
+++ b/packages/blade-core/src/styles/Alert/alert.module.css
@@ -5,17 +5,16 @@
   padding: var(--spacing-4);
   box-sizing: border-box;
   align-items: flex-start;
+  border-radius: var(--border-radius-medium);
 }
 
 .alert:not(.full-width) {
   max-width: 584px;
-  border-radius: var(--border-radius-medium);
 }
 
 /* Full Width Variant */
 .full-width {
   width: 100%;
-  border-radius: var(--border-radius-none);
 }
 
 /* Color × Emphasis compound variants */

--- a/packages/blade-core/src/styles/AppBar/appBar.module.css
+++ b/packages/blade-core/src/styles/AppBar/appBar.module.css
@@ -74,7 +74,9 @@
 }
 
 /* --- AppBarLeading ---
-   React: flex row, align center, gap spacing.3, minWidth 0 (truncation). */
+   React: flex row, align center, gap spacing.3, minWidth 0 (truncation).
+   No overflow:hidden here — it clips Avatar wrapper outlines that extend
+   outside the box. Title truncation uses overflow on title wrappers below. */
 .appBarLeading {
   display: flex;
   flex-direction: row;
@@ -82,7 +84,6 @@
   gap: var(--spacing-3);
   min-width: 0;
   flex: 1 1 0;
-  overflow: hidden;
 }
 
 .appBarLeadingLogo {

--- a/packages/blade-core/src/styles/Avatar/avatar.module.css
+++ b/packages/blade-core/src/styles/Avatar/avatar.module.css
@@ -294,7 +294,7 @@
 
 .top-addon-circle-xlarge {
   right: 4px;
-  top: 2px;
+  top: 4px;
 }
 
 /* Top addon offsets for square variant */

--- a/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.stories.svelte
@@ -22,6 +22,8 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
+  import { getFlagOfCountry, getFlagsForAllCountries } from '@razorpay/i18nify-js/geo';
   import ActionListItem from './ActionListItem.svelte';
   import ActionListItemAsset from './ActionListItemAsset.svelte';
   import ActionListItemText from './ActionListItemText.svelte';
@@ -44,9 +46,12 @@
     CloseIcon,
   } from '../Icons';
 
+  const flags = untrack(() => getFlagsForAllCountries()) as Record<string, { '4X3': string }>;
+  const indiaFlagSrc = getFlagOfCountry('IN')['4X3'];
+
   // Country List is the only BottomSheet story, so it owns the single open-state bucket.
   let isCountryOpen = $state(false);
-  let selectedCountry = $state<string | undefined>('in');
+  let selectedCountry = $state<string | undefined>('IN');
 
   // Drives the interactive standalone single-select story.
   let selectedStandalone = $state<string | undefined>('transactions');
@@ -62,21 +67,17 @@
   }
 
   const countries = [
-    { value: 'in', name: 'India', code: 'in', dialCode: '+91' },
-    { value: 'us', name: 'United States', code: 'us', dialCode: '+1' },
-    { value: 'gb', name: 'United Kingdom', code: 'gb', dialCode: '+44' },
-    { value: 'au', name: 'Australia', code: 'au', dialCode: '+61' },
-    { value: 'de', name: 'Germany', code: 'de', dialCode: '+49' },
-    { value: 'fr', name: 'France', code: 'fr', dialCode: '+33' },
-    { value: 'jp', name: 'Japan', code: 'jp', dialCode: '+81' },
-    { value: 'sg', name: 'Singapore', code: 'sg', dialCode: '+65' },
-    { value: 'ae', name: 'United Arab Emirates', code: 'ae', dialCode: '+971' },
-    { value: 'br', name: 'Brazil', code: 'br', dialCode: '+55' },
+    { value: 'IN', name: 'India', code: 'IN', dialCode: '+91' },
+    { value: 'US', name: 'United States', code: 'US', dialCode: '+1' },
+    { value: 'GB', name: 'United Kingdom', code: 'GB', dialCode: '+44' },
+    { value: 'AU', name: 'Australia', code: 'AU', dialCode: '+61' },
+    { value: 'DE', name: 'Germany', code: 'DE', dialCode: '+49' },
+    { value: 'FR', name: 'France', code: 'FR', dialCode: '+33' },
+    { value: 'JP', name: 'Japan', code: 'JP', dialCode: '+81' },
+    { value: 'SG', name: 'Singapore', code: 'SG', dialCode: '+65' },
+    { value: 'AE', name: 'United Arab Emirates', code: 'AE', dialCode: '+971' },
+    { value: 'BR', name: 'Brazil', code: 'BR', dialCode: '+55' },
   ];
-
-  function flagSrc(code: string): string {
-    return `https://flagcdn.com/w20/${code}.png`;
-  }
 </script>
 
 <!-- Mirrors React `Default`. Args drive Controls panel. -->
@@ -108,7 +109,7 @@
         </ActionListItem>
         <ActionListItem title="Pricing" value="pricing">
           {#snippet leading()}
-            <ActionListItemAsset src="https://flagcdn.com/w20/in.png" alt="india" />
+            <ActionListItemAsset src={indiaFlagSrc} alt="India" />
           {/snippet}
         </ActionListItem>
       {/snippet}
@@ -399,7 +400,10 @@
                   {#each countries as country (country.value)}
                     <ActionListItem title={country.name} value={country.value}>
                       {#snippet leading()}
-                        <ActionListItemAsset src={flagSrc(country.code)} alt={`${country.name} flag`} />
+                        <ActionListItemAsset
+                          src={flags[country.code]?.['4X3'] ?? ''}
+                          alt={`${country.name} flag`}
+                        />
                       {/snippet}
                       {#snippet trailing()}
                         <ActionListItemText>{country.dialCode}</ActionListItemText>

--- a/packages/blade-svelte/src/components/ActionList/index.ts
+++ b/packages/blade-svelte/src/components/ActionList/index.ts
@@ -23,6 +23,7 @@
  * @example
  * ```svelte
  * <script lang="ts">
+ *   import { getFlagOfCountry } from '@razorpay/i18nify-js/geo';
  *   import {
  *     ActionList,
  *     ActionListItem,
@@ -34,7 +35,7 @@
  *   } from '@razorpay/blade-svelte/components';
  *
  *   let isOpen = $state(false);
- *   let selected = $state<string | undefined>('in');
+ *   let selected = $state<string | undefined>('IN');
  * </script>
  *
  * <BottomSheet {isOpen} onDismiss={() => (isOpen = false)}>
@@ -50,9 +51,9 @@
  *           }}
  *         >
  *           {#snippet children()}
- *             <ActionListItem title="India" value="in">
+ *             <ActionListItem title="India" value="IN">
  *               {#snippet leading()}
- *                 <ActionListItemAsset src="https://flagcdn.com/w20/in.png" alt="India" />
+ *                 <ActionListItemAsset src={getFlagOfCountry('IN')['4X3']} alt="India" />
  *               {/snippet}
  *               {#snippet trailing()}
  *                 <ActionListItemText>+91</ActionListItemText>

--- a/packages/blade-svelte/src/components/AppBar/AppBar.stories.svelte
+++ b/packages/blade-svelte/src/components/AppBar/AppBar.stories.svelte
@@ -169,7 +169,7 @@
 <Story name="Variations" asChild parameters={{ docs: { disable: true } }}>
   <div style="{checkoutBackgroundStyle} {variationsStackStyle}">
     {#each trustBadgeRows as row (row.label)}
-      <AppBar showBackButton onBackButtonClick={noop}>
+      <AppBar isSticky={false} showBackButton onBackButtonClick={noop}>
         <AppBarLeading trustBadgeVariant={row.trustBadgeVariant}>
           {#snippet logo()}
             {@render optimizerLogo()}
@@ -180,7 +180,7 @@
         </AppBarActions>
       </AppBar>
 
-      <AppBar showBackButton onBackButtonClick={noop}>
+      <AppBar isSticky={false} showBackButton onBackButtonClick={noop}>
         <AppBarLeading title="Maven Shop" trustBadgeVariant={row.trustBadgeVariant}>
           {#snippet logo()}
             {@render titleInitialsLogo()}
@@ -191,7 +191,7 @@
         </AppBarActions>
       </AppBar>
 
-      <AppBar showBackButton onBackButtonClick={noop}>
+      <AppBar isSticky={false} showBackButton onBackButtonClick={noop}>
         <AppBarLeading title="Maven Shop" trustBadgeVariant={row.trustBadgeVariant} />
         <AppBarActions>
           {@render defaultAppBarActions()}

--- a/packages/blade-svelte/src/components/Avatar/Avatar.stories.svelte
+++ b/packages/blade-svelte/src/components/Avatar/Avatar.stories.svelte
@@ -66,7 +66,7 @@
 <Story name="Icon Avatars" asChild>
   <div style="display: flex; flex-direction: row; gap: 20px;">
     {#each sizes as avatarSize}
-      <Avatar size={avatarSize} icon={BuildingIcon} variant="square" />
+      <Avatar size={avatarSize} icon={BuildingIcon} variant="circle" />
     {/each}
   </div>
 </Story>

--- a/packages/blade-svelte/src/components/Button/Button.stories.svelte
+++ b/packages/blade-svelte/src/components/Button/Button.stories.svelte
@@ -127,8 +127,18 @@
   ];
 </script>
 
-<script>
-  // Button is already imported in the module context
+<script lang="ts">
+  let isDefiniteLoadingDemoActive = $state(false);
+
+  function startDefiniteLoadingDemo(): void {
+    if (isDefiniteLoadingDemoActive) return;
+    isDefiniteLoadingDemoActive = true;
+  }
+
+  function handleDefiniteLoadingComplete(): void {
+    console.log('Loading complete!');
+    isDefiniteLoadingDemoActive = false;
+  }
 </script>
 
 <!-- Playground story - auto-renders Button with args -->
@@ -190,11 +200,12 @@
 <Story name="Definite Loading With Complete Callback" asChild>
   <Button
     size="large"
-    loadingType="definite"
-    loadingTimer={2500}
-    onLoadingComplete={() => window.alert('Loading complete!')}
+    loadingType={isDefiniteLoadingDemoActive ? 'definite' : 'indefinite'}
+    loadingTimer={isDefiniteLoadingDemoActive ? 2500 : undefined}
+    onClick={startDefiniteLoadingDemo}
+    onLoadingComplete={handleDefiniteLoadingComplete}
   >
-    Complete in 2.5s
+    {isDefiniteLoadingDemoActive ? 'Processing' : 'Complete in 2.5s'}
   </Button>
 </Story>
 

--- a/packages/blade-svelte/src/components/Checkbox/CheckboxIcon.svelte
+++ b/packages/blade-svelte/src/components/Checkbox/CheckboxIcon.svelte
@@ -30,30 +30,30 @@
   const showDash = $derived(Boolean(isIndeterminate));
   const showTick = $derived(Boolean(isChecked) && !isIndeterminate);
 
+  function fadeBaseClasses(show: boolean): string {
+    return [templateClasses.fade, show ? templateClasses.fadeShown : ''].filter(Boolean).join(' ');
+  }
+
   // Mirror React's Fade: skip animation on first paint (`prev === undefined`).
   // Only animate when visibility actually changes — avoids fadeOut on a never-shown
   // icon (its keyframe starts at opacity 1, which flashes the dash on mount).
-  type FadeIconParams = { show: boolean };
-
-  function fadeIcon(node: HTMLElement, { show }: FadeIconParams) {
+  function fadeIcon(node: HTMLElement, show: boolean) {
     let prev: boolean | undefined = undefined;
 
     function apply(nextShow: boolean): void {
+      if (prev === nextShow) return;
       const shouldAnimate = prev !== undefined && prev !== nextShow;
-      node.className = [
-        templateClasses.fade,
-        nextShow ? templateClasses.fadeShown : '',
-        shouldAnimate ? (nextShow ? templateClasses.fadeIn : templateClasses.fadeOut) : '',
-      ]
-        .filter(Boolean)
-        .join(' ');
+      node.classList.remove(templateClasses.fadeIn, templateClasses.fadeOut);
+      if (shouldAnimate) {
+        node.classList.add(nextShow ? templateClasses.fadeIn : templateClasses.fadeOut);
+      }
       prev = nextShow;
     }
 
     apply(show);
 
     return {
-      update({ show: nextShow }: FadeIconParams) {
+      update(nextShow: boolean) {
         apply(nextShow);
       },
     };
@@ -64,7 +64,7 @@
 </script>
 
 <div class={iconClasses} {...wrapperMeta}>
-  <div use:fadeIcon={{ show: showDash }} {...fadeMeta}>
+  <div class={fadeBaseClasses(showDash)} use:fadeIcon={showDash} {...fadeMeta}>
     <svg
       class={svgClasses}
       viewBox="0 0 8 8"
@@ -84,7 +84,7 @@
       />
     </svg>
   </div>
-  <div use:fadeIcon={{ show: showTick }} {...fadeMeta}>
+  <div class={fadeBaseClasses(showTick)} use:fadeIcon={showTick} {...fadeMeta}>
     <svg
       class={svgClasses}
       viewBox="0 0 8 8"

--- a/packages/blade-svelte/src/components/Checkbox/CheckboxIcon.svelte
+++ b/packages/blade-svelte/src/components/Checkbox/CheckboxIcon.svelte
@@ -30,21 +30,33 @@
   const showDash = $derived(Boolean(isIndeterminate));
   const showTick = $derived(Boolean(isChecked) && !isIndeterminate);
 
-  // Mirror React's Fade: `show === undefined` on first mount → no animation
-  // (prevents a flash of animation). After mount, animate enter/exit.
-  let mounted = $state(false);
-  $effect(() => {
-    mounted = true;
-  });
+  // Mirror React's Fade: skip animation on first paint (`prev === undefined`).
+  // Only animate when visibility actually changes — avoids fadeOut on a never-shown
+  // icon (its keyframe starts at opacity 1, which flashes the dash on mount).
+  type FadeIconParams = { show: boolean };
 
-  function fadeClasses(show: boolean): string {
-    return [
-      templateClasses.fade,
-      show ? templateClasses.fadeShown : '',
-      mounted ? (show ? templateClasses.fadeIn : templateClasses.fadeOut) : '',
-    ]
-      .filter(Boolean)
-      .join(' ');
+  function fadeIcon(node: HTMLElement, { show }: FadeIconParams) {
+    let prev: boolean | undefined = undefined;
+
+    function apply(nextShow: boolean): void {
+      const shouldAnimate = prev !== undefined && prev !== nextShow;
+      node.className = [
+        templateClasses.fade,
+        nextShow ? templateClasses.fadeShown : '',
+        shouldAnimate ? (nextShow ? templateClasses.fadeIn : templateClasses.fadeOut) : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      prev = nextShow;
+    }
+
+    apply(show);
+
+    return {
+      update({ show: nextShow }: FadeIconParams) {
+        apply(nextShow);
+      },
+    };
   }
 
   const wrapperMeta = metaAttribute({ name: 'checkbox-icon-wrapper' });
@@ -52,7 +64,7 @@
 </script>
 
 <div class={iconClasses} {...wrapperMeta}>
-  <div class={fadeClasses(showDash)} {...fadeMeta}>
+  <div use:fadeIcon={{ show: showDash }} {...fadeMeta}>
     <svg
       class={svgClasses}
       viewBox="0 0 8 8"
@@ -72,7 +84,7 @@
       />
     </svg>
   </div>
-  <div class={fadeClasses(showTick)} {...fadeMeta}>
+  <div use:fadeIcon={{ show: showTick }} {...fadeMeta}>
     <svg
       class={svgClasses}
       viewBox="0 0 8 8"

--- a/packages/blade-svelte/src/components/Input/SearchInput/SearchInput.stories.svelte
+++ b/packages/blade-svelte/src/components/Input/SearchInput/SearchInput.stories.svelte
@@ -37,7 +37,34 @@
   import Link from '../../Link/Link.svelte';
   import Tooltip from '../../Tooltip/Tooltip.svelte';
   import Text from '../../Typography/Text/Text.svelte';
-  import { InfoIcon } from '../../Icons';
+  import ActionList from '../../ActionList/ActionList.svelte';
+  import ActionListItem from '../../ActionList/ActionListItem.svelte';
+  import ActionListSection from '../../ActionList/ActionListSection.svelte';
+  import ActionListItemIcon from '../../ActionList/ActionListItemIcon.svelte';
+  import {
+    BankIcon,
+    BuildingIcon,
+    CreditCardIcon,
+    InfoIcon,
+    LockIcon,
+    UserIcon,
+    type IconComponent,
+  } from '../../Icons';
+
+  const menuItems: { title: string; icon: IconComponent }[] = [
+    { title: 'Account & Settings', icon: LockIcon },
+    { title: 'Profile', icon: UserIcon },
+    { title: 'Transactions', icon: CreditCardIcon },
+    { title: 'Help', icon: InfoIcon },
+    { title: 'Settlements', icon: BankIcon },
+    { title: 'Payouts', icon: BuildingIcon },
+  ];
+
+  let searchTerm = $state('');
+
+  const filteredItems = $derived(
+    menuItems.filter((item) => item.title.toLowerCase().includes(searchTerm.toLowerCase())),
+  );
 </script>
 
 <!-- 1 -->
@@ -50,7 +77,25 @@
 <!-- 2 -->
 <Story name="SearchInput with Help Text" args={{ helpText: 'Please enter an item to search' }}>
   {#snippet template(args)}
-    <SearchInput {...args} />
+    <div>
+      <SearchInput
+        {...args}
+        onChange={({ value }) => {
+          searchTerm = value ?? '';
+        }}
+      />
+      <ActionList>
+        <ActionListSection title={`${filteredItems.length} items found`}>
+          {#each filteredItems as item, index (index)}
+            <ActionListItem title={item.title} value={item.title}>
+              {#snippet leading()}
+                <ActionListItemIcon icon={item.icon} />
+              {/snippet}
+            </ActionListItem>
+          {/each}
+        </ActionListSection>
+      </ActionList>
+    </div>
   {/snippet}
 </Story>
 

--- a/packages/blade-svelte/src/components/Input/SearchInput/SearchInput.svelte
+++ b/packages/blade-svelte/src/components/Input/SearchInput/SearchInput.svelte
@@ -53,11 +53,10 @@
 
   const clearInput = () => {
     const el = baseInput?.getInput();
-    if (el) {
+    if (value === undefined && el) {
       el.value = '';
       el.focus();
     }
-    handleChange({ name, value: '' });
     onClearButtonClick?.();
     baseInput?.focus();
     shouldShowClearButton = false;

--- a/packages/blade-svelte/src/components/Input/SearchInput/SearchInput.svelte
+++ b/packages/blade-svelte/src/components/Input/SearchInput/SearchInput.svelte
@@ -57,6 +57,7 @@
       el.value = '';
       el.focus();
     }
+    handleChange({ name, value: '' });
     onClearButtonClick?.();
     baseInput?.focus();
     shouldShowClearButton = false;
@@ -98,7 +99,7 @@
   {value}
   {name}
   type="search"
-  onChange={handleChange}
+  onInput={handleChange}
   {onFocus}
   {onBlur}
   {onClick}

--- a/packages/blade-svelte/src/components/Input/SearchInput/types.ts
+++ b/packages/blade-svelte/src/components/Input/SearchInput/types.ts
@@ -38,7 +38,7 @@ interface SearchInputCommonProps extends StyledPropsBlade, DataAnalyticsAttribut
   value?: string;
   /** Name of the input. */
   name?: string;
-  /** Change callback. */
+  /** Change callback. Fires on every keystroke (matches React SearchInput onChange). */
   onChange?: FormInputOnEvent;
   /** Focus callback. */
   onFocus?: FormInputOnEvent;

--- a/packages/blade-svelte/src/components/InputGroup/InputGroup.stories.svelte
+++ b/packages/blade-svelte/src/components/InputGroup/InputGroup.stories.svelte
@@ -58,6 +58,7 @@
 <script lang="ts">
   import InputRow from './InputRow.svelte';
   import TextInput from '../Input/TextInput/TextInput.svelte';
+  import PasswordInput from '../Input/PasswordInput/PasswordInput.svelte';
   import Button from '../Button/Button.svelte';
   import Heading from '../Typography/Heading/Heading.svelte';
   import ToastContainer from '../Toast/ToastContainer.svelte';
@@ -300,8 +301,7 @@
           onChange={({ value }) => setValidationField('expiryDate', value ?? '')}
           validationState={validationStateFor('expiryDate')}
         />
-        <!-- PasswordInput not migrated → TextInput substitute. -->
-        <TextInput
+        <PasswordInput
           placeholder="CVV"
           label="CVV"
           value={validationForm.cvv}
@@ -419,8 +419,7 @@
           onChange={({ value }) => setFormatField('expiryDate', value ?? '')}
           validationState={formatStateFor('expiryDate')}
         />
-        <!-- PasswordInput not migrated → TextInput substitute. -->
-        <TextInput
+        <PasswordInput
           label="CVV (3 digits)"
           placeholder="123"
           maxCharacters={3}

--- a/packages/blade-svelte/src/components/Tabs/Tabs.stories.svelte
+++ b/packages/blade-svelte/src/components/Tabs/Tabs.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import Tabs from './Tabs.svelte';
 
@@ -6,8 +6,18 @@
     title: 'Components/Tabs',
     component: Tabs,
     tags: ['autodocs'],
-    args: {},
+    args: {
+      variant: 'bordered',
+      size: 'medium',
+      orientation: 'horizontal',
+      isFullWidthTabItem: false,
+      isLazy: false,
+    },
     argTypes: {
+      children: { table: { disable: true } },
+      value: { table: { disable: true } },
+      defaultValue: { table: { disable: true } },
+      onChange: { table: { disable: true } },
       variant: {
         control: 'select',
         options: ['bordered', 'borderless', 'filled'],
@@ -51,12 +61,28 @@
   import { HomeIcon } from '../Icons/HomeIcon';
   import { SearchIcon } from '../Icons/SearchIcon';
   import { CreditCardIcon } from '../Icons/CreditCardIcon';
+  import type { TabsProps } from './types';
+
+  type TabsStoryArgs = Partial<Omit<TabsProps, 'children'>> & { children?: unknown };
 
   let controlledValue = $state('plans');
+
+  function getTabsArgs(args: TabsStoryArgs): Omit<TabsProps, 'children'> {
+    const { children: _children, ...tabsArgs } = args;
+    return tabsArgs as Omit<TabsProps, 'children'>;
+  }
+
+  function getPanelStyle(orientation: TabsProps['orientation'] = 'horizontal'): string {
+    return orientation === 'vertical'
+      ? 'padding-left: var(--spacing-4);'
+      : 'padding-top: var(--spacing-4);';
+  }
 </script>
 
-<Story name="Default" asChild>
-  <Tabs variant="bordered" orientation="horizontal">
+{#snippet interactiveTabs(args: TabsStoryArgs)}
+  {@const panelStyle = getPanelStyle(args.orientation)}
+  {@const panelSize = args.size ?? 'medium'}
+  <Tabs {...getTabsArgs(args)}>
     {#snippet children()}
       <TabList>
         {#snippet children()}
@@ -73,27 +99,35 @@
       </TabList>
       <TabPanel value="subscriptions">
         {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Subscriptions Panel - This is an overview of your active subscriptions.</Text>
+          <div style={panelStyle}>
+            <Text size={panelSize}>
+              Subscriptions Panel - This is an overview of your active subscriptions.
+            </Text>
           </div>
         {/snippet}
       </TabPanel>
       <TabPanel value="plans">
         {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Plans Panel - This is an overview of all your plans.</Text>
+          <div style={panelStyle}>
+            <Text size={panelSize}>Plans Panel - This is an overview of all your plans.</Text>
           </div>
         {/snippet}
       </TabPanel>
       <TabPanel value="settings">
         {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Settings Panel - This is an overview of your settings.</Text>
+          <div style={panelStyle}>
+            <Text size={panelSize}>Settings Panel - This is an overview of your settings.</Text>
           </div>
         {/snippet}
       </TabPanel>
     {/snippet}
   </Tabs>
+{/snippet}
+
+<Story name="Playground">
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
 <Story name="Controlled" asChild>
@@ -156,332 +190,52 @@
   </div>
 </Story>
 
-<Story name="Size: Medium" asChild>
-  <Tabs variant="bordered" size="medium">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Size: Medium">
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Size: Small" asChild>
-  <Tabs variant="bordered" size="small">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text size="small">Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text size="small">Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text size="small">Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Size: Small" args={{ size: 'small' }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Size: Large" asChild>
-  <Tabs variant="bordered" size="large">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text size="large">Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text size="large">Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text size="large">Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Size: Large" args={{ size: 'large' }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Filled" asChild>
-  <Tabs variant="filled">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Filled" args={{ variant: 'filled' }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Filled Vertical" asChild>
-  <Tabs variant="filled" orientation="vertical">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-left: var(--spacing-4);">
-            <Text>Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-left: var(--spacing-4);">
-            <Text>Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-left: var(--spacing-4);">
-            <Text>Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Filled Vertical" args={{ variant: 'filled', orientation: 'vertical' }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Bordered Vertical" asChild>
-  <Tabs variant="bordered" orientation="vertical">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-left: var(--spacing-4);">
-            <Text>Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-left: var(--spacing-4);">
-            <Text>Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-left: var(--spacing-4);">
-            <Text>Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Bordered Vertical" args={{ orientation: 'vertical' }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Borderless" asChild>
-  <Tabs variant="borderless">
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Borderless" args={{ variant: 'borderless' }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
-<Story name="Full Width TabItem" asChild>
-  <Tabs variant="bordered" isFullWidthTabItem={true}>
-    {#snippet children()}
-      <TabList>
-        {#snippet children()}
-          <TabItem value="subscriptions">
-            {#snippet children()}Subscription{/snippet}
-          </TabItem>
-          <TabItem value="plans">
-            {#snippet children()}Plans{/snippet}
-          </TabItem>
-          <TabItem value="settings">
-            {#snippet children()}Settings{/snippet}
-          </TabItem>
-        {/snippet}
-      </TabList>
-      <TabPanel value="subscriptions">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Subscriptions Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="plans">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Plans Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-      <TabPanel value="settings">
-        {#snippet children()}
-          <div style="padding-top: var(--spacing-4);">
-            <Text>Settings Panel</Text>
-          </div>
-        {/snippet}
-      </TabPanel>
-    {/snippet}
-  </Tabs>
+<Story name="Full Width TabItem" args={{ isFullWidthTabItem: true }}>
+  {#snippet template(args)}
+    {@render interactiveTabs(args)}
+  {/snippet}
 </Story>
 
 <Story name="With Leading Icon" asChild>
@@ -613,52 +367,17 @@
   </Tabs>
 </Story>
 
-<Story name="Lazy Rendering" asChild>
-  <div>
-    <Text color="surface.text.gray.subtle" size="small">
-      With isLazy=true, TabPanel content only mounts when selected (check DOM inspector).
-    </Text>
-    <div style="margin-top: var(--spacing-4);">
-      <Tabs variant="bordered" isLazy={true}>
-        {#snippet children()}
-          <TabList>
-            {#snippet children()}
-              <TabItem value="subscriptions">
-                {#snippet children()}Subscription{/snippet}
-              </TabItem>
-              <TabItem value="plans">
-                {#snippet children()}Plans{/snippet}
-              </TabItem>
-              <TabItem value="settings">
-                {#snippet children()}Settings{/snippet}
-              </TabItem>
-            {/snippet}
-          </TabList>
-          <TabPanel value="subscriptions">
-            {#snippet children()}
-              <div style="padding-top: var(--spacing-4);">
-                <Text>Subscriptions Panel (lazy loaded)</Text>
-              </div>
-            {/snippet}
-          </TabPanel>
-          <TabPanel value="plans">
-            {#snippet children()}
-              <div style="padding-top: var(--spacing-4);">
-                <Text>Plans Panel (lazy loaded)</Text>
-              </div>
-            {/snippet}
-          </TabPanel>
-          <TabPanel value="settings">
-            {#snippet children()}
-              <div style="padding-top: var(--spacing-4);">
-                <Text>Settings Panel (lazy loaded)</Text>
-              </div>
-            {/snippet}
-          </TabPanel>
-        {/snippet}
-      </Tabs>
+<Story name="Lazy Rendering" args={{ isLazy: true }}>
+  {#snippet template(args)}
+    <div>
+      <Text color="surface.text.gray.subtle" size="small">
+        With isLazy=true, TabPanel content only mounts when selected (check DOM inspector).
+      </Text>
+      <div style="margin-top: var(--spacing-4);">
+        {@render interactiveTabs(args)}
+      </div>
     </div>
-  </div>
+  {/snippet}
 </Story>
 
 <Story name="With Href (Link Tab)" asChild>

--- a/packages/blade-svelte/src/components/Typography/Code/Code.stories.svelte
+++ b/packages/blade-svelte/src/components/Typography/Code/Code.stories.svelte
@@ -61,13 +61,13 @@
 
 <Story name="Code with Bold Color" args={{ children: 'SENTRY_AUTH_TOKEN', isHighlighted: false, size: 'medium', weight: 'bold', color: 'interactive.text.positive.subtle' }} />
 
-<Story name="Code in Text Context">
+<Story name="Code in Text Context" asChild>
   <Text as="p" size="medium">
     Lorem ipsum normal text <Code isHighlighted size="medium" weight="regular">SENTRY_AUTH_TOKEN</Code> component
   </Text>
 </Story>
 
-<Story name="Code Sizes">
+<Story name="Code Sizes" asChild>
   <div style="display: flex; flex-direction: column; gap: 0.5rem;">
     <Text as="p" size="small">
       Small size: <Code size="small" isHighlighted>npm install @razorpay/blade</Code>


### PR DESCRIPTION
## Summary
- Wire Storybook Controls for Tabs (and related story fixes for Button definite loading, SearchInput filtered list, InputGroup PasswordInput)
- Fix CheckboxIcon dash flash on mount by only animating when visibility actually changes
- Polish blade-core styles (Alert border-radius consistency, Avatar top-addon offset) and ActionList country flags via `@razorpay/i18nify-js/geo`

## Test plan
- [ ] Open Storybook → Components/Tabs → Playground; toggle variant, size, orientation, isFullWidthTabItem, isLazy in Controls
- [ ] Components/Button → Definite Loading: click button, confirm progress overlay runs and resets without alert
- [ ] Components/Checkbox: toggle checked/indeterminate — no dash flash on initial render
- [ ] Components/Input/SearchInput → With ActionList: type in search, list filters live
- [ ] Components/InputGroup → validation stories use PasswordInput for CVV fields
- [ ] Components/ActionList → Country List: flags render from i18nify, selection works with uppercase codes
- [ ] Components/Alert + Avatar: visual spot-check border-radius and top-addon badge position


Made with [Cursor](https://cursor.com)