### PR TITLE
fix(blade-mcp): validate changelog requests

### DIFF
--- a/.changeset/clean-pandas-listen.md
+++ b/.changeset/clean-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade-mcp': patch
+---
+
+fix: validate Blade changelog versions and fetch failures

--- a/packages/blade-mcp/src/tools/__tests__/getChangelog.test.ts
+++ b/packages/blade-mcp/src/tools/__tests__/getChangelog.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as analyticsUtils from '../../utils/analyticsUtils.js';
+import { getChangelogToolCallback, getChangelogToolSchema } from '../getChangelog.js';
+
+vi.mock('../../utils/analyticsUtils.js', async () => {
+  const actual = await vi.importActual<typeof analyticsUtils>('../../utils/analyticsUtils.js');
+  return {
+    ...actual,
+    sendAnalytics: vi.fn(),
+  };
+});
+
+const changelog = `# @razorpay/blade
+
+## 12.2.0
+
+### Minor Changes
+
+- Added a new component
+
+## 12.1.0
+
+### Patch Changes
+
+- Fixed component behavior
+
+## 12.0.0
+
+### Patch Changes
+
+- Updated component styles
+`;
+
+const fetchMock = vi.fn();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockContext = (): any => ({
+  signal: new AbortController().signal,
+  requestId: 'test-request-id',
+  sendNotification: vi.fn().mockResolvedValue(undefined),
+  sendRequest: vi.fn().mockResolvedValue({}),
+});
+
+const getResponseText = (result: Awaited<ReturnType<typeof getChangelogToolCallback>>): string => {
+  const content = result.content[0];
+  return content.type === 'text' ? content.text : '';
+};
+
+describe('get_blade_changelog tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(changelog),
+    });
+  });
+
+  it('accepts only latest or a complete semantic version', () => {
+    expect(getChangelogToolSchema.fromVersion.safeParse('latest').success).toBe(true);
+    expect(getChangelogToolSchema.fromVersion.safeParse('12.10.0').success).toBe(true);
+    expect(getChangelogToolSchema.fromVersion.safeParse('v12.10').success).toBe(false);
+  });
+
+  it('returns a single requested release', async () => {
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: '12.1.0',
+        toVersion: undefined,
+        isRange: undefined,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    expect(getResponseText(result)).toContain('Changelog for: version 12.1.0');
+    expect(getResponseText(result)).toContain('Fixed component behavior');
+    expect(getResponseText(result)).not.toContain('Added a new component');
+    expect(analyticsUtils.sendAnalytics).toHaveBeenCalledWith({
+      eventName: expect.any(String),
+      properties: {
+        toolName: 'get_blade_changelog',
+        fromVersion: '12.1.0',
+        toVersion: undefined,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+    });
+  });
+
+  it('resolves latest and returns an inclusive range', async () => {
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: '12.1.0',
+        toVersion: 'latest',
+        isRange: true,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).not.toHaveProperty('isError');
+    expect(getResponseText(result)).toContain('range from 12.1.0 to 12.2.0');
+    expect(getResponseText(result)).toContain('Added a new component');
+    expect(getResponseText(result)).toContain('Fixed component behavior');
+    expect(getResponseText(result)).not.toContain('Updated component styles');
+  });
+
+  it('rejects a range hint without an end version before fetching', async () => {
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: '12.1.0',
+        toVersion: undefined,
+        isRange: true,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    expect(getResponseText(result)).toContain('`toVersion` is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(analyticsUtils.sendAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('returns a useful error when a release is unavailable', async () => {
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: '11.0.0',
+        toVersion: undefined,
+        isRange: undefined,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    expect(getResponseText(result)).toContain('No Blade changelog entry was found for 11.0.0');
+    expect(getResponseText(result)).toContain('latest available version is 12.2.0');
+    expect(getResponseText(result)).not.toContain('undefined');
+    expect(analyticsUtils.sendAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('rejects reversed ranges', async () => {
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: '12.2.0',
+        toVersion: '12.0.0',
+        isRange: undefined,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    expect(getResponseText(result)).toContain(
+      'fromVersion (12.2.0) must be less than or equal to toVersion (12.0.0)',
+    );
+    expect(analyticsUtils.sendAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('reports upstream HTTP failures without parsing the response', async () => {
+    const responseText = vi.fn();
+    fetchMock.mockResolvedValue({ ok: false, status: 503, text: responseText });
+
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: '12.1.0',
+        toVersion: undefined,
+        isRange: undefined,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    expect(getResponseText(result)).toContain('HTTP 503');
+    expect(responseText).not.toHaveBeenCalled();
+    expect(analyticsUtils.sendAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('reports malformed changelog responses', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue('# @razorpay/blade\n\nNo releases yet'),
+    });
+
+    const result = await getChangelogToolCallback(
+      {
+        fromVersion: 'latest',
+        toVersion: undefined,
+        isRange: undefined,
+        currentProjectRootDirectory: '/Users/test/project',
+      },
+      createMockContext(),
+    );
+
+    expect(result).toHaveProperty('isError', true);
+    expect(getResponseText(result)).toContain('did not contain any release entries');
+    expect(analyticsUtils.sendAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/packages/blade-mcp/src/tools/getChangelog.ts
+++ b/packages/blade-mcp/src/tools/getChangelog.ts
@@ -3,8 +3,10 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { handleError, sendAnalytics } from '../utils/analyticsUtils.js';
 import {
+  compareVersions,
   getLatestVersion,
   getRangeChangelogs,
+  parseChangelog,
   stringifyChangelog,
 } from '../utils/changelogParser.js';
 import { analyticsToolCallEventName } from '../utils/tokens.js';
@@ -16,9 +18,9 @@ Get the changelog of blade to help consumer with blade upgrades and checking rel
 
 Intent examples:
 - help me with upgrades -> read \`package.json\` to get consumer's blade version to use it as \`fromVersion\` and then use \`toVersion\` as \`latest\` version (range)
-- what was changed in x.x.x version? -> Just \`fromVersion\` (set isRange to false & omit toVersion)
-- what was changed between x.x.x and y.y.y versions? -> \`fromVersion\` and \`toVersion\` (set isRange to true)
-- what is the latest version of blade? -> \`fromVersion\` as \`latest\` (set isRange to false & omit toVersion)
+- what was changed in x.x.x version? -> use \`fromVersion\` and omit \`toVersion\`
+- what was changed between x.x.x and y.y.y versions? -> use both \`fromVersion\` and \`toVersion\`
+- what is the latest version of blade? -> use \`fromVersion\` as \`latest\` and omit \`toVersion\`
 
 You will provide high level summary of notable changes in this output format:
 
@@ -43,19 +45,26 @@ https://github.com/razorpay/blade/releases/tag/%40razorpay%2Fblade%4012.0.0
 Example: \`(v12.0.0)\` becomes [(v12.0.0)](https://github.com/razorpay/blade/releases/tag/%40razorpay%2Fblade%4012.0.0)
 `;
 
+const versionPattern = /^\d+\.\d+\.\d+$/;
+const changelogVersionSchema = z
+  .string()
+  .refine(
+    (version) => version === 'latest' || versionPattern.test(version),
+    'Expected "latest" or a semantic version such as 12.10.0',
+  );
+
 const getChangelogToolSchema = {
-  fromVersion: z
-    .string()
-    .describe('The start version of the range to get the changelog for. E.g. 10.15.0'),
-  toVersion: z
-    .string()
+  fromVersion: changelogVersionSchema.describe(
+    'The version to get, or the start version of a range. E.g. 10.15.0 or latest',
+  ),
+  toVersion: changelogVersionSchema
     .optional()
-    .describe('The end version of the range to get the changelog for. E.g. 10.16.0'),
+    .describe('The end version of a range. E.g. 10.16.0 or latest'),
   isRange: z
     .boolean()
     .optional()
     .describe(
-      'Whether to get the changelog for a range of versions or a specific version, this is based on intent of user.',
+      'Optional intent hint retained for compatibility. Providing toVersion always requests a range.',
     ),
   currentProjectRootDirectory: z
     .string()
@@ -71,33 +80,73 @@ const getChangelogToolCallback: ToolCallback<typeof getChangelogToolSchema> = as
   currentProjectRootDirectory,
 }) => {
   try {
+    if (isRange && !toVersion) {
+      return handleError({
+        toolName: getChangelogToolName,
+        mcpErrorMessage: '`toVersion` is required when `isRange` is true.',
+      });
+    }
+
     const changelogURL =
       'https://raw.githubusercontent.com/razorpay/blade/refs/heads/master/packages/blade/CHANGELOG.md';
     const response = await fetch(changelogURL, {
       method: 'GET',
+      signal: AbortSignal.timeout(10_000),
     });
-    const changelogText = await response.text();
 
-    const isToVersionLatest = toVersion === 'latest';
-    if (isToVersionLatest) {
-      const latestVersion = getLatestVersion(changelogText);
-      toVersion = latestVersion?.version ?? '';
+    if (!response.ok) {
+      return handleError({
+        toolName: getChangelogToolName,
+        mcpErrorMessage: `Failed to fetch Blade changelog (HTTP ${response.status}). Please try again.`,
+      });
     }
-    const isFromVersionLatest = fromVersion === 'latest';
-    if (isFromVersionLatest) {
-      const latestVersion = getLatestVersion(changelogText);
-      fromVersion = latestVersion?.version ?? fromVersion;
+
+    const changelogText = await response.text();
+    const availableChangelog = parseChangelog(changelogText);
+    const latestVersion = getLatestVersion(changelogText);
+
+    if (!latestVersion) {
+      return handleError({
+        toolName: getChangelogToolName,
+        mcpErrorMessage: 'The Blade changelog did not contain any release entries.',
+      });
+    }
+
+    fromVersion = fromVersion === 'latest' ? latestVersion.version : fromVersion;
+    toVersion = toVersion === 'latest' ? latestVersion.version : toVersion;
+
+    if (!availableChangelog[fromVersion]) {
+      return handleError({
+        toolName: getChangelogToolName,
+        mcpErrorMessage: `No Blade changelog entry was found for ${fromVersion}. The latest available version is ${latestVersion.version}.`,
+      });
+    }
+
+    if (toVersion && !availableChangelog[toVersion]) {
+      return handleError({
+        toolName: getChangelogToolName,
+        mcpErrorMessage: `No Blade changelog entry was found for ${toVersion}. The latest available version is ${latestVersion.version}.`,
+      });
+    }
+
+    if (toVersion && compareVersions(fromVersion, toVersion) > 0) {
+      return handleError({
+        toolName: getChangelogToolName,
+        mcpErrorMessage: `Invalid Blade changelog range: fromVersion (${fromVersion}) must be less than or equal to toVersion (${toVersion}).`,
+      });
     }
 
     const parsedChangelog = getRangeChangelogs(changelogText, fromVersion, toVersion);
-    const stringifiedChangelog = stringifyChangelog(parsedChangelog);
 
-    if (parsedChangelog === undefined) {
+    if (!parsedChangelog) {
       return handleError({
         toolName: getChangelogToolName,
-        mcpErrorMessage: `Failed to fetch changelog.`,
+        mcpErrorMessage: 'Failed to resolve the requested Blade changelog entries.',
       });
     }
+
+    const stringifiedChangelog = stringifyChangelog(parsedChangelog);
+    const isRangeRequest = Boolean(toVersion);
 
     sendAnalytics({
       eventName: analyticsToolCallEventName,
@@ -115,7 +164,9 @@ const getChangelogToolCallback: ToolCallback<typeof getChangelogToolSchema> = as
           type: 'text',
           text: dedent`
             ## Changelog for: ${
-              isRange ? `range from ${fromVersion} to ${toVersion}` : `version ${fromVersion}`
+              isRangeRequest
+                ? `range from ${fromVersion} to ${toVersion}`
+                : `version ${fromVersion}`
             }
 
             \`\`\`
@@ -128,7 +179,9 @@ const getChangelogToolCallback: ToolCallback<typeof getChangelogToolSchema> = as
   } catch (error: unknown) {
     return handleError({
       toolName: getChangelogToolName,
-      mcpErrorMessage: `Failed to fetch changelog, ${error}`,
+      mcpErrorMessage: `Failed to fetch Blade changelog: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
     });
   }
 };

--- a/packages/blade-mcp/src/utils/__tests__/changelogParser.test.ts
+++ b/packages/blade-mcp/src/utils/__tests__/changelogParser.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareVersions,
+  getLatestVersion,
+  getRangeChangelogs,
+  parseChangelog,
+  stringifyChangelog,
+} from '../changelogParser.js';
+
+const changelog = `# @razorpay/blade
+
+## 12.2.0
+
+### Minor Changes
+
+- Added a new component
+
+## 12.1.0
+
+### Patch Changes
+
+- Fixed component behavior
+
+## 12.0.0
+
+### Patch Changes
+
+- Updated component styles
+`;
+
+describe('changelogParser', () => {
+  it('parses release entries and their descriptions', () => {
+    expect(parseChangelog(changelog)).toEqual({
+      '12.2.0': '### Minor Changes\n\n- Added a new component',
+      '12.1.0': '### Patch Changes\n\n- Fixed component behavior',
+      '12.0.0': '### Patch Changes\n\n- Updated component styles',
+    });
+  });
+
+  it('compares semantic versions numerically', () => {
+    expect(compareVersions('12.10.0', '12.9.9')).toBe(1);
+    expect(compareVersions('12.1.0', '12.1.0')).toBe(0);
+    expect(compareVersions('11.99.0', '12.0.0')).toBe(-1);
+  });
+
+  it('finds the highest semantic version regardless of changelog order', () => {
+    const unorderedChangelog = `## 12.1.0\n\nFirst\n\n## 12.10.0\n\nLatest`;
+
+    expect(getLatestVersion(unorderedChangelog)).toEqual({
+      version: '12.10.0',
+      description: 'Latest',
+    });
+  });
+
+  it('returns one requested release when no end version is provided', () => {
+    expect(getRangeChangelogs(changelog, '12.1.0')).toEqual({
+      '12.1.0': '### Patch Changes\n\n- Fixed component behavior',
+    });
+  });
+
+  it('returns an inclusive range of releases', () => {
+    expect(getRangeChangelogs(changelog, '12.0.0', '12.1.0')).toEqual({
+      '12.1.0': '### Patch Changes\n\n- Fixed component behavior',
+      '12.0.0': '### Patch Changes\n\n- Updated component styles',
+    });
+  });
+
+  it('rejects missing and reversed range boundaries', () => {
+    expect(getRangeChangelogs(changelog, '11.0.0')).toBeUndefined();
+    expect(getRangeChangelogs(changelog, '12.0.0', '12.3.0')).toBeUndefined();
+    expect(getRangeChangelogs(changelog, '12.2.0', '12.0.0')).toBeUndefined();
+  });
+
+  it('stringifies parsed entries without undefined descriptions', () => {
+    const parsed = getRangeChangelogs(changelog, '12.1.0');
+
+    expect(parsed).toBeDefined();
+    expect(stringifyChangelog(parsed ?? {})).toBe(
+      '\n## 12.1.0\n### Patch Changes\n\n- Fixed component behavior',
+    );
+  });
+});

--- a/packages/blade-mcp/src/utils/changelogParser.ts
+++ b/packages/blade-mcp/src/utils/changelogParser.ts
@@ -104,14 +104,26 @@ function isVersionInRange(version: string, from: string, to: string): boolean {
  * @param to - Ending version of the range (e.g., "12.15.0")
  * @returns Object with version numbers as keys and descriptions as values for versions in range
  */
-function getRangeChangelogs(changelogContent: string, from: string, to?: string): ParsedChangelog {
+function getRangeChangelogs(
+  changelogContent: string,
+  from: string,
+  to?: string,
+): ParsedChangelog | undefined {
   const parsed = parseChangelog(changelogContent);
   const result: ParsedChangelog = {};
 
-  // if to is not provided, return only the changelog for the version
+  const fromDescription = parsed[from];
+  if (!fromDescription) {
+    return undefined;
+  }
+
+  // If to is not provided, return only the changelog for the version
   if (!to) {
-    result[from] = parsed[from];
-    return result;
+    return { [from]: fromDescription };
+  }
+
+  if (!parsed[to] || compareVersions(from, to) > 0) {
+    return undefined;
   }
 
   for (const [version, description] of Object.entries(parsed)) {
@@ -157,4 +169,10 @@ function getLatestVersion(
   };
 }
 
-export { getRangeChangelogs, stringifyChangelog, getLatestVersion };
+export {
+  compareVersions,
+  getRangeChangelogs,
+  getLatestVersion,
+  parseChangelog,
+  stringifyChangelog,
+};


### PR DESCRIPTION
## Summary

- validate exact and range versions before returning changelog content
- resolve `latest` consistently and reject missing or reversed ranges with actionable errors
- handle upstream HTTP failures, malformed responses, and stalled requests
- add focused parser and MCP tool coverage for success and failure paths

## Testing Status

- [x] `npm test -- --run` (71 tests)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint`

## Related

Not applicable — Blade MCP reliability fix.