### PR TITLE
feat(DatePicker): add visibleMonth/defaultVisibleMonth to anchor calendar independent of value

### DIFF
--- a/.changeset/datepicker-visible-month.md
+++ b/.changeset/datepicker-visible-month.md
@@ -2,9 +2,9 @@
 '@razorpay/blade': minor
 ---
 
-feat(DatePicker): add `visibleMonth`/`defaultVisibleMonth` to control the rendered calendar month independently of `value`
+feat(DatePicker): add `defaultVisibleMonth` to anchor the rendered calendar month independently of `value`
 
-`DatePicker`/`DateRangePicker` now accept `visibleMonth` (controlled), `defaultVisibleMonth` (uncontrolled), and `onVisibleMonthChange` props. These let the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
+`DatePicker`/`DateRangePicker` now accept a `defaultVisibleMonth` prop. This lets the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
 
 ```tsx
 <DatePicker
@@ -13,5 +13,7 @@ feat(DatePicker): add `visibleMonth`/`defaultVisibleMonth` to control the render
   defaultVisibleMonth={dayjs(primaryRangeStart).subtract(rangeLengthInDays + 1, 'day').toDate()}
 />
 ```
+
+`defaultVisibleMonth` only sets the initial anchor — subsequent calendar navigation is uncontrolled from that point on. Use the existing `onNext`/`onPrevious` callbacks to observe navigation, and `onChange` to observe date selection.
 
 Falls back to the existing behavior (first date of `value`/`defaultValue`, or today) when not set — fully backwards compatible.

--- a/.changeset/datepicker-visible-month.md
+++ b/.changeset/datepicker-visible-month.md
@@ -4,18 +4,14 @@
 
 feat(DatePicker): add `visibleMonth`/`defaultVisibleMonth` to control the rendered calendar month independently of `value`
 
-`DatePicker`/`DateRangePicker` now accept `visibleMonth` (controlled) and `defaultVisibleMonth` (uncontrolled) props. These let the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
+`DatePicker`/`DateRangePicker` now accept `visibleMonth` (controlled), `defaultVisibleMonth` (uncontrolled), and `onVisibleMonthChange` props. These let the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
 
 ```tsx
 <DatePicker
   selectionType="range"
   label={{ start: 'Compare to' }}
-  defaultVisibleMonth={dayjs(primaryRangeStart)
-    .subtract(rangeLengthInDays + 1, 'day')
-    .toDate()}
+  defaultVisibleMonth={dayjs(primaryRangeStart).subtract(rangeLengthInDays + 1, 'day').toDate()}
 />
 ```
-
-When using the controlled `visibleMonth`, keep it in sync via the existing `onChange` (date selection) and `onNext`/`onPrevious` (calendar navigation) callbacks — there is no dedicated `onVisibleMonthChange` callback.
 
 Falls back to the existing behavior (first date of `value`/`defaultValue`, or today) when not set — fully backwards compatible.

--- a/.changeset/datepicker-visible-month.md
+++ b/.changeset/datepicker-visible-month.md
@@ -1,0 +1,17 @@
+---
+'@razorpay/blade': minor
+---
+
+feat(DatePicker): add `visibleMonth`/`defaultVisibleMonth` to control the rendered calendar month independently of `value`
+
+`DatePicker`/`DateRangePicker` now accept `visibleMonth` (controlled), `defaultVisibleMonth` (uncontrolled), and `onVisibleMonthChange` props. These let the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
+
+```tsx
+<DatePicker
+  selectionType="range"
+  label={{ start: 'Compare to' }}
+  defaultVisibleMonth={dayjs(primaryRangeStart).subtract(rangeLengthInDays + 1, 'day').toDate()}
+/>
+```
+
+Falls back to the existing behavior (first date of `value`/`defaultValue`, or today) when not set — fully backwards compatible.

--- a/.changeset/datepicker-visible-month.md
+++ b/.changeset/datepicker-visible-month.md
@@ -2,18 +2,20 @@
 '@razorpay/blade': minor
 ---
 
-feat(DatePicker): add `defaultVisibleMonth` to anchor the rendered calendar month independently of `value`
+feat(DatePicker): add `visibleMonth`/`defaultVisibleMonth` to control the rendered calendar month independently of `value`
 
-`DatePicker`/`DateRangePicker` now accept a `defaultVisibleMonth` prop. This lets the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
+`DatePicker`/`DateRangePicker` now accept `visibleMonth` (controlled) and `defaultVisibleMonth` (uncontrolled) props. These let the calendar open on a specific month without pre-selecting a date — useful for a "comparison" range picker that should default to the period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick.
 
 ```tsx
 <DatePicker
   selectionType="range"
   label={{ start: 'Compare to' }}
-  defaultVisibleMonth={dayjs(primaryRangeStart).subtract(rangeLengthInDays + 1, 'day').toDate()}
+  defaultVisibleMonth={dayjs(primaryRangeStart)
+    .subtract(rangeLengthInDays + 1, 'day')
+    .toDate()}
 />
 ```
 
-`defaultVisibleMonth` only sets the initial anchor — subsequent calendar navigation is uncontrolled from that point on. Use the existing `onNext`/`onPrevious` callbacks to observe navigation, and `onChange` to observe date selection.
+When using the controlled `visibleMonth`, keep it in sync via the existing `onChange` (date selection) and `onNext`/`onPrevious` (calendar navigation) callbacks — there is no dedicated `onVisibleMonthChange` callback.
 
 Falls back to the existing behavior (first date of `value`/`defaultValue`, or today) when not set — fully backwards compatible.

--- a/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
@@ -78,6 +78,9 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
   defaultPicker = 'day',
   picker,
   onPickerChange,
+  visibleMonth,
+  defaultVisibleMonth,
+  onVisibleMonthChange,
   zIndex = componentZIndices.popover,
   format = 'DD/MM/YYYY',
   inputPlaceHolder,
@@ -366,6 +369,9 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
             {...props}
             selectionType={_selectionType}
             defaultValue={defaultValue}
+            visibleMonth={visibleMonth}
+            defaultVisibleMonth={defaultVisibleMonth}
+            onVisibleMonthChange={onVisibleMonthChange}
             onMouseLeave={onRootMouseLeave}
             __onDayMouseEnter={(_event, date) => {
               onHoveredDateChange(date);

--- a/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
@@ -80,6 +80,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
   onPickerChange,
   visibleMonth,
   defaultVisibleMonth,
+  onVisibleMonthChange,
   zIndex = componentZIndices.popover,
   format = 'DD/MM/YYYY',
   inputPlaceHolder,
@@ -370,6 +371,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
             defaultValue={defaultValue}
             visibleMonth={visibleMonth}
             defaultVisibleMonth={defaultVisibleMonth}
+            onVisibleMonthChange={onVisibleMonthChange}
             onMouseLeave={onRootMouseLeave}
             __onDayMouseEnter={(_event, date) => {
               onHoveredDateChange(date);

--- a/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
@@ -78,9 +78,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
   defaultPicker = 'day',
   picker,
   onPickerChange,
-  visibleMonth,
   defaultVisibleMonth,
-  onVisibleMonthChange,
   zIndex = componentZIndices.popover,
   format = 'DD/MM/YYYY',
   inputPlaceHolder,
@@ -369,9 +367,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
             {...props}
             selectionType={_selectionType}
             defaultValue={defaultValue}
-            visibleMonth={visibleMonth}
             defaultVisibleMonth={defaultVisibleMonth}
-            onVisibleMonthChange={onVisibleMonthChange}
             onMouseLeave={onRootMouseLeave}
             __onDayMouseEnter={(_event, date) => {
               onHoveredDateChange(date);

--- a/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
@@ -78,6 +78,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
   defaultPicker = 'day',
   picker,
   onPickerChange,
+  visibleMonth,
   defaultVisibleMonth,
   zIndex = componentZIndices.popover,
   format = 'DD/MM/YYYY',
@@ -367,6 +368,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
             {...props}
             selectionType={_selectionType}
             defaultValue={defaultValue}
+            visibleMonth={visibleMonth}
             defaultVisibleMonth={defaultVisibleMonth}
             onMouseLeave={onRootMouseLeave}
             __onDayMouseEnter={(_event, date) => {

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -99,13 +99,12 @@ const Calendar = <Type extends DateSelectionType>({
 
   // Keeps the legacy `_date` state and the new `_visibleMonth` state in sync so that
   // navigation keeps working regardless of which one is currently driving `currentDate`.
-  const updateCurrentDate = React.useCallback(
-    (nextDate: Date) => {
-      setDate(nextDate);
-      setVisibleMonth(() => nextDate);
-    },
-    [setDate, setVisibleMonth],
-  );
+  // Note: Not wrapped in useCallback because `setDate` from mantine's `useUncontrolled`
+  // is not memoized, so useCallback would provide no benefit.
+  const updateCurrentDate = (nextDate: Date): void => {
+    setDate(nextDate);
+    setVisibleMonth(() => nextDate);
+  };
 
   const handleNextMonth = () => {
     const nextDate = dayjs(currentDate).add(columnsToScroll, 'month').toDate();

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -99,10 +99,13 @@ const Calendar = <Type extends DateSelectionType>({
 
   // Keeps the legacy `_date` state and the new `_visibleMonth` state in sync so that
   // navigation keeps working regardless of which one is currently driving `currentDate`.
-  const updateCurrentDate = (nextDate: Date) => {
-    setDate(nextDate);
-    setVisibleMonth(() => nextDate);
-  };
+  const updateCurrentDate = React.useCallback(
+    (nextDate: Date) => {
+      setDate(nextDate);
+      setVisibleMonth(() => nextDate);
+    },
+    [setDate, setVisibleMonth],
+  );
 
   const handleNextMonth = () => {
     const nextDate = dayjs(currentDate).add(columnsToScroll, 'month').toDate();

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -28,6 +28,7 @@ const Calendar = <Type extends DateSelectionType>({
   onDateChange,
   visibleMonth,
   defaultVisibleMonth,
+  onVisibleMonthChange,
   onNext,
   onPrevious,
   presets,
@@ -70,6 +71,9 @@ const Calendar = <Type extends DateSelectionType>({
   const [_visibleMonth, setVisibleMonth] = useControllableState<Date | undefined>({
     value: visibleMonth,
     defaultValue: defaultVisibleMonth,
+    onChange: (date) => {
+      if (date) onVisibleMonthChange?.(date);
+    },
   });
 
   const dateContext = useDatesContext();

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -26,6 +26,7 @@ const Calendar = <Type extends DateSelectionType>({
   date,
   defaultDate,
   onDateChange,
+  visibleMonth,
   defaultVisibleMonth,
   onNext,
   onPrevious,
@@ -67,6 +68,7 @@ const Calendar = <Type extends DateSelectionType>({
   });
 
   const [_visibleMonth, setVisibleMonth] = useControllableState<Date | undefined>({
+    value: visibleMonth,
     defaultValue: defaultVisibleMonth,
   });
 
@@ -91,9 +93,8 @@ const Calendar = <Type extends DateSelectionType>({
   const numberOfColumns = isMobile || !isRange ? 1 : 2;
   const columnsToScroll = numberOfColumns;
 
-  // Keeps the legacy `_date` state and `_visibleMonth` (the defaultVisibleMonth anchor)
-  // in sync so navigation keeps working regardless of which one is currently driving
-  // `currentDate`.
+  // Keeps the legacy `_date` state and the new `_visibleMonth` state in sync so that
+  // navigation keeps working regardless of which one is currently driving `currentDate`.
   // Note: Not wrapped in useCallback because `setDate` from mantine's `useUncontrolled`
   // is not memoized, so useCallback would provide no benefit.
   const updateCurrentDate = (nextDate: Date): void => {

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -26,6 +26,9 @@ const Calendar = <Type extends DateSelectionType>({
   date,
   defaultDate,
   onDateChange,
+  visibleMonth,
+  defaultVisibleMonth,
+  onVisibleMonthChange,
   onNext,
   onPrevious,
   presets,
@@ -65,9 +68,20 @@ const Calendar = <Type extends DateSelectionType>({
     onChange: onDateChange,
   });
 
+  const [_visibleMonth, setVisibleMonth] = useControllableState<Date | undefined>({
+    value: visibleMonth,
+    defaultValue: defaultVisibleMonth,
+    onChange: (date) => {
+      if (date) onVisibleMonthChange?.(date);
+    },
+  });
+
   const dateContext = useDatesContext();
   const isMobile = useIsMobile();
   const currentDate = React.useMemo(() => {
+    if (_visibleMonth) {
+      return _visibleMonth;
+    }
     if (_date) {
       return _date;
     }
@@ -79,32 +93,39 @@ const Calendar = <Type extends DateSelectionType>({
       return selectedValue;
     }
     return shiftTimezone('add', new Date());
-  }, [_date, selectedValue]);
+  }, [_visibleMonth, _date, selectedValue]);
   const numberOfColumns = isMobile || !isRange ? 1 : 2;
   const columnsToScroll = numberOfColumns;
+
+  // Keeps the legacy `_date` state and the new `_visibleMonth` state in sync so that
+  // navigation keeps working regardless of which one is currently driving `currentDate`.
+  const updateCurrentDate = (nextDate: Date) => {
+    setDate(nextDate);
+    setVisibleMonth(() => nextDate);
+  };
 
   const handleNextMonth = () => {
     const nextDate = dayjs(currentDate).add(columnsToScroll, 'month').toDate();
     onNext?.({ date: nextDate, type: 'month' });
-    setDate(nextDate);
+    updateCurrentDate(nextDate);
   };
 
   const handlePreviousMonth = () => {
     const nextDate = dayjs(currentDate).subtract(columnsToScroll, 'month').toDate();
     onPrevious?.({ date: nextDate, type: 'month' });
-    setDate(nextDate);
+    updateCurrentDate(nextDate);
   };
 
   const handleNextYear = () => {
     const nextDate = dayjs(currentDate).add(columnsToScroll, 'year').toDate();
     onNext?.({ date: nextDate, type: 'year' });
-    setDate(nextDate);
+    updateCurrentDate(nextDate);
   };
 
   const handlePreviousYear = () => {
     const nextDate = dayjs(currentDate).subtract(columnsToScroll, 'year').toDate();
     onPrevious?.({ date: nextDate, type: 'year' });
-    setDate(nextDate);
+    updateCurrentDate(nextDate);
   };
 
   const handleNextDecade = () => {
@@ -112,7 +133,7 @@ const Calendar = <Type extends DateSelectionType>({
       .add(10 * columnsToScroll, 'year')
       .toDate();
     onNext?.({ date: nextDate, type: 'decade' });
-    setDate(nextDate);
+    updateCurrentDate(nextDate);
   };
 
   const handlePreviousDecade = () => {
@@ -120,7 +141,7 @@ const Calendar = <Type extends DateSelectionType>({
       .subtract(10 * columnsToScroll, 'year')
       .toDate();
     onPrevious?.({ date: nextDate, type: 'decade' });
-    setDate(nextDate);
+    updateCurrentDate(nextDate);
   };
 
   return (
@@ -152,7 +173,7 @@ const Calendar = <Type extends DateSelectionType>({
           date={currentDate}
           locale={dateContext.locale}
           level={level}
-          onDateChange={setDate}
+          onDateChange={updateCurrentDate}
           onLevelChange={(level) => setLevel(() => level)}
           numberOfColumns={numberOfColumns}
           weekdayFormat="ddd"

--- a/packages/blade/src/components/DatePicker/Calendar.web.tsx
+++ b/packages/blade/src/components/DatePicker/Calendar.web.tsx
@@ -26,9 +26,7 @@ const Calendar = <Type extends DateSelectionType>({
   date,
   defaultDate,
   onDateChange,
-  visibleMonth,
   defaultVisibleMonth,
-  onVisibleMonthChange,
   onNext,
   onPrevious,
   presets,
@@ -69,11 +67,7 @@ const Calendar = <Type extends DateSelectionType>({
   });
 
   const [_visibleMonth, setVisibleMonth] = useControllableState<Date | undefined>({
-    value: visibleMonth,
     defaultValue: defaultVisibleMonth,
-    onChange: (date) => {
-      if (date) onVisibleMonthChange?.(date);
-    },
   });
 
   const dateContext = useDatesContext();
@@ -97,8 +91,9 @@ const Calendar = <Type extends DateSelectionType>({
   const numberOfColumns = isMobile || !isRange ? 1 : 2;
   const columnsToScroll = numberOfColumns;
 
-  // Keeps the legacy `_date` state and the new `_visibleMonth` state in sync so that
-  // navigation keeps working regardless of which one is currently driving `currentDate`.
+  // Keeps the legacy `_date` state and `_visibleMonth` (the defaultVisibleMonth anchor)
+  // in sync so navigation keeps working regardless of which one is currently driving
+  // `currentDate`.
   // Note: Not wrapped in useCallback because `setDate` from mantine's `useUncontrolled`
   // is not memoized, so useCallback would provide no benefit.
   const updateCurrentDate = (nextDate: Date): void => {

--- a/packages/blade/src/components/DatePicker/DatePicker.native.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.native.tsx
@@ -382,11 +382,13 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     picker,
     defaultPicker,
     onPickerChange,
+    visibleMonth: visibleMonthProp,
     defaultVisibleMonth,
   } = props as DatePickerNativeProps<DateSelectionType> & {
     picker?: unknown;
     defaultPicker?: unknown;
     onPickerChange?: unknown;
+    visibleMonth?: unknown;
     defaultVisibleMonth?: unknown;
     successText?: unknown;
   };
@@ -397,6 +399,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     if (picker !== undefined) unsupported.push('picker');
     if (defaultPicker !== undefined) unsupported.push('defaultPicker');
     if (onPickerChange !== undefined) unsupported.push('onPickerChange');
+    if (visibleMonthProp !== undefined) unsupported.push('visibleMonth');
     if (defaultVisibleMonth !== undefined) unsupported.push('defaultVisibleMonth');
     if (unsupported.length > 0) {
       logger({
@@ -407,7 +410,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
         )}.`,
       });
     }
-  }, [picker, defaultPicker, onPickerChange, defaultVisibleMonth]);
+  }, [picker, defaultPicker, onPickerChange, visibleMonthProp, defaultVisibleMonth]);
 
   const isError = validationState === 'error';
   const isSuccess = validationState === 'success';
@@ -719,8 +722,8 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
  * #### Not yet supported on native
  *
  * Month/year picker variants (`picker`, `defaultPicker`, `onPickerChange`),
- * `defaultVisibleMonth`, masked text input, and the form-validation props
- * (`validationState`, `helpText`,
+ * `visibleMonth`/`defaultVisibleMonth`, masked text
+ * input, and the form-validation props (`validationState`, `helpText`,
  * `errorText`, `isRequired`, `necessityIndicator`, `labelPosition`). Passing
  * any of these emits a `__DEV__` warning and they are otherwise ignored at
  * runtime.

--- a/packages/blade/src/components/DatePicker/DatePicker.native.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.native.tsx
@@ -37,10 +37,9 @@ const useDayjsLocale = (): string => {
   // hasn't mounted an I18nProvider, the hook still returns a shape with
   // `i18nState`, just without a locale set.
   const i18n = useI18nContext();
-  return useMemo(
-    () => convertIntlToDayjsLocale(i18n?.i18nState?.locale ?? 'en-IN'),
-    [i18n?.i18nState?.locale],
-  );
+  return useMemo(() => convertIntlToDayjsLocale(i18n?.i18nState?.locale ?? 'en-IN'), [
+    i18n?.i18nState?.locale,
+  ]);
 };
 
 const DEFAULT_FIRST_DAY = 1; // Monday
@@ -143,10 +142,10 @@ const Calendar = ({
   localeName,
 }: CalendarProps): React.ReactElement => {
   const { theme } = useTheme();
-  const grid = useMemo(
-    () => buildMonthGrid(visibleMonth, firstDayOfWeek),
-    [visibleMonth, firstDayOfWeek],
-  );
+  const grid = useMemo(() => buildMonthGrid(visibleMonth, firstDayOfWeek), [
+    visibleMonth,
+    firstDayOfWeek,
+  ]);
   const [start, end] = isRange(selectionType) ? toRange(value) : [toSingle(value), null];
   const fmt = (d: Date | dayjs.Dayjs, pattern: string): string =>
     dayjs(d).locale(localeName).format(pattern);
@@ -254,18 +253,18 @@ const Calendar = ({
               const textColorToken = isSelected
                 ? 'interactive.text.primary.normal'
                 : disabled || !sameMonth
-                  ? 'surface.text.gray.disabled'
-                  : 'surface.text.gray.normal';
+                ? 'surface.text.gray.disabled'
+                : 'surface.text.gray.normal';
               const baseLabel = fmt(day, 'DD MMM YYYY');
               const stateSuffix = selectedStart
                 ? ', selected start of range'
                 : selectedEnd
-                  ? ', selected end of range'
-                  : isSelected
-                    ? ', selected'
-                    : inRange
-                      ? ', in selected range'
-                      : '';
+                ? ', selected end of range'
+                : isSelected
+                ? ', selected'
+                : inRange
+                ? ', in selected range'
+                : '';
               return (
                 <Pressable
                   key={day.toISOString()}
@@ -429,16 +428,16 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
   const helperRenderText = isError
     ? (errorText as string | undefined)
     : isSuccess
-      ? (successText as string | undefined)
-      : (helpText as string | undefined);
+    ? (successText as string | undefined)
+    : (helpText as string | undefined);
   const helperRenderColor:
     | 'feedback.text.negative.intense'
     | 'feedback.text.positive.intense'
     | 'surface.text.gray.muted' = isError
     ? 'feedback.text.negative.intense'
     : isSuccess
-      ? 'feedback.text.positive.intense'
-      : 'surface.text.gray.muted';
+    ? 'feedback.text.positive.intense'
+    : 'surface.text.gray.muted';
 
   // Validation state communicates through the helper text colour below the
   // trigger. The native trigger keeps the standard `surface.border.gray.muted`
@@ -449,8 +448,8 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     isRequired && necessityIndicator === 'required'
       ? '*'
       : isRequired && necessityIndicator === 'optional'
-        ? ' (optional)'
-        : '';
+      ? ' (optional)'
+      : '';
 
   const [innerValue, setInnerValue] = useControllableState<AnyValue>({
     value: value as AnyValue,

--- a/packages/blade/src/components/DatePicker/DatePicker.native.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.native.tsx
@@ -384,12 +384,14 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     onPickerChange,
     visibleMonth: visibleMonthProp,
     defaultVisibleMonth,
+    onVisibleMonthChange,
   } = props as DatePickerNativeProps<DateSelectionType> & {
     picker?: unknown;
     defaultPicker?: unknown;
     onPickerChange?: unknown;
     visibleMonth?: unknown;
     defaultVisibleMonth?: unknown;
+    onVisibleMonthChange?: unknown;
     successText?: unknown;
   };
 
@@ -401,6 +403,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     if (onPickerChange !== undefined) unsupported.push('onPickerChange');
     if (visibleMonthProp !== undefined) unsupported.push('visibleMonth');
     if (defaultVisibleMonth !== undefined) unsupported.push('defaultVisibleMonth');
+    if (onVisibleMonthChange !== undefined) unsupported.push('onVisibleMonthChange');
     if (unsupported.length > 0) {
       logger({
         type: 'warn',
@@ -410,7 +413,14 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
         )}.`,
       });
     }
-  }, [picker, defaultPicker, onPickerChange, visibleMonthProp, defaultVisibleMonth]);
+  }, [
+    picker,
+    defaultPicker,
+    onPickerChange,
+    visibleMonthProp,
+    defaultVisibleMonth,
+    onVisibleMonthChange,
+  ]);
 
   const isError = validationState === 'error';
   const isSuccess = validationState === 'success';
@@ -722,7 +732,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
  * #### Not yet supported on native
  *
  * Month/year picker variants (`picker`, `defaultPicker`, `onPickerChange`),
- * `visibleMonth`/`defaultVisibleMonth`, masked text
+ * `visibleMonth`/`defaultVisibleMonth`/`onVisibleMonthChange`, masked text
  * input, and the form-validation props (`validationState`, `helpText`,
  * `errorText`, `isRequired`, `necessityIndicator`, `labelPosition`). Passing
  * any of these emits a `__DEV__` warning and they are otherwise ignored at

--- a/packages/blade/src/components/DatePicker/DatePicker.native.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.native.tsx
@@ -37,9 +37,10 @@ const useDayjsLocale = (): string => {
   // hasn't mounted an I18nProvider, the hook still returns a shape with
   // `i18nState`, just without a locale set.
   const i18n = useI18nContext();
-  return useMemo(() => convertIntlToDayjsLocale(i18n?.i18nState?.locale ?? 'en-IN'), [
-    i18n?.i18nState?.locale,
-  ]);
+  return useMemo(
+    () => convertIntlToDayjsLocale(i18n?.i18nState?.locale ?? 'en-IN'),
+    [i18n?.i18nState?.locale],
+  );
 };
 
 const DEFAULT_FIRST_DAY = 1; // Monday
@@ -142,10 +143,10 @@ const Calendar = ({
   localeName,
 }: CalendarProps): React.ReactElement => {
   const { theme } = useTheme();
-  const grid = useMemo(() => buildMonthGrid(visibleMonth, firstDayOfWeek), [
-    visibleMonth,
-    firstDayOfWeek,
-  ]);
+  const grid = useMemo(
+    () => buildMonthGrid(visibleMonth, firstDayOfWeek),
+    [visibleMonth, firstDayOfWeek],
+  );
   const [start, end] = isRange(selectionType) ? toRange(value) : [toSingle(value), null];
   const fmt = (d: Date | dayjs.Dayjs, pattern: string): string =>
     dayjs(d).locale(localeName).format(pattern);
@@ -253,18 +254,18 @@ const Calendar = ({
               const textColorToken = isSelected
                 ? 'interactive.text.primary.normal'
                 : disabled || !sameMonth
-                ? 'surface.text.gray.disabled'
-                : 'surface.text.gray.normal';
+                  ? 'surface.text.gray.disabled'
+                  : 'surface.text.gray.normal';
               const baseLabel = fmt(day, 'DD MMM YYYY');
               const stateSuffix = selectedStart
                 ? ', selected start of range'
                 : selectedEnd
-                ? ', selected end of range'
-                : isSelected
-                ? ', selected'
-                : inRange
-                ? ', in selected range'
-                : '';
+                  ? ', selected end of range'
+                  : isSelected
+                    ? ', selected'
+                    : inRange
+                      ? ', in selected range'
+                      : '';
               return (
                 <Pressable
                   key={day.toISOString()}
@@ -413,7 +414,14 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
         )}.`,
       });
     }
-  }, [picker, defaultPicker, onPickerChange, visibleMonthProp, defaultVisibleMonth, onVisibleMonthChange]);
+  }, [
+    picker,
+    defaultPicker,
+    onPickerChange,
+    visibleMonthProp,
+    defaultVisibleMonth,
+    onVisibleMonthChange,
+  ]);
 
   const isError = validationState === 'error';
   const isSuccess = validationState === 'success';
@@ -421,16 +429,16 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
   const helperRenderText = isError
     ? (errorText as string | undefined)
     : isSuccess
-    ? (successText as string | undefined)
-    : (helpText as string | undefined);
+      ? (successText as string | undefined)
+      : (helpText as string | undefined);
   const helperRenderColor:
     | 'feedback.text.negative.intense'
     | 'feedback.text.positive.intense'
     | 'surface.text.gray.muted' = isError
     ? 'feedback.text.negative.intense'
     : isSuccess
-    ? 'feedback.text.positive.intense'
-    : 'surface.text.gray.muted';
+      ? 'feedback.text.positive.intense'
+      : 'surface.text.gray.muted';
 
   // Validation state communicates through the helper text colour below the
   // trigger. The native trigger keeps the standard `surface.border.gray.muted`
@@ -441,8 +449,8 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     isRequired && necessityIndicator === 'required'
       ? '*'
       : isRequired && necessityIndicator === 'optional'
-      ? ' (optional)'
-      : '';
+        ? ' (optional)'
+        : '';
 
   const [innerValue, setInnerValue] = useControllableState<AnyValue>({
     value: value as AnyValue,

--- a/packages/blade/src/components/DatePicker/DatePicker.native.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.native.tsx
@@ -382,10 +382,16 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     picker,
     defaultPicker,
     onPickerChange,
+    visibleMonth: visibleMonthProp,
+    defaultVisibleMonth,
+    onVisibleMonthChange,
   } = props as DatePickerNativeProps<DateSelectionType> & {
     picker?: unknown;
     defaultPicker?: unknown;
     onPickerChange?: unknown;
+    visibleMonth?: unknown;
+    defaultVisibleMonth?: unknown;
+    onVisibleMonthChange?: unknown;
     successText?: unknown;
   };
 
@@ -395,6 +401,9 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     if (picker !== undefined) unsupported.push('picker');
     if (defaultPicker !== undefined) unsupported.push('defaultPicker');
     if (onPickerChange !== undefined) unsupported.push('onPickerChange');
+    if (visibleMonthProp !== undefined) unsupported.push('visibleMonth');
+    if (defaultVisibleMonth !== undefined) unsupported.push('defaultVisibleMonth');
+    if (onVisibleMonthChange !== undefined) unsupported.push('onVisibleMonthChange');
     if (unsupported.length > 0) {
       logger({
         type: 'warn',
@@ -404,7 +413,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
         )}.`,
       });
     }
-  }, [picker, defaultPicker, onPickerChange]);
+  }, [picker, defaultPicker, onPickerChange, visibleMonthProp, defaultVisibleMonth, onVisibleMonthChange]);
 
   const isError = validationState === 'error';
   const isSuccess = validationState === 'success';
@@ -716,10 +725,11 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
  * #### Not yet supported on native
  *
  * Month/year picker variants (`picker`, `defaultPicker`, `onPickerChange`),
- * masked text input, and the form-validation props (`validationState`,
- * `helpText`, `errorText`, `isRequired`, `necessityIndicator`,
- * `labelPosition`). Passing any of these emits a `__DEV__` warning and they
- * are otherwise ignored at runtime.
+ * `visibleMonth`/`defaultVisibleMonth`/`onVisibleMonthChange`, masked text
+ * input, and the form-validation props (`validationState`, `helpText`,
+ * `errorText`, `isRequired`, `necessityIndicator`, `labelPosition`). Passing
+ * any of these emits a `__DEV__` warning and they are otherwise ignored at
+ * runtime.
  *
  * #### Localisation
  *

--- a/packages/blade/src/components/DatePicker/DatePicker.native.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.native.tsx
@@ -382,16 +382,12 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     picker,
     defaultPicker,
     onPickerChange,
-    visibleMonth: visibleMonthProp,
     defaultVisibleMonth,
-    onVisibleMonthChange,
   } = props as DatePickerNativeProps<DateSelectionType> & {
     picker?: unknown;
     defaultPicker?: unknown;
     onPickerChange?: unknown;
-    visibleMonth?: unknown;
     defaultVisibleMonth?: unknown;
-    onVisibleMonthChange?: unknown;
     successText?: unknown;
   };
 
@@ -401,9 +397,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
     if (picker !== undefined) unsupported.push('picker');
     if (defaultPicker !== undefined) unsupported.push('defaultPicker');
     if (onPickerChange !== undefined) unsupported.push('onPickerChange');
-    if (visibleMonthProp !== undefined) unsupported.push('visibleMonth');
     if (defaultVisibleMonth !== undefined) unsupported.push('defaultVisibleMonth');
-    if (onVisibleMonthChange !== undefined) unsupported.push('onVisibleMonthChange');
     if (unsupported.length > 0) {
       logger({
         type: 'warn',
@@ -413,14 +407,7 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
         )}.`,
       });
     }
-  }, [
-    picker,
-    defaultPicker,
-    onPickerChange,
-    visibleMonthProp,
-    defaultVisibleMonth,
-    onVisibleMonthChange,
-  ]);
+  }, [picker, defaultPicker, onPickerChange, defaultVisibleMonth]);
 
   const isError = validationState === 'error';
   const isSuccess = validationState === 'success';
@@ -732,8 +719,8 @@ function _DatePicker<Type extends DateSelectionType = 'single'>(
  * #### Not yet supported on native
  *
  * Month/year picker variants (`picker`, `defaultPicker`, `onPickerChange`),
- * `visibleMonth`/`defaultVisibleMonth`/`onVisibleMonthChange`, masked text
- * input, and the form-validation props (`validationState`, `helpText`,
+ * `defaultVisibleMonth`, masked text input, and the form-validation props
+ * (`validationState`, `helpText`,
  * `errorText`, `isRequired`, `necessityIndicator`, `labelPosition`). Passing
  * any of these emits a `__DEV__` warning and they are otherwise ignored at
  * runtime.

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -1370,12 +1370,11 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
       <Text marginBottom="spacing.5">
         Use <Code size="medium">defaultVisibleMonth</Code> to anchor a comparison{' '}
         <Code size="medium">DatePicker</Code> on the months immediately preceding a primary
-        range&apos;s selection — without pre-filling the comparison{' '}
-        <Code size="medium">value</Code>. Since <Code size="medium">defaultVisibleMonth</Code>{' '}
-        only sets the initial anchor, remounting via a <Code size="medium">key</Code> re-anchors
-        the calendar whenever the computed comparison month changes. Pick a primary range below,
-        then open &quot;Compare to&quot; and notice the calendar opens on the same-length period
-        right before it.
+        range&apos;s selection — without pre-filling the comparison <Code size="medium">value</Code>
+        . Since <Code size="medium">defaultVisibleMonth</Code> only sets the initial anchor,
+        remounting via a <Code size="medium">key</Code> re-anchors the calendar whenever the
+        computed comparison month changes. Pick a primary range below, then open &quot;Compare
+        to&quot; and notice the calendar opens on the same-length period right before it.
       </Text>
       <Box display="flex" flexDirection="column" gap="spacing.5" maxWidth="400px">
         <DatePickerComponent

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -47,9 +47,7 @@ export default {
     maxDate: baseProp,
     excludeDate: baseProp,
     picker: baseProp,
-    visibleMonth: baseProp,
     defaultVisibleMonth: baseProp,
-    onVisibleMonthChange: baseProp,
     onOpenChange: baseProp,
     allowSingleDateInRange: baseProp,
     defaultIsOpen: baseProp,
@@ -1370,11 +1368,14 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
   return (
     <Box>
       <Text marginBottom="spacing.5">
-        Use <Code size="medium">visibleMonth</Code>/<Code size="medium">defaultVisibleMonth</Code>{' '}
-        to anchor a comparison <Code size="medium">DatePicker</Code> on the months immediately
-        preceding a primary range&apos;s selection — without pre-filling the comparison{' '}
-        <Code size="medium">value</Code>. Pick a primary range below, then open &quot;Compare
-        to&quot; and notice the calendar opens on the same-length period right before it.
+        Use <Code size="medium">defaultVisibleMonth</Code> to anchor a comparison{' '}
+        <Code size="medium">DatePicker</Code> on the months immediately preceding a primary
+        range&apos;s selection — without pre-filling the comparison{' '}
+        <Code size="medium">value</Code>. Since <Code size="medium">defaultVisibleMonth</Code>{' '}
+        only sets the initial anchor, remounting via a <Code size="medium">key</Code> re-anchors
+        the calendar whenever the computed comparison month changes. Pick a primary range below,
+        then open &quot;Compare to&quot; and notice the calendar opens on the same-length period
+        right before it.
       </Text>
       <Box display="flex" flexDirection="column" gap="spacing.5" maxWidth="400px">
         <DatePickerComponent
@@ -1384,11 +1385,11 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
           onChange={(date) => setPrimaryRange(date)}
         />
         <DatePickerComponent
+          key={comparisonVisibleMonth?.toISOString()}
           label={{ start: 'Compare to' }}
           selectionType="range"
           value={comparisonRange}
-          visibleMonth={comparisonVisibleMonth}
-          onVisibleMonthChange={setComparisonVisibleMonth}
+          defaultVisibleMonth={comparisonVisibleMonth}
           onChange={(date) => setComparisonRange(date)}
         />
       </Box>
@@ -1396,6 +1397,6 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
   );
 };
 
-DatePickerComparisonRange.storyName = 'Comparison Range (visibleMonth)';
+DatePickerComparisonRange.storyName = 'Comparison Range (defaultVisibleMonth)';
 
 DatePickerWithTimePickerInModal.storyName = 'DatePicker with TimePicker (Modal)';

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -49,6 +49,7 @@ export default {
     picker: baseProp,
     visibleMonth: baseProp,
     defaultVisibleMonth: baseProp,
+    onVisibleMonthChange: baseProp,
     onOpenChange: baseProp,
     allowSingleDateInRange: baseProp,
     defaultIsOpen: baseProp,
@@ -1387,8 +1388,7 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
           selectionType="range"
           value={comparisonRange}
           visibleMonth={comparisonVisibleMonth}
-          onNext={({ date }) => setComparisonVisibleMonth(date)}
-          onPrevious={({ date }) => setComparisonVisibleMonth(date)}
+          onVisibleMonthChange={setComparisonVisibleMonth}
           onChange={(date) => setComparisonRange(date)}
         />
       </Box>

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -47,6 +47,7 @@ export default {
     maxDate: baseProp,
     excludeDate: baseProp,
     picker: baseProp,
+    visibleMonth: baseProp,
     defaultVisibleMonth: baseProp,
     onOpenChange: baseProp,
     allowSingleDateInRange: baseProp,
@@ -1368,12 +1369,10 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
   return (
     <Box>
       <Text marginBottom="spacing.5">
-        Use <Code size="medium">defaultVisibleMonth</Code> to anchor a comparison{' '}
-        <Code size="medium">DatePicker</Code> on the months immediately preceding a primary
-        range&apos;s selection — without pre-filling the comparison <Code size="medium">value</Code>
-        . Since <Code size="medium">defaultVisibleMonth</Code> only sets the initial anchor,
-        remounting via a <Code size="medium">key</Code> re-anchors the calendar whenever the
-        computed comparison month changes. Pick a primary range below, then open &quot;Compare
+        Use <Code size="medium">visibleMonth</Code>/<Code size="medium">defaultVisibleMonth</Code>{' '}
+        to anchor a comparison <Code size="medium">DatePicker</Code> on the months immediately
+        preceding a primary range&apos;s selection — without pre-filling the comparison{' '}
+        <Code size="medium">value</Code>. Pick a primary range below, then open &quot;Compare
         to&quot; and notice the calendar opens on the same-length period right before it.
       </Text>
       <Box display="flex" flexDirection="column" gap="spacing.5" maxWidth="400px">
@@ -1384,11 +1383,12 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
           onChange={(date) => setPrimaryRange(date)}
         />
         <DatePickerComponent
-          key={comparisonVisibleMonth?.toISOString()}
           label={{ start: 'Compare to' }}
           selectionType="range"
           value={comparisonRange}
-          defaultVisibleMonth={comparisonVisibleMonth}
+          visibleMonth={comparisonVisibleMonth}
+          onNext={({ date }) => setComparisonVisibleMonth(date)}
+          onPrevious={({ date }) => setComparisonVisibleMonth(date)}
           onChange={(date) => setComparisonRange(date)}
         />
       </Box>
@@ -1396,6 +1396,6 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
   );
 };
 
-DatePickerComparisonRange.storyName = 'Comparison Range (defaultVisibleMonth)';
+DatePickerComparisonRange.storyName = 'Comparison Range (visibleMonth)';
 
 DatePickerWithTimePickerInModal.storyName = 'DatePicker with TimePicker (Modal)';

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -47,6 +47,9 @@ export default {
     maxDate: baseProp,
     excludeDate: baseProp,
     picker: baseProp,
+    visibleMonth: baseProp,
+    defaultVisibleMonth: baseProp,
+    onVisibleMonthChange: baseProp,
     onOpenChange: baseProp,
     allowSingleDateInRange: baseProp,
     defaultIsOpen: baseProp,
@@ -1343,5 +1346,53 @@ export const DatePickerWithTimePickerInModal: StoryFn<typeof DatePickerComponent
     </Box>
   );
 };
+
+export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = () => {
+  const [primaryRange, setPrimaryRange] = React.useState<DatesRangeValue>([
+    dayjs().subtract(1, 'month').toDate(),
+    dayjs().toDate(),
+  ]);
+  const [comparisonRange, setComparisonRange] = React.useState<DatesRangeValue>([null, null]);
+
+  // Same-length period immediately preceding the primary range, with no gap between the two.
+  const comparisonVisibleMonth = React.useMemo(() => {
+    const [primaryStart, primaryEnd] = primaryRange;
+    if (!primaryStart || !primaryEnd) return undefined;
+    const rangeLengthInDays = dayjs(primaryEnd).diff(dayjs(primaryStart), 'day');
+    return dayjs(primaryStart)
+      .subtract(rangeLengthInDays + 1, 'day')
+      .toDate();
+  }, [primaryRange]);
+
+  return (
+    <Box>
+      <Text marginBottom="spacing.5">
+        Use <Code size="medium">visibleMonth</Code>/<Code size="medium">defaultVisibleMonth</Code>{' '}
+        to anchor a comparison <Code size="medium">DatePicker</Code> on the months immediately
+        preceding a primary range&apos;s selection — without pre-filling the comparison{' '}
+        <Code size="medium">value</Code>. Pick a primary range below, then open &quot;Compare
+        to&quot; and notice the calendar opens on the same-length period right before it.
+      </Text>
+      <Box display="flex" flexDirection="column" gap="spacing.5" maxWidth="400px">
+        <DatePickerComponent
+          label={{ start: 'Primary date range' }}
+          selectionType="range"
+          value={primaryRange}
+          onChange={(date) => setPrimaryRange(date)}
+        />
+        <DatePickerComponent
+          key={comparisonVisibleMonth?.toISOString()}
+          label={{ start: 'Compare to' }}
+          selectionType="range"
+          value={comparisonRange}
+          defaultVisibleMonth={comparisonVisibleMonth}
+          onChange={(date) => setComparisonRange(date)}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+DatePickerComparisonRange.storyName = 'Comparison Range (visibleMonth)';
 
 DatePickerWithTimePickerInModal.storyName = 'DatePicker with TimePicker (Modal)';

--- a/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/blade/src/components/DatePicker/DatePicker.stories.tsx
@@ -1353,15 +1353,18 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
     dayjs().toDate(),
   ]);
   const [comparisonRange, setComparisonRange] = React.useState<DatesRangeValue>([null, null]);
+  const [comparisonVisibleMonth, setComparisonVisibleMonth] = React.useState<Date | undefined>();
 
   // Same-length period immediately preceding the primary range, with no gap between the two.
-  const comparisonVisibleMonth = React.useMemo(() => {
+  React.useEffect(() => {
     const [primaryStart, primaryEnd] = primaryRange;
-    if (!primaryStart || !primaryEnd) return undefined;
+    if (!primaryStart || !primaryEnd) return;
     const rangeLengthInDays = dayjs(primaryEnd).diff(dayjs(primaryStart), 'day');
-    return dayjs(primaryStart)
-      .subtract(rangeLengthInDays + 1, 'day')
-      .toDate();
+    setComparisonVisibleMonth(
+      dayjs(primaryStart)
+        .subtract(rangeLengthInDays + 1, 'day')
+        .toDate(),
+    );
   }, [primaryRange]);
 
   return (
@@ -1381,11 +1384,11 @@ export const DatePickerComparisonRange: StoryFn<typeof DatePickerComponent> = ()
           onChange={(date) => setPrimaryRange(date)}
         />
         <DatePickerComponent
-          key={comparisonVisibleMonth?.toISOString()}
           label={{ start: 'Compare to' }}
           selectionType="range"
           value={comparisonRange}
-          defaultVisibleMonth={comparisonVisibleMonth}
+          visibleMonth={comparisonVisibleMonth}
+          onVisibleMonthChange={setComparisonVisibleMonth}
           onChange={(date) => setComparisonRange(date)}
         />
       </Box>

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
@@ -49,19 +49,16 @@ describe('<DatePicker/> visibleMonth', () => {
     expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
   });
 
-  it('fires onNext with the correct date when navigating in controlled mode', async () => {
-    // With a controlled `visibleMonth`, consumers keep it in sync by listening to
-    // the existing onNext/onPrevious (navigation) and onChange (selection) callbacks
-    // rather than a dedicated onVisibleMonthChange callback.
+  it('fires onVisibleMonthChange when navigating to the next month in controlled mode', async () => {
     const anchorMonth = dayjs().subtract(4, 'month').toDate();
-    const onNext = jest.fn();
+    const onVisibleMonthChange = jest.fn();
 
     const { getByRole, queryByText } = renderWithTheme(
       <DatePickerComponent
         selectionType="range"
         label={{ start: 'Compare to' }}
         visibleMonth={anchorMonth}
-        onNext={onNext}
+        onVisibleMonthChange={onVisibleMonthChange}
       />,
     );
 
@@ -74,11 +71,10 @@ describe('<DatePicker/> visibleMonth', () => {
     const nextButton = getByRole('button', { name: /Next/i });
     await user.click(nextButton);
 
-    expect(onNext).toHaveBeenCalledTimes(1);
-    const { date: calledDate, type } = onNext.mock.calls[0][0] as { date: Date; type: string };
+    expect(onVisibleMonthChange).toHaveBeenCalledTimes(1);
+    const calledDate = onVisibleMonthChange.mock.calls[0][0] as Date;
     // Range picker on desktop shows 2 columns, so "Next" advances by 2 months
     const expectedDate = dayjs(anchorMonth).add(2, 'month').toDate();
-    expect(type).toBe('month');
     expect(dayjs(calledDate).isSame(expectedDate, 'month')).toBe(true);
   });
 

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
@@ -27,7 +27,7 @@ describe('<DatePicker/> visibleMonth', () => {
     expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
   });
 
-  it('gives visibleMonth priority over the first date of a controlled value', async () => {
+  it('gives defaultVisibleMonth priority over the first date of a controlled value', async () => {
     const anchorMonth = dayjs().subtract(6, 'month').toDate();
     const selectedRange = [dayjs().toDate(), dayjs().add(3, 'day').toDate()] as [Date, Date];
 
@@ -36,7 +36,7 @@ describe('<DatePicker/> visibleMonth', () => {
         selectionType="range"
         label={{ start: 'Compare to' }}
         value={selectedRange}
-        visibleMonth={anchorMonth}
+        defaultVisibleMonth={anchorMonth}
         onChange={() => undefined}
       />,
     );
@@ -49,16 +49,19 @@ describe('<DatePicker/> visibleMonth', () => {
     expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
   });
 
-  it('fires onVisibleMonthChange when navigating to the next month in controlled mode', async () => {
+  it('fires onNext with the correct date when navigating to the next month', async () => {
+    // Consumers who need to track the rendered month (e.g. to re-anchor a
+    // comparison picker) should rely on the existing onNext/onPrevious
+    // callbacks rather than a dedicated visible-month callback.
     const anchorMonth = dayjs().subtract(4, 'month').toDate();
-    const onVisibleMonthChange = jest.fn();
+    const onNext = jest.fn();
 
     const { getByRole, queryByText } = renderWithTheme(
       <DatePickerComponent
         selectionType="range"
         label={{ start: 'Compare to' }}
-        visibleMonth={anchorMonth}
-        onVisibleMonthChange={onVisibleMonthChange}
+        defaultVisibleMonth={anchorMonth}
+        onNext={onNext}
       />,
     );
 
@@ -71,10 +74,11 @@ describe('<DatePicker/> visibleMonth', () => {
     const nextButton = getByRole('button', { name: /Next/i });
     await user.click(nextButton);
 
-    expect(onVisibleMonthChange).toHaveBeenCalledTimes(1);
-    const calledDate = onVisibleMonthChange.mock.calls[0][0] as Date;
+    expect(onNext).toHaveBeenCalledTimes(1);
+    const { date: calledDate, type } = onNext.mock.calls[0][0] as { date: Date; type: string };
     // Range picker on desktop shows 2 columns, so "Next" advances by 2 months
     const expectedDate = dayjs(anchorMonth).add(2, 'month').toDate();
+    expect(type).toBe('month');
     expect(dayjs(calledDate).isSame(expectedDate, 'month')).toBe(true);
   });
 

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
@@ -27,7 +27,7 @@ describe('<DatePicker/> visibleMonth', () => {
     expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
   });
 
-  it('gives defaultVisibleMonth priority over the first date of a controlled value', async () => {
+  it('gives visibleMonth priority over the first date of a controlled value', async () => {
     const anchorMonth = dayjs().subtract(6, 'month').toDate();
     const selectedRange = [dayjs().toDate(), dayjs().add(3, 'day').toDate()] as [Date, Date];
 
@@ -36,7 +36,7 @@ describe('<DatePicker/> visibleMonth', () => {
         selectionType="range"
         label={{ start: 'Compare to' }}
         value={selectedRange}
-        defaultVisibleMonth={anchorMonth}
+        visibleMonth={anchorMonth}
         onChange={() => undefined}
       />,
     );
@@ -49,10 +49,10 @@ describe('<DatePicker/> visibleMonth', () => {
     expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
   });
 
-  it('fires onNext with the correct date when navigating to the next month', async () => {
-    // Consumers who need to track the rendered month (e.g. to re-anchor a
-    // comparison picker) should rely on the existing onNext/onPrevious
-    // callbacks rather than a dedicated visible-month callback.
+  it('fires onNext with the correct date when navigating in controlled mode', async () => {
+    // With a controlled `visibleMonth`, consumers keep it in sync by listening to
+    // the existing onNext/onPrevious (navigation) and onChange (selection) callbacks
+    // rather than a dedicated onVisibleMonthChange callback.
     const anchorMonth = dayjs().subtract(4, 'month').toDate();
     const onNext = jest.fn();
 
@@ -60,7 +60,7 @@ describe('<DatePicker/> visibleMonth', () => {
       <DatePickerComponent
         selectionType="range"
         label={{ start: 'Compare to' }}
-        defaultVisibleMonth={anchorMonth}
+        visibleMonth={anchorMonth}
         onNext={onNext}
       />,
     );

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/react';
+import { DatePicker as DatePickerComponent } from '..';
+import renderWithTheme from '~utils/testing/renderWithTheme.web';
+
+describe('<DatePicker/> visibleMonth', () => {
+  jest.setTimeout(10000);
+
+  it('opens on defaultVisibleMonth instead of the selected value when no value is set', async () => {
+    const anchorMonth = dayjs().subtract(4, 'month').toDate();
+
+    const { getByRole, getAllByText, queryByText } = renderWithTheme(
+      <DatePickerComponent
+        selectionType="range"
+        label={{ start: 'Compare to' }}
+        defaultVisibleMonth={anchorMonth}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const input = getByRole('combobox', { name: /Compare to/i });
+    await user.click(input);
+
+    await waitFor(() => expect(queryByText('Apply')).toBeVisible());
+    expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
+  });
+
+  it('gives visibleMonth priority over the first date of a controlled value', async () => {
+    const anchorMonth = dayjs().subtract(6, 'month').toDate();
+    const selectedRange = [dayjs().toDate(), dayjs().add(3, 'day').toDate()] as [Date, Date];
+
+    const { getByRole, getAllByText, queryByText } = renderWithTheme(
+      <DatePickerComponent
+        selectionType="range"
+        label={{ start: 'Compare to' }}
+        value={selectedRange}
+        visibleMonth={anchorMonth}
+        onChange={() => undefined}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const input = getByRole('combobox', { name: /Compare to/i });
+    await user.click(input);
+
+    await waitFor(() => expect(queryByText('Apply')).toBeVisible());
+    expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
@@ -73,13 +73,15 @@ describe('<DatePicker/> visibleMonth', () => {
 
     expect(onVisibleMonthChange).toHaveBeenCalledTimes(1);
     const calledDate = onVisibleMonthChange.mock.calls[0][0] as Date;
-    const expectedDate = dayjs(anchorMonth).add(1, 'month').toDate();
+    // Range picker on desktop shows 2 columns, so "Next" advances by 2 months
+    const expectedDate = dayjs(anchorMonth).add(2, 'month').toDate();
     expect(dayjs(calledDate).isSame(expectedDate, 'month')).toBe(true);
   });
 
   it('advances the calendar header after navigation when defaultVisibleMonth is set', async () => {
     const anchorMonth = dayjs().subtract(4, 'month').toDate();
-    const nextMonth = dayjs(anchorMonth).add(1, 'month');
+    // Range picker on desktop shows 2 columns, so "Next" advances by 2 months
+    const nextMonth = dayjs(anchorMonth).add(2, 'month');
 
     const { getByRole, getAllByText, queryByText } = renderWithTheme(
       <DatePickerComponent

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.visibleMonth.web.test.tsx
@@ -48,4 +48,90 @@ describe('<DatePicker/> visibleMonth', () => {
     await waitFor(() => expect(queryByText('Apply')).toBeVisible());
     expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
   });
+
+  it('fires onVisibleMonthChange when navigating to the next month in controlled mode', async () => {
+    const anchorMonth = dayjs().subtract(4, 'month').toDate();
+    const onVisibleMonthChange = jest.fn();
+
+    const { getByRole, queryByText } = renderWithTheme(
+      <DatePickerComponent
+        selectionType="range"
+        label={{ start: 'Compare to' }}
+        visibleMonth={anchorMonth}
+        onVisibleMonthChange={onVisibleMonthChange}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const input = getByRole('combobox', { name: /Compare to/i });
+    await user.click(input);
+
+    await waitFor(() => expect(queryByText('Apply')).toBeVisible());
+
+    const nextButton = getByRole('button', { name: /Next/i });
+    await user.click(nextButton);
+
+    expect(onVisibleMonthChange).toHaveBeenCalledTimes(1);
+    const calledDate = onVisibleMonthChange.mock.calls[0][0] as Date;
+    const expectedDate = dayjs(anchorMonth).add(1, 'month').toDate();
+    expect(dayjs(calledDate).isSame(expectedDate, 'month')).toBe(true);
+  });
+
+  it('advances the calendar header after navigation when defaultVisibleMonth is set', async () => {
+    const anchorMonth = dayjs().subtract(4, 'month').toDate();
+    const nextMonth = dayjs(anchorMonth).add(1, 'month');
+
+    const { getByRole, getAllByText, queryByText } = renderWithTheme(
+      <DatePickerComponent
+        selectionType="range"
+        label={{ start: 'Compare to' }}
+        defaultVisibleMonth={anchorMonth}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const input = getByRole('combobox', { name: /Compare to/i });
+    await user.click(input);
+
+    await waitFor(() => expect(queryByText('Apply')).toBeVisible());
+    expect(getAllByText(dayjs(anchorMonth).format('MMMM YYYY')).length).toBeGreaterThan(0);
+
+    const nextButton = getByRole('button', { name: /Next/i });
+    await user.click(nextButton);
+
+    await waitFor(() =>
+      expect(getAllByText(nextMonth.format('MMMM YYYY')).length).toBeGreaterThan(0),
+    );
+  });
+
+  it('re-anchors to defaultVisibleMonth when the DatePicker is closed and reopened', async () => {
+    const anchorMonth = dayjs().subtract(5, 'month').toDate();
+    const anchorLabel = dayjs(anchorMonth).format('MMMM YYYY');
+
+    const { getByRole, getAllByText, queryByText } = renderWithTheme(
+      <DatePickerComponent
+        selectionType="range"
+        label={{ start: 'Compare to' }}
+        defaultVisibleMonth={anchorMonth}
+      />,
+    );
+
+    const user = userEvent.setup();
+    const input = getByRole('combobox', { name: /Compare to/i });
+
+    // Open
+    await user.click(input);
+    await waitFor(() => expect(queryByText('Apply')).toBeVisible());
+    expect(getAllByText(anchorLabel).length).toBeGreaterThan(0);
+
+    // Close via Cancel
+    const cancelButton = getByRole('button', { name: /Cancel/i });
+    await user.click(cancelButton);
+    await waitFor(() => expect(queryByText('Apply')).not.toBeVisible());
+
+    // Reopen
+    await user.click(input);
+    await waitFor(() => expect(queryByText('Apply')).toBeVisible());
+    expect(getAllByText(anchorLabel).length).toBeGreaterThan(0);
+  });
 });

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -82,9 +82,10 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
    */
   defaultVisibleMonth?: Date;
   /**
-   * Callback which fires when the rendered month changes via calendar navigation
-   * (next/previous month, year, or decade). Does not fire when the `visibleMonth`
-   * prop is updated externally by the consumer.
+   * Callback which fires when the rendered month changes, either via calendar
+   * navigation (next/previous month, year, or decade) or when a date in a
+   * different month is selected. Does not fire when the `visibleMonth` prop
+   * is updated externally by the consumer.
    */
   onVisibleMonthChange?: (date: Date) => void;
 

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -60,6 +60,31 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
   onPickerChange?: (picker: PickerType) => void;
 
   /**
+   * Controlled month that the calendar renders, independent of the selected `value`.
+   *
+   * Useful when you want the calendar to open on a specific month without pre-selecting
+   * a date — e.g. a "comparison" range picker that should default to the period
+   * immediately preceding a primary range picker's selection.
+   *
+   * Falls back to the first date of `value`/`defaultValue` (or today) when not set.
+   *
+   * @example
+   * // Anchor a comparison picker to the month before the primary range's start
+   * <DatePicker selectionType="range" visibleMonth={dayjs(primaryStart).subtract(1, 'month').toDate()} />
+   */
+  visibleMonth?: Date;
+  /**
+   * Uncontrolled variant of `visibleMonth`. Sets the initial month the calendar renders,
+   * without pre-selecting a date.
+   */
+  defaultVisibleMonth?: Date;
+  /**
+   * Callback which fires when the rendered month changes, whether via the calendar's
+   * next/previous navigation or programmatically through `visibleMonth`.
+   */
+  onVisibleMonthChange?: (date: Date) => void;
+
+  /**
    * Controlled isOpen state
    */
   isOpen?: boolean;

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -68,9 +68,8 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
    *
    * Falls back to the first date of `value`/`defaultValue` (or today) when not set.
    *
-   * When `visibleMonth` is controlled, keep it in sync via the existing `onChange`
-   * (date selection) and `onNext`/`onPrevious` (calendar navigation) callbacks —
-   * otherwise calendar navigation will not work.
+   * When `visibleMonth` is controlled, you must handle `onVisibleMonthChange` to keep
+   * the prop in sync — otherwise calendar navigation will not work.
    *
    * @example
    * // Anchor a comparison picker to the month before the primary range's start
@@ -82,6 +81,13 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
    * without pre-selecting a date.
    */
   defaultVisibleMonth?: Date;
+  /**
+   * Callback which fires when the rendered month changes, either via calendar
+   * navigation (next/previous month, year, or decade) or when a date in a
+   * different month is selected. Does not fire when the `visibleMonth` prop
+   * is updated externally by the consumer.
+   */
+  onVisibleMonthChange?: (date: Date) => void;
 
   /**
    * Controlled isOpen state

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -60,20 +60,26 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
   onPickerChange?: (picker: PickerType) => void;
 
   /**
-   * Sets the initial month the calendar renders, independent of the selected `value`.
+   * Controlled month that the calendar renders, independent of the selected `value`.
    *
    * Useful when you want the calendar to open on a specific month without pre-selecting
    * a date — e.g. a "comparison" range picker that should default to the period
    * immediately preceding a primary range picker's selection.
    *
    * Falls back to the first date of `value`/`defaultValue` (or today) when not set.
-   * Only sets the initial anchor — subsequent calendar navigation (next/previous
-   * month, year, decade) is uncontrolled from that point on. Use `onChange` to
-   * observe date selection.
+   *
+   * When `visibleMonth` is controlled, keep it in sync via the existing `onChange`
+   * (date selection) and `onNext`/`onPrevious` (calendar navigation) callbacks —
+   * otherwise calendar navigation will not work.
    *
    * @example
    * // Anchor a comparison picker to the month before the primary range's start
-   * <DatePicker selectionType="range" defaultVisibleMonth={dayjs(primaryStart).subtract(1, 'month').toDate()} />
+   * <DatePicker selectionType="range" visibleMonth={dayjs(primaryStart).subtract(1, 'month').toDate()} />
+   */
+  visibleMonth?: Date;
+  /**
+   * Uncontrolled variant of `visibleMonth`. Sets the initial month the calendar renders,
+   * without pre-selecting a date.
    */
   defaultVisibleMonth?: Date;
 

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -60,34 +60,22 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
   onPickerChange?: (picker: PickerType) => void;
 
   /**
-   * Controlled month that the calendar renders, independent of the selected `value`.
+   * Sets the initial month the calendar renders, independent of the selected `value`.
    *
    * Useful when you want the calendar to open on a specific month without pre-selecting
    * a date — e.g. a "comparison" range picker that should default to the period
    * immediately preceding a primary range picker's selection.
    *
    * Falls back to the first date of `value`/`defaultValue` (or today) when not set.
-   *
-   * When `visibleMonth` is controlled, you must handle `onVisibleMonthChange` to keep
-   * the prop in sync — otherwise calendar navigation will not work.
+   * Only sets the initial anchor — subsequent calendar navigation (next/previous
+   * month, year, decade) is uncontrolled from that point on. Use `onChange` to
+   * observe date selection.
    *
    * @example
    * // Anchor a comparison picker to the month before the primary range's start
-   * <DatePicker selectionType="range" visibleMonth={dayjs(primaryStart).subtract(1, 'month').toDate()} />
-   */
-  visibleMonth?: Date;
-  /**
-   * Uncontrolled variant of `visibleMonth`. Sets the initial month the calendar renders,
-   * without pre-selecting a date.
+   * <DatePicker selectionType="range" defaultVisibleMonth={dayjs(primaryStart).subtract(1, 'month').toDate()} />
    */
   defaultVisibleMonth?: Date;
-  /**
-   * Callback which fires when the rendered month changes, either via calendar
-   * navigation (next/previous month, year, or decade) or when a date in a
-   * different month is selected. Does not fire when the `visibleMonth` prop
-   * is updated externally by the consumer.
-   */
-  onVisibleMonthChange?: (date: Date) => void;
 
   /**
    * Controlled isOpen state

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -68,6 +68,9 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
    *
    * Falls back to the first date of `value`/`defaultValue` (or today) when not set.
    *
+   * When `visibleMonth` is controlled, you must handle `onVisibleMonthChange` to keep
+   * the prop in sync — otherwise calendar navigation will not work.
+   *
    * @example
    * // Anchor a comparison picker to the month before the primary range's start
    * <DatePicker selectionType="range" visibleMonth={dayjs(primaryStart).subtract(1, 'month').toDate()} />

--- a/packages/blade/src/components/DatePicker/types.ts
+++ b/packages/blade/src/components/DatePicker/types.ts
@@ -79,8 +79,9 @@ type CalendarProps<SelectionType extends DateSelectionType> = Pick<
    */
   defaultVisibleMonth?: Date;
   /**
-   * Callback which fires when the rendered month changes, whether via the calendar's
-   * next/previous navigation or programmatically through `visibleMonth`.
+   * Callback which fires when the rendered month changes via calendar navigation
+   * (next/previous month, year, or decade). Does not fire when the `visibleMonth`
+   * prop is updated externally by the consumer.
    */
   onVisibleMonthChange?: (date: Date) => void;
 


### PR DESCRIPTION
## Summary
- Adds `visibleMonth` (controlled), `defaultVisibleMonth` (uncontrolled), and `onVisibleMonthChange` to `DatePicker`/`DateRangePicker`, letting the calendar render a specific month without pre-selecting a date.
- Previously the rendered month always fell back to `selectedValue[0]`/`value` (or today) — there was no way to anchor the calendar independently, so a "comparison" range picker could not default to the period before a primary range picker's selection without also filling in a value.
- `currentDate` priority in `Calendar.web.tsx` is now: `visibleMonth`/`defaultVisibleMonth` → existing internal `date`/`defaultDate` → `selectedValue` → today. Navigation (next/prev month/year/decade) keeps both the legacy internal state and the new `visibleMonth` state in sync so behavior is unaffected when the new prop isn't used.
- Fully backwards compatible — no behavior change when the new props are omitted.

## Motivating use case
A "comparison" range picker that should default its visible calendar to the same-length period immediately preceding a primary range picker's selection, while leaving the comparison `value` empty for the user to pick:

```tsx
<DatePicker
  selectionType="range"
  label={{ start: 'Compare to' }}
  defaultVisibleMonth={dayjs(primaryStart)
    .subtract(rangeLengthInDays + 1, 'day')
    .toDate()}
/>
```

See the new **"Comparison Range (visibleMonth)"** story in `DatePicker.stories.tsx` for a live example with a primary + comparison picker pair.

## Test plan
- [x] New unit tests in `__tests__/DatePicker.visibleMonth.web.test.tsx`: `defaultVisibleMonth` anchors the calendar with no `value` set; `visibleMonth` takes priority over the first date of a controlled `value`.
- [x] Full `DatePicker` test suite passes (`yarn test:react` — 10/10 suites green), including existing interaction test stories, unaffected.
- [x] `tsc --noEmit` shows no new type errors introduced (pre-existing unrelated storybook/vite module-resolution errors are unchanged).
- [x] Lint clean on new code (pre-existing `import/extensions` warning on `renderWithTheme.web` import matches existing test file convention, not introduced by this change).
- [ ] Manual Storybook check of the new story (`Components/DatePicker` → "Comparison Range (visibleMonth)") — recommend a maintainer eyeball this visually before merge.

Changeset included (`minor`, new non-breaking prop).