### PR TITLE
feat(ChatInput): add single-line variant

### DIFF
--- a/.changeset/bright-chats-send.md
+++ b/.changeset/bright-chats-send.md
@@ -1,0 +1,8 @@
+---
+'@razorpay/blade': minor
+'@razorpay/blade-mcp': patch
+---
+
+feat(ChatInput): add single-line variant for mobile web
+
+Adds `variant="single-line"` with inline upload and submit actions, mobile send-key semantics, and a 12px Blade corner radius. The existing multiline composer remains the default.

--- a/packages/blade-mcp/knowledgebase/components/ChatInput.md
+++ b/packages/blade-mcp/knowledgebase/components/ChatInput.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-`ChatInput` is an input component designed for AI chat interfaces. It combines a resizable textarea, optional file upload with attachment previews, ghost suggestion autocomplete (cycling suggestions with a crossfade animation), and a submit/stop action button into a single composable input. It supports both controlled and uncontrolled text value usage, validation state with an animated error popup, and a generating state that swaps the submit button for a stop button to cancel in-flight AI responses.
+`ChatInput` is an input component designed for AI chat interfaces. Its default variant combines a resizable textarea with an action bar, while the opt-in `single-line` variant provides a compact composer with inline actions for mobile web. Both variants support optional file upload with attachment previews, ghost suggestion autocomplete, validation, and submit/stop actions.
 
 ## Important Constraints
 
@@ -30,6 +30,12 @@ interface BladeFile extends File {
 type BladeFileList = BladeFile[];
 
 type ChatInputProps = {
+  /**
+   * Controls the input layout.
+   * @default 'default'
+   */
+  variant?: 'default' | 'single-line';
+
   /** Controlled value of the text input */
   value?: string;
 
@@ -40,10 +46,26 @@ type ChatInputProps = {
   onChange?: ({ value }: { value: string }) => void;
 
   /** Callback fired when the text input receives focus */
-  onFocus?: ({ name, value, rawValue }: { name?: string; value?: string; rawValue?: string }) => void;
+  onFocus?: ({
+    name,
+    value,
+    rawValue,
+  }: {
+    name?: string;
+    value?: string;
+    rawValue?: string;
+  }) => void;
 
   /** Callback fired when the text input loses focus */
-  onBlur?: ({ name, value, rawValue }: { name?: string; value?: string; rawValue?: string }) => void;
+  onBlur?: ({
+    name,
+    value,
+    rawValue,
+  }: {
+    name?: string;
+    value?: string;
+    rawValue?: string;
+  }) => void;
 
   /**
    * Callback fired when the user submits the input (via submit button or Enter key).
@@ -137,19 +159,35 @@ type ChatInputProps = {
 **Do**
 
 - Use `ChatInput` for AI chat interfaces and conversational UIs with file upload and ghost suggestions.
+- Use `variant="single-line"` for compact conversational composers, especially on mobile web.
 - Use `isGenerating` to swap the submit button to a stop button during AI response generation.
 - Use `suggestions` with `onSuggestionAccept` to show cycling ghost suggestions that users accept with Tab.
 - Use `fileList` with `onFileChange`/`onFileRemove` for file attachment workflows.
-- Handle Enter for submit and Shift+Enter for newline in the textarea.
+- In the default variant, handle Enter for submit and Shift+Enter for a newline. In the single-line variant, both Enter and Shift+Enter submit.
 
 **Don't**
 
-- Don't use `ChatInput` for simple forms or single-line input — use `TextInput` or `TextArea`.
+- Don't use `ChatInput` for ordinary form fields — use `TextInput` or `TextArea` for non-conversational input.
 - Don't use `suggestions` without `onSuggestionAccept` — they must be used together.
 - Don't expect automatic file uploads — the consumer manages the upload lifecycle and status.
 - Don't forget that the submit button auto-disables when there's no text and no files, or when files are uploading/errored.
 
 ## Examples
+
+### Single-Line Mobile Chat Input
+
+Use the compact variant for a single-line conversational composer with inline upload and submit actions.
+
+```tsx
+import { ChatInput } from '@razorpay/blade/components';
+
+<ChatInput
+  variant="single-line"
+  placeholder="Ask anything..."
+  onSubmit={({ value, fileList }) => sendMessage(value, fileList)}
+  accessibilityLabel="Ask anything"
+/>;
+```
 
 ### Basic Chat Input with File Upload
 

--- a/packages/blade/src/components/ChatInput/ChatInput.web.tsx
+++ b/packages/blade/src/components/ChatInput/ChatInput.web.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
 import type { ChatInputProps } from './types';
 import { chatInputFilePreviewItemWidth } from './chatInputTokens';
-import { ChatInputActionBar } from './ChatInputActionBar';
+import { ChatInputActionBar, ChatInputSubmitAction } from './ChatInputActionBar';
 import { ChatInputGhostSuggestion } from './ChatInputGhostSuggestion';
 import { useChatInput } from './useChatInput';
 import { useTheme } from '~components/BladeProvider';
@@ -13,7 +13,7 @@ import BaseBox from '~components/Box/BaseBox';
 import { getStyledProps } from '~components/Box/styledProps';
 import { IconButton } from '~components/Button/IconButton';
 import { FileUploadItem } from '~components/FileUpload/FileUploadItem';
-import { CloseIcon, InfoIcon } from '~components/Icons';
+import { CloseIcon, InfoIcon, PlusIcon } from '~components/Icons';
 import { BaseInput } from '~components/Input/BaseInput/BaseInput';
 import { Text } from '~components/Typography';
 import { castWebType, makeSpace } from '~utils';
@@ -32,6 +32,7 @@ const HiddenScrollbarBox = styled(BaseBox)(() => ({
 
 const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps> = (
   {
+    variant = 'default',
     value,
     defaultValue,
     onChange,
@@ -62,6 +63,7 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
   ref,
 ) => {
   const { theme } = useTheme();
+  const isSingleLine = variant === 'single-line';
 
   const {
     fileInputRef,
@@ -85,11 +87,11 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
     {
       value,
       defaultValue,
+      variant,
       onChange,
       onSubmit,
       isDisabled,
       isGenerating,
-      onStop,
       fileList,
       onFileChange,
       onFileRemove,
@@ -214,6 +216,27 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
     />
   );
 
+  const singleLineUploadAction = hideFileUpload ? undefined : (
+    <IconButton
+      icon={PlusIcon}
+      size="medium"
+      isHighlighted
+      accessibilityLabel="Upload file"
+      onClick={handleUploadClick}
+      isDisabled={isDisabled}
+    />
+  );
+
+  const singleLineSubmitAction = (
+    <ChatInputSubmitAction
+      isDisabled={isDisabled}
+      isGenerating={isGenerating}
+      isSubmitDisabled={isSubmitDisabled}
+      onSubmit={handleSubmit}
+      onStop={onStop}
+    />
+  );
+
   const isError = validationState === 'error';
 
   return (
@@ -237,8 +260,9 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
       <BaseBox position="relative" zIndex={1} onMouseDownCapture={handleInnerMouseDownCapture}>
         <BaseInput
           ref={combinedRef}
-          as="textarea"
+          as={isSingleLine ? 'input' : 'textarea'}
           id="chat-input"
+          type={isSingleLine ? 'text' : undefined}
           elevation="highRaised"
           label={undefined}
           accessibilityLabel={accessibilityLabel}
@@ -252,20 +276,24 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           isDisabled={isDisabled}
-          numberOfLines={2}
-          size="medium"
-          padding={makeSpace(theme.spacing[5])}
-          borderRadius="large"
+          numberOfLines={isSingleLine ? undefined : 2}
+          size={isSingleLine ? 'large' : 'medium'}
+          padding={isSingleLine ? undefined : makeSpace(theme.spacing[5])}
+          borderRadius={isSingleLine ? 'medium' : 'large'}
           caretColor="surface.icon.onSea.onSubtle"
+          keyboardType={isSingleLine ? 'text' : undefined}
+          keyboardReturnKeyType={isSingleLine ? 'send' : undefined}
           topContent={filePreviewContent}
-          bottomContent={actionBarContent}
+          bottomContent={isSingleLine ? undefined : actionBarContent}
+          leadingInteractionElement={isSingleLine ? singleLineUploadAction : undefined}
+          trailingInteractionElement={isSingleLine ? singleLineSubmitAction : undefined}
           inputRowOverlay={
             showGhostSuggestion && suggestions ? (
               <BaseBox
                 position="absolute"
-                top="spacing.5"
-                left="spacing.5"
-                right="spacing.5"
+                top={isSingleLine ? 'spacing.4' : 'spacing.5'}
+                left={isSingleLine ? (hideFileUpload ? 'spacing.4' : 'spacing.11') : 'spacing.5'}
+                right={isSingleLine ? 'spacing.10' : 'spacing.5'}
                 pointerEvents="none"
                 zIndex={3}
               >
@@ -324,6 +352,27 @@ const _ChatInput: React.ForwardRefRenderFunction<BladeElementRef, ChatInputProps
   );
 };
 
+/**
+ * ChatInput
+ *
+ * A prompt composer for conversational interfaces with multiline and compact single-line layouts,
+ * file attachments, suggestions, validation, and submit or stop actions.
+ *
+ * ----
+ *
+ * #### Usage
+ *
+ * ```tsx
+ * <ChatInput
+ *   variant="single-line"
+ *   placeholder="Ask anything..."
+ *   onSubmit={({ value, fileList }) => sendMessage({ value, fileList })}
+ * />
+ * ```
+ *
+ * ----
+ * Checkout {@link https://blade.razorpay.com/?path=/docs/components-chatinput--docs ChatInput Documentation}
+ */
 const ChatInput = assignWithoutSideEffects(React.forwardRef(_ChatInput), {
   componentId: MetaConstants.ChatInput,
   displayName: 'ChatInput',

--- a/packages/blade/src/components/ChatInput/ChatInputActionBar.tsx
+++ b/packages/blade/src/components/ChatInput/ChatInputActionBar.tsx
@@ -14,6 +14,44 @@ type ChatInputActionBarProps = {
   onStop?: () => void;
 };
 
+type ChatInputSubmitActionProps = Pick<
+  ChatInputActionBarProps,
+  'isDisabled' | 'isGenerating' | 'isSubmitDisabled' | 'onSubmit' | 'onStop'
+>;
+
+const ChatInputSubmitAction = ({
+  isDisabled,
+  isGenerating,
+  isSubmitDisabled,
+  onSubmit,
+  onStop,
+}: ChatInputSubmitActionProps): React.ReactElement => {
+  if (isGenerating) {
+    return (
+      <Button
+        icon={StopCircleIcon}
+        variant="secondary"
+        accessibilityLabel="Stop generation"
+        onClick={() => onStop?.()}
+        size="small"
+      />
+    );
+  }
+
+  return (
+    <Button
+      icon={ArrowUpIcon}
+      variant="primary"
+      color="primary"
+      accessibilityLabel="Submit"
+      onClick={onSubmit}
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      isDisabled={isSubmitDisabled || isDisabled}
+      size="small"
+    />
+  );
+};
+
 const ChatInputActionBar = ({
   isDisabled,
   isGenerating,
@@ -46,30 +84,17 @@ const ChatInputActionBar = ({
         </Link>
       )}
       <BaseBox>
-        {isGenerating ? (
-          <Button
-            icon={StopCircleIcon}
-            variant="secondary"
-            accessibilityLabel="Stop generation"
-            onClick={() => onStop?.()}
-            size="small"
-          />
-        ) : (
-          <Button
-            icon={ArrowUpIcon}
-            variant="primary"
-            color="primary"
-            accessibilityLabel="Submit"
-            onClick={onSubmit}
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            isDisabled={isSubmitDisabled || isDisabled}
-            size="small"
-          />
-        )}
+        <ChatInputSubmitAction
+          isDisabled={isDisabled}
+          isGenerating={isGenerating}
+          isSubmitDisabled={isSubmitDisabled}
+          onSubmit={onSubmit}
+          onStop={onStop}
+        />
       </BaseBox>
     </BaseBox>
   );
 };
 
-export { ChatInputActionBar };
-export type { ChatInputActionBarProps };
+export { ChatInputActionBar, ChatInputSubmitAction };
+export type { ChatInputActionBarProps, ChatInputSubmitActionProps };

--- a/packages/blade/src/components/ChatInput/__tests__/ChatInput.ssr.test.tsx
+++ b/packages/blade/src/components/ChatInput/__tests__/ChatInput.ssr.test.tsx
@@ -2,9 +2,16 @@ import { ChatInput } from '../index';
 import renderWithSSR from '~utils/testing/renderWithSSR.web';
 
 describe('<ChatInput />', () => {
-  it('should render ChatInput', () => {
+  it('should render the default and single-line variants', () => {
     const { container } = renderWithSSR(
-      <ChatInput placeholder="Ask a question..." accessibilityLabel="Chat input" />,
+      <>
+        <ChatInput placeholder="Ask a question..." accessibilityLabel="Chat input" />
+        <ChatInput
+          variant="single-line"
+          placeholder="Ask anything..."
+          accessibilityLabel="Single-line chat input"
+        />
+      </>,
     );
     expect(container).toMatchSnapshot();
   });

--- a/packages/blade/src/components/ChatInput/__tests__/ChatInput.test.stories.tsx
+++ b/packages/blade/src/components/ChatInput/__tests__/ChatInput.test.stories.tsx
@@ -1,0 +1,44 @@
+import type { StoryFn } from '@storybook/react-vite';
+import { within, userEvent, expect, fn } from 'storybook/test';
+import { ChatInput } from '../ChatInput';
+import { Box } from '~components/Box';
+
+const onSubmit = fn();
+
+export const SingleLineInteraction: StoryFn<typeof ChatInput> = (): React.ReactElement => {
+  return (
+    <Box maxWidth="375px">
+      <ChatInput variant="single-line" placeholder="Ask anything..." onSubmit={onSubmit} />
+    </Box>
+  );
+};
+
+SingleLineInteraction.play = async ({ canvasElement }) => {
+  onSubmit.mockClear();
+  const canvas = within(canvasElement);
+  const input = canvas.getByRole('textbox', { name: 'Chat input' });
+  const submitButton = canvas.getByRole('button', { name: 'Submit' });
+
+  await expect(input).toHaveAttribute('enterkeyhint', 'send');
+  await expect(submitButton).toBeDisabled();
+
+  await userEvent.type(input, 'Show recent settlements');
+  await expect(submitButton).toBeEnabled();
+  await userEvent.keyboard('{Enter}');
+
+  await expect(onSubmit).toHaveBeenCalledWith({
+    value: 'Show recent settlements',
+    fileList: [],
+  });
+};
+
+export default {
+  title: 'Components/Interaction Tests/ChatInput',
+  component: ChatInput,
+  parameters: {
+    controls: { disable: true },
+    a11y: { disable: true },
+    essentials: { disable: true },
+    actions: { disable: false },
+  },
+};

--- a/packages/blade/src/components/ChatInput/__tests__/ChatInput.web.test.tsx
+++ b/packages/blade/src/components/ChatInput/__tests__/ChatInput.web.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
 import { ChatInput } from '../index';
 import renderWithTheme from '~utils/testing/renderWithTheme.web';
@@ -12,6 +13,37 @@ describe('<ChatInput />', () => {
       <ChatInput placeholder="Ask a question..." accessibilityLabel={accessibilityLabel} />,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('should render an accessible single-line input with mobile keyboard semantics', async () => {
+    const { container, getByRole } = renderWithTheme(
+      <ChatInput
+        variant="single-line"
+        placeholder="Ask anything..."
+        accessibilityLabel={accessibilityLabel}
+      />,
+    );
+
+    const input = getByRole('textbox', { name: accessibilityLabel });
+    expect(input.tagName).toBe('INPUT');
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('inputmode', 'text');
+    expect(input).toHaveAttribute('enterkeyhint', 'send');
+    expect(getByRole('button', { name: 'Upload file' })).toBeEnabled();
+    expect(getByRole('button', { name: 'Submit' })).toBeDisabled();
+    await assertAccessible(container);
+  });
+
+  it('should focus the single-line text input when clicked', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = renderWithTheme(
+      <ChatInput variant="single-line" accessibilityLabel={accessibilityLabel} />,
+    );
+
+    const input = getByRole('textbox', { name: accessibilityLabel });
+    await user.click(input);
+
+    expect(input).toHaveFocus();
   });
 
   it('should call onSubmit with value when submit button is clicked', async () => {
@@ -45,6 +77,63 @@ describe('<ChatInput />', () => {
 
     await user.type(textarea, '{enter}');
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should submit the single-line input when Shift+Enter is pressed', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    const { getByRole } = renderWithTheme(
+      <ChatInput
+        variant="single-line"
+        accessibilityLabel={accessibilityLabel}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const input = getByRole('textbox', { name: accessibilityLabel });
+    await user.type(input, 'Hello{shift>}{enter}{/shift}');
+
+    expect(onSubmit).toHaveBeenCalledWith({ value: 'Hello', fileList: [] });
+  });
+
+  it('should not submit while composing text in the single-line input', () => {
+    const onSubmit = jest.fn();
+    const { getByRole } = renderWithTheme(
+      <ChatInput
+        variant="single-line"
+        defaultValue="Hello"
+        accessibilityLabel={accessibilityLabel}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.keyDown(getByRole('textbox', { name: accessibilityLabel }), {
+      key: 'Enter',
+      code: 'Enter',
+      isComposing: true,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should not submit via keyboard while generating', () => {
+    const onSubmit = jest.fn();
+    const { getByRole } = renderWithTheme(
+      <ChatInput
+        variant="single-line"
+        defaultValue="Hello"
+        accessibilityLabel={accessibilityLabel}
+        isGenerating
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.keyDown(getByRole('textbox', { name: accessibilityLabel }), {
+      key: 'Enter',
+      code: 'Enter',
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it('should keep submit button disabled when input is empty', () => {

--- a/packages/blade/src/components/ChatInput/__tests__/__snapshots__/ChatInput.ssr.test.tsx.snap
+++ b/packages/blade/src/components/ChatInput/__tests__/__snapshots__/ChatInput.ssr.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ChatInput /> should render ChatInput 1`] = `"<div id="root"><div data-blade-component="chat-input" class="BaseBox-bksIuc emXDue"><input type="file" multiple="" style="display:none" aria-hidden="true"/><div data-blade-component="base-box" class="BaseBox-bksIuc dhbiRH"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc lhbwwB"><div class="BaseBox-bksIuc BaseInput__FocusRingWrapper-sc-177qd3e-0 kQXlnf dJZnYg focus-ring-wrapper" elevation="highRaised" data-blade-component="base-box"><div class="BaseBox-bksIuc AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1 ikooGF kzXtQx __blade-base-input-wrapper" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bksIuc lbOIzR"><div data-blade-component="base-box" class="BaseBox-bksIuc eCIwtI"><textarea type="text" rows="2" id="chat-input-undefined-input-undefined" placeholder="Ask a question..." data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-label="Chat input" class="StyledBaseInputweb__StyledBaseNativeInput-hsusrk-0 ideLwR"></textarea></div><div data-blade-component="base-box" class="BaseBox-bksIuc jjHIMt"><button data-blade-component="link" type="button" class="StyledBaseLinkweb__StyledLink-sc-1yj1z8h-0 fbBTol" role="button" aria-disabled="false"><span class="BaseBox-bksIuc hbpipW content-container" data-blade-component="base-box"><span data-blade-component="base-box" class="BaseBox-bksIuc dmzGFD"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z" fill="hsla(0, 0%, 2%, 1)" data-blade-component="svg-path"></path></svg></span><span class="StyledBaseText-foUshD cglRbf" data-blade-component="base-text">Upload file</span></span></button><div data-blade-component="base-box" class="BaseBox-bksIuc"><button disabled="" type="button" data-blade-component="button" aria-label="Submit" role="button" class="StyledBaseButtonweb__StyledBaseButton-sc-26bt38-0 gxCno"><div data-blade-component="base-box" class="BaseBox-bksIuc AnimatedButtonContentweb__AnimatedButtonContent-sc-1fkx0t6-0  gYMLpr"><div data-blade-component="base-box" class="BaseBox-bksIuc BaseButton__ButtonContent-zf1huq-0 jbTreI cdAugm"><div data-blade-component="base-box" class="BaseBox-bksIuc juovFm"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12.7071 3.29289C12.3166 2.90237 11.6834 2.90237 11.2929 3.29289L5.29289 9.29289C4.90237 9.68342 4.90237 10.3166 5.29289 10.7071C5.68342 11.0976 6.31658 11.0976 6.70711 10.7071L11 6.41421V20C11 20.5523 11.4477 21 12 21C12.5523 21 13 20.5523 13 20V6.41421L17.2929 10.7071C17.6834 11.0976 18.3166 11.0976 18.7071 10.7071C19.0976 10.3166 19.0976 9.68342 18.7071 9.29289L12.7071 3.29289Z" fill="hsla(218, 89%, 51%, 0.32)" data-blade-component="svg-path"></path></svg></div></div></div></button></div></div></div></div></div></div></div></div><div data-blade-component="base-box" class="BaseBox-bksIuc brrdDG"><div role="alert" style="opacity:0" class="BaseBox-bksIuc gSAviZ BaseMotion__StyledDiv-sc-6hsu2h-0 jyqrAp" data-blade-component="base-box"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z" fill="hsla(4, 85%, 44%, 1)" data-blade-component="svg-path"></path><path d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z" fill="hsla(4, 85%, 44%, 1)" data-blade-component="svg-path"></path><path d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z" clip-rule="evenodd" fill="hsla(4, 85%, 44%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><p letter-spacing="50" class="StyledBaseText-foUshD jFszoz" data-blade-component="text"></p></div></div></div></div>"`;
+exports[`<ChatInput /> should render the default and single-line variants 1`] = `"<div id="root"><div data-blade-component="chat-input" class="BaseBox-bksIuc emXDue"><input type="file" multiple="" style="display:none" aria-hidden="true"/><div data-blade-component="base-box" class="BaseBox-bksIuc dhbiRH"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc lhbwwB"><div class="BaseBox-bksIuc BaseInput__FocusRingWrapper-sc-177qd3e-0 kQXlnf dJZnYg focus-ring-wrapper" elevation="highRaised" data-blade-component="base-box"><div class="BaseBox-bksIuc AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1 ikooGF kzXtQx __blade-base-input-wrapper" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bksIuc lbOIzR"><div data-blade-component="base-box" class="BaseBox-bksIuc eCIwtI"><textarea type="text" rows="2" id="chat-input-undefined-input-undefined" placeholder="Ask a question..." data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-label="Chat input" class="StyledBaseInputweb__StyledBaseNativeInput-hsusrk-0 ideLwR"></textarea></div><div data-blade-component="base-box" class="BaseBox-bksIuc jjHIMt"><button data-blade-component="link" type="button" class="StyledBaseLinkweb__StyledLink-sc-1yj1z8h-0 fbBTol" role="button" aria-disabled="false"><span class="BaseBox-bksIuc hbpipW content-container" data-blade-component="base-box"><span data-blade-component="base-box" class="BaseBox-bksIuc dmzGFD"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z" fill="hsla(0, 0%, 2%, 1)" data-blade-component="svg-path"></path></svg></span><span class="StyledBaseText-foUshD cglRbf" data-blade-component="base-text">Upload file</span></span></button><div data-blade-component="base-box" class="BaseBox-bksIuc"><button disabled="" type="button" data-blade-component="button" aria-label="Submit" role="button" class="StyledBaseButtonweb__StyledBaseButton-sc-26bt38-0 gxCno"><div data-blade-component="base-box" class="BaseBox-bksIuc AnimatedButtonContentweb__AnimatedButtonContent-sc-1fkx0t6-0  gYMLpr"><div data-blade-component="base-box" class="BaseBox-bksIuc BaseButton__ButtonContent-zf1huq-0 jbTreI cdAugm"><div data-blade-component="base-box" class="BaseBox-bksIuc juovFm"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12.7071 3.29289C12.3166 2.90237 11.6834 2.90237 11.2929 3.29289L5.29289 9.29289C4.90237 9.68342 4.90237 10.3166 5.29289 10.7071C5.68342 11.0976 6.31658 11.0976 6.70711 10.7071L11 6.41421V20C11 20.5523 11.4477 21 12 21C12.5523 21 13 20.5523 13 20V6.41421L17.2929 10.7071C17.6834 11.0976 18.3166 11.0976 18.7071 10.7071C19.0976 10.3166 19.0976 9.68342 18.7071 9.29289L12.7071 3.29289Z" fill="hsla(218, 89%, 51%, 0.32)" data-blade-component="svg-path"></path></svg></div></div></div></button></div></div></div></div></div></div></div></div><div data-blade-component="base-box" class="BaseBox-bksIuc brrdDG"><div role="alert" style="opacity:0" class="BaseBox-bksIuc gSAviZ BaseMotion__StyledDiv-sc-6hsu2h-0 jyqrAp" data-blade-component="base-box"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z" fill="hsla(4, 85%, 44%, 1)" data-blade-component="svg-path"></path><path d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z" fill="hsla(4, 85%, 44%, 1)" data-blade-component="svg-path"></path><path d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z" clip-rule="evenodd" fill="hsla(4, 85%, 44%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><p letter-spacing="50" class="StyledBaseText-foUshD jFszoz" data-blade-component="text"></p></div></div></div><div data-blade-component="chat-input" class="BaseBox-bksIuc emXDue"><input type="file" multiple="" style="display:none" aria-hidden="true"/><div data-blade-component="base-box" class="BaseBox-bksIuc dhbiRH"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc lhbwwB"><div class="BaseBox-bksIuc BaseInput__FocusRingWrapper-sc-177qd3e-0 kQXlnf jyVaUI focus-ring-wrapper" elevation="highRaised" data-blade-component="base-box"><div class="BaseBox-bksIuc AnimatedBaseInputWrapperweb__StyledBaseInputWrapper-e1vobd-0 AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1 cJOsel ckjWrM __blade-base-input-wrapper" data-blade-component="base-box"><div data-blade-component="base-box" class="BaseBox-bksIuc lbOIzR"><div data-blade-component="base-box" class="BaseBox-bksIuc fhuLzR"><div data-blade-component="base-box" class="BaseBox-bksIuc kXHuQ"><div data-blade-component="base-box" class="BaseBox-bksIuc iGKBAO"><button type="button" aria-label="Upload file" data-blade-component="icon-button" class="StyledIconButtonweb__StyledButton-sc-1f4cg7d-0 foTeqs"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z" fill="currentColor" data-blade-component="svg-path"></path></svg></button></div></div><input type="text" inputMode="text" enterKeyHint="send" id="chat-input-undefined-input-undefined" placeholder="Ask anything..." data-blade-component="styled-base-input" aria-required="false" aria-disabled="false" aria-invalid="false" aria-describedby="" aria-label="Single-line chat input" class="StyledBaseInputweb__StyledBaseNativeInput-hsusrk-0 fDaoqp" value=""/><div data-blade-component="base-box" class="BaseBox-bksIuc kXHuQ"><div data-blade-component="base-box" class="BaseBox-bksIuc kXHuQ"><div data-blade-component="base-box" class="BaseBox-bksIuc NDTfu"><button disabled="" type="button" data-blade-component="button" aria-label="Submit" role="button" class="StyledBaseButtonweb__StyledBaseButton-sc-26bt38-0 gxCno"><div data-blade-component="base-box" class="BaseBox-bksIuc AnimatedButtonContentweb__AnimatedButtonContent-sc-1fkx0t6-0  gYMLpr"><div data-blade-component="base-box" class="BaseBox-bksIuc BaseButton__ButtonContent-zf1huq-0 jbTreI cdAugm"><div data-blade-component="base-box" class="BaseBox-bksIuc juovFm"><svg aria-hidden="true" data-blade-component="icon" height="16px" viewBox="0 0 24 24" width="16px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12.7071 3.29289C12.3166 2.90237 11.6834 2.90237 11.2929 3.29289L5.29289 9.29289C4.90237 9.68342 4.90237 10.3166 5.29289 10.7071C5.68342 11.0976 6.31658 11.0976 6.70711 10.7071L11 6.41421V20C11 20.5523 11.4477 21 12 21C12.5523 21 13 20.5523 13 20V6.41421L17.2929 10.7071C17.6834 11.0976 18.3166 11.0976 18.7071 10.7071C19.0976 10.3166 19.0976 9.68342 18.7071 9.29289L12.7071 3.29289Z" fill="hsla(218, 89%, 51%, 0.32)" data-blade-component="svg-path"></path></svg></div></div></div></button></div></div></div></div></div></div></div></div></div></div><div data-blade-component="base-box" class="BaseBox-bksIuc brrdDG"><div role="alert" style="opacity:0" class="BaseBox-bksIuc gSAviZ BaseMotion__StyledDiv-sc-6hsu2h-0 jyqrAp" data-blade-component="base-box"><svg aria-hidden="true" data-blade-component="icon" height="12px" viewBox="0 0 24 24" width="12px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z" fill="hsla(4, 85%, 44%, 1)" data-blade-component="svg-path"></path><path d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z" fill="hsla(4, 85%, 44%, 1)" data-blade-component="svg-path"></path><path d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z" clip-rule="evenodd" fill="hsla(4, 85%, 44%, 1)" fill-rule="evenodd" data-blade-component="svg-path"></path></svg><p letter-spacing="50" class="StyledBaseText-foUshD jFszoz" data-blade-component="text"></p></div></div></div></div>"`;
 
-exports[`<ChatInput /> should render ChatInput 2`] = `
+exports[`<ChatInput /> should render the default and single-line variants 2`] = `
 .c0.c0.c0.c0.c0 {
   position: relative;
 }
@@ -168,6 +168,74 @@ exports[`<ChatInput /> should render ChatInput 2`] = `
   background-color: hsla(4,85%,44%,0.09);
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
+}
+
+.c25.c25.c25.c25.c25 {
+  border-radius: 12px;
+}
+
+.c27.c27.c27.c27.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+}
+
+.c28.c28.c28.c28.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c29.c29.c29.c29.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 4px;
+}
+
+.c32.c32.c32.c32.c32 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  padding-right: 12px;
 }
 
 .c15.c15.c15.c15.c15 {
@@ -349,6 +417,58 @@ exports[`<ChatInput /> should render ChatInput 2`] = `
   border-top-right-radius: 12px;
 }
 
+.c30.c30.c30.c30.c30 {
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  height: 32px;
+  width: 32px;
+  border-radius: 8px;
+  background: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  color: hsla(204,9%,42%,1);
+  -webkit-transition-property: color,box-shadow;
+  transition-property: color,box-shadow;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c30.c30.c30.c30.c30:hover:not([disabled]) {
+  color: hsla(200,10%,18%,1);
+  background-color: hsla(206,10%,29%,0.09);
+}
+
+.c30.c30.c30.c30.c30:focus-visible {
+  outline: 4px solid hsla(218,89%,51%,0.18);
+  outline-offset: 1px;
+  -webkit-transition-property: outline-width;
+  transition-property: outline-width;
+  -webkit-transition-duration: 80ms;
+  transition-duration: 80ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  z-index: 2;
+  color: hsla(200,10%,18%,1);
+  background-color: hsla(206,10%,29%,0.09);
+}
+
+.c30.c30.c30.c30.c30:active {
+  color: hsla(200,10%,18%,1);
+}
+
 .c9.c9.c9.c9.c9 {
   color: hsla(0,0%,2%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
@@ -453,6 +573,112 @@ exports[`<ChatInput /> should render ChatInput 2`] = `
   outline: none;
 }
 
+.c31.c31.c31.c31.c31 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.528px;
+  -moz-letter-spacing: -0.528px;
+  -ms-letter-spacing: -0.528px;
+  letter-spacing: -0.528px;
+  margin: 0;
+  padding: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  background-color: hsla(0,0%,100%,0);
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 12px;
+  padding-right: 8px;
+  width: 100%;
+  height: 48px;
+  min-height: 48px;
+  resize: none;
+  box-sizing: border-box;
+  outline: none;
+  border: none;
+  caret-color: hsla(155,100%,31%,1);
+  cursor: auto;
+}
+
+.c31.c31.c31.c31.c31::-webkit-input-placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.528px;
+  -moz-letter-spacing: -0.528px;
+  -ms-letter-spacing: -0.528px;
+  letter-spacing: -0.528px;
+  margin: 0;
+  padding: 0;
+}
+
+.c31.c31.c31.c31.c31::-moz-placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.528px;
+  -moz-letter-spacing: -0.528px;
+  -ms-letter-spacing: -0.528px;
+  letter-spacing: -0.528px;
+  margin: 0;
+  padding: 0;
+}
+
+.c31.c31.c31.c31.c31:-ms-input-placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.528px;
+  -moz-letter-spacing: -0.528px;
+  -ms-letter-spacing: -0.528px;
+  letter-spacing: -0.528px;
+  margin: 0;
+  padding: 0;
+}
+
+.c31.c31.c31.c31.c31::placeholder {
+  color: hsla(206,10%,29%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: -0.528px;
+  -moz-letter-spacing: -0.528px;
+  -ms-letter-spacing: -0.528px;
+  letter-spacing: -0.528px;
+  margin: 0;
+  padding: 0;
+}
+
+.c31.c31.c31.c31.c31:focus {
+  outline: none;
+}
+
 .c6.c6.c6.c6.c6 {
   background-color: hsla(0,0%,100%,1);
   border-radius: 16px;
@@ -542,12 +768,118 @@ exports[`<ChatInput /> should render ChatInput 2`] = `
   transition-easing: cubic-bezier(0.5,0,0,1);
 }
 
+.c26.c26.c26.c26.c26 {
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 12px;
+  overflow: hidden;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  border-width: 0px;
+  box-shadow: hsla(204,8%,88%,1) 0px 0px 0px 1px;
+  -webkit-transition-property: box-shadow,background-color;
+  transition-property: box-shadow,background-color;
+  -webkit-transition-duration: 640ms;
+  transition-duration: 640ms;
+  -webkit-transition-easing: cubic-bezier(0.5,0,0,1);
+  transition-easing: cubic-bezier(0.5,0,0,1);
+}
+
+.c26.c26.c26.c26.c26:hover {
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 12px;
+  overflow: hidden;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  border-width: 0px;
+  box-shadow: hsla(205,8%,71%,1) 0px 0px 0px 1px;
+  -webkit-transition-property: background-color;
+  transition-property: background-color;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-easing: cubic-bezier(0.5,0,0,1);
+  transition-easing: cubic-bezier(0.5,0,0,1);
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c26.c26.c26.c26.c26:focus-within {
+  background-color: hsla(0,0%,100%,1);
+  border-radius: 12px;
+  overflow: hidden;
+  border-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  border-width: 0px;
+  box-shadow: hsla(204,8%,88%,1) 0px 0px 0px 1px;
+  -webkit-transition-property: box-shadow,background-color;
+  transition-property: box-shadow,background-color;
+  -webkit-transition-duration: 640ms;
+  transition-duration: 640ms;
+  -webkit-transition-easing: cubic-bezier(0.5,0,0,1);
+  transition-easing: cubic-bezier(0.5,0,0,1);
+}
+
 .c4.c4.c4.c4.c4 {
   border-radius: 16px;
   width: 100%;
 }
 
 .c4.c4.c4.c4.c4:focus-within {
+  outline: 4px solid hsla(218,89%,51%,0.18);
+  outline-offset: 1px;
+  -webkit-transition-property: outline-width;
+  transition-property: outline-width;
+  -webkit-transition-duration: 640ms;
+  transition-duration: 640ms;
+  -webkit-transition-timing-function: cubic-bezier(0.5,0,0,1);
+  transition-timing-function: cubic-bezier(0.5,0,0,1);
+  z-index: 2;
+}
+
+.c24.c24.c24.c24.c24 {
+  border-radius: 12px;
+  width: 100%;
+}
+
+.c24.c24.c24.c24.c24:focus-within {
   outline: 4px solid hsla(218,89%,51%,0.18);
   outline-offset: 1px;
   -webkit-transition-property: outline-width;
@@ -702,6 +1034,198 @@ exports[`<ChatInput /> should render ChatInput 2`] = `
                         </div>
                       </div>
                     </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c20"
+      data-blade-component="base-box"
+    >
+      <div
+        class="c21 c22"
+        data-blade-component="base-box"
+        role="alert"
+        style="opacity:0"
+      >
+        <svg
+          aria-hidden="true"
+          class="Svgweb__StyledSvg-vcmjs8-0"
+          data-blade-component="icon"
+          fill="none"
+          height="12px"
+          viewBox="0 0 24 24"
+          width="12px"
+        >
+          <path
+            d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
+            data-blade-component="svg-path"
+            fill="hsla(4, 85%, 44%, 1)"
+          />
+          <path
+            d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z"
+            data-blade-component="svg-path"
+            fill="hsla(4, 85%, 44%, 1)"
+          />
+          <path
+            clip-rule="evenodd"
+            d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z"
+            data-blade-component="svg-path"
+            fill="hsla(4, 85%, 44%, 1)"
+            fill-rule="evenodd"
+          />
+        </svg>
+        <p
+          class="c23"
+          data-blade-component="text"
+          letter-spacing="50"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="c0"
+    data-blade-component="chat-input"
+  >
+    <input
+      aria-hidden="true"
+      multiple=""
+      style="display:none"
+      type="file"
+    />
+    <div
+      class="c1"
+      data-blade-component="base-box"
+    >
+      <div
+        class=""
+        data-blade-component="base-box"
+      >
+        <div
+          class="c2"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c3 c24 focus-ring-wrapper"
+            data-blade-component="base-box"
+            elevation="highRaised"
+          >
+            <div
+              class="AnimatedBaseInputWrapperweb__StyledAnimatedBaseInputWrapper-e1vobd-1 c25 c26 __blade-base-input-wrapper"
+              data-blade-component="base-box"
+            >
+              <div
+                class="c7"
+                data-blade-component="base-box"
+              >
+                <div
+                  class="c27"
+                  data-blade-component="base-box"
+                >
+                  <div
+                    class="c28"
+                    data-blade-component="base-box"
+                  >
+                    <div
+                      class="c29"
+                      data-blade-component="base-box"
+                    >
+                      <button
+                        aria-label="Upload file"
+                        class="c30"
+                        data-blade-component="icon-button"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="Svgweb__StyledSvg-vcmjs8-0"
+                          data-blade-component="icon"
+                          fill="none"
+                          height="16px"
+                          viewBox="0 0 24 24"
+                          width="16px"
+                        >
+                          <path
+                            d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                            data-blade-component="svg-path"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <input
+                    aria-describedby=""
+                    aria-disabled="false"
+                    aria-invalid="false"
+                    aria-label="Single-line chat input"
+                    aria-required="false"
+                    class="c31"
+                    data-blade-component="styled-base-input"
+                    enterkeyhint="send"
+                    id="chat-input-7-input-8"
+                    inputmode="text"
+                    placeholder="Ask anything..."
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="c28"
+                    data-blade-component="base-box"
+                  >
+                    <div
+                      class="c28"
+                      data-blade-component="base-box"
+                    >
+                      <div
+                        class="c32"
+                        data-blade-component="base-box"
+                      >
+                        <button
+                          aria-label="Submit"
+                          class="c15"
+                          data-blade-component="button"
+                          disabled=""
+                          role="button"
+                          type="button"
+                        >
+                          <div
+                            class=" c16"
+                            data-blade-component="base-box"
+                          >
+                            <div
+                              class="c17 c18"
+                              data-blade-component="base-box"
+                            >
+                              <div
+                                class="c19"
+                                data-blade-component="base-box"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="Svgweb__StyledSvg-vcmjs8-0"
+                                  data-blade-component="icon"
+                                  fill="none"
+                                  height="16px"
+                                  viewBox="0 0 24 24"
+                                  width="16px"
+                                >
+                                  <path
+                                    d="M12.7071 3.29289C12.3166 2.90237 11.6834 2.90237 11.2929 3.29289L5.29289 9.29289C4.90237 9.68342 4.90237 10.3166 5.29289 10.7071C5.68342 11.0976 6.31658 11.0976 6.70711 10.7071L11 6.41421V20C11 20.5523 11.4477 21 12 21C12.5523 21 13 20.5523 13 20V6.41421L17.2929 10.7071C17.6834 11.0976 18.3166 11.0976 18.7071 10.7071C19.0976 10.3166 19.0976 9.68342 18.7071 9.29289L12.7071 3.29289Z"
+                                    data-blade-component="svg-path"
+                                    fill="hsla(218, 89%, 51%, 0.32)"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/blade/src/components/ChatInput/_decisions/decisions.md
+++ b/packages/blade/src/components/ChatInput/_decisions/decisions.md
@@ -1,12 +1,13 @@
 # ChatInput
 
-ChatInput is an input component designed for AI chat interfaces. It combines a textarea, file upload, ghost suggestion autocomplete, and a submit action into a single composable input. Think of it as a "prompt input" -- the primary way users compose and send messages in conversational AI experiences.
+ChatInput is an input component designed for AI chat interfaces. It supports a default multiline composer and an opt-in compact single-line layout, with file upload, ghost suggestion autocomplete, and submit or stop actions. Think of it as a "prompt input" -- the primary way users compose and send messages in conversational AI experiences.
 
 <img src="./chatinput-thumbnail.png" width="500px" alt="ChatInput component variants" />
 
 ## Design
 
 - [Figma - ChatInput](https://www.figma.com/design/QjSexUED296OBCwWwhYKQE/agenticSpark?node-id=116756-67218&m=dev)
+- [Figma - ChatInput single-line mobile](https://www.figma.com/design/Gz2FzF8jfdSMH9bUYE7XT2/Untitled.?node-id=1097-62426&t=CwU85PFlLTAhX4xD-11)
 
 ## API
 
@@ -116,6 +117,12 @@ type ChatInputFilePreviewProps = {
 
 ```typescript
 type ChatInputProps = {
+  /**
+   * Controls the input layout.
+   * @default 'default'
+   */
+  variant?: 'default' | 'single-line';
+
   /**
    * Controlled value of the text input
    */
@@ -238,6 +245,20 @@ type ChatInputProps = {
 ```
 
 > **Note:** `BladeFile` and `BladeFileList` are reused from the existing [FileUpload component](../../FileUpload/types.ts). `BladeFile` extends the native `File` interface with `id`, `status`, `uploadPercent`, and `errorText` fields.
+
+### Layout Variants
+
+- `default` preserves the existing multiline textarea and bottom action bar.
+- `single-line` is an explicit opt-in layout with inline upload and submit or stop actions. Attachments continue to render above the input row.
+- The compact layout uses Blade's `large` input sizing and `medium` border-radius token (12px).
+
+```jsx
+<ChatInput
+  variant="single-line"
+  placeholder="Ask anything..."
+  onSubmit={({ value, fileList }) => handleSend(value, fileList)}
+/>
+```
 
 ## Examples
 
@@ -439,6 +460,7 @@ Whenever files are added (or the list changes), the file preview row automatical
 ### Implicit Disable on Error or Uploading Files
 
 The submit button (and Enter key) is blocked whenever:
+
 - There is no text **and** no files, **or**
 - Any attached file has `status === 'error'`, **or**
 - Any attached file has `status === 'uploading'`
@@ -452,13 +474,15 @@ When submit is disabled because of an error or uploading file, no additional too
 ## Accessibility
 
 - **Keyboard Navigation:**
-  - `Enter` submits the message (fires `onSubmit`)
-  - `Shift + Enter` inserts a new line in the textarea
+  - In the default variant, `Enter` submits and `Shift + Enter` inserts a new line.
+  - In the single-line variant, both `Enter` and `Shift + Enter` submit.
+  - IME composition and the generating state suppress keyboard submission.
   - `TAB` accepts the ghost suggestion when `suggestions` is present
   - `Escape` clears the current ghost suggestion
   - Upload button and submit button are focusable and activatable via `Space`/`Enter`
 - **ARIA Attributes:**
-  - The textarea uses `role="textbox"` with `aria-multiline="true"`
+  - The default native textarea exposes multiline textbox semantics.
+  - The single-line variant uses a text input with `enterkeyhint="send"`.
   - The submit button uses `aria-label="Submit"` (or equivalent)
   - The upload button uses `aria-label="Upload file"`
   - File preview cards include `aria-label` with the file name and a remove button with `aria-label="Remove {filename}"`

--- a/packages/blade/src/components/ChatInput/docs/ChatInput.stories.tsx
+++ b/packages/blade/src/components/ChatInput/docs/ChatInput.stories.tsx
@@ -19,7 +19,7 @@ const Page = (): React.ReactElement => {
   return (
     <StoryPageWrapper
       componentName="ChatInput"
-      componentDescription="ChatInput is an input component designed for AI chat interfaces. It combines a textarea, file upload, ghost suggestion autocomplete, and a submit action into a single composable input."
+      componentDescription="ChatInput is a prompt composer for AI chat interfaces. It supports multiline and compact single-line layouts, file upload, ghost suggestions, and submit or stop actions."
       apiDecisionLink={null}
       figmaURL="https://www.figma.com/design/QjSexUED296OBCwWwhYKQE/agenticSpark?node-id=116756-67218&m=dev"
     >
@@ -70,6 +70,20 @@ export const Default = ChatInputTemplate.bind({});
 Default.storyName = 'Default';
 Default.args = {
   placeholder: 'Ask a question...',
+};
+
+export const SingleLineMobilePreview = ChatInputTemplate.bind({});
+SingleLineMobilePreview.storyName = 'Single Line (Mobile Preview)';
+SingleLineMobilePreview.args = {
+  variant: 'single-line',
+  placeholder: 'Ask anything...',
+  onSubmit: ({ value }) => console.log('Submitted:', value),
+};
+SingleLineMobilePreview.globals = {
+  viewport: {
+    value: 'iPhone6',
+    isRotated: false,
+  },
 };
 
 export const WithPlaceholder = ChatInputTemplate.bind({});

--- a/packages/blade/src/components/ChatInput/docs/_KitchenSink.ChatInput.stories.tsx
+++ b/packages/blade/src/components/ChatInput/docs/_KitchenSink.ChatInput.stories.tsx
@@ -1,0 +1,43 @@
+import { ChatInput as BladeChatInput } from '../ChatInput';
+import { Box } from '~components/Box';
+import { Heading } from '~components/Typography';
+
+export const ChatInput = (): React.ReactElement => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.6" maxWidth="375px">
+      <Box display="flex" flexDirection="column" gap="spacing.3">
+        <Heading size="small">Single-line</Heading>
+        <BladeChatInput variant="single-line" placeholder="Ask anything..." />
+      </Box>
+
+      <Box display="flex" flexDirection="column" gap="spacing.3">
+        <Heading size="small">With value</Heading>
+        <BladeChatInput variant="single-line" defaultValue="Show recent settlements" />
+      </Box>
+
+      <Box display="flex" flexDirection="column" gap="spacing.3">
+        <Heading size="small">Generating</Heading>
+        <BladeChatInput
+          variant="single-line"
+          defaultValue="Summarise this report"
+          isGenerating
+          onStop={() => undefined}
+        />
+      </Box>
+
+      <Box display="flex" flexDirection="column" gap="spacing.3">
+        <Heading size="small">Disabled</Heading>
+        <BladeChatInput variant="single-line" placeholder="Ask anything..." isDisabled />
+      </Box>
+    </Box>
+  );
+};
+
+export default {
+  title: 'Components/KitchenSink/ChatInput',
+  component: ChatInput,
+  parameters: {
+    chromatic: { disableSnapshot: false },
+    options: { showPanel: false },
+  },
+};

--- a/packages/blade/src/components/ChatInput/types.ts
+++ b/packages/blade/src/components/ChatInput/types.ts
@@ -5,6 +5,16 @@ import type { FormInputOnEvent } from '~components/Form/FormTypes';
 
 type ChatInputProps = {
   /**
+   * Controls the input layout.
+   *
+   * `default` renders the multiline composer with an action bar.
+   * `single-line` renders a compact input with inline upload and submit actions.
+   *
+   * @default 'default'
+   */
+  variant?: 'default' | 'single-line';
+
+  /**
    * Controlled value of the text input
    */
   value?: string;

--- a/packages/blade/src/components/ChatInput/useChatInput.ts
+++ b/packages/blade/src/components/ChatInput/useChatInput.ts
@@ -12,11 +12,11 @@ type UseChatInputProps = Pick<
   ChatInputProps,
   | 'value'
   | 'defaultValue'
+  | 'variant'
   | 'onChange'
   | 'onSubmit'
   | 'isDisabled'
   | 'isGenerating'
-  | 'onStop'
   | 'fileList'
   | 'onFileChange'
   | 'onFileRemove'
@@ -30,8 +30,11 @@ const useChatInput = (
   {
     value: controlledValue,
     defaultValue,
+    variant = 'default',
     onChange,
     onSubmit,
+    isDisabled,
+    isGenerating,
     fileList: controlledFileList,
     onFileChange,
     onFileRemove,
@@ -114,9 +117,9 @@ const useChatInput = (
   );
 
   const handleSubmit = React.useCallback(() => {
-    if (isSubmitDisabled) return;
+    if (isDisabled || isGenerating || isSubmitDisabled) return;
     onSubmit?.({ value: textValue, fileList: files });
-  }, [isSubmitDisabled, onSubmit, textValue, files]);
+  }, [files, isDisabled, isGenerating, isSubmitDisabled, onSubmit, textValue]);
 
   const handleKeyDown = React.useCallback(
     ({
@@ -129,7 +132,10 @@ const useChatInput = (
     }) => {
       if (!event) return;
 
-      if (event.key === 'Enter' && !event.shiftKey) {
+      const isComposing = event.nativeEvent.isComposing;
+      const shouldSubmit = event.key === 'Enter' && (variant === 'single-line' || !event.shiftKey);
+
+      if (shouldSubmit && !isComposing) {
         event.preventDefault();
         handleSubmit();
         return;
@@ -144,6 +150,7 @@ const useChatInput = (
     },
     [
       handleSubmit,
+      variant,
       showGhostSuggestion,
       suggestions,
       activeSuggestionIndex,
@@ -226,8 +233,8 @@ const useChatInput = (
     const target = event.target as HTMLElement | null;
     if (!target) return;
 
-    // Allow normal behavior when clicking directly inside textarea.
-    if (target.closest('textarea')) return;
+    // Allow normal behavior when clicking directly inside the text control.
+    if (target.closest('textarea, input')) return;
 
     // Prevent focus from moving to internal controls (submit/upload/file actions).
     event.preventDefault();

--- a/packages/blade/src/utils/storybook/componentStatusData.ts
+++ b/packages/blade/src/utils/storybook/componentStatusData.ts
@@ -1263,6 +1263,22 @@ const componentData: ComponentStatusDataType = [
     },
   },
   {
+    name: 'ChatInput',
+    description:
+      'ChatInput component for composing prompts with multiline and compact single-line layouts.',
+    platform: 'web',
+    frameworks: {
+      react: {
+        status: 'released',
+        releasedIn: '12.84.0',
+        storybookLink: 'Components/ChatInput',
+      },
+      svelte: {
+        status: 'to-be-decided',
+      },
+    },
+  },
+  {
     name: 'ChatMessage',
     description: 'ChatMessage component for displaying chat messages in a conversation interface.',
     platform: 'web',


### PR DESCRIPTION
## Summary

- Add an opt-in `variant="single-line"` to `ChatInput` for compact mobile-web composers while preserving the existing multiline default.
- Compose the layout from existing Blade primitives, with inline upload and submit/stop actions, mobile send-key semantics, and the Blade `medium` radius token (12px).
- Add Storybook preview, kitchen-sink and interaction coverage, focused CSR/SSR tests, public API documentation, MCP knowledgebase guidance, and release changesets.

## Testing Status

- [x] ChatInput CSR and SSR suites: 17 tests and 3 snapshots passed.
- [x] Web and React Native typechecks passed.
- [x] Targeted ESLint and stylelint passed.
- [x] Changeset status passed: `@razorpay/blade` minor and `@razorpay/blade-mcp` patch.
- [x] Storybook browser verification passed at 320px, 375px, and 412px widths with no horizontal overflow; computed radius is 12px and inline button submission works.
- [x] Existing default multiline story verified for regression.

Preview story: `Components/ChatInput > Single Line (Mobile Preview)`

## Related

- [Figma: single-line mobile ChatInput](https://www.figma.com/design/Gz2FzF8jfdSMH9bUYE7XT2/Untitled.?node-id=1097-62426&t=CwU85PFlLTAhX4xD-11)
