### PR TITLE
chore(ci): extend PR auto-labeling for all packages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,8 +17,7 @@ blade-mcp:
 react-native:
   - changed-files:
       - any-glob-to-any-file:
-          - 'packages/blade/**/*.native.tsx'
-          - 'packages/blade/**/*.native.ts'
+          - 'packages/blade/**/*.native.*'
           - 'packages/blade/android/**'
           - 'packages/blade/ios/**'
           - 'packages/blade/.storybook/react-native/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,43 @@
+blade:
+  - changed-files:
+      - any-glob-to-any-file: ['packages/blade/**']
+
 blade-svelte:
   - changed-files:
+      - any-glob-to-any-file: ['packages/blade-svelte/**']
+
+blade-core:
+  - changed-files:
+      - any-glob-to-any-file: ['packages/blade-core/**']
+
+blade-mcp:
+  - changed-files:
+      - any-glob-to-any-file: ['packages/blade-mcp/**']
+
+react-native:
+  - changed-files:
       - any-glob-to-any-file:
-          - packages/blade-svelte/**
-          - packages/blade-core/**
+          - 'packages/blade/**/*.native.tsx'
+          - 'packages/blade/**/*.native.ts'
+          - 'packages/blade/android/**'
+          - 'packages/blade/ios/**'
+          - 'packages/blade/.storybook/react-native/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**']
+
+figma-plugins:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/plugin-figma-*/**'
+          - 'packages/plugin-blade-*/**'
+          - 'packages/widget-figma-*/**'
+
+eslint-plugin-blade:
+  - changed-files:
+      - any-glob-to-any-file: ['packages/eslint-plugin-blade/**']
+
+examples:
+  - changed-files:
+      - any-glob-to-any-file: ['packages/examples/**']

--- a/.github/workflows/blade-label.yml
+++ b/.github/workflows/blade-label.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary

- Expand `.github/labeler.yml` to auto-label PRs by package scope: `blade`, `blade-svelte`, `blade-core`, `blade-mcp`, `react-native`, `ci`, `figma-plugins`, `eslint-plugin-blade`, and `examples`
- Split `blade-core` out of the `blade-svelte` rule into its own label
- Enable `sync-labels: true` in the labeler workflow so stale labels are removed when PR files change
- Created missing GitHub labels: `blade`, `blade-core`, `blade-mcp`, `ci`, `figma-plugins`, `eslint-plugin-blade`, `examples` (`blade-svelte` and `react-native` already existed)

## Test plan

- [ ] Open a test PR touching only `packages/blade/**` — expect `blade` label
- [ ] Open a test PR touching `packages/blade-core/**` — expect `blade-core` label (not `blade-svelte`)
- [ ] Open a test PR touching `.github/**` — expect `ci` label on this PR
- [ ] Push new commits that remove files from a package — verify stale label is removed (`sync-labels`)
- [ ] Open a test PR with `*.native.tsx` changes — expect `react-native` label in addition to `blade`


Made with [Cursor](https://cursor.com)