### PR TITLE
fix: avoid oversized payloads in agentic metrics

### DIFF
--- a/.github/scripts/fetch-metrics.mjs
+++ b/.github/scripts/fetch-metrics.mjs
@@ -8,7 +8,7 @@
  *   days: number of days to look back (default: 1)
  */
 
-import { execSync } from "child_process";
+import { fetchComments, runGh } from "./github-cli.mjs";
 
 const REPO = "razorpay/blade";
 const AGENT_AUTHORS = new Set(["rzp-slash", "rzp-slash-public"]);
@@ -18,8 +18,7 @@ const AUTO_APPROVE_LABEL = "✨ Agentic Merge Ready ✨";
 const IGNORE_LABEL = "Ignore - Test PR";
 
 function gh(...args) {
-  const result = execSync(`gh ${args.join(" ")}`, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
-  return result.trim() ? JSON.parse(result) : [];
+  return runGh(args);
 }
 
 function pct(n, d) {
@@ -56,8 +55,8 @@ let agentComments = 0;
 let resolvedByAgent = 0;
 
 for (const pr of prs) {
-  const reviewComments = gh("api", `repos/${REPO}/pulls/${pr.number}/comments`, "--paginate");
-  const issueComments = gh("api", `repos/${REPO}/issues/${pr.number}/comments`, "--paginate");
+  const reviewComments = fetchComments({ repo: REPO, prNumber: pr.number, type: "review" });
+  const issueComments = fetchComments({ repo: REPO, prNumber: pr.number, type: "issue" });
 
   for (const c of [...reviewComments, ...issueComments]) {
     const user = c.user.login;

--- a/.github/scripts/github-cli.mjs
+++ b/.github/scripts/github-cli.mjs
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const COMMENT_PROJECTION = '.[] | {user: {login: .user.login}, body: (.body // "")}';
+
+function parseJsonLines(output) {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function runGh(args, { format = "json", execFile = execFileSync } = {}) {
+  const output = execFile("gh", args, {
+    encoding: "utf8",
+    maxBuffer: MAX_BUFFER_BYTES,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  if (!output.trim()) return [];
+  return format === "json-lines" ? parseJsonLines(output) : JSON.parse(output);
+}
+
+function fetchComments({ repo, prNumber, type }, options) {
+  const endpoint =
+    type === "review"
+      ? `repos/${repo}/pulls/${prNumber}/comments`
+      : `repos/${repo}/issues/${prNumber}/comments`;
+
+  return runGh(
+    ["api", endpoint, "--paginate", "--jq", COMMENT_PROJECTION],
+    { ...options, format: "json-lines" },
+  );
+}
+
+export { COMMENT_PROJECTION, MAX_BUFFER_BYTES, fetchComments, parseJsonLines, runGh };

--- a/.github/scripts/github-cli.test.mjs
+++ b/.github/scripts/github-cli.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  COMMENT_PROJECTION,
+  MAX_BUFFER_BYTES,
+  fetchComments,
+  parseJsonLines,
+  runGh,
+} from "./github-cli.mjs";
+
+test("parseJsonLines parses paginated gh output", () => {
+  const output = [
+    JSON.stringify({ user: { login: "reviewer" }, body: "First" }),
+    JSON.stringify({ user: { login: "author" }, body: "Second\nline" }),
+    "",
+  ].join("\n");
+
+  assert.deepEqual(parseJsonLines(output), [
+    { user: { login: "reviewer" }, body: "First" },
+    { user: { login: "author" }, body: "Second\nline" },
+  ]);
+});
+
+test("runGh executes gh without a shell and raises the output buffer", () => {
+  const calls = [];
+  const result = runGh(["pr", "list", "--json", "number"], {
+    execFile: (file, args, options) => {
+      calls.push({ file, args, options });
+      return '[{"number":1}]';
+    },
+  });
+
+  assert.deepEqual(result, [{ number: 1 }]);
+  assert.equal(calls[0].file, "gh");
+  assert.deepEqual(calls[0].args, ["pr", "list", "--json", "number"]);
+  assert.equal(calls[0].options.maxBuffer, MAX_BUFFER_BYTES);
+});
+
+test("fetchComments requests only the fields used by the metrics report", () => {
+  const calls = [];
+  const comments = fetchComments(
+    { repo: "razorpay/blade", prNumber: 3733, type: "review" },
+    {
+      execFile: (file, args) => {
+        calls.push({ file, args });
+        return '{"user":{"login":"rzp-slash-public[bot]"},"body":"Review"}\n';
+      },
+    },
+  );
+
+  assert.deepEqual(comments, [
+    { user: { login: "rzp-slash-public[bot]" }, body: "Review" },
+  ]);
+  assert.deepEqual(calls[0], {
+    file: "gh",
+    args: [
+      "api",
+      "repos/razorpay/blade/pulls/3733/comments",
+      "--paginate",
+      "--jq",
+      COMMENT_PROJECTION,
+    ],
+  });
+  assert.equal(COMMENT_PROJECTION.includes("diff_hunk"), false);
+});
+
+test("fetchComments supports issue comments", () => {
+  const calls = [];
+  fetchComments(
+    { repo: "razorpay/blade", prNumber: 42, type: "issue" },
+    {
+      execFile: (file, args) => {
+        calls.push({ file, args });
+        return "";
+      },
+    },
+  );
+
+  assert.equal(calls[0].args[1], "repos/razorpay/blade/issues/42/comments");
+});

--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 22
+      - name: Test Agentic Scripts
+        run: |
+          find .github/scripts -type f \( -name "*.test.js" -o -name "*.test.mjs" \) -print0 \
+            | xargs -0 --no-run-if-empty node --test
       - name: Pre-Generate Documentation Lock File
         run: yarn generate-docs-lockfile
       - name: Setup Cache & Install Dependencies


### PR DESCRIPTION
## Summary

- fetch only the author and body fields needed for comment metrics
- preserve pagination while avoiding large review diff payloads
- use argument-safe GitHub CLI execution with focused regression tests
- run agentic script tests in the existing validation workflow

## Testing Status

- [x] `node --test .github/scripts/github-cli.test.mjs`
- [x] 1-day report matches the current implementation byte-for-byte
- [x] 7-day and 30-day reports complete successfully against live repository data
- [x] workflow YAML and diff validation pass

## Related

Fixes the `ENOBUFS` failure in [Agentic Blade Metrics run #29624245592](https://github.com/razorpay/blade/actions/runs/29624245592). No changeset is needed because this only changes repository automation.