### PR TITLE
fix: count actual Slash resolution attempts

### DIFF
--- a/.github/scripts/slash-resolve-comments/check-resolve-run-count.js
+++ b/.github/scripts/slash-resolve-comments/check-resolve-run-count.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Checks how many times the auto-resolve workflow has already run on this PR.
- * Exits with code 1 (and outputs "allowed=false") if the limit is reached.
+ * Outputs "allowed=false" when the review is ineligible or the limit is reached.
  *
  * The max-count limit only applies to "slash comments" — i.e. auto-resolution
  * of high-confidence comments posted by rzp-slash-public[bot].  Reviews that
@@ -11,13 +11,17 @@
  * Outputs "allowed=true/false" to GITHUB_OUTPUT.
  */
 
-const { execSync } = require('child_process');
 const fs = require('fs');
+const {
+  countResolutionAttempts,
+  isManualDelegation,
+  selectEligibleComments,
+} = require('./comment-selection');
+const { runGh } = require('./github-api');
 
 const repo = process.env.GITHUB_REPOSITORY;
 const prNumber = parseInt(process.env.PR_NUMBER, 10);
 const reviewId = process.env.REVIEW_ID;
-const workflowRef = process.env.GITHUB_WORKFLOW_REF;
 const githubOutput = process.env.GITHUB_OUTPUT;
 const MAX_RUNS = 10;
 const HUMAN_HELP_NEEDED_LABEL = 'Human Help Needed 🧑🏻‍💻';
@@ -30,58 +34,69 @@ function output(allowed) {
 
 function addHumanHelpNeededLabel() {
   try {
-    execSync(
-      `gh api "repos/${repo}/issues/${prNumber}/labels" --method POST --field "labels[]=${HUMAN_HELP_NEEDED_LABEL}"`,
-      { encoding: 'utf8', stdio: 'pipe' },
-    );
+    runGh([
+      'api',
+      `repos/${repo}/issues/${prNumber}/labels`,
+      '--method',
+      'POST',
+      '--field',
+      `labels[]=${HUMAN_HELP_NEEDED_LABEL}`,
+    ]);
     console.log(`Added '${HUMAN_HELP_NEEDED_LABEL}' label to PR #${prNumber}.`);
   } catch (err) {
     console.error(`Failed to add '${HUMAN_HELP_NEEDED_LABEL}' label:`, err.message);
   }
 }
 
-/**
- * Returns true when the current review contains at least one comment that
- * explicitly mentions @rzp-slash-public or @razorpay/slash-public (manual delegation).  These comments
- * are outside the scope of the max-count limit.
- */
-function reviewHasManualDelegation() {
-  if (!reviewId) return false;
-  try {
-    const comments = JSON.parse(
-      execSync(`gh api "repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments"`, {
-        encoding: 'utf8',
-      }),
-    );
-    return comments.some((c) => c.body.includes('@rzp-slash-public') || c.body.includes('@razorpay/slash-public'));
-  } catch (err) {
-    console.log(`Could not fetch review comments to check for manual delegation: ${err.message}`);
-    return false;
-  }
+if (!reviewId) {
+  console.error('REVIEW_ID is required to evaluate the current review.');
+  output('false');
+  process.exit(1);
 }
 
-// GITHUB_WORKFLOW_REF format: "org/repo/.github/workflows/filename.yml@refs/heads/branch"
-const workflowFilename = workflowRef.split('@')[0].split('/').pop();
-
-const count = parseInt(
-  execSync(
-    `gh api "repos/${repo}/actions/workflows/${workflowFilename}/runs?event=pull_request_review&per_page=100" --jq '[.workflow_runs[] | select(.pull_requests[]?.number == ${prNumber})] | length'`,
-    { encoding: 'utf8' },
-  ).trim(),
-  10,
+const currentReviewComments = runGh(
+  [
+    'api',
+    `repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {body: (.body // ""), user: {login: .user.login}}',
+  ],
+  { format: 'json-lines' },
 );
+const selectedComments = selectEligibleComments(currentReviewComments);
+
+if (selectedComments.length === 0) {
+  console.log('No eligible comments in this review, skipping.');
+  output('false');
+  process.exit(0);
+}
+
+if (selectedComments.some(isManualDelegation)) {
+  console.log('Review contains an explicit Slash mention — allowing manual delegation.');
+  output('true');
+  process.exit(0);
+}
+
+const previousReviewComments = runGh(
+  [
+    'api',
+    `repos/${repo}/pulls/${prNumber}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {body: (.body // "")}',
+  ],
+  { format: 'json-lines' },
+);
+const count = countResolutionAttempts(previousReviewComments);
 
 console.log(`Auto-resolve has run ${count} time(s) on this PR (max: ${MAX_RUNS}).`);
 
 if (count >= MAX_RUNS) {
-  if (reviewHasManualDelegation()) {
-    console.log('Limit reached, but review contains an explicit @rzp-slash-public or @razorpay/slash-public mention — allowing.');
-    output('true');
-  } else {
-    console.log('Limit reached — skipping to prevent feedback loop.');
-    addHumanHelpNeededLabel();
-    output('false');
-  }
-} else {
-  output('true');
+  console.log('Limit reached — skipping to prevent feedback loop.');
+  addHumanHelpNeededLabel();
+  output('false');
+  process.exit(0);
 }
+
+output('true');

--- a/.github/scripts/slash-resolve-comments/comment-selection.js
+++ b/.github/scripts/slash-resolve-comments/comment-selection.js
@@ -1,0 +1,43 @@
+const MANUAL_MENTIONS = ['@rzp-slash-public', '@razorpay/slash-public'];
+const AGENT_REVIEWER = 'rzp-slash-public[bot]';
+const AUTO_RESOLVE_CONFIDENCE = /confidence: ([5-9]|10)\/10/;
+const RESOLUTION_MARKER = 'Auto Comment Resolution Triggered';
+const RESOLUTION_TASK_ID = /\/tasks\/([^/\s)]+)\/execution-logs/;
+
+function isManualDelegation(comment) {
+  const body = comment.body ?? '';
+  return MANUAL_MENTIONS.some((mention) => body.includes(mention));
+}
+
+function isEligibleAutoResolveComment(comment) {
+  return (
+    comment.user?.login === AGENT_REVIEWER &&
+    AUTO_RESOLVE_CONFIDENCE.test(comment.body ?? '')
+  );
+}
+
+function selectEligibleComments(comments) {
+  return comments.filter(
+    (comment) => isManualDelegation(comment) || isEligibleAutoResolveComment(comment),
+  );
+}
+
+function countResolutionAttempts(comments) {
+  const taskIds = new Set();
+
+  for (const comment of comments) {
+    const body = comment.body ?? '';
+    if (!body.includes(RESOLUTION_MARKER)) continue;
+
+    const taskId = body.match(RESOLUTION_TASK_ID)?.[1];
+    if (taskId) taskIds.add(taskId);
+  }
+
+  return taskIds.size;
+}
+
+module.exports = {
+  countResolutionAttempts,
+  isManualDelegation,
+  selectEligibleComments,
+};

--- a/.github/scripts/slash-resolve-comments/github-api.js
+++ b/.github/scripts/slash-resolve-comments/github-api.js
@@ -1,0 +1,24 @@
+const { execFileSync } = require('child_process');
+
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+function parseJsonLines(output) {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function runGh(args, { format = 'json', execFile = execFileSync } = {}) {
+  const output = execFile('gh', args, {
+    encoding: 'utf8',
+    maxBuffer: MAX_BUFFER_BYTES,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  if (!output.trim()) return [];
+  return format === 'json-lines' ? parseJsonLines(output) : JSON.parse(output);
+}
+
+module.exports = { MAX_BUFFER_BYTES, parseJsonLines, runGh };

--- a/.github/scripts/slash-resolve-comments/resolve-review-comments.js
+++ b/.github/scripts/slash-resolve-comments/resolve-review-comments.js
@@ -7,23 +7,26 @@
  *   - were posted by rzp-slash-public (auto-resolution, comments with confidence >= 5/10)
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
+const { selectEligibleComments } = require('./comment-selection');
+const { runGh } = require('./github-api');
 
 const repo = process.env.GITHUB_REPOSITORY;
 const prNumber = process.env.PR_NUMBER;
 const reviewId = process.env.REVIEW_ID;
 
-const allComments = JSON.parse(
-  execSync(`gh api "repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments"`, {
-    encoding: 'utf8',
-  }),
+const allComments = runGh(
+  [
+    'api',
+    `repos/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {id, html_url, body: (.body // ""), user: {login: .user.login}}',
+  ],
+  { format: 'json-lines' },
 );
 
-const selected = allComments.filter(
-  (c) =>
-    (c.body.includes('@rzp-slash-public') || c.body.includes('@razorpay/slash-public')) ||
-    (c.user.login === 'rzp-slash-public[bot]' && /confidence: ([5-9]|10)\/10/.test(c.body)),
-);
+const selected = selectEligibleComments(allComments);
 
 if (selected.length === 0) {
   console.log('No eligible comments in this review, skipping.');
@@ -35,7 +38,7 @@ const commentIds = selected.map((c) => c.id);
 
 const prompt = `Resolve the review comments on PR #${prNumber} using the /resolve-comments skill from the blade repo. COMMENT_URLS:\n${commentUrls}\n\nStrictly use the resolve-comments skill from the blade repo only. Do not use any other skill.`;
 
-const responseOutput = execSync(`node .github/scripts/run-slash.js ${JSON.stringify(prompt)}`, {
+const responseOutput = execFileSync('node', ['.github/scripts/run-slash.js', prompt], {
   encoding: 'utf8',
 });
 console.log(responseOutput);
@@ -48,12 +51,17 @@ const taskIdMatch = responseJson.match(/"task_id"\s*:\s*"([^"]+)"/);
 if (!taskIdMatch) process.exit(0);
 
 const executionUrl = `https://slash.concierge.razorpay.com/tasks/${taskIdMatch[1]}/execution-logs`;
+const resolutionComment =
+  `**✨ Agentic Resolution ✨:** Auto Comment Resolution Triggered ` +
+  `([**View Logs**](${executionUrl}))`;
 
 for (const commentId of commentIds) {
-  execSync(
-    `gh api "repos/${repo}/pulls/${prNumber}/comments/${commentId}/replies" --method POST --field body=${JSON.stringify(
-      `**✨ Agentic Resolution ✨:** Auto Comment Resolution Triggered ([**View Logs**](${executionUrl}))`,
-    )}`,
-    { encoding: 'utf8' },
-  );
+  runGh([
+    'api',
+    `repos/${repo}/pulls/${prNumber}/comments/${commentId}/replies`,
+    '--method',
+    'POST',
+    '--field',
+    `body=${resolutionComment}`,
+  ]);
 }

--- a/.github/scripts/slash-resolve-comments/slash-resolve-comments.test.js
+++ b/.github/scripts/slash-resolve-comments/slash-resolve-comments.test.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  countResolutionAttempts,
+  isManualDelegation,
+  selectEligibleComments,
+} = require('./comment-selection');
+const { MAX_BUFFER_BYTES, parseJsonLines, runGh } = require('./github-api');
+
+test('selectEligibleComments includes both supported manual mentions', () => {
+  const comments = [
+    { body: 'Please fix this @rzp-slash-public', user: { login: 'maintainer' } },
+    { body: '@razorpay/slash-public can you handle this?', user: { login: 'author' } },
+    { body: 'No delegation here', user: { login: 'maintainer' } },
+  ];
+
+  assert.deepEqual(selectEligibleComments(comments), comments.slice(0, 2));
+  assert.equal(isManualDelegation(comments[0]), true);
+});
+
+test('selectEligibleComments applies the configured bot confidence threshold', () => {
+  const comments = [
+    { body: 'confidence: 5/10', user: { login: 'rzp-slash-public[bot]' } },
+    { body: 'confidence: 10/10', user: { login: 'rzp-slash-public[bot]' } },
+    { body: 'confidence: 4/10', user: { login: 'rzp-slash-public[bot]' } },
+    { body: 'confidence: 9/10', user: { login: 'another-bot[bot]' } },
+  ];
+
+  assert.deepEqual(selectEligibleComments(comments), comments.slice(0, 2));
+});
+
+test('countResolutionAttempts counts unique Slash tasks rather than reply comments', () => {
+  const firstTask =
+    '**Agentic Resolution:** Auto Comment Resolution Triggered https://slash.concierge.razorpay.com/tasks/task-1/execution-logs';
+  const comments = [
+    { body: firstTask },
+    { body: firstTask },
+    {
+      body: 'Auto Comment Resolution Triggered https://slash.concierge.razorpay.com/tasks/task-2/execution-logs',
+    },
+    {
+      body: 'Slash AI Review: https://slash.concierge.razorpay.com/tasks/review-task/execution-logs',
+    },
+    { body: 'A normal review comment' },
+  ];
+
+  assert.equal(countResolutionAttempts(comments), 2);
+});
+
+test('runGh uses argument-safe execution and supports paginated JSON lines', () => {
+  const calls = [];
+  const result = runGh(['api', 'repos/razorpay/blade/pulls/1/comments', '--paginate'], {
+    format: 'json-lines',
+    execFile: (file, args, options) => {
+      calls.push({ file, args, options });
+      return '{"body":"one"}\n{"body":"two"}\n';
+    },
+  });
+
+  assert.deepEqual(result, [{ body: 'one' }, { body: 'two' }]);
+  assert.equal(calls[0].file, 'gh');
+  assert.equal(calls[0].options.maxBuffer, MAX_BUFFER_BYTES);
+  assert.deepEqual(parseJsonLines(''), []);
+});

--- a/.github/workflows/blade-validate.yml
+++ b/.github/workflows/blade-validate.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 22
+      - name: Test Agentic Scripts
+        run: |
+          find .github/scripts -type f \( -name "*.test.js" -o -name "*.test.mjs" \) -print0 \
+            | xargs -0 --no-run-if-empty node --test
       - name: Pre-Generate Documentation Lock File
         run: yarn generate-docs-lockfile
       - name: Setup Cache & Install Dependencies

--- a/.github/workflows/slash-resolve-comments.yml
+++ b/.github/workflows/slash-resolve-comments.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
+          REVIEW_ID: ${{ github.event.review.id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: node .github/scripts/slash-resolve-comments/check-resolve-run-count.js
 


### PR DESCRIPTION
## Summary

- pass the current review ID so explicit Slash mentions can bypass the automatic run limit
- skip reviews without eligible comments before applying the limit
- count unique auto-resolution tasks instead of every review-triggered workflow run
- share comment eligibility rules between gating and execution, with focused regression tests
- use argument-safe, paginated GitHub API calls with minimal response fields

## Testing Status

- [x] `node --test .github/scripts/slash-resolve-comments/slash-resolve-comments.test.js`
- [x] syntax checks for all modified scripts
- [x] workflow YAML and diff validation pass
- [x] verified task counting against existing PR review comments

## Related

Restores the manual-delegation behavior intended by [#3621](https://github.com/razorpay/blade/pull/3621). No changeset is needed because this only changes repository automation.