### PR TITLE
fix(SankeyChart): reduce last-column label width to minimize right-side whitespace

### DIFF
--- a/.changeset/sankey-last-column-label-width.md
+++ b/.changeset/sankey-last-column-label-width.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade": patch
+---
+
+fix(SankeyChart): reduce last-column label max-width to minimize right-side whitespace
+
+Right margin is now computed from last-column nodes only (120px cap) instead of the widest chip across all columns (160px), so the chart flow area fills the container more evenly.

--- a/packages/blade/src/components/Charts/SankeyChart/SankeyChart.web.tsx
+++ b/packages/blade/src/components/Charts/SankeyChart/SankeyChart.web.tsx
@@ -31,6 +31,7 @@ import {
   NODE_WIDTH,
   CHIP_MIN_WIDTH,
   CHIP_MAX_WIDTH,
+  CHIP_MAX_WIDTH_LAST_COLUMN,
   CHIP_VALUE_BUDGET,
   NODE_MIN_HEIGHT,
   TOOLTIP_Z_INDEX,
@@ -445,27 +446,6 @@ const _ChartSankey = ({
     [data.links, nodeIdToIndex],
   );
 
-  // Dynamic right margin — based on widest chip across all nodes
-  const dynamicRightMargin = useMemo(() => {
-    if (!showLabels) return theme.spacing[3];
-    if (!showLabelChip) {
-      const maxTextW = data.nodes.reduce((max, node) => {
-        const nameW = measureText(node.name, theme.typography.fonts.weight.semibold);
-        return Math.max(max, nameW + theme.spacing[2] + CHIP_VALUE_BUDGET);
-      }, 0);
-      return Math.min(CHIP_MAX_WIDTH, maxTextW) + CHIP_GAP + theme.spacing[3];
-    }
-    const maxChipW = data.nodes.reduce((max, node) => {
-      const nameW = measureText(node.name, theme.typography.fonts.weight.semibold);
-      const chipW = Math.min(
-        CHIP_MAX_WIDTH,
-        Math.max(CHIP_MIN_WIDTH, nameW + theme.spacing[2] + CHIP_VALUE_BUDGET + CHIP_PAD_X * 2),
-      );
-      return Math.max(max, chipW);
-    }, 0);
-    return maxChipW + CHIP_GAP + theme.spacing[3];
-  }, [showLabels, showLabelChip, data.nodes, measureText, theme, CHIP_PAD_X, CHIP_GAP]);
-
   // Node depth map + count per level — suppress percentage for sole node at a level
   const nodeDepthInfo = useMemo(() => {
     const incomingCount = new Map<string, number>(data.nodes.map((n) => [n.id, 0]));
@@ -486,9 +466,47 @@ const _ChartSankey = ({
       });
     }
     const countPerDepth = new Map<number, number>();
-    depthOf.forEach((d) => countPerDepth.set(d, (countPerDepth.get(d) ?? 0) + 1));
-    return { depthOf, countPerDepth };
+    let maxDepth = 0;
+    depthOf.forEach((d) => {
+      countPerDepth.set(d, (countPerDepth.get(d) ?? 0) + 1);
+      if (d > maxDepth) maxDepth = d;
+    });
+    return { depthOf, countPerDepth, maxDepth };
   }, [data.nodes, data.links]);
+
+  // Dynamic right margin — based on widest chip in the LAST column only
+  const dynamicRightMargin = useMemo(() => {
+    if (!showLabels) return theme.spacing[3];
+    const lastColNodes = data.nodes.filter(
+      (n) => nodeDepthInfo.depthOf.get(n.id) === nodeDepthInfo.maxDepth,
+    );
+    const candidates = lastColNodes.length > 0 ? lastColNodes : data.nodes;
+    if (!showLabelChip) {
+      const maxTextW = candidates.reduce((max, node) => {
+        const nameW = measureText(node.name, theme.typography.fonts.weight.semibold);
+        return Math.max(max, nameW + theme.spacing[2] + CHIP_VALUE_BUDGET);
+      }, 0);
+      return Math.min(CHIP_MAX_WIDTH_LAST_COLUMN, maxTextW) + CHIP_GAP + theme.spacing[3];
+    }
+    const maxChipW = candidates.reduce((max, node) => {
+      const nameW = measureText(node.name, theme.typography.fonts.weight.semibold);
+      const chipW = Math.min(
+        CHIP_MAX_WIDTH_LAST_COLUMN,
+        Math.max(CHIP_MIN_WIDTH, nameW + theme.spacing[2] + CHIP_VALUE_BUDGET + CHIP_PAD_X * 2),
+      );
+      return Math.max(max, chipW);
+    }, 0);
+    return maxChipW + CHIP_GAP + theme.spacing[3];
+  }, [
+    showLabels,
+    showLabelChip,
+    data.nodes,
+    nodeDepthInfo,
+    measureText,
+    theme,
+    CHIP_PAD_X,
+    CHIP_GAP,
+  ]);
 
   // Total value = sum of outflows from root nodes
   const totalValue = useMemo(() => {
@@ -555,12 +573,11 @@ const _ChartSankey = ({
       const labelW = measureText(labelValue, theme.typography.fonts.weight.regular);
       const contentW = nameW + theme.spacing[2] + labelW;
 
-      const shouldWrap = contentW + CHIP_PAD_X * 2 > CHIP_MAX_WIDTH;
+      const isLastColumn = nodeDepth === nodeDepthInfo.maxDepth;
+      const chipMaxW = isLastColumn ? CHIP_MAX_WIDTH_LAST_COLUMN : CHIP_MAX_WIDTH;
+      const shouldWrap = contentW + CHIP_PAD_X * 2 > chipMaxW;
       const chipW = shouldWrap
-        ? Math.min(
-            CHIP_MAX_WIDTH,
-            Math.max(CHIP_MIN_WIDTH, Math.max(nameW, labelW) + CHIP_PAD_X * 2),
-          )
+        ? Math.min(chipMaxW, Math.max(CHIP_MIN_WIDTH, Math.max(nameW, labelW) + CHIP_PAD_X * 2))
         : Math.max(CHIP_MIN_WIDTH, contentW + CHIP_PAD_X * 2);
 
       const lineGap = theme.spacing[2]; // 4px — fixed y-formula gives 16px baseline-to-baseline at size[75]

--- a/packages/blade/src/components/Charts/SankeyChart/__tests__/__snapshots__/SankeyChart.web.test.tsx.snap
+++ b/packages/blade/src/components/Charts/SankeyChart/__tests__/__snapshots__/SankeyChart.web.test.tsx.snap
@@ -41,12 +41,12 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
             <path
               d="
         M22,50.54369962503995
-        C165.5,50.54369962503995
-          165.5,48
-          309,48
-        L309,8
-        C165.5,8
-          165.5,10.543699625039949
+        C175.5,50.54369962503995
+          175.5,48
+          329,48
+        L329,8
+        C175.5,8
+          175.5,10.543699625039949
           22,10.543699625039949
         Z
       "
@@ -61,12 +61,12 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
             <path
               d="
         M22,82.54369962503995
-        C165.5,82.54369962503995
-          165.5,92
-          309,92
-        L309,60
-        C165.5,60
-          165.5,50.54369962503995
+        C175.5,82.54369962503995
+          175.5,92
+          329,92
+        L329,60
+        C175.5,60
+          175.5,50.54369962503995
           22,50.54369962503995
         Z
       "
@@ -80,14 +80,14 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           >
             <path
               d="
-        M323,43
-        C466.5,43
-          466.5,43
-          610,43
-        L610,8.000000000000004
-        C466.5,8.000000000000004
-          466.5,8
-          323,8
+        M343,43
+        C496.5,43
+          496.5,43
+          650,43
+        L650,8.000000000000004
+        C496.5,8.000000000000004
+          496.5,8
+          343,8
         Z
       "
               fill="hsla(149, 38%, 86%, 1)"
@@ -100,14 +100,14 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           >
             <path
               d="
-        M323,48
-        C466.5,48
-          466.5,88
-          610,88
-        L610,83
-        C466.5,83
-          466.5,43
-          323,43
+        M343,48
+        C496.5,48
+          496.5,88
+          650,88
+        L650,83
+        C496.5,83
+          496.5,43
+          343,43
         Z
       "
               fill="hsla(149, 38%, 86%, 1)"
@@ -120,14 +120,14 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           >
             <path
               d="
-        M323,88
-        C466.5,88
-          466.5,71
-          610,71
-        L610,43
-        C466.5,43
-          466.5,60
-          323,60
+        M343,88
+        C496.5,88
+          496.5,71
+          650,71
+        L650,43
+        C496.5,43
+          496.5,60
+          343,60
         Z
       "
               fill="hsla(46, 86%, 83%, 1)"
@@ -140,14 +140,14 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
           >
             <path
               d="
-        M323,92
-        C466.5,92
-          466.5,92
-          610,92
-        L610,88
-        C466.5,88
-          466.5,88
-          323,88
+        M343,92
+        C496.5,92
+          496.5,92
+          650,92
+        L650,88
+        C496.5,88
+          496.5,88
+          343,88
         Z
       "
               fill="hsla(46, 86%, 83%, 1)"
@@ -224,7 +224,7 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                 rx="0"
                 style="cursor: pointer;"
                 width="14"
-                x="309"
+                x="329"
                 y="7.999999999999998"
               />
               <g
@@ -237,13 +237,13 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                   stroke="hsla(206, 10%, 29%, 0.18)"
                   stroke-width="1"
                   width="90.35546875"
-                  x="331.5"
+                  x="351.5"
                   y="14.5"
                 />
                 <text
                   font-size="12"
                   style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                  x="339"
+                  x="359"
                   y="32.32"
                 >
                   <tspan
@@ -276,7 +276,7 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                 rx="0"
                 style="cursor: pointer;"
                 width="14"
-                x="309"
+                x="329"
                 y="60"
               />
               <g
@@ -289,13 +289,13 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                   stroke="hsla(206, 10%, 29%, 0.18)"
                   stroke-width="1"
                   width="107.69921875"
-                  x="331.5"
+                  x="351.5"
                   y="62.5"
                 />
                 <text
                   font-size="12"
                   style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                  x="339"
+                  x="359"
                   y="80.32"
                 >
                   <tspan
@@ -328,7 +328,7 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                 rx="0"
                 style="cursor: pointer;"
                 width="14"
-                x="610"
+                x="650"
                 y="8.000000000000004"
               />
               <g
@@ -336,30 +336,31 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
               >
                 <rect
                   fill="hsla(0, 0%, 100%, 1)"
-                  height="27"
+                  height="43"
                   rx="8"
                   stroke="hsla(206, 10%, 29%, 0.18)"
                   stroke-width="1"
-                  width="143.72265625"
-                  x="632.5"
-                  y="26"
+                  width="79"
+                  x="672.5"
+                  y="18"
                 />
                 <text
                   font-size="12"
                   style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                  x="640"
-                  y="43.82"
                 >
                   <tspan
                     fill="hsla(0, 0%, 2%, 1)"
                     font-weight="600"
+                    x="680"
+                    y="35.82"
                   >
                     Successful
                   </tspan>
                   <tspan
-                    dx="4"
                     fill="hsla(204, 9%, 42%, 1)"
                     font-weight="400"
+                    x="680"
+                    y="51.82"
                   >
                     6.3k  (88%)
                   </tspan>
@@ -380,7 +381,7 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                 rx="0"
                 style="cursor: pointer;"
                 width="14"
-                x="610"
+                x="650"
                 y="83"
               />
               <g
@@ -393,13 +394,13 @@ exports[`SankeyChart — rendering matches snapshot 1`] = `
                   stroke="hsla(206, 10%, 29%, 0.18)"
                   stroke-width="1"
                   width="112.375"
-                  x="632.5"
+                  x="672.5"
                   y="74"
                 />
                 <text
                   font-size="12"
                   style="user-select: none; font-family: "Inter", "Inter Fallback Arial", Arial;"
-                  x="640"
+                  x="680"
                   y="91.82"
                 >
                   <tspan

--- a/packages/blade/src/components/Charts/SankeyChart/tokens.ts
+++ b/packages/blade/src/components/Charts/SankeyChart/tokens.ts
@@ -18,6 +18,8 @@ export const CHIP_MIN_WIDTH = 80;
  * Content wider than (CHIP_MAX_WIDTH - horizontal padding) wraps to two lines.
  */
 export const CHIP_MAX_WIDTH = 160;
+/** Tighter cap for the last node column — labels only extend rightward, so less margin is needed. */
+export const CHIP_MAX_WIDTH_LAST_COLUMN = 120;
 /**
  * Fixed pixel budget reserved for the humanized value + percentage part of a label chip,
  * e.g. "1.24L txn  (100%)". Used when computing the dynamic right margin before


### PR DESCRIPTION
## Summary
- Reduces max label chip width for the **last node column** from 160px to 120px (`CHIP_MAX_WIDTH_LAST_COLUMN` token)
- Computes `dynamicRightMargin` from last-column nodes only, instead of the widest chip across all columns
- Detects last column via `nodeDepthInfo.maxDepth` and applies the tighter cap in `renderNode`

This reclaims ~40px of flow-area width, making the left and right padding visually balanced.

## Test plan
- [x] Verified visually in Storybook — labels wrap consistently, whitespace is even
- [x] All 25 existing SankeyChart tests pass (snapshot updated for shifted x-coordinates)