### PR TITLE
chore: code and CI maintenance

### DIFF
--- a/packages/blade-coverage-extension/.npmrc
+++ b/packages/blade-coverage-extension/.npmrc
@@ -1,1 +1,2 @@
 @razorpay:registry=https://registry.npmjs.org/
+min-release-age = 7

--- a/packages/blade/blade-dashboard-template/.npmrc
+++ b/packages/blade/blade-dashboard-template/.npmrc
@@ -2,3 +2,4 @@
 //npm.pkg.github.com/:always-auth=true
 //npm.pkg.github.com/:_authToken=${GITHUB_ACCESS_TOKEN}
 chromedriver_skip_install=true
+min-release-age = 7

--- a/packages/examples/vite-example/.npmrc
+++ b/packages/examples/vite-example/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers = false
+min-release-age = 7


### PR DESCRIPTION
Code and CI configuration maintenance. Small, behaviour-preserving improvements to the files below. Generated automatically.

| File | Change |
|---|---|
| `.github/workflows/blade-browserstack.yml` | Pin the flagged actions/setup-node v3 reference to the full commit SHA |
| `packages/blade-coverage-extension/.npmrc` | Add npm's seven-day minimum package release-age policy to the package- |
| `packages/blade-mcp/base-blade-template/.npmrc` | Add the required seven-day minimum release age while retaining the exi |
| `packages/examples/vite-example/.npmrc` | Add npm's seven-day minimum release-age policy while retaining the exi |
| `packages/plugin-figma-blade-coverage/.npmrc` | Add npm's seven-day minimum release-age gate to the package-local regi |
| `.github/workflows/blade-agentic-metrics.yml` | Pin actions/setup-node to the full commit SHA for v4.4.0. |
| `.github/workflows/blade-label.yml` | Pin actions/labeler v5.0.0 to its full commit SHA and retain a version |
| `.github/workflows/blade-mcp-validate.yml` | Pin actions/setup-node to the repository-established full SHA for v3.8 |
| `.github/workflows/slash-pr-healer.yml` | Pin actions/checkout to the full commit SHA for v4.2.2 while retaining |
| `.github/workflows/slash-resolve-comments.yml` | Pin actions/checkout to the full commit SHA for v4.2.2 and retain the  |
| `.github/workflows/slash-terminate-task.yml` | Pin actions/checkout to the full commit SHA for v4.2.2 while retaining |
