### PR TITLE
fix: prevent FormLabel accessibility text from polluting accessible name

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,5 +108,6 @@
     "*.(json|js|jsx|ts|tsx)": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/blade/src/components/Form/FormLabel.tsx
+++ b/packages/blade/src/components/Form/FormLabel.tsx
@@ -129,7 +129,7 @@ const FormLabel = ({
   const computedAccessibilityNode = (
     <VisuallyHidden>
       {necessityIndicator !== 'none' && <Text>{necessityIndicator}</Text>}
-      <Text>{accessibilityText}</Text>
+      {isReactNative && accessibilityText && <Text>{accessibilityText}</Text>}
     </VisuallyHidden>
   );
 
@@ -172,36 +172,43 @@ const FormLabel = ({
   const width = isLabelLeftPositioned && isDesktop ? makeSize(labelWidth[size]) : '100%';
 
   return (
-    <Component
-      htmlFor={htmlFor}
-      style={{
-        width,
-        flexShrink: 0,
-        marginRight: isLabelLeftPositioned
-          ? makeSpace(getIn(theme, labelLeftMarginRight[size]))
-          : makeSpace(getIn(theme, 'spacing.0')),
-      }}
-      id={id}
-      {...metaAttribute({ name: MetaConstants.FormLabel })}
-    >
-      <BaseBox
-        width="100%"
-        display="flex"
-        flexDirection={isLabelLeftPositioned ? 'column' : 'row'}
-        alignItems={isLabelLeftPositioned ? 'flex-start' : 'center'}
-        marginBottom={isLabelLeftPositioned ? 'spacing.0' : labelMarginBottom[size]}
+    <>
+      <Component
+        htmlFor={htmlFor}
+        style={{
+          width,
+          flexShrink: 0,
+          marginRight: isLabelLeftPositioned
+            ? makeSpace(getIn(theme, labelLeftMarginRight[size]))
+            : makeSpace(getIn(theme, 'spacing.0')),
+        }}
+        id={id}
+        {...metaAttribute({ name: MetaConstants.FormLabel })}
       >
-        <BaseBox display="flex" flexDirection="row" alignItems="center" gap="spacing.2">
-          <BaseBox>{textNode}</BaseBox>
-          {labelSuffix ? <BaseBox display="flex">{labelSuffix}</BaseBox> : null}
-        </BaseBox>
-        {labelTrailing ? (
-          <BaseBox marginLeft={isLabelLeftPositioned ? 'spacing.0' : 'auto'}>
-            {labelTrailing}
+        <BaseBox
+          width="100%"
+          display="flex"
+          flexDirection={isLabelLeftPositioned ? 'column' : 'row'}
+          alignItems={isLabelLeftPositioned ? 'flex-start' : 'center'}
+          marginBottom={isLabelLeftPositioned ? 'spacing.0' : labelMarginBottom[size]}
+        >
+          <BaseBox display="flex" flexDirection="row" alignItems="center" gap="spacing.2">
+            <BaseBox>{textNode}</BaseBox>
+            {labelSuffix ? <BaseBox display="flex">{labelSuffix}</BaseBox> : null}
           </BaseBox>
-        ) : null}
-      </BaseBox>
-    </Component>
+          {labelTrailing ? (
+            <BaseBox marginLeft={isLabelLeftPositioned ? 'spacing.0' : 'auto'}>
+              {labelTrailing}
+            </BaseBox>
+          ) : null}
+        </BaseBox>
+      </Component>
+      {accessibilityText && (
+        <VisuallyHidden>
+          <Text>{accessibilityText}</Text>
+        </VisuallyHidden>
+      )}
+    </>
   );
 };
 

--- a/packages/blade/src/components/Radio/__tests__/RadioGroup.ssr.test.tsx
+++ b/packages/blade/src/components/Radio/__tests__/RadioGroup.ssr.test.tsx
@@ -7,16 +7,15 @@ describe('<RadioGroup />', () => {
   it('should render with help text', () => {
     const labelText = 'Select fruit';
     const helpText = 'Select one';
-    const { container } = renderWithSSR(
+    const { container, getByRole, getByText } = renderWithSSR(
       <RadioGroup helpText={helpText} label={labelText}>
         <Radio value="apple">Apple</Radio>
         <Radio value="mango">Mango</Radio>
         <Radio value="orange">Orange</Radio>
       </RadioGroup>,
     );
-    // expect(getByRole('group', { name: labelText })).toBeInTheDocument();
-    // @TODO: help and label are creating issues since its read as one
-    // expect(getByText(helpText)).toBeInTheDocument();
+    expect(getByRole('group', { name: labelText })).toBeInTheDocument();
+    expect(getByText(helpText)).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Fixes #3782.

The FormLabel component encloses the screen-reader-only VisuallyHidden container (which contains accessibilityText/helper/error text) directly inside the wrapper Component (e.g. label or span) node: https://github.com/razorpay/blade/blob/master/packages/blade/src/components/Form/FormLabel.tsx#L129-L134

Because the visually hidden text is nested inside the element carrying the id attribute, any screen-reader accessible name calculations (such as when input groups refer to the label via labelledBy) will concatenate the label text with this description text. For example, a RadioGroup with label "Select fruit" and helper text "Select one" gets computed with the accessible name: "Select fruit ,Select one" (instead of "Select fruit").

This PR refactors the FormLabel web implementation to render the accessibilityText outside the Component element that has the id. The React Native implementation remains unchanged to preserve existing behavior on mobile.

Additionally, this PR un-comments and fixes the assertions in the RadioGroup SSR test suite which were disabled due to this issue.

Changes
FormLabel.tsx: Render the visually hidden accessibilityText as a sibling outside the parent Component wrapper on Web.
RadioGroup.ssr.test.tsx: Destructured getByRole and getByText and un-commented the assertions checking the accessible name of the group and help text rendering.
Verification
Local unit tests in RadioGroup.ssr.test.tsx pass.