### PR TITLE
feat(tokens): add bladeNeutralTheme and multi-theme token publishing

### DIFF
--- a/.changeset/blade-neutral-theme.md
+++ b/.changeset/blade-neutral-theme.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(tokens): add bladeNeutralTheme and support publishing multiple themes from the Figma token publisher

--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -1,15 +1,27 @@
 const fs = require('fs');
 const path = require('path');
+const zlib = require('zlib');
 const execa = require('execa');
 const randomNameGenerator = require('moniker');
 
 const GITHUB_BOT_EMAIL = 'tools+cibot@razorpay.com';
 const GITHUB_BOT_USERNAME = 'rzpcibot';
 
+// The Figma plugin gzip + base64 encodes the tokens payload to stay under GitHub's
+// 65,535 character workflow_dispatch input limit. Decompress it here, falling back to
+// treating the argument as raw JSON for backward compatibility.
+const parseTokensArg = (arg) => {
+  try {
+    return JSON.parse(zlib.gunzipSync(Buffer.from(arg, 'base64')).toString('utf8'));
+  } catch (error) {
+    return JSON.parse(arg);
+  }
+};
+
 const uploadColorTokens = async () => {
   try {
     // 1. read the tokens object
-    const colorTokens = JSON.parse(process.argv[2]);
+    const colorTokens = parseTokensArg(process.argv[2]);
 
     const themeColorTokensRegex = /const colors: ColorsWithModes = {(.|\n)+?};/gm;
     // Each theme in the payload is written into its own source file.

--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -33,7 +33,9 @@ const uploadColorTokens = async () => {
     for (const [themeName, themeModes] of Object.entries(colorTokens?.themeColorTokens ?? {})) {
       const targetRelativePath = THEME_TARGETS[themeName];
       if (!targetRelativePath) {
-        console.warn(`No target file configured for theme: ${themeName}. Update THEME_TARGETS in scripts/uploadTokens.js.`);
+        console.warn(
+          `No target file configured for theme: ${themeName}. Update THEME_TARGETS in scripts/uploadTokens.js.`,
+        );
         continue;
       }
       if (

--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -20,8 +20,11 @@ const uploadColorTokens = async () => {
 
     for (const [themeName, themeModes] of Object.entries(colorTokens?.themeColorTokens ?? {})) {
       const targetRelativePath = THEME_TARGETS[themeName];
+      if (!targetRelativePath) {
+        console.warn(`No target file configured for theme: ${themeName}. Update THEME_TARGETS in scripts/uploadTokens.js.`);
+        continue;
+      }
       if (
-        !targetRelativePath ||
         !Object.keys(themeModes?.onLight ?? {}).length ||
         !Object.keys(themeModes?.onDark ?? {}).length
       ) {

--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -11,27 +11,39 @@ const uploadColorTokens = async () => {
     // 1. read the tokens object
     const colorTokens = JSON.parse(process.argv[2]);
 
-    if (
-      Object.keys(colorTokens?.themeColorTokens?.onLight).length &&
-      Object.keys(colorTokens?.themeColorTokens?.onDark).length
-    ) {
-      const themeColorTokensRegex = /const colors: ColorsWithModes = {(.|\n)+?};/gm;
-      // 2. read the bladeTheme File
-      const bladeThemePath = path.resolve(__dirname, '../src/tokens/theme/bladeTheme.ts');
-      const bladeTheme = fs.readFileSync(bladeThemePath, 'utf8');
+    const themeColorTokensRegex = /const colors: ColorsWithModes = {(.|\n)+?};/gm;
+    // Each theme in the payload is written into its own source file.
+    const THEME_TARGETS = {
+      bladeTheme: 'src/tokens/theme/bladeTheme.ts',
+      bladeNeutralTheme: 'src/tokens/theme/bladeNeutralTheme.ts',
+    };
 
-      // 3. write the new tokens to bladeTheme file
-      const updatedbladeThemeColors = JSON.stringify(colorTokens.themeColorTokens, null, 2)
+    for (const [themeName, themeModes] of Object.entries(colorTokens?.themeColorTokens ?? {})) {
+      const targetRelativePath = THEME_TARGETS[themeName];
+      if (
+        !targetRelativePath ||
+        !Object.keys(themeModes?.onLight ?? {}).length ||
+        !Object.keys(themeModes?.onDark ?? {}).length
+      ) {
+        continue;
+      }
+
+      // 2. read the theme file
+      const themeFilePath = path.resolve(__dirname, '..', targetRelativePath);
+      const themeFileContent = fs.readFileSync(themeFilePath, 'utf8');
+
+      // 3. write the new tokens to the theme file
+      const updatedThemeColors = JSON.stringify(themeModes, null, 2)
         .replace(/"([a-zA-Z_$][a-zA-Z0-9_$]*)":/g, '$1:') // Remove quotes only from valid JS identifiers
         .replace(/"(\d+)":/g, '$1:') // Remove quotes from numeric keys
         .replace(/: "([^"]+)"/g, ': $1'); // Remove quotes from values
-      const updatedbladeTheme = bladeTheme.replace(
+      const updatedThemeFile = themeFileContent.replace(
         themeColorTokensRegex,
-        `const colors: ColorsWithModes = ${updatedbladeThemeColors};`,
+        `const colors: ColorsWithModes = ${updatedThemeColors};`,
       );
-      fs.writeFileSync(bladeThemePath, updatedbladeTheme);
+      fs.writeFileSync(themeFilePath, updatedThemeFile);
       // prettify the file
-      execa.commandSync('yarn prettier --write src/tokens/theme/bladeTheme.ts');
+      execa.commandSync(`yarn prettier --write ${targetRelativePath}`);
     }
 
     if (Object.keys(colorTokens?.globalColorTokens).length) {

--- a/packages/blade/src/tokens/theme/bladeNeutralTheme.ts
+++ b/packages/blade/src/tokens/theme/bladeNeutralTheme.ts
@@ -1,0 +1,1405 @@
+import type { ThemeTokens, ColorsWithModes } from './theme';
+import {
+  border,
+  backdropBlur,
+  breakpoints,
+  colors as globalColors,
+  motion,
+  spacing,
+  typography,
+  elevation,
+  opacity,
+} from '~tokens/global';
+
+const colors: ColorsWithModes = {
+  onLight: {
+    surface: {
+      background: {
+        gray: {
+          subtle: globalColors.neutral.blueGrayLight[100],
+          moderate: globalColors.neutral.blueGrayLight[50],
+          intense: globalColors.neutral.blueGrayLight[0],
+        },
+        primary: {
+          subtle: globalColors.chromatic.azure.a50,
+          intense: globalColors.chromatic.azure[500],
+        },
+        sea: {
+          subtle: globalColors.chromatic.sea[50],
+          intense: globalColors.chromatic.sea[800],
+        },
+        cloud: {
+          subtle: globalColors.chromatic.cloud[50],
+          intense: globalColors.chromatic.cloud[800],
+        },
+      },
+      border: {
+        gray: {
+          normal: globalColors.neutral.blueGrayLight[300],
+          subtle: globalColors.neutral.blueGrayLight[200],
+          muted: globalColors.neutral.blueGrayLight.a912,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[500],
+          muted: globalColors.chromatic.azure.a100,
+        },
+      },
+      text: {
+        gray: {
+          normal: globalColors.neutral.blueGrayLight[1300],
+          subtle: globalColors.neutral.blueGrayLight[1100],
+          muted: globalColors.neutral.blueGrayLight[700],
+          disabled: globalColors.neutral.blueGrayLight.a932,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[500],
+        },
+        onSea: {
+          onSubtle: globalColors.chromatic.forest[800],
+          onIntense: globalColors.chromatic.forest[200],
+        },
+        onCloud: {
+          onSubtle: globalColors.chromatic.azure[600],
+          onIntense: globalColors.chromatic.azure[200],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[450],
+          muted: globalColors.neutral.white[200],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[300],
+          muted: globalColors.neutral.black[200],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+      icon: {
+        gray: {
+          normal: globalColors.neutral.blueGrayLight[1300],
+          subtle: globalColors.neutral.blueGrayLight[1100],
+          muted: globalColors.neutral.blueGrayLight[700],
+          disabled: globalColors.neutral.blueGrayLight.a932,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[500],
+        },
+        onSea: {
+          onSubtle: globalColors.chromatic.forest[600],
+          onIntense: globalColors.chromatic.forest[400],
+        },
+        onCloud: {
+          onSubtle: globalColors.chromatic.azure[400],
+          onIntense: globalColors.chromatic.azure[300],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[450],
+          muted: globalColors.neutral.white[200],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[300],
+          muted: globalColors.neutral.black[200],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+    },
+    feedback: {
+      background: {
+        positive: {
+          subtle: globalColors.chromatic.emerald.a50,
+          intense: globalColors.chromatic.emerald[600],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson.a50,
+          intense: globalColors.chromatic.crimson[600],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider.a50,
+          intense: globalColors.chromatic.cider[600],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire.a50,
+          intense: globalColors.chromatic.sapphire[600],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayLight.a909,
+          intense: globalColors.neutral.blueGrayLight[1100],
+        },
+      },
+      border: {
+        positive: {
+          subtle: globalColors.chromatic.emerald.a100,
+          intense: globalColors.chromatic.emerald[700],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson.a100,
+          intense: globalColors.chromatic.crimson[700],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider.a100,
+          intense: globalColors.chromatic.cider[700],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire.a100,
+          intense: globalColors.chromatic.sapphire[700],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayLight.a918,
+          intense: globalColors.neutral.blueGrayLight[900],
+        },
+      },
+      text: {
+        positive: {
+          subtle: globalColors.chromatic.emerald[100],
+          intense: globalColors.chromatic.emerald[700],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson[100],
+          intense: globalColors.chromatic.crimson[600],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider[100],
+          intense: globalColors.chromatic.cider[700],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire[100],
+          intense: globalColors.chromatic.sapphire[700],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayLight[500],
+          intense: globalColors.neutral.blueGrayLight[1100],
+        },
+      },
+      icon: {
+        positive: {
+          subtle: globalColors.chromatic.emerald[100],
+          intense: globalColors.chromatic.emerald[700],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson[100],
+          intense: globalColors.chromatic.crimson[600],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider[100],
+          intense: globalColors.chromatic.cider[700],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire[100],
+          intense: globalColors.chromatic.sapphire[700],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayLight[500],
+          intense: globalColors.neutral.blueGrayLight[1100],
+        },
+      },
+    },
+    interactive: {
+      background: {
+        positive: {
+          default: globalColors.chromatic.emerald[600],
+          highlighted: globalColors.chromatic.emerald[700],
+          disabled: globalColors.chromatic.emerald.a50,
+          faded: globalColors.chromatic.emerald.a50,
+          fadedHighlighted: globalColors.chromatic.emerald.a100,
+        },
+        negative: {
+          default: globalColors.chromatic.crimson[600],
+          highlighted: globalColors.chromatic.crimson[700],
+          disabled: globalColors.chromatic.crimson.a50,
+          faded: globalColors.chromatic.crimson.a50,
+          fadedHighlighted: globalColors.chromatic.crimson.a100,
+        },
+        notice: {
+          default: globalColors.chromatic.cider[600],
+          highlighted: globalColors.chromatic.cider[700],
+          disabled: globalColors.chromatic.cider.a50,
+          faded: globalColors.chromatic.cider.a50,
+          fadedHighlighted: globalColors.chromatic.cider.a100,
+        },
+        information: {
+          default: globalColors.chromatic.sapphire[600],
+          highlighted: globalColors.chromatic.sapphire[700],
+          disabled: globalColors.chromatic.sapphire.a50,
+          faded: globalColors.chromatic.sapphire.a50,
+          fadedHighlighted: globalColors.chromatic.sapphire.a100,
+        },
+        neutral: {
+          default: globalColors.neutral.blueGrayLight[1000],
+          highlighted: globalColors.neutral.blueGrayLight[1100],
+          disabled: globalColors.neutral.blueGrayLight.a918,
+          faded: globalColors.neutral.blueGrayLight.a912,
+          fadedHighlighted: globalColors.neutral.blueGrayLight.a918,
+        },
+        gray: {
+          default: globalColors.neutral.blueGrayLight.a906,
+          highlighted: globalColors.neutral.blueGrayLight.a912,
+          disabled: globalColors.neutral.blueGrayLight.a906,
+          faded: globalColors.neutral.blueGrayLight.a906,
+          fadedHighlighted: globalColors.neutral.blueGrayLight.a909,
+          ghost: globalColors.neutral.blueGrayLight.a1,
+        },
+        primary: {
+          default: globalColors.chromatic.azure[500],
+          highlighted: globalColors.chromatic.azure[600],
+          disabled: globalColors.chromatic.azure.a100,
+          faded: globalColors.chromatic.azure.a50,
+          fadedHighlighted: globalColors.chromatic.azure.a100,
+        },
+        staticBlack: {
+          default: globalColors.neutral.black[500],
+          highlighted: globalColors.neutral.black[500],
+          disabled: globalColors.neutral.black[200],
+          faded: globalColors.neutral.black[50],
+          fadedHighlighted: globalColors.neutral.black[100],
+          ghost: globalColors.neutral.black[1],
+        },
+        staticWhite: {
+          default: globalColors.neutral.white[500],
+          highlighted: globalColors.neutral.white[400],
+          disabled: globalColors.neutral.white[50],
+          faded: globalColors.neutral.white[50],
+          fadedHighlighted: globalColors.neutral.white[100],
+          ghost: globalColors.neutral.white[1],
+        },
+      },
+      border: {
+        positive: {
+          default: globalColors.chromatic.emerald[600],
+          highlighted: globalColors.chromatic.emerald[700],
+          disabled: globalColors.chromatic.emerald.a100,
+          faded: globalColors.chromatic.emerald.a100,
+        },
+        negative: {
+          default: globalColors.chromatic.crimson[600],
+          highlighted: globalColors.chromatic.crimson[700],
+          disabled: globalColors.chromatic.crimson.a100,
+          faded: globalColors.chromatic.crimson.a100,
+        },
+        notice: {
+          default: globalColors.chromatic.cider[600],
+          highlighted: globalColors.chromatic.cider[700],
+          disabled: globalColors.chromatic.cider.a100,
+          faded: globalColors.chromatic.cider.a100,
+        },
+        information: {
+          default: globalColors.chromatic.sapphire[600],
+          highlighted: globalColors.chromatic.sapphire[700],
+          disabled: globalColors.chromatic.sapphire.a100,
+          faded: globalColors.chromatic.sapphire.a100,
+        },
+        neutral: {
+          default: globalColors.neutral.blueGrayLight[1200],
+          highlighted: globalColors.neutral.blueGrayLight[1300],
+          disabled: globalColors.neutral.blueGrayLight[300],
+          faded: globalColors.neutral.blueGrayLight.a912,
+        },
+        gray: {
+          default: globalColors.neutral.blueGrayLight[200],
+          highlighted: globalColors.neutral.blueGrayLight[400],
+          disabled: globalColors.neutral.blueGrayLight[200],
+          faded: globalColors.neutral.blueGrayLight.a918,
+        },
+        primary: {
+          default: globalColors.chromatic.azure[500],
+          highlighted: globalColors.chromatic.azure[600],
+          disabled: globalColors.chromatic.azure.a100,
+          faded: globalColors.chromatic.azure.a100,
+        },
+        staticWhite: {
+          default: globalColors.neutral.white[500],
+          highlighted: globalColors.neutral.white[400],
+          disabled: globalColors.neutral.white[100],
+          faded: globalColors.neutral.white[50],
+          fadedHighlighted: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          default: globalColors.neutral.black[500],
+          highlighted: globalColors.neutral.black[500],
+          disabled: globalColors.neutral.black[100],
+          faded: globalColors.neutral.black[100],
+          fadedHighlighted: globalColors.neutral.black[50],
+        },
+      },
+      text: {
+        positive: {
+          normal: globalColors.chromatic.emerald[700],
+          subtle: globalColors.chromatic.emerald[600],
+          muted: globalColors.chromatic.emerald[400],
+          disabled: globalColors.chromatic.emerald.a200,
+        },
+        negative: {
+          normal: globalColors.chromatic.crimson[600],
+          subtle: globalColors.chromatic.crimson[500],
+          muted: globalColors.chromatic.crimson[400],
+          disabled: globalColors.chromatic.crimson.a200,
+        },
+        notice: {
+          normal: globalColors.chromatic.cider[700],
+          subtle: globalColors.chromatic.cider[600],
+          muted: globalColors.chromatic.cider[400],
+          disabled: globalColors.chromatic.cider.a200,
+        },
+        information: {
+          normal: globalColors.chromatic.sapphire[700],
+          subtle: globalColors.chromatic.sapphire[600],
+          muted: globalColors.chromatic.sapphire[400],
+          disabled: globalColors.chromatic.sapphire.a200,
+        },
+        neutral: {
+          normal: globalColors.neutral.blueGrayLight[1300],
+          subtle: globalColors.neutral.blueGrayLight[1100],
+          muted: globalColors.neutral.blueGrayLight[700],
+          disabled: globalColors.neutral.blueGrayLight.a932,
+        },
+        gray: {
+          normal: globalColors.neutral.blueGrayLight[1300],
+          subtle: globalColors.neutral.blueGrayLight[1100],
+          muted: globalColors.neutral.blueGrayLight[700],
+          disabled: globalColors.neutral.blueGrayLight.a932,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[600],
+          subtle: globalColors.chromatic.azure[500],
+          muted: globalColors.chromatic.azure[400],
+          disabled: globalColors.chromatic.azure.a200,
+        },
+        onPrimary: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[400],
+          muted: globalColors.neutral.black[300],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+      icon: {
+        positive: {
+          normal: globalColors.chromatic.emerald[700],
+          subtle: globalColors.chromatic.emerald[600],
+          muted: globalColors.chromatic.emerald[400],
+          disabled: globalColors.chromatic.emerald.a200,
+        },
+        negative: {
+          normal: globalColors.chromatic.crimson[600],
+          subtle: globalColors.chromatic.crimson[500],
+          muted: globalColors.chromatic.crimson[400],
+          disabled: globalColors.chromatic.crimson.a200,
+        },
+        notice: {
+          normal: globalColors.chromatic.cider[700],
+          subtle: globalColors.chromatic.cider[600],
+          muted: globalColors.chromatic.cider[400],
+          disabled: globalColors.chromatic.cider.a200,
+        },
+        information: {
+          normal: globalColors.chromatic.sapphire[700],
+          subtle: globalColors.chromatic.sapphire[600],
+          muted: globalColors.chromatic.sapphire[400],
+          disabled: globalColors.chromatic.sapphire.a200,
+        },
+        neutral: {
+          normal: globalColors.neutral.blueGrayLight[1300],
+          subtle: globalColors.neutral.blueGrayLight[1100],
+          muted: globalColors.neutral.blueGrayLight[700],
+          disabled: globalColors.neutral.blueGrayLight.a932,
+        },
+        gray: {
+          normal: globalColors.neutral.blueGrayLight[1300],
+          subtle: globalColors.neutral.blueGrayLight[1100],
+          muted: globalColors.neutral.blueGrayLight[700],
+          disabled: globalColors.neutral.blueGrayLight.a932,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[600],
+          subtle: globalColors.chromatic.azure[500],
+          muted: globalColors.chromatic.azure[400],
+          disabled: globalColors.chromatic.azure.a200,
+        },
+        onPrimary: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[400],
+          muted: globalColors.neutral.black[300],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+    },
+    overlay: {
+      background: {
+        moderate: globalColors.neutral.blueGrayLight.a918,
+        subtle: globalColors.neutral.black[200],
+      },
+    },
+    popup: {
+      background: {
+        // @deprecated
+        subtle: globalColors.neutral.blueGrayLight[0],
+        // @deprecated
+        intense: globalColors.neutral.blueGrayLight[1000],
+        gray: {
+          subtle: globalColors.neutral.blueGrayLight[0],
+          moderate: globalColors.neutral.blueGrayLight.a48,
+          intense: globalColors.neutral.black[300],
+        },
+        positive: {
+          moderate: globalColors.chromatic.emerald.a700,
+        },
+        negative: {
+          moderate: globalColors.chromatic.crimson.a700,
+        },
+        notice: {
+          moderate: globalColors.chromatic.cider.a700,
+        },
+        information: {
+          moderate: globalColors.chromatic.sapphire.a700,
+        },
+        neutral: {
+          moderate: globalColors.neutral.blueGrayLight.a1288,
+        },
+      },
+      border: {
+        // @deprecated
+        subtle: globalColors.neutral.blueGrayLight.a100,
+        // @deprecated
+        intense: globalColors.neutral.blueGrayLight[900],
+        gray: {
+          subtle: globalColors.neutral.blueGrayLight.a909,
+          moderate: globalColors.neutral.blueGrayLight[100],
+          intense: globalColors.neutral.blueGrayLight[1000],
+        },
+        positive: {
+          moderate: globalColors.chromatic.emerald[600],
+        },
+        negative: {
+          moderate: globalColors.chromatic.crimson[600],
+        },
+        notice: {
+          moderate: globalColors.chromatic.cider[600],
+        },
+        information: {
+          moderate: globalColors.chromatic.sapphire[600],
+        },
+        neutral: {
+          moderate: globalColors.neutral.blueGrayLight[1100],
+        },
+      },
+    },
+    data: {
+      background: {
+        categorical: {
+          blue: {
+            faint: globalColors.chromatic.azure[100],
+            subtle: globalColors.chromatic.azure[200],
+            moderate: globalColors.chromatic.azure[300],
+            intense: globalColors.chromatic.azure[400],
+            strong: globalColors.chromatic.azure[500],
+          },
+          green: {
+            faint: globalColors.chromatic.emerald[100],
+            subtle: globalColors.chromatic.emerald[200],
+            moderate: globalColors.chromatic.emerald[300],
+            intense: globalColors.chromatic.emerald[400],
+            strong: globalColors.chromatic.emerald[500],
+          },
+          red: {
+            faint: globalColors.chromatic.crimson[100],
+            subtle: globalColors.chromatic.crimson[200],
+            moderate: globalColors.chromatic.crimson[300],
+            intense: globalColors.chromatic.crimson[400],
+            strong: globalColors.chromatic.crimson[500],
+          },
+          orange: {
+            faint: globalColors.chromatic.cider[100],
+            subtle: globalColors.chromatic.cider[200],
+            moderate: globalColors.chromatic.cider[300],
+            intense: globalColors.chromatic.cider[400],
+            strong: globalColors.chromatic.cider[500],
+          },
+          skyBlue: {
+            faint: globalColors.chromatic.sapphire[100],
+            subtle: globalColors.chromatic.sapphire[200],
+            moderate: globalColors.chromatic.sapphire[300],
+            intense: globalColors.chromatic.sapphire[400],
+            strong: globalColors.chromatic.sapphire[500],
+          },
+          purple: {
+            faint: globalColors.chromatic.orchid[100],
+            subtle: globalColors.chromatic.orchid[200],
+            moderate: globalColors.chromatic.orchid[300],
+            intense: globalColors.chromatic.orchid[400],
+            strong: globalColors.chromatic.orchid[500],
+          },
+          pink: {
+            faint: globalColors.chromatic.magenta[100],
+            subtle: globalColors.chromatic.magenta[200],
+            moderate: globalColors.chromatic.magenta[300],
+            intense: globalColors.chromatic.magenta[400],
+            strong: globalColors.chromatic.magenta[500],
+          },
+          gold: {
+            faint: globalColors.chromatic.topaz[50],
+            subtle: globalColors.chromatic.topaz[100],
+            moderate: globalColors.chromatic.topaz[200],
+            intense: globalColors.chromatic.topaz[300],
+            strong: globalColors.chromatic.topaz[400],
+          },
+          gray: {
+            faint: globalColors.neutral.blueGrayLight[0],
+            subtle: globalColors.neutral.blueGrayLight[50],
+            moderate: globalColors.neutral.blueGrayLight[100],
+            intense: globalColors.neutral.blueGrayLight[400],
+            strong: globalColors.neutral.blueGrayLight[700],
+          },
+        },
+        sequential: {
+          blue: {
+            50: globalColors.chromatic.azure[50],
+            100: globalColors.chromatic.azure[100],
+            200: globalColors.chromatic.azure[200],
+            300: globalColors.chromatic.azure[300],
+            400: globalColors.chromatic.azure[400],
+            500: globalColors.chromatic.azure[500],
+            600: globalColors.chromatic.azure[600],
+            700: globalColors.chromatic.azure[700],
+            800: globalColors.chromatic.azure[800],
+            900: globalColors.chromatic.azure[900],
+            1000: globalColors.chromatic.azure[1000],
+          },
+          green: {
+            50: globalColors.chromatic.emerald[50],
+            100: globalColors.chromatic.emerald[100],
+            200: globalColors.chromatic.emerald[200],
+            300: globalColors.chromatic.emerald[300],
+            400: globalColors.chromatic.emerald[400],
+            500: globalColors.chromatic.emerald[500],
+            600: globalColors.chromatic.emerald[600],
+            700: globalColors.chromatic.emerald[700],
+            800: globalColors.chromatic.emerald[800],
+            900: globalColors.chromatic.emerald[900],
+            1000: globalColors.chromatic.emerald[1000],
+          },
+          red: {
+            50: globalColors.chromatic.crimson[50],
+            100: globalColors.chromatic.crimson[100],
+            200: globalColors.chromatic.crimson[200],
+            300: globalColors.chromatic.crimson[300],
+            400: globalColors.chromatic.crimson[400],
+            500: globalColors.chromatic.crimson[500],
+            600: globalColors.chromatic.crimson[600],
+            700: globalColors.chromatic.crimson[700],
+            800: globalColors.chromatic.crimson[800],
+            900: globalColors.chromatic.crimson[900],
+            1000: globalColors.chromatic.crimson[1000],
+          },
+          orange: {
+            50: globalColors.chromatic.cider[50],
+            100: globalColors.chromatic.cider[100],
+            200: globalColors.chromatic.cider[200],
+            300: globalColors.chromatic.cider[300],
+            400: globalColors.chromatic.cider[400],
+            500: globalColors.chromatic.cider[500],
+            600: globalColors.chromatic.cider[600],
+            700: globalColors.chromatic.cider[700],
+            800: globalColors.chromatic.cider[800],
+            900: globalColors.chromatic.cider[900],
+            1000: globalColors.chromatic.cider[1000],
+          },
+          skyBlue: {
+            50: globalColors.chromatic.sapphire[50],
+            100: globalColors.chromatic.sapphire[100],
+            200: globalColors.chromatic.sapphire[200],
+            300: globalColors.chromatic.sapphire[300],
+            400: globalColors.chromatic.sapphire[400],
+            500: globalColors.chromatic.sapphire[500],
+            600: globalColors.chromatic.sapphire[600],
+            700: globalColors.chromatic.sapphire[700],
+            800: globalColors.chromatic.sapphire[800],
+            900: globalColors.chromatic.sapphire[900],
+            1000: globalColors.chromatic.sapphire[1000],
+          },
+          purple: {
+            50: globalColors.chromatic.orchid[50],
+            100: globalColors.chromatic.orchid[100],
+            200: globalColors.chromatic.orchid[200],
+            300: globalColors.chromatic.orchid[300],
+            400: globalColors.chromatic.orchid[400],
+            500: globalColors.chromatic.orchid[500],
+            600: globalColors.chromatic.orchid[600],
+            700: globalColors.chromatic.orchid[700],
+            800: globalColors.chromatic.orchid[800],
+            900: globalColors.chromatic.orchid[900],
+            1000: globalColors.chromatic.orchid[1000],
+          },
+          pink: {
+            50: globalColors.chromatic.magenta[50],
+            100: globalColors.chromatic.magenta[100],
+            200: globalColors.chromatic.magenta[200],
+            300: globalColors.chromatic.magenta[300],
+            400: globalColors.chromatic.magenta[400],
+            500: globalColors.chromatic.magenta[500],
+            600: globalColors.chromatic.magenta[600],
+            700: globalColors.chromatic.magenta[700],
+            800: globalColors.chromatic.magenta[800],
+            900: globalColors.chromatic.magenta[900],
+            1000: globalColors.chromatic.magenta[1000],
+          },
+          gold: {
+            50: globalColors.chromatic.topaz[50],
+            100: globalColors.chromatic.topaz[100],
+            200: globalColors.chromatic.topaz[200],
+            300: globalColors.chromatic.topaz[300],
+            400: globalColors.chromatic.topaz[400],
+            500: globalColors.chromatic.topaz[500],
+            600: globalColors.chromatic.topaz[600],
+            700: globalColors.chromatic.topaz[700],
+            800: globalColors.chromatic.topaz[800],
+            900: globalColors.chromatic.topaz[900],
+            1000: globalColors.chromatic.topaz[1000],
+          },
+          gray: {
+            0: globalColors.neutral.blueGrayLight[0],
+            50: globalColors.neutral.blueGrayLight[50],
+            100: globalColors.neutral.blueGrayLight[100],
+            200: globalColors.neutral.blueGrayLight[200],
+            300: globalColors.neutral.blueGrayLight[300],
+            400: globalColors.neutral.blueGrayLight[400],
+            500: globalColors.neutral.blueGrayLight[500],
+            600: globalColors.neutral.blueGrayLight[600],
+            700: globalColors.neutral.blueGrayLight[700],
+            800: globalColors.neutral.blueGrayLight[800],
+            900: globalColors.neutral.blueGrayLight[900],
+            1000: globalColors.neutral.blueGrayLight[1000],
+          },
+        },
+      },
+    },
+    transparent: `hsla(0, 0%, 100%, ${opacity[0]})`,
+  },
+  onDark: {
+    surface: {
+      background: {
+        gray: {
+          subtle: globalColors.neutral.blueGrayDark[1300],
+          moderate: globalColors.neutral.blueGrayDark[1200],
+          intense: globalColors.neutral.blueGrayDark[1100],
+        },
+        primary: {
+          subtle: globalColors.chromatic.azure.a200,
+          intense: globalColors.chromatic.azure[500],
+        },
+        sea: {
+          subtle: globalColors.chromatic.sea[900],
+          intense: globalColors.chromatic.sea[100],
+        },
+        cloud: {
+          subtle: globalColors.chromatic.cloud[900],
+          intense: globalColors.chromatic.cloud[100],
+        },
+      },
+      border: {
+        gray: {
+          normal: globalColors.neutral.blueGrayDark[600],
+          subtle: globalColors.neutral.blueGrayDark[800],
+          muted: globalColors.neutral.blueGrayDark.a518,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[500],
+          muted: globalColors.chromatic.azure.a200,
+        },
+      },
+      text: {
+        gray: {
+          normal: globalColors.neutral.blueGrayDark[0],
+          subtle: globalColors.neutral.blueGrayDark[300],
+          muted: globalColors.neutral.blueGrayDark[500],
+          disabled: globalColors.neutral.blueGrayDark.a564,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[300],
+        },
+        onSea: {
+          onSubtle: globalColors.chromatic.forest[200],
+          onIntense: globalColors.chromatic.forest[800],
+        },
+        onCloud: {
+          onSubtle: globalColors.chromatic.azure[200],
+          onIntense: globalColors.chromatic.azure[600],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[450],
+          muted: globalColors.neutral.white[200],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[300],
+          muted: globalColors.neutral.black[200],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+      icon: {
+        gray: {
+          normal: globalColors.neutral.blueGrayDark[0],
+          subtle: globalColors.neutral.blueGrayDark[300],
+          muted: globalColors.neutral.blueGrayDark[500],
+          disabled: globalColors.neutral.blueGrayDark.a532,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[300],
+        },
+        onSea: {
+          onSubtle: globalColors.chromatic.forest[400],
+          onIntense: globalColors.chromatic.forest[600],
+        },
+        onCloud: {
+          onSubtle: globalColors.chromatic.azure[300],
+          onIntense: globalColors.chromatic.azure[400],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[450],
+          muted: globalColors.neutral.white[200],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[300],
+          muted: globalColors.neutral.black[200],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+    },
+    feedback: {
+      background: {
+        positive: {
+          subtle: globalColors.chromatic.emerald.a100,
+          intense: globalColors.chromatic.emerald[700],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson.a100,
+          intense: globalColors.chromatic.crimson[700],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider.a100,
+          intense: globalColors.chromatic.cider[700],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire.a100,
+          intense: globalColors.chromatic.sapphire[700],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayDark.a509,
+          intense: globalColors.neutral.blueGrayDark[800],
+        },
+      },
+      border: {
+        positive: {
+          subtle: globalColors.chromatic.emerald.a200,
+          intense: globalColors.chromatic.emerald[800],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson.a200,
+          intense: globalColors.chromatic.crimson[800],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider.a200,
+          intense: globalColors.chromatic.cider[800],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire.a200,
+          intense: globalColors.chromatic.sapphire[800],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayDark.a518,
+          intense: globalColors.neutral.blueGrayDark[800],
+        },
+      },
+      text: {
+        positive: {
+          subtle: globalColors.chromatic.emerald[50],
+          intense: globalColors.chromatic.emerald[400],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson[50],
+          intense: globalColors.chromatic.crimson[400],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider[50],
+          intense: globalColors.chromatic.cider[400],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire[50],
+          intense: globalColors.chromatic.sapphire[400],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayDark[500],
+          intense: globalColors.neutral.blueGrayDark[300],
+        },
+      },
+      icon: {
+        positive: {
+          subtle: globalColors.chromatic.emerald[50],
+          intense: globalColors.chromatic.emerald[400],
+        },
+        negative: {
+          subtle: globalColors.chromatic.crimson[50],
+          intense: globalColors.chromatic.crimson[400],
+        },
+        notice: {
+          subtle: globalColors.chromatic.cider[50],
+          intense: globalColors.chromatic.cider[400],
+        },
+        information: {
+          subtle: globalColors.chromatic.sapphire[50],
+          intense: globalColors.chromatic.sapphire[400],
+        },
+        neutral: {
+          subtle: globalColors.neutral.blueGrayDark[500],
+          intense: globalColors.neutral.blueGrayDark[300],
+        },
+      },
+    },
+    interactive: {
+      background: {
+        positive: {
+          default: globalColors.chromatic.emerald[600],
+          highlighted: globalColors.chromatic.emerald[700],
+          disabled: globalColors.chromatic.emerald.a100,
+          faded: globalColors.chromatic.emerald.a150,
+          fadedHighlighted: globalColors.chromatic.emerald.a200,
+        },
+        negative: {
+          default: globalColors.chromatic.crimson[600],
+          highlighted: globalColors.chromatic.crimson[700],
+          disabled: globalColors.chromatic.crimson.a100,
+          faded: globalColors.chromatic.crimson.a150,
+          fadedHighlighted: globalColors.chromatic.crimson.a200,
+        },
+        notice: {
+          default: globalColors.chromatic.cider[600],
+          highlighted: globalColors.chromatic.cider[700],
+          disabled: globalColors.chromatic.cider.a100,
+          faded: globalColors.chromatic.cider.a150,
+          fadedHighlighted: globalColors.chromatic.cider.a200,
+        },
+        information: {
+          default: globalColors.chromatic.sapphire[600],
+          highlighted: globalColors.chromatic.sapphire[700],
+          disabled: globalColors.chromatic.sapphire.a100,
+          faded: globalColors.chromatic.sapphire.a150,
+          fadedHighlighted: globalColors.chromatic.sapphire.a200,
+        },
+        neutral: {
+          default: globalColors.neutral.blueGrayDark[50],
+          highlighted: globalColors.neutral.blueGrayDark[200],
+          disabled: globalColors.neutral.blueGrayDark.a518,
+          faded: globalColors.neutral.blueGrayDark.a512,
+          fadedHighlighted: globalColors.neutral.blueGrayDark.a518,
+        },
+        gray: {
+          default: globalColors.neutral.blueGrayDark.a512,
+          highlighted: globalColors.neutral.blueGrayDark.a532,
+          disabled: globalColors.neutral.blueGrayDark.a509,
+          faded: globalColors.neutral.blueGrayDark.a509,
+          fadedHighlighted: globalColors.neutral.blueGrayDark.a518,
+          ghost: globalColors.neutral.blueGrayDark.a1388,
+        },
+        primary: {
+          default: globalColors.chromatic.azure[400],
+          highlighted: globalColors.chromatic.azure[500],
+          disabled: globalColors.chromatic.azure.a150,
+          faded: globalColors.chromatic.azure.a150,
+          fadedHighlighted: globalColors.chromatic.azure.a200,
+        },
+        staticBlack: {
+          default: globalColors.neutral.black[500],
+          highlighted: globalColors.neutral.black[500],
+          disabled: globalColors.neutral.black[200],
+          faded: globalColors.neutral.black[50],
+          fadedHighlighted: globalColors.neutral.black[100],
+          ghost: globalColors.neutral.black[1],
+        },
+        staticWhite: {
+          default: globalColors.neutral.white[500],
+          highlighted: globalColors.neutral.white[400],
+          disabled: globalColors.neutral.white[50],
+          faded: globalColors.neutral.white[50],
+          fadedHighlighted: globalColors.neutral.white[100],
+          ghost: globalColors.neutral.white[1],
+        },
+      },
+      border: {
+        positive: {
+          default: globalColors.chromatic.emerald[600],
+          highlighted: globalColors.chromatic.emerald[700],
+          disabled: globalColors.chromatic.emerald.a100,
+          faded: globalColors.chromatic.emerald.a100,
+        },
+        negative: {
+          default: globalColors.chromatic.crimson[600],
+          highlighted: globalColors.chromatic.crimson[700],
+          disabled: globalColors.chromatic.crimson.a100,
+          faded: globalColors.chromatic.crimson.a100,
+        },
+        notice: {
+          default: globalColors.chromatic.cider[600],
+          highlighted: globalColors.chromatic.cider[700],
+          disabled: globalColors.chromatic.cider.a100,
+          faded: globalColors.chromatic.cider.a100,
+        },
+        information: {
+          default: globalColors.chromatic.sapphire[600],
+          highlighted: globalColors.chromatic.sapphire[700],
+          disabled: globalColors.chromatic.sapphire.a100,
+          faded: globalColors.chromatic.sapphire.a100,
+        },
+        neutral: {
+          default: globalColors.neutral.blueGrayDark[100],
+          highlighted: globalColors.neutral.blueGrayDark[0],
+          disabled: globalColors.neutral.blueGrayDark[800],
+          faded: globalColors.neutral.blueGrayDark.a518,
+        },
+        gray: {
+          default: globalColors.neutral.blueGrayDark[800],
+          highlighted: globalColors.neutral.blueGrayDark[700],
+          disabled: globalColors.neutral.blueGrayDark[1000],
+          faded: globalColors.neutral.blueGrayDark.a518,
+        },
+        primary: {
+          default: globalColors.chromatic.azure[400],
+          highlighted: globalColors.chromatic.azure[600],
+          disabled: globalColors.chromatic.azure.a200,
+          faded: globalColors.chromatic.azure.a150,
+        },
+        staticWhite: {
+          default: globalColors.neutral.white[500],
+          highlighted: globalColors.neutral.white[400],
+          disabled: globalColors.neutral.white[100],
+          faded: globalColors.neutral.white[50],
+          fadedHighlighted: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          default: globalColors.neutral.black[500],
+          highlighted: globalColors.neutral.black[500],
+          disabled: globalColors.neutral.black[100],
+          faded: globalColors.neutral.black[100],
+          fadedHighlighted: globalColors.neutral.black[50],
+        },
+      },
+      text: {
+        positive: {
+          normal: globalColors.chromatic.emerald[400],
+          subtle: globalColors.chromatic.emerald[500],
+          muted: globalColors.chromatic.emerald[700],
+          disabled: globalColors.chromatic.emerald.a200,
+        },
+        negative: {
+          normal: globalColors.chromatic.crimson[400],
+          subtle: globalColors.chromatic.crimson[500],
+          muted: globalColors.chromatic.crimson[700],
+          disabled: globalColors.chromatic.crimson.a200,
+        },
+        notice: {
+          normal: globalColors.chromatic.cider[400],
+          subtle: globalColors.chromatic.cider[500],
+          muted: globalColors.chromatic.cider[700],
+          disabled: globalColors.chromatic.cider.a200,
+        },
+        information: {
+          normal: globalColors.chromatic.sapphire[400],
+          subtle: globalColors.chromatic.sapphire[500],
+          muted: globalColors.chromatic.sapphire[700],
+          disabled: globalColors.chromatic.sapphire.a200,
+        },
+        neutral: {
+          normal: globalColors.neutral.blueGrayDark[0],
+          subtle: globalColors.neutral.blueGrayDark[300],
+          muted: globalColors.neutral.blueGrayDark[500],
+          disabled: globalColors.neutral.blueGrayDark.a532,
+        },
+        gray: {
+          normal: globalColors.neutral.blueGrayDark[0],
+          subtle: globalColors.neutral.blueGrayDark[300],
+          muted: globalColors.neutral.blueGrayDark[500],
+          disabled: globalColors.neutral.blueGrayDark.a532,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[300],
+          subtle: globalColors.chromatic.azure[400],
+          muted: globalColors.chromatic.azure[600],
+          disabled: globalColors.chromatic.azure.a400,
+        },
+        onPrimary: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[400],
+          muted: globalColors.neutral.black[300],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+      icon: {
+        positive: {
+          normal: globalColors.chromatic.emerald[400],
+          subtle: globalColors.chromatic.emerald[500],
+          muted: globalColors.chromatic.emerald[700],
+          disabled: globalColors.chromatic.emerald.a200,
+        },
+        negative: {
+          normal: globalColors.chromatic.crimson[400],
+          subtle: globalColors.chromatic.crimson[500],
+          muted: globalColors.chromatic.crimson[700],
+          disabled: globalColors.chromatic.crimson.a200,
+        },
+        notice: {
+          normal: globalColors.chromatic.cider[400],
+          subtle: globalColors.chromatic.cider[500],
+          muted: globalColors.chromatic.cider[700],
+          disabled: globalColors.chromatic.cider.a200,
+        },
+        information: {
+          normal: globalColors.chromatic.sapphire[400],
+          subtle: globalColors.chromatic.sapphire[500],
+          muted: globalColors.chromatic.sapphire[700],
+          disabled: globalColors.chromatic.sapphire.a200,
+        },
+        neutral: {
+          normal: globalColors.neutral.blueGrayDark[0],
+          subtle: globalColors.neutral.blueGrayDark[300],
+          muted: globalColors.neutral.blueGrayDark[500],
+          disabled: globalColors.neutral.blueGrayDark.a532,
+        },
+        gray: {
+          normal: globalColors.neutral.blueGrayDark[0],
+          subtle: globalColors.neutral.blueGrayDark[300],
+          muted: globalColors.neutral.blueGrayDark[500],
+          disabled: globalColors.neutral.blueGrayDark.a532,
+        },
+        primary: {
+          normal: globalColors.chromatic.azure[300],
+          subtle: globalColors.chromatic.azure[400],
+          muted: globalColors.chromatic.azure[600],
+          disabled: globalColors.chromatic.azure.a400,
+        },
+        onPrimary: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticWhite: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        staticBlack: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[400],
+          muted: globalColors.neutral.black[300],
+          disabled: globalColors.neutral.black[100],
+        },
+      },
+    },
+    overlay: {
+      background: {
+        moderate: globalColors.neutral.blueGrayDark.a518,
+        subtle: globalColors.neutral.black[400],
+      },
+    },
+    popup: {
+      background: {
+        // @deprecated
+        subtle: globalColors.neutral.blueGrayDark[1000],
+        // @deprecated
+        intense: globalColors.neutral.blueGrayDark[700],
+        gray: {
+          subtle: globalColors.neutral.blueGrayDark[1300],
+          moderate: globalColors.neutral.blueGrayDark.a1188,
+          intense: globalColors.neutral.black[300],
+        },
+        positive: {
+          moderate: globalColors.chromatic.emerald.a700,
+        },
+        negative: {
+          moderate: globalColors.chromatic.crimson.a700,
+        },
+        notice: {
+          moderate: globalColors.chromatic.cider.a700,
+        },
+        information: {
+          moderate: globalColors.chromatic.sapphire.a700,
+        },
+        neutral: {
+          moderate: globalColors.neutral.blueGrayDark.a888,
+        },
+      },
+      border: {
+        // @deprecated
+        subtle: globalColors.neutral.blueGrayDark.a100,
+        // @deprecated
+        intense: globalColors.neutral.blueGrayDark.a100,
+        gray: {
+          subtle: globalColors.neutral.blueGrayDark.a512,
+          moderate: globalColors.neutral.blueGrayDark[800],
+          intense: globalColors.neutral.blueGrayDark[1000],
+        },
+        positive: {
+          moderate: globalColors.chromatic.emerald[600],
+        },
+        negative: {
+          moderate: globalColors.chromatic.crimson[600],
+        },
+        notice: {
+          moderate: globalColors.chromatic.cider[600],
+        },
+        information: {
+          moderate: globalColors.chromatic.sapphire[600],
+        },
+        neutral: {
+          moderate: globalColors.neutral.blueGrayDark[800],
+        },
+      },
+    },
+    data: {
+      background: {
+        categorical: {
+          blue: {
+            faint: globalColors.chromatic.azure[800],
+            subtle: globalColors.chromatic.azure[700],
+            moderate: globalColors.chromatic.azure[600],
+            intense: globalColors.chromatic.azure[500],
+            strong: globalColors.chromatic.azure[400],
+          },
+          green: {
+            faint: globalColors.chromatic.emerald[800],
+            subtle: globalColors.chromatic.emerald[700],
+            moderate: globalColors.chromatic.emerald[600],
+            intense: globalColors.chromatic.emerald[500],
+            strong: globalColors.chromatic.emerald[400],
+          },
+          red: {
+            faint: globalColors.chromatic.crimson[800],
+            subtle: globalColors.chromatic.crimson[700],
+            moderate: globalColors.chromatic.crimson[600],
+            intense: globalColors.chromatic.crimson[500],
+            strong: globalColors.chromatic.crimson[400],
+          },
+          orange: {
+            faint: globalColors.chromatic.cider[800],
+            subtle: globalColors.chromatic.cider[700],
+            moderate: globalColors.chromatic.cider[600],
+            intense: globalColors.chromatic.cider[500],
+            strong: globalColors.chromatic.cider[400],
+          },
+          skyBlue: {
+            faint: globalColors.chromatic.sapphire[800],
+            subtle: globalColors.chromatic.sapphire[700],
+            moderate: globalColors.chromatic.sapphire[600],
+            intense: globalColors.chromatic.sapphire[500],
+            strong: globalColors.chromatic.sapphire[400],
+          },
+          purple: {
+            faint: globalColors.chromatic.orchid[800],
+            subtle: globalColors.chromatic.orchid[700],
+            moderate: globalColors.chromatic.orchid[600],
+            intense: globalColors.chromatic.orchid[500],
+            strong: globalColors.chromatic.orchid[400],
+          },
+          pink: {
+            faint: globalColors.chromatic.magenta[800],
+            subtle: globalColors.chromatic.magenta[700],
+            moderate: globalColors.chromatic.magenta[600],
+            intense: globalColors.chromatic.magenta[500],
+            strong: globalColors.chromatic.magenta[400],
+          },
+          gold: {
+            faint: globalColors.chromatic.topaz[700],
+            subtle: globalColors.chromatic.topaz[600],
+            moderate: globalColors.chromatic.topaz[500],
+            intense: globalColors.chromatic.topaz[400],
+            strong: globalColors.chromatic.topaz[300],
+          },
+          gray: {
+            faint: globalColors.neutral.blueGrayDark[1200],
+            subtle: globalColors.neutral.blueGrayDark[1000],
+            moderate: globalColors.neutral.blueGrayDark[900],
+            intense: globalColors.neutral.blueGrayDark[300],
+            strong: globalColors.neutral.blueGrayDark[600],
+          },
+        },
+        sequential: {
+          blue: {
+            50: globalColors.chromatic.azure[1000],
+            100: globalColors.chromatic.azure[900],
+            200: globalColors.chromatic.azure[800],
+            300: globalColors.chromatic.azure[700],
+            400: globalColors.chromatic.azure[600],
+            500: globalColors.chromatic.azure[500],
+            600: globalColors.chromatic.azure[400],
+            700: globalColors.chromatic.azure[300],
+            800: globalColors.chromatic.azure[200],
+            900: globalColors.chromatic.azure[100],
+            1000: globalColors.chromatic.azure[50],
+          },
+          green: {
+            50: globalColors.chromatic.emerald[1000],
+            100: globalColors.chromatic.emerald[900],
+            200: globalColors.chromatic.emerald[800],
+            300: globalColors.chromatic.emerald[700],
+            400: globalColors.chromatic.emerald[600],
+            500: globalColors.chromatic.emerald[500],
+            600: globalColors.chromatic.emerald[400],
+            700: globalColors.chromatic.emerald[300],
+            800: globalColors.chromatic.emerald[200],
+            900: globalColors.chromatic.emerald[100],
+            1000: globalColors.chromatic.emerald[50],
+          },
+          red: {
+            50: globalColors.chromatic.crimson[1000],
+            100: globalColors.chromatic.crimson[900],
+            200: globalColors.chromatic.crimson[800],
+            300: globalColors.chromatic.crimson[700],
+            400: globalColors.chromatic.crimson[600],
+            500: globalColors.chromatic.crimson[500],
+            600: globalColors.chromatic.crimson[400],
+            700: globalColors.chromatic.crimson[300],
+            800: globalColors.chromatic.crimson[200],
+            900: globalColors.chromatic.crimson[100],
+            1000: globalColors.chromatic.crimson[50],
+          },
+          orange: {
+            50: globalColors.chromatic.cider[1000],
+            100: globalColors.chromatic.cider[900],
+            200: globalColors.chromatic.cider[800],
+            300: globalColors.chromatic.cider[700],
+            400: globalColors.chromatic.cider[600],
+            500: globalColors.chromatic.cider[500],
+            600: globalColors.chromatic.cider[400],
+            700: globalColors.chromatic.cider[300],
+            800: globalColors.chromatic.cider[200],
+            900: globalColors.chromatic.cider[100],
+            1000: globalColors.chromatic.cider[50],
+          },
+          skyBlue: {
+            50: globalColors.chromatic.sapphire[1000],
+            100: globalColors.chromatic.sapphire[900],
+            200: globalColors.chromatic.sapphire[800],
+            300: globalColors.chromatic.sapphire[700],
+            400: globalColors.chromatic.sapphire[600],
+            500: globalColors.chromatic.sapphire[500],
+            600: globalColors.chromatic.sapphire[400],
+            700: globalColors.chromatic.sapphire[300],
+            800: globalColors.chromatic.sapphire[200],
+            900: globalColors.chromatic.sapphire[100],
+            1000: globalColors.chromatic.sapphire[50],
+          },
+          purple: {
+            50: globalColors.chromatic.orchid[1000],
+            100: globalColors.chromatic.orchid[900],
+            200: globalColors.chromatic.orchid[800],
+            300: globalColors.chromatic.orchid[700],
+            400: globalColors.chromatic.orchid[600],
+            500: globalColors.chromatic.orchid[500],
+            600: globalColors.chromatic.orchid[400],
+            700: globalColors.chromatic.orchid[300],
+            800: globalColors.chromatic.orchid[200],
+            900: globalColors.chromatic.orchid[100],
+            1000: globalColors.chromatic.orchid[50],
+          },
+          pink: {
+            50: globalColors.chromatic.magenta[1000],
+            100: globalColors.chromatic.magenta[900],
+            200: globalColors.chromatic.magenta[800],
+            300: globalColors.chromatic.magenta[700],
+            400: globalColors.chromatic.magenta[600],
+            500: globalColors.chromatic.magenta[500],
+            600: globalColors.chromatic.magenta[400],
+            700: globalColors.chromatic.magenta[300],
+            800: globalColors.chromatic.magenta[200],
+            900: globalColors.chromatic.magenta[100],
+            1000: globalColors.chromatic.magenta[50],
+          },
+          gold: {
+            50: globalColors.chromatic.topaz[1000],
+            100: globalColors.chromatic.topaz[900],
+            200: globalColors.chromatic.topaz[800],
+            300: globalColors.chromatic.topaz[700],
+            400: globalColors.chromatic.topaz[600],
+            500: globalColors.chromatic.topaz[500],
+            600: globalColors.chromatic.topaz[400],
+            700: globalColors.chromatic.topaz[300],
+            800: globalColors.chromatic.topaz[200],
+            900: globalColors.chromatic.topaz[100],
+            1000: globalColors.chromatic.topaz[50],
+          },
+          gray: {
+            0: globalColors.neutral.blueGrayDark[1300],
+            50: globalColors.neutral.blueGrayDark[1200],
+            100: globalColors.neutral.blueGrayDark[1100],
+            200: globalColors.neutral.blueGrayDark[1000],
+            300: globalColors.neutral.blueGrayDark[900],
+            400: globalColors.neutral.blueGrayDark[800],
+            500: globalColors.neutral.blueGrayDark[800],
+            600: globalColors.neutral.blueGrayDark[700],
+            700: globalColors.neutral.blueGrayDark[600],
+            800: globalColors.neutral.blueGrayDark[500],
+            900: globalColors.neutral.blueGrayDark[400],
+            1000: globalColors.neutral.blueGrayDark[300],
+          },
+        },
+      },
+    },
+    transparent: `hsla(210, 6%, 13%, ${opacity[0]})`,
+  },
+};
+
+const bladeNeutralTheme: ThemeTokens = {
+  name: 'bladeNeutralTheme',
+  border,
+  backdropBlur,
+  breakpoints,
+  colors,
+  motion,
+  spacing,
+  elevation,
+  typography,
+};
+
+export default bladeNeutralTheme;

--- a/packages/blade/src/tokens/theme/index.ts
+++ b/packages/blade/src/tokens/theme/index.ts
@@ -1,4 +1,5 @@
 export { default as bladeTheme } from './bladeTheme';
+export { default as bladeNeutralTheme } from './bladeNeutralTheme';
 export { default as overrideTheme } from './overrideTheme';
 export type {
   ColorSchemeNames,

--- a/packages/plugin-figma-token-publisher/package.json
+++ b/packages/plugin-figma-token-publisher/package.json
@@ -23,6 +23,8 @@
     "is-plain-object": "5.0.0",
     "is-primitive": "3.0.1",
     "js-string-compression": "1.0.1",
+    "pako": "2.1.0",
+    "@types/pako": "2.0.3",
     "set-value": "4.1.0",
     "style-loader": "3.3.1",
     "ts-loader": "9.4.2",

--- a/packages/plugin-figma-token-publisher/src/app/api/api.ts
+++ b/packages/plugin-figma-token-publisher/src/app/api/api.ts
@@ -1,9 +1,27 @@
 /* eslint-disable @typescript-eslint/no-implicit-any-catch */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import pako from 'pako';
+
 const GITHUB_BASE_URL = 'https://api.github.com/repos';
 
 type ColorTokens = Record<string, any>;
+
+// GitHub's workflow_dispatch inputs are capped at 65,535 characters. The token payload can
+// exceed that (especially with multiple themes), so we gzip + base64 it before sending.
+// The workflow's uploadTokens.js script decompresses it back.
+const compressTokens = (colorTokens: ColorTokens): string => {
+  const gzipped = pako.gzip(JSON.stringify(colorTokens));
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < gzipped.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(
+      null,
+      (gzipped.subarray(i, i + chunkSize) as unknown) as number[],
+    );
+  }
+  return btoa(binary);
+};
 
 export const uploadTokens = async ({
   orgName = 'razorpay',
@@ -30,7 +48,7 @@ export const uploadTokens = async ({
     body: JSON.stringify({
       ref: 'master',
       inputs: {
-        tokens: JSON.stringify(colorTokens),
+        tokens: compressTokens(colorTokens),
       },
     }),
   });

--- a/packages/plugin-figma-token-publisher/src/plugin/makeColorTokens.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/makeColorTokens.ts
@@ -121,8 +121,9 @@ const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
 
     // prepare for storing variables in code in the format of dark and light modes
     for (const [modeName, modeId] of Object.entries(colorModes)) {
-      // mode names are of the form `<figmaThemePrefix>/<scheme>` eg: blade/onLight, bladeNeutral/onDark
-      const [figmaThemePrefix, scheme] = modeName.split('/');
+      // mode names are of the form `<figmaThemePrefix><separator><scheme>` where the separator
+      // is either " - " or "/" eg: "bladeNeutral - onLight", "blade/onDark"
+      const [figmaThemePrefix, scheme] = modeName.split(/\s*[-/]\s*/);
       const themeName = FIGMA_MODE_THEME_MAP[figmaThemePrefix];
       if (!themeName || (scheme !== 'onLight' && scheme !== 'onDark')) {
         continue;

--- a/packages/plugin-figma-token-publisher/src/plugin/makeColorTokens.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/makeColorTokens.ts
@@ -9,6 +9,13 @@ const THEME_TOKENS_COLLECTION = 'Blade Theme Tokens';
 
 const GLOBAL_TOKENS_COLLECTION = '_global-tokens';
 
+// Figma modes are named `<figmaThemePrefix>/<scheme>` (eg: blade/onLight, bladeNeutral/onDark).
+// This maps the Figma theme prefix to the corresponding code theme name.
+const FIGMA_MODE_THEME_MAP: Record<string, string> = {
+  blade: 'bladeTheme',
+  bladeNeutral: 'bladeNeutralTheme',
+};
+
 const makeGlobalColorTokenName = (variableName: string): string => {
   return variableName.split('/').slice(1).join('.');
 };
@@ -74,9 +81,12 @@ const rgbaToHsla = ({ r, g, b, a }: RGBA): string => {
   return `hsla(${h}, ${Math.round(s)}%, ${Math.round(l)}%, ${opacityMap[a.toFixed(2)]})`;
 };
 const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
-  const themeColorTokens = {
-    onLight: {},
-    onDark: {},
+  const themeColorTokens: Record<
+    string,
+    { onLight: Record<string, any>; onDark: Record<string, any> }
+  > = {
+    bladeTheme: { onLight: {}, onDark: {} },
+    bladeNeutralTheme: { onLight: {}, onDark: {} },
   };
 
   // filter colors collection
@@ -111,18 +121,23 @@ const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
 
     // prepare for storing variables in code in the format of dark and light modes
     for (const [modeName, modeId] of Object.entries(colorModes)) {
+      // mode names are of the form `<figmaThemePrefix>/<scheme>` eg: blade/onLight, bladeNeutral/onDark
+      const [figmaThemePrefix, scheme] = modeName.split('/');
+      const themeName = FIGMA_MODE_THEME_MAP[figmaThemePrefix];
+      if (!themeName || (scheme !== 'onLight' && scheme !== 'onDark')) {
+        continue;
+      }
+
       const variableModeValue: VariableValue = variable.valuesByMode[modeId as string];
       // if the variable references another variable then we take the name of the referenced variable and set that as a value
       // eg: surface.background.neutral.subtle -> globalColors.gray.200
       if (typeof variableModeValue === 'object' && 'id' in variableModeValue) {
-        const referencedVariable = await figma.variables.getVariableByIdAsync(
-          variableModeValue.id,
-        );
+        const referencedVariable = await figma.variables.getVariableByIdAsync(variableModeValue.id);
         if (!referencedVariable) {
           continue;
         }
         setValue(
-          themeColorTokens[modeName],
+          themeColorTokens[themeName][scheme],
           tokenName,
           makeThemeTokenName(referencedVariable.name, true),
         );
@@ -131,13 +146,9 @@ const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
         (tokenName.includes('transparent') || tokenName.includes('elevation'))
       ) {
         const tokenHSLAValue = rgbaToHsla(variableModeValue as RGBA);
-        setValue(themeColorTokens[modeName], tokenName, `\`${tokenHSLAValue}\``);
+        setValue(themeColorTokens[themeName][scheme], tokenName, `\`${tokenHSLAValue}\``);
       } else {
-        console.error(
-          'the theme variable token has hardcoded value',
-          tokenName,
-          variableModeValue,
-        );
+        console.error('the theme variable token has hardcoded value', tokenName, variableModeValue);
       }
     }
   }
@@ -185,8 +196,9 @@ export const makeColorTokens = async (): Promise<void> => {
   const themeColorTokens = await makeThemeColorTokens();
   const globalColorTokens = await makeGlobalColorTokens();
 
-  const hasThemeTokens =
-    Object.keys(themeColorTokens.onLight).length && Object.keys(themeColorTokens.onDark).length;
+  const hasThemeTokens = Object.values(themeColorTokens).some(
+    (theme) => Object.keys(theme.onLight).length && Object.keys(theme.onDark).length,
+  );
   const hasGlobalTokens = Object.keys(globalColorTokens).length;
 
   if (hasThemeTokens || hasGlobalTokens) {

--- a/packages/plugin-figma-token-publisher/yarn.lock
+++ b/packages/plugin-figma-token-publisher/yarn.lock
@@ -90,6 +90,11 @@
   dependencies:
     undici-types "~6.20.0"
 
+"@types/pako@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-2.0.3.tgz#b6993334f3af27c158f3fe0dfeeba987c578afb1"
+  integrity sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==
+
 "@types/prop-types@*":
   version "15.7.11"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
@@ -927,6 +932,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 param-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Extends the Figma token publisher so it can push **two** themes instead of one:
- `bladeTheme` (branded) - `onLight` / `onDark`
- `bladeNeutralTheme` (new) - `onLight` / `onDark`

The four Figma modes (`blade/onLight`, `blade/onDark`, `bladeNeutral/onLight`, `bladeNeutral/onDark`) in the `Blade Theme Tokens` collection are parsed as `<prefix>/<scheme>` and routed into a theme-keyed payload. Previously only `onLight`/`onDark` of a single theme were pushed and any extra Figma modes were silently dropped.

### Changes
- **Plugin** (`makeColorTokens.ts`): `FIGMA_MODE_THEME_MAP` (`blade -> bladeTheme`, `bladeNeutral -> bladeNeutralTheme`); payload is now `{ bladeTheme: { onLight, onDark }, bladeNeutralTheme: { onLight, onDark } }`; success guard checks whether any theme is populated.
- **New theme** `src/tokens/theme/bladeNeutralTheme.ts`: a valid `ThemeTokens` (cloned from `bladeTheme`, `name: 'bladeNeutralTheme'`), exported from `tokens/theme/index.ts`. The seeded colors block is overwritten on the first real Figma push. No `BladeProvider`/consumption changes in this PR.
- **Upload script** (`scripts/uploadTokens.js`): iterates `themeColorTokens` and writes each theme into its own file via a `THEME_TARGETS` map, reusing the same quote-stripping + Prettier steps. Global colors and the branch/commit/PR steps are unchanged.

## Rollout note
The `blade-tokens-upload` Action runs `uploadTokens.js` from `master` (`ref: master`), so this PR (script + theme file) must be merged **before** the Figma modes are renamed to the `blade/*` + `bladeNeutral/*` convention.

## Test plan
- [x] `yarn build` for the plugin compiles (webpack + ts-loader)
- [x] `node --check scripts/uploadTokens.js`
- [x] Dry-run: regex matches and rewrites the colors block in both `bladeTheme.ts` and `bladeNeutralTheme.ts`
- [x] `yarn typecheck` (web + native) passes with the new theme file/export
- [ ] End-to-end: rename Figma modes, run **Publish Color Tokens**, confirm the generated PR updates both theme files

Made with [Cursor](https://cursor.com)