### PR TITLE
chore(token-publisher): register as new figma plugin

### DIFF
--- a/packages/plugin-figma-token-publisher/manifest.json
+++ b/packages/plugin-figma-token-publisher/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Token Publisher",
-  "id": "1316333516996895237",
+  "name": "Blade Token Publisher",
+  "id": "1661423237412340803",
   "api": "1.0.0",
   "main": "dist/plugin.js",
   "ui": "dist/ui.html",


### PR DESCRIPTION
## Summary
- Point `packages/plugin-figma-token-publisher/manifest.json` at the newly published Figma community plugin (`1661423237412340803`).
- Rename the plugin from **Token Publisher** to **Blade Token Publisher**.

## Why
The manifest was still linked to the legacy community listing (`1316333516996895237`), so any publish went out as an *update* to the old plugin (old title/description/icon). This repoints the repo to the fresh listing that owns the updated multi-theme publishing flow, so future publishes go to the correct plugin.

## Notes
- Manifest `id`/`name` are the only source-of-truth link to a published Figma plugin; the built `dist/` is uploaded at publish time and is not affected by this change.
- The legacy plugin (`1316…`) is untouched and remains published.

## Test plan
- [x] `cd packages/plugin-figma-token-publisher && yarn build`
- [x] Import updated manifest in Figma → Development, confirm it links to `Blade Token Publisher` (`1661423237412340803`)
- [ ] Run the plugin commands (Publish Color Tokens, Generate Token's Dev Names, Export Blade Icons) to confirm they work against the new listing

Made with [Cursor](https://cursor.com)