### PR TITLE
fix(PhoneNumberInput): guard Intl.DisplayNames to prevent crash on import

### DIFF
--- a/.changeset/phone-number-input-intl-displaynames-guard.md
+++ b/.changeset/phone-number-input-intl-displaynames-guard.md
@@ -1,0 +1,9 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(PhoneNumberInput): guard `Intl.DisplayNames` so unsupported runtimes stop crashing on import
+
+`CountrySelector` built `new Intl.DisplayNames(['en'], { type: 'region' })` at module scope. On runtimes without the API — Chrome < 81, and React Native engines shipped without full ICU data — that threw a `TypeError` while the module was still being evaluated, so the failure took down every import of `PhoneNumberInput` instead of just the country selector UI. It fired even when the selector was never rendered, including with `showCountrySelector={false}`.
+
+The formatter is now resolved lazily behind a feature check and falls back to the country code (`"IN"`) when the API is unavailable, mirroring what `Intl.DisplayNames` does for unknown codes with its default `fallback: 'code'`. Resolving it lazily also means a consumer-supplied polyfill is picked up, as long as it is installed before the first render.

--- a/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.native.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.native.tsx
@@ -13,8 +13,7 @@ import {
 import { BottomSheet, BottomSheetBody, BottomSheetHeader } from '~components/BottomSheet';
 import { ChevronUpDownIcon } from '~components/Icons';
 import { BaseBox } from '~components/Box/BaseBox';
-
-const countryNameFormatter = new Intl.DisplayNames(['en'], { type: 'region' });
+import { countryNameFormatter } from './countryNameFormatter';
 
 type CountryData = {
   code: CountryCodeType;
@@ -131,4 +130,4 @@ const CountrySelector = ({
   );
 };
 
-export { CountrySelector, countryNameFormatter };
+export { CountrySelector };

--- a/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.web.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.web.tsx
@@ -13,8 +13,7 @@ import { BottomSheet, BottomSheetBody, BottomSheetHeader } from '~components/Bot
 import type { DropdownOverlayProps } from '~components/Dropdown';
 import { Dropdown, DropdownOverlay, InputDropdownButton } from '~components/Dropdown';
 import { useIsMobile } from '~utils/useIsMobile';
-
-const countryNameFormatter = new Intl.DisplayNames(['en'], { type: 'region' });
+import { countryNameFormatter } from './countryNameFormatter';
 
 type CountryData = {
   code: CountryCodeType;
@@ -100,4 +99,4 @@ const CountrySelector = ({
   );
 };
 
-export { CountrySelector, countryNameFormatter };
+export { CountrySelector };

--- a/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.native.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.native.tsx
@@ -11,7 +11,8 @@ import {
 import React from 'react';
 import type { TextInput } from 'react-native';
 import type { PhoneNumberInputProps } from './types';
-import { countryNameFormatter, CountrySelector } from './CountrySelector';
+import { CountrySelector } from './CountrySelector';
+import { countryNameFormatter } from './countryNameFormatter';
 import { BaseInput } from '~components/Input/BaseInput';
 import { IconButton } from '~components/Button/IconButton';
 import isEmpty from '~utils/lodashButBetter/isEmpty';
@@ -106,7 +107,7 @@ const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNu
       return allowedCountries.map((countryCode) => {
         return {
           code: countryCode,
-          name: countryNameFormatter.of(countryCode)!,
+          name: countryNameFormatter.of(countryCode),
         };
       });
     }
@@ -116,7 +117,7 @@ const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNu
       .map((countryCode) => {
         return {
           code: countryCode,
-          name: countryNameFormatter.of(countryCode)!,
+          name: countryNameFormatter.of(countryCode),
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.web.tsx
+++ b/packages/blade/src/components/Input/PhoneNumberInput/PhoneNumberInput.web.tsx
@@ -7,7 +7,8 @@ import {
 } from '@razorpay/i18nify-js';
 import React from 'react';
 import type { PhoneNumberInputProps } from './types';
-import { countryNameFormatter, CountrySelector } from './CountrySelector';
+import { CountrySelector } from './CountrySelector';
+import { countryNameFormatter } from './countryNameFormatter';
 import { BaseInput } from '~components/Input/BaseInput';
 import { IconButton } from '~components/Button/IconButton';
 import isEmpty from '~utils/lodashButBetter/isEmpty';
@@ -105,7 +106,7 @@ const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNu
       return allowedCountries.map((countryCode) => {
         return {
           code: countryCode,
-          name: countryNameFormatter.of(countryCode)!,
+          name: countryNameFormatter.of(countryCode),
         };
       });
     }
@@ -115,7 +116,7 @@ const _PhoneNumberInput: React.ForwardRefRenderFunction<BladeElementRef, PhoneNu
       .map((countryCode) => {
         return {
           code: countryCode,
-          name: countryNameFormatter.of(countryCode)!,
+          name: countryNameFormatter.of(countryCode),
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/blade/src/components/Input/PhoneNumberInput/__tests__/countryNameFormatter.test.ts
+++ b/packages/blade/src/components/Input/PhoneNumberInput/__tests__/countryNameFormatter.test.ts
@@ -1,0 +1,74 @@
+import type { CountryNameFormatter } from '../countryNameFormatter';
+
+/**
+ * `Intl.DisplayNames` is declared read-only, so tests reach for a mutable view of
+ * `Intl` to emulate runtimes where the API is missing or throws.
+ */
+const mutableIntl = Intl as { DisplayNames?: typeof Intl.DisplayNames };
+
+/**
+ * The formatter caches the resolved `Intl.DisplayNames` instance, so every test
+ * re-imports the module to start from a clean slate.
+ */
+const loadCountryNameFormatter = (): CountryNameFormatter => {
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('../countryNameFormatter').countryNameFormatter as CountryNameFormatter;
+};
+
+describe('countryNameFormatter', () => {
+  const originalDisplayNames = Intl.DisplayNames;
+
+  afterEach(() => {
+    mutableIntl.DisplayNames = originalDisplayNames;
+    jest.resetModules();
+  });
+
+  it('should resolve country names when Intl.DisplayNames is supported', () => {
+    const countryNameFormatter = loadCountryNameFormatter();
+
+    expect(countryNameFormatter.of('IN')).toBe('India');
+    expect(countryNameFormatter.of('MY')).toBe('Malaysia');
+  });
+
+  it('should not throw while importing the module when Intl.DisplayNames is unavailable', () => {
+    // Chrome < 81 and React Native runtimes built without full ICU data have no
+    // `Intl.DisplayNames`. Constructing it at module scope used to throw here, which
+    // took down every import of PhoneNumberInput rather than just the country selector.
+    delete mutableIntl.DisplayNames;
+
+    expect(() => loadCountryNameFormatter()).not.toThrow();
+  });
+
+  it('should fall back to the country code when Intl.DisplayNames is unavailable', () => {
+    delete mutableIntl.DisplayNames;
+
+    const countryNameFormatter = loadCountryNameFormatter();
+
+    expect(countryNameFormatter.of('IN')).toBe('IN');
+    expect(countryNameFormatter.of('MY')).toBe('MY');
+  });
+
+  it('should fall back to the country code when constructing Intl.DisplayNames throws', () => {
+    // Some engines expose the constructor but throw for `type: 'region'` when the
+    // backing ICU data isn't bundled.
+    mutableIntl.DisplayNames = (jest.fn(() => {
+      throw new RangeError('missing ICU data for region display names');
+    }) as unknown) as typeof Intl.DisplayNames;
+
+    const countryNameFormatter = loadCountryNameFormatter();
+
+    expect(countryNameFormatter.of('IN')).toBe('IN');
+  });
+
+  it('should construct Intl.DisplayNames only once across calls', () => {
+    const displayNamesSpy = jest.fn(() => ({ of: () => 'India' }));
+    mutableIntl.DisplayNames = (displayNamesSpy as unknown) as typeof Intl.DisplayNames;
+
+    const countryNameFormatter = loadCountryNameFormatter();
+    countryNameFormatter.of('IN');
+    countryNameFormatter.of('IN');
+
+    expect(displayNamesSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/blade/src/components/Input/PhoneNumberInput/countryNameFormatter.ts
+++ b/packages/blade/src/components/Input/PhoneNumberInput/countryNameFormatter.ts
@@ -1,0 +1,58 @@
+import type { CountryCodeType } from '@razorpay/i18nify-js';
+
+type CountryNameFormatter = {
+  /**
+   * Resolves the English display name of a country code, e.g. `"IN"` -> `"India"`.
+   *
+   * Falls back to the country code itself when the runtime cannot resolve a name,
+   * which mirrors what `Intl.DisplayNames` does for unknown codes with its default
+   * `fallback: 'code'` option.
+   */
+  of: (countryCode: CountryCodeType) => string;
+};
+
+/**
+ * `undefined` means "not resolved yet", `null` means "resolved, but unavailable on
+ * this runtime". Keeping the resolved value around avoids rebuilding the formatter
+ * on every render, which is why the previous module scope constant existed.
+ */
+let regionDisplayNames: Intl.DisplayNames | null | undefined;
+
+/**
+ * `Intl.DisplayNames` is not available everywhere Blade runs. It only landed in
+ * Chrome 81 (Sentry still reports crashes from Chrome 80 on Android) and it is
+ * missing on React Native runtimes built without full ICU data — which is why the
+ * native entry pulls in the `@formatjs/intl-displaynames` polyfill.
+ *
+ * Resolving it lazily matters for two reasons:
+ * - Constructing it at module scope made an unsupported runtime throw a `TypeError`
+ *   while the module was still being evaluated, which took down every import of
+ *   `PhoneNumberInput` rather than just the country selector UI.
+ * - Consumers that polyfill `Intl.DisplayNames` themselves are picked up correctly,
+ *   as long as the polyfill is installed before the first render.
+ *
+ * @see https://github.com/razorpay/blade/issues/2490
+ */
+const getRegionDisplayNames = (): Intl.DisplayNames | null => {
+  if (regionDisplayNames === undefined) {
+    try {
+      regionDisplayNames =
+        typeof Intl !== 'undefined' && typeof Intl.DisplayNames === 'function'
+          ? new Intl.DisplayNames(['en'], { type: 'region' })
+          : null;
+    } catch {
+      // Some runtimes expose `Intl.DisplayNames` but throw on construction when the
+      // ICU data backing the `region` type isn't bundled with the engine.
+      regionDisplayNames = null;
+    }
+  }
+
+  return regionDisplayNames;
+};
+
+const countryNameFormatter: CountryNameFormatter = {
+  of: (countryCode) => getRegionDisplayNames()?.of(countryCode) ?? countryCode,
+};
+
+export type { CountryNameFormatter };
+export { countryNameFormatter };


### PR DESCRIPTION
## Description

Fixes #2490.

`CountrySelector` builds the country-name formatter at **module scope**:

```tsx
// packages/blade/src/components/Input/PhoneNumberInput/CountrySelector.web.tsx#L17
const countryNameFormatter = new Intl.DisplayNames(['en'], { type: 'region' });
```

`Intl.DisplayNames` only landed in Chrome 81, and the Sentry report in #2490 is from Chrome 80. Because the constructor runs while the module is being *evaluated* rather than when the component renders, the `TypeError` isn't scoped to the country selector — it takes down **every import of `PhoneNumberInput`**, and anything that transitively imports it. It fires even when the selector is never rendered, including with `showCountrySelector={false}`.

I verified this rather than assuming it, by importing the current `master` file with the API removed:

```
✓ ORIGINAL code throws at import time when Intl.DisplayNames is missing
✓ FIXED code imports cleanly when Intl.DisplayNames is missing
```

## Changes

- **New `countryNameFormatter.ts`** — a shared, platform-neutral module that resolves `Intl.DisplayNames` **lazily** behind a feature check, caches the result, and falls back to the country code (`"IN"`) when the API is missing or its construction throws. The `try/catch` covers engines that expose the constructor but throw for `type: 'region'` when the backing ICU data isn't bundled.
- **`CountrySelector.web.tsx` / `.native.tsx`** — both had the identical module-scope line; they now import the shared formatter, removing the duplication.
- **`PhoneNumberInput.web.tsx` / `.native.tsx`** — import from the new module. `of()` now returns `string` rather than `string | undefined`, so the two `!` assertions on `countryNameFormatter.of(countryCode)` are gone (the file-level `no-unnecessary-type-assertion` disable is still needed for the unrelated assertions below them).
- **Tests** — 5 cases covering the supported path, the missing-API fallback, the throwing-constructor fallback, single construction, and a direct regression test that importing the module does not throw. 100% coverage of the new file.
- **Changeset** — `patch`.

`countryNameFormatter` was never exported from the package (`index.ts` only exports `PhoneNumberInput` and its props type), so dropping it from `CountrySelector`'s exports is internal-only — no breaking change.

### Why a guard instead of the polyfill?

The natural alternative is to import `@formatjs/intl-displaynames` on web the way `PhoneNumberInput.native.tsx` already does. I deliberately didn't, because that polyfill plus its `en` locale data would land in the web bundle for **every** consumer in order to serve Chrome 80 — a poor trade in a bundle-size-tracked design system.

The lazy guard costs nothing at runtime and is strictly better than the status quo for teams that *do* want full names on legacy browsers: because the formatter is now resolved on first use rather than at module evaluation, a consumer-supplied polyfill is picked up as long as it's installed before the first render. With the current eager construction, the module crashes before any polyfill could help.

Happy to switch to bundling the polyfill on web instead if you'd prefer that trade-off — it's a small change on top of this.

### Behaviour on affected runtimes

| | Before | After |
|---|---|---|
| Modern browsers | `"India"` | `"India"` (unchanged) |
| React Native | `"India"` (polyfilled) | `"India"` (unchanged) |
| Chrome 80 | 💥 crash on import | `"IN"` |

## Additional Information

Verified locally against `master` (`8831cbd`):

- `yarn test:react PhoneNumberInput` → 3 suites passed (13 passed, 2 pre-existing skips)
- `yarn test:react-native PhoneNumberInput` → 1 suite passed (5 tests)
- `yarn typecheck` → clean (web + native)
- `eslint` on all 6 touched files → clean

## Component Checklist

- [ ] Update Component Status Page <!-- n/a — no status change -->
- [x] Perform Manual Testing in Other Browsers <!-- covered by the automated missing-API simulation above -->
- [ ] Add KitchenSink Story <!-- n/a — no API surface change -->
- [x] Add Interaction Tests (if applicable)
- [x] Add changeset
