### PR TITLE
fix(BaseInput): pass Android autofill hint via autoComplete instead of removed autoCompleteType

### DIFF
--- a/.changeset/tidy-moons-repair.md
+++ b/.changeset/tidy-moons-repair.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(BaseInput): pass Android autofill hint via `autoComplete` instead of the removed `autoCompleteType` prop
+
+React Native renamed `autoCompleteType` to `autoComplete` in 0.66, so the Android autofill hint (e.g. `sms-otp` for `OTPInput`'s `autoCompleteSuggestionType="oneTimeCode"`) was silently dropped and never reached the native `EditText`. OTP keyboard suggestions and other autofill hints now work on Android.

--- a/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
+++ b/packages/blade/src/components/Input/BaseInput/StyledBaseInput.native.tsx
@@ -32,7 +32,10 @@ type StyledComponentAutoCompleteAndroid =
   | 'email'
   | 'username'
   | 'password'
+  | 'password-new'
+  | 'sms-otp'
   | 'postal-code'
+  | 'postal-address-country'
   | 'tel'
   | undefined;
 
@@ -87,7 +90,7 @@ type StyledComponentInputProps = Omit<
 > & {
   isTextArea?: boolean;
   isFocused: boolean;
-  autoCompleteType?: typeof autoCompleteSuggestionTypeAndroid[keyof typeof autoCompleteSuggestionTypeAndroid];
+  autoComplete?: typeof autoCompleteSuggestionTypeAndroid[keyof typeof autoCompleteSuggestionTypeAndroid];
   editable?: boolean;
   onPress?: (event: GestureResponderEvent) => void;
   $size: NonNullable<BaseInputProps['size']>;
@@ -416,7 +419,7 @@ const _StyledBaseInput: React.ForwardRefRenderFunction<
       // source: https://reactnative.dev/docs/textinput/#keyboardtype
       keyboardType={KeyboardTypeToNativeValuesMap[keyboardType]}
       returnKeyType={keyboardReturnKeyType}
-      autoCompleteType={
+      autoComplete={
         autoCompleteSuggestionType
           ? (autoCompleteSuggestionTypeAndroid[
               autoCompleteSuggestionType as Platform.CastNative<

--- a/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/DropdownInputTriggers/__tests__/__snapshots__/AutoComplete.native.test.tsx.snap
@@ -398,7 +398,7 @@ exports[`<Dropdown /> with <AutoComplete /> should render AutoComplete 1`] = `
                               }
                             }
                             accessible={true}
-                            autoCompleteType="off"
+                            autoComplete="off"
                             data-blade-component="styled-base-input"
                             editable={true}
                             hasLeadingDropdown={false}

--- a/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/OTPInput/__tests__/__snapshots__/OTPInput.native.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`<OTPInput /> should render 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -489,7 +489,7 @@ exports[`<OTPInput /> should render 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -676,7 +676,7 @@ exports[`<OTPInput /> should render 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -863,7 +863,7 @@ exports[`<OTPInput /> should render 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -1050,7 +1050,7 @@ exports[`<OTPInput /> should render 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -1237,7 +1237,7 @@ exports[`<OTPInput /> should render 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -1615,7 +1615,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -1803,7 +1803,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -1991,7 +1991,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -2179,7 +2179,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -2367,7 +2367,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}
@@ -2554,7 +2554,7 @@ exports[`<OTPInput /> should render large size 1`] = `
                         }
                       }
                       accessible={true}
-                      autoCompleteType="sms-otp"
+                      autoComplete="sms-otp"
                       data-blade-component="styled-base-input"
                       editable={true}
                       hasLeadingDropdown={false}

--- a/packages/blade/src/components/Input/SearchInput/__tests__/SearchInput.native.test.tsx
+++ b/packages/blade/src/components/Input/SearchInput/__tests__/SearchInput.native.test.tsx
@@ -279,7 +279,7 @@ describe('<SearchInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'default');
     expect(input).toHaveProp('returnKeyType', 'search');
-    expect(input).toHaveProp('autoCompleteType', 'off');
+    expect(input).toHaveProp('autoComplete', 'off');
     expect(input).toHaveProp('textContentType', 'none');
   });
 

--- a/packages/blade/src/components/Input/SearchInput/__tests__/__snapshots__/SearchInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/SearchInput/__tests__/__snapshots__/SearchInput.native.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`<SearchInput /> should render 1`] = `
                           }
                         }
                         accessible={true}
-                        autoCompleteType="off"
+                        autoComplete="off"
                         data-blade-component="styled-base-input"
                         editable={true}
                         hasLeadingDropdown={false}

--- a/packages/blade/src/components/Input/TextInput/__tests__/TextInput.native.test.tsx
+++ b/packages/blade/src/components/Input/TextInput/__tests__/TextInput.native.test.tsx
@@ -361,7 +361,7 @@ describe('<TextInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'default');
     expect(input).toHaveProp('returnKeyType', 'default');
-    expect(input).toHaveProp('autoCompleteType', 'off');
+    expect(input).toHaveProp('autoComplete', 'off');
     expect(input).toHaveProp('textContentType', 'none');
   });
 
@@ -376,7 +376,7 @@ describe('<TextInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'phone-pad');
     expect(input).toHaveProp('returnKeyType', 'done');
-    expect(input).toHaveProp('autoCompleteType', 'tel');
+    expect(input).toHaveProp('autoComplete', 'tel');
     expect(input).toHaveProp('textContentType', 'telephoneNumber');
   });
 
@@ -391,7 +391,7 @@ describe('<TextInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'email-address');
     expect(input).toHaveProp('returnKeyType', 'done');
-    expect(input).toHaveProp('autoCompleteType', 'email');
+    expect(input).toHaveProp('autoComplete', 'email');
     expect(input).toHaveProp('textContentType', 'emailAddress');
   });
 
@@ -406,7 +406,7 @@ describe('<TextInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'url');
     expect(input).toHaveProp('returnKeyType', 'go');
-    expect(input).toHaveProp('autoCompleteType', 'off');
+    expect(input).toHaveProp('autoComplete', 'off');
     expect(input).toHaveProp('textContentType', 'none');
     expect(input).toHaveProp('autoCapitalize', 'none');
   });
@@ -422,7 +422,7 @@ describe('<TextInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'decimal-pad');
     expect(input).toHaveProp('returnKeyType', 'done');
-    expect(input).toHaveProp('autoCompleteType', 'off');
+    expect(input).toHaveProp('autoComplete', 'off');
     expect(input).toHaveProp('textContentType', 'none');
   });
 
@@ -437,7 +437,7 @@ describe('<TextInput />', () => {
 
     expect(input).toHaveProp('keyboardType', 'default');
     expect(input).toHaveProp('returnKeyType', 'search');
-    expect(input).toHaveProp('autoCompleteType', 'off');
+    expect(input).toHaveProp('autoComplete', 'off');
     expect(input).toHaveProp('textContentType', 'none');
   });
 

--- a/packages/blade/src/components/Input/TextInput/__tests__/__snapshots__/TextInput.native.test.tsx.snap
+++ b/packages/blade/src/components/Input/TextInput/__tests__/__snapshots__/TextInput.native.test.tsx.snap
@@ -270,7 +270,7 @@ exports[`<TextInput /> should render 1`] = `
                 }
               }
               accessible={true}
-              autoCompleteType="off"
+              autoComplete="off"
               data-blade-component="styled-base-input"
               editable={true}
               hasLeadingDropdown={false}
@@ -794,7 +794,7 @@ exports[`<TextInput /> should render with icon, prefix, suffix 1`] = `
               }
               accessible={true}
               autoCapitalize="none"
-              autoCompleteType="off"
+              autoComplete="off"
               data-blade-component="styled-base-input"
               editable={true}
               hasLeadingDropdown={false}


### PR DESCRIPTION
## Description

Android autofill hints never reach the native `EditText` on React Native, because `StyledBaseInput.native.tsx` passes them via `autoCompleteType` — the prop React Native renamed to `autoComplete` in 0.66 (blade peers on `react-native ^0.72`, which only reads `autoComplete`). Most visible effect: `OTPInput` with `autoCompleteSuggestionType="oneTimeCode"` never shows the SMS-OTP keyboard suggestion on Android, while iOS (`textContentType="oneTimeCode"`) works fine.

## Changes

- `StyledBaseInput.native.tsx`: rename the forwarded prop `autoCompleteType` → `autoComplete` (2 lines). iOS `textContentType` is untouched and still takes precedence over the RN 0.71+ `autoComplete` → `textContentType` mapping, so no iOS behaviour change.
- Extend the `StyledComponentAutoCompleteAndroid` union with the three values the map already emits but the type omitted (`password-new`, `sms-otp`, `postal-address-country`) — all valid RN 0.72 `autoComplete` values.
- Update test assertions + regenerated native snapshots (TextInput, SearchInput, OTPInput, AutoComplete).

## Additional Information

- Web build unaffected — the change is confined to a `.native.tsx` file.
- Verified: `yarn types:typecheck:native` clean; `yarn test:react-native TextInput SearchInput OTPInput AutoComplete` — 61 tests, 6 snapshots pass.
- Found while auditing OTP autofill in the merchant mobile app (RN 0.85): the OTP screens set `autoCompleteSuggestionType="oneTimeCode"` correctly but Android never surfaces the code because the hint is dropped here.

## Component Checklist

- [ ] Update Component Status Page (N/A — no API change)
- [ ] Perform Manual Testing in Other Browsers (N/A — native-only file)
- [ ] Add KitchenSink Story (N/A — bug fix, no new component)
- [ ] Add Interaction Tests (N/A)
- [x] Add changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)