### PR TITLE
fix(DatePicker): allow reopening a controlled range FilterChipDatePicker

### DIFF
--- a/.changeset/quick-poems-repeat.md
+++ b/.changeset/quick-poems-repeat.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(DatePicker): allow reopening a controlled range `FilterChipDatePicker` after a range is selected
+
+The auto-close effect that commits a selection when `showFooterActions` is false compared the selected value by reference. For `selectionType="range"` in controlled mode (`value` + `onChange`) the value is rebuilt into a new array on every render, so the effect re-ran on each render and immediately closed the flyout whenever the existing range was already complete, making the picker impossible to reopen. The selection is now compared by content so auto-close only happens on an actual selection change.

--- a/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
+++ b/packages/blade/src/components/DatePicker/BaseDatePicker.web.tsx
@@ -44,6 +44,16 @@ import { fireNativeEvent } from '~utils/fireNativeEvent';
 import { useListViewFilterContext } from '~components/ListView/ListViewFiltersContext.web';
 import { useFilterChipGroupContext } from '~components/Dropdown/FilterChipGroupContext.web';
 
+// `controlledValue` is rebuilt (via shiftTimezone) on every render when the picker is
+// controlled, so its identity cannot be used to detect a selection change. This serialises
+// the selection so it can be compared by content instead.
+const getSelectionKey = (value: DatesRangeValue | Date | null | undefined): string => {
+  if (Array.isArray(value)) {
+    return value.map((date) => (date ? date.getTime() : 'null')).join('|');
+  }
+  return value ? String(value.getTime()) : 'null';
+};
+
 // Calendar dimensions for consistent layout
 const CALENDAR_HEIGHTS = {
   // Height includes: Calendar grid (6 weeks * ~44px) + header (~48px) + footer actions (~64px) + padding
@@ -166,6 +176,7 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
     },
   });
   const [oldValue, setOldValue] = React.useState<DatesRangeValue | null>(controlledValue);
+  const lastSelectionKey = React.useRef(getSelectionKey(controlledValue));
 
   // Sync selectedPreset with controlledValue for initial preset matching
   React.useEffect(() => {
@@ -260,9 +271,19 @@ const BaseDatePicker = <Type extends DateSelectionType = 'single'>({
   // and the selection is complete — this is the chip/filter mode behaviour where
   // selecting a date range is itself the confirmation.
   React.useEffect(() => {
+    const previousSelectionKey = lastSelectionKey.current;
+    const currentSelectionKey = getSelectionKey(controlledValue);
+    lastSelectionKey.current = currentSelectionKey;
+
     if (shouldApplyAfterPresetSelection.current) {
       shouldApplyAfterPresetSelection.current = false;
       handleApply();
+      return;
+    }
+
+    // Bail out when the selection did not actually change, otherwise reopening a picker that
+    // already holds a complete selection would auto-close it right away.
+    if (currentSelectionKey === previousSelectionKey) {
       return;
     }
 

--- a/packages/blade/src/components/DatePicker/__tests__/DatePicker.web.test.tsx
+++ b/packages/blade/src/components/DatePicker/__tests__/DatePicker.web.test.tsx
@@ -171,3 +171,136 @@ describe('<FilterChipDatePicker/> clear button', () => {
     expect(queryByLabelText('Clear Date value')).toBeTruthy();
   });
 });
+
+describe('<FilterChipDatePicker/> open state', () => {
+  jest.setTimeout(15000);
+
+  // The flyout stays mounted after closing (floating-ui keeps it for the exit transition, which
+  // never completes in jsdom), so presence in the DOM cannot be used to assert open/closed state.
+  const expectExpanded = async (chip: HTMLElement, isExpanded: boolean): Promise<void> => {
+    await waitFor(() =>
+      expect(chip).toHaveAttribute('aria-expanded', isExpanded ? 'true' : 'false'),
+    );
+  };
+
+  it('should reopen when a complete range is already selected (controlled)', async () => {
+    const Comp = (): React.ReactElement => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const [date, setDate] = React.useState<DatesRangeValue>([
+        dayjs('1999-04-22').toDate(),
+        dayjs('1999-04-25').toDate(),
+      ]);
+
+      return (
+        <FilterChipDatePicker
+          label="Date"
+          selectionType="range"
+          isOpen={isOpen}
+          onOpenChange={({ isOpen }) => setIsOpen(isOpen)}
+          value={date}
+          onChange={(value) => setDate(value as DatesRangeValue)}
+        />
+      );
+    };
+
+    const user = userEvent.setup();
+    const { getByRole } = renderWithTheme(<Comp />);
+    const chip = getByRole('combobox', { name: /Date/i });
+
+    await user.click(chip);
+    await expectExpanded(chip, true);
+
+    // a fresh selection still commits and closes the flyout
+    await user.click(getByRole('button', { name: '5 April 1999' }));
+    await expectExpanded(chip, true);
+    await user.click(getByRole('button', { name: '9 April 1999' }));
+    await expectExpanded(chip, false);
+
+    await user.click(chip);
+    await expectExpanded(chip, true);
+  });
+
+  it('should reopen when a complete range is already selected (uncontrolled)', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = renderWithTheme(
+      <FilterChipDatePicker
+        label="Date"
+        selectionType="range"
+        defaultValue={[dayjs('1999-04-22').toDate(), dayjs('1999-04-25').toDate()]}
+      />,
+    );
+    const chip = getByRole('combobox', { name: /Date/i });
+
+    await user.click(chip);
+    await expectExpanded(chip, true);
+  });
+
+  it('should reopen when a date is already selected (controlled, single)', async () => {
+    const Comp = (): React.ReactElement => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const [date, setDate] = React.useState<Date | undefined>(dayjs('1999-04-22').toDate());
+
+      return (
+        <FilterChipDatePicker
+          label="Date"
+          selectionType="single"
+          isOpen={isOpen}
+          onOpenChange={({ isOpen }) => setIsOpen(isOpen)}
+          value={date}
+          onChange={(value) => setDate(value as Date)}
+        />
+      );
+    };
+
+    const user = userEvent.setup();
+    const { getByRole } = renderWithTheme(<Comp />);
+    const chip = getByRole('combobox', { name: /Date/i });
+
+    await user.click(chip);
+    await expectExpanded(chip, true);
+
+    await user.click(getByRole('button', { name: '10 April 1999' }));
+    await expectExpanded(chip, false);
+
+    await user.click(chip);
+    await expectExpanded(chip, true);
+  });
+
+  it('should fire onOpenChange once per open and close (controlled)', async () => {
+    const onOpenChange = jest.fn();
+    const Comp = (): React.ReactElement => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const [date, setDate] = React.useState<DatesRangeValue>([null, null]);
+
+      return (
+        <FilterChipDatePicker
+          label="Date"
+          selectionType="range"
+          isOpen={isOpen}
+          onOpenChange={({ isOpen }) => {
+            onOpenChange(isOpen);
+            setIsOpen(isOpen);
+          }}
+          value={date}
+          onChange={(value) => setDate(value as DatesRangeValue)}
+        />
+      );
+    };
+
+    const user = userEvent.setup();
+    const { getByRole } = renderWithTheme(<Comp />);
+    const chip = getByRole('combobox', { name: /Date/i });
+
+    await user.click(chip);
+    await expectExpanded(chip, true);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+
+    const start = dayjs().startOf('month').add(9, 'day');
+    await user.click(getByRole('button', { name: start.format('D MMMM YYYY') }));
+    await user.click(getByRole('button', { name: start.add(3, 'day').format('D MMMM YYYY') }));
+
+    await expectExpanded(chip, false);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Description

A controlled `FilterChipDatePicker` with `selectionType="range"` cannot be reopened once a range has been selected. Clicking the chip opens the flyout and immediately closes it again, so the user is stuck with whatever range was picked first.

Reproducible on the published Storybook: [Controlled FilterChip DatePicker (range)](https://blade.razorpay.com/?path=/story/components-datepicker--controlled-filter-chip-date-picker-range).

### Root cause

`FilterChipDatePicker` sets `showFooterActions={false}`, so there is no Apply button. Instead, `BaseDatePicker` uses an effect to commit the selection and close the flyout as soon as the selection is complete. That effect was keyed on the *identity* of the selected value:

```tsx
React.useEffect(() => {
  ...
  if (!showFooterActions && controllableIsOpen) { /* commit + close */ }
}, [controlledValue]);
```

`controlledValue` is not identity-stable in controlled mode. `useDatesState` → `useControlledDates` passes the incoming `value` through `shiftTimezone('add', value)`, and for an array that does `date.map(...)`, returning a brand new array on every render. The effect therefore re-ran on **every render** rather than only on selection changes. Once a complete range existed, clicking the chip set open to `true`, the effect fired, saw a complete selection, and closed it again — the trigger never left `aria-expanded="false"`.

Introduced in #3566 (`fix(DatePicker): auto-close FilterChipDatePicker flyout on range/preset selection`).

### Scope

- Affects **range** selection only. `shiftTimezone` returns the *same* `Date` instance when there is no timezone to apply, so single selection keeps a stable identity and was never broken.
- Affects **controlled** usage only (`value` + `onChange`). Uncontrolled `defaultValue` uses internal state with a stable reference.
- The regular `DatePicker` is unaffected in its default configuration because it keeps footer actions, which skips this code path entirely. A `DatePicker` with `showFooterActions={false}` and a controlled range would have hit the same bug, and is fixed by the same change.

## Changes

- `BaseDatePicker.web.tsx`: compare the selection by content (a serialised key held in a ref) instead of by reference, and bail out of the effect when nothing actually changed. Auto-close now only fires on a genuine selection change, while the auto-close-on-pick behaviour is preserved.
- `DatePicker.web.test.tsx`: four tests covering controlled/uncontrolled range reopen, controlled single reopen, and `onOpenChange` firing exactly once per open and close.

## Additional Information

**On asserting open/closed state in tests.** The flyout stays mounted in the DOM after closing — floating-ui keeps it around for the exit transition, which never completes in jsdom. Querying for calendar markup is therefore not a valid open/closed signal and silently passes even when the picker is broken. The new tests assert `aria-expanded` on the trigger instead, which was verified to be `"false"` without the fix and `"true"` with it.

**Wider audit.** All 29 DatePicker stories were reviewed, and the interactive ones were driven through an open → select → apply → reopen cycle against a pristine checkout to confirm nothing else regressed. Only the controlled range FilterChip failed. Everything else was clean: single/range uncontrolled with footer, controlled `DatePicker` (`isOpen` + `value`), presets (incl. `displayFormat="compact"`), validations, min/max dates, excluded dates, month picker, `WithoutActionButtons`, FilterChip single/range uncontrolled, FilterChip with presets, `showClearButton={false}`, controlled FilterChip single, disabled chip, clear button controlled, and the comparison range (`visibleMonth`) story.

**One observation, not changed here.** The preset dropdown rendered inside the input (`renderPresetDropdown`) sets the auto-apply flag unconditionally, whereas the preset sidebar guards it with `if (!showFooterActions)`. So picking a preset from the input's leading dropdown applies and closes immediately even when Apply/Cancel are visible. This looks intentional (it is a different affordance) so it is left alone, but flagging it in case the asymmetry is not deliberate.

## Test plan

- [x] `yarn test:react DatePicker` — 24 passing
- [x] New tests verified to fail on a pristine checkout of `BaseDatePicker.web.tsx` and pass with the fix
- [x] `yarn typecheck` clean, no new lint errors
- [x] Verify the [controlled FilterChip range story](https://blade.razorpay.com/?path=/story/components-datepicker--controlled-filter-chip-date-picker-range) in the Chromatic build: pick a range, then reopen the chip

## Component Checklist

- [x] Update Component Status Page
- [x] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [x] Add Interaction Tests (if applicable)
- [x] Add changeset

Made with [Cursor](https://cursor.com)