### PR TITLE
fix(TrustBadge): restore pill alignment in blade-svelte

### DIFF
--- a/.changeset/trustbadge-spacing-fix.md
+++ b/.changeset/trustbadge-spacing-fix.md
@@ -1,0 +1,6 @@
+---
+"@razorpay/blade-svelte": patch
+"@razorpay/blade-core": patch
+---
+
+fix(TrustBadge): restore flat layout to fix icon and label vertical alignment within the pill

--- a/packages/blade-core/src/styles/TrustBadge/trustBadge.module.css
+++ b/packages/blade-core/src/styles/TrustBadge/trustBadge.module.css
@@ -12,11 +12,8 @@
   flex-shrink: 0;
 }
 
-/* Default variant — icon + label in a sea-subtle pill. */
+/* Default variant — icon + label in a sea-subtle pill. Pair with `.trustBadge`. */
 .trustBadgeWithPill {
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
   gap: var(--spacing-2);
   height: 24px;
   padding: var(--spacing-2) var(--spacing-3);
@@ -24,11 +21,8 @@
   background-color: var(--surface-background-sea-subtle);
 }
 
-/* Icon-only variant — shield with compact padding, no pill. */
+/* Icon-only variant — shield with compact padding, no pill. Pair with `.trustBadge`. */
 .trustBadgeIconOnly {
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
   padding: var(--spacing-2);
 }
 

--- a/packages/blade-svelte/src/components/TrustBadge/TrustBadge.svelte
+++ b/packages/blade-svelte/src/components/TrustBadge/TrustBadge.svelte
@@ -43,7 +43,7 @@
   );
 
   const iconA11yAttrs = $derived(
-    isIconOnly ? makeAccessible({ role: 'img', label }) : { 'aria-hidden': 'true' },
+    isIconOnly ? makeAccessible({ role: 'img', label }) : { 'aria-hidden': true },
   );
 </script>
 

--- a/packages/blade-svelte/src/components/TrustBadge/TrustBadge.svelte
+++ b/packages/blade-svelte/src/components/TrustBadge/TrustBadge.svelte
@@ -11,12 +11,9 @@
     getTrustBadgeTemplateClasses,
     getTrustBadgeTextColorToken,
     getTrustBadgeVariantClass,
-    getTextProps,
   } from '@razorpay/blade-core/styles';
-  import BaseText from '../Typography/BaseText/BaseText.svelte';
+  import Text from '../Typography/Text/Text.svelte';
   import { RazorpayTrustIcon } from '../Icons';
-  import type { IconColor } from '../Icons/types';
-  import type { TextColors } from '../Typography/BaseText/types';
   import type { TrustBadgeProps } from './types';
 
   const DEFAULT_LABEL = 'Razorpay Trusted Business';
@@ -31,28 +28,19 @@
   }: TrustBadgeProps = $props();
 
   const isIconOnly = $derived(variant === 'icon-only');
-
-  const textColor = $derived(getTrustBadgeTextColorToken() as TextColors);
-
-  const labelTextProps = $derived(
-    getTextProps({
-      variant: 'body',
-      weight: 'regular',
-      size: 'xsmall',
-    }),
-  );
-
-  const iconRenderColor = 'surface.icon.gray.normal' as IconColor;
+  const textColor = $derived(getTrustBadgeTextColorToken());
 
   const metaAttrs = $derived(metaAttribute({ name: MetaConstants.TrustBadge, testID }));
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const styledProps = $derived(getStyledPropsClasses(rest));
 
   const rootClasses = $derived(
-    cx(templateClasses.trustBadge, ...(styledProps.classes ?? [])),
+    cx(
+      templateClasses.trustBadge,
+      getTrustBadgeVariantClass(variant),
+      ...(styledProps.classes ?? []),
+    ),
   );
-
-  const pillClasses = $derived(getTrustBadgeVariantClass(variant));
 
   const iconA11yAttrs = $derived(
     isIconOnly ? makeAccessible({ role: 'img', label }) : { 'aria-hidden': 'true' },
@@ -60,16 +48,12 @@
 </script>
 
 <div class={rootClasses} {...metaAttrs} {...analyticsAttrs}>
-  <div class={pillClasses}>
-    <span class={templateClasses.trustBadgeIcon} {...iconA11yAttrs}>
-      <RazorpayTrustIcon size="medium" color={iconRenderColor} />
-    </span>
-    {#if !isIconOnly}
-      <span>
-        <BaseText as="span" {...labelTextProps} color={textColor}>
-          {label}
-        </BaseText>
-      </span>
-    {/if}
-  </div>
+  <span class={templateClasses.trustBadgeIcon} {...iconA11yAttrs}>
+    <RazorpayTrustIcon size="medium" />
+  </span>
+  {#if !isIconOnly}
+    <Text size="xsmall" weight="regular" color={textColor}>
+      {label}
+    </Text>
+  {/if}
 </div>


### PR DESCRIPTION
## Summary
- Fixes vertical alignment regression in `TrustBadge` where icon and label sat too high inside the pill
- Restores flat layout from before the BladeProvider refactor: variant pill styles apply on the same flex root as icon + label (matches React)
- Removes redundant nested wrapper div and extra span around label text

## Root cause
PR #3722 nested the pill wrapper inside the root container and moved label rendering to `BaseText` inside an extra span. That broke flex centering within the 24px pill.

## Test plan
- [x] `yarn test` in `packages/blade-svelte`
- [ ] Verify TrustBadge Storybook story — icon and label vertically centered in default variant
- [ ] Verify icon-only variant still renders correctly


Made with [Cursor](https://cursor.com)