### PR TITLE
feat: declare sideEffects in package.json to enable consumer tree-shaking

### DIFF
--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,0 +1,17 @@
+---
+'@razorpay/blade': patch
+---
+
+feat: declare `sideEffects` in `package.json` to enable consumer tree-shaking
+
+Blade's build output is already per-module (`preserveModules`) and side-effect free apart from a
+handful of known modules, but without a `sideEffects` field bundlers must assume every one of the
+~2,400 emitted modules has import-time side effects. That prevents webpack/Turbopack from pruning
+anything out of our `export *` barrels — importing a single component pulls in most of the library.
+
+This declares an explicit allowlist of the modules that genuinely do have side effects
+(the `dayjs.extend()` registrations, the native `@formatjs` polyfills, `fonts.css`, the CJS
+`bladeCoverage` entry, and inlined third-party code), leaving the rest prunable.
+
+Note: this must stay an allowlist. A bare `"sideEffects": false` would let bundlers delete
+`import '@razorpay/blade/fonts.css'` and the dayjs plugin registrations, both of which fail silently.

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -30,6 +30,17 @@
     "utils.native.js",
     "coverageUtils.d.ts"
   ],
+  "sideEffects": [
+    "*.css",
+    "./fonts.css",
+    "./build/lib/**/components/DatePicker/utils.js",
+    "./build/lib/**/components/DatePicker/shiftTimezone.js",
+    "./build/lib/**/components/DatePicker/DatePicker.native.js",
+    "./build/lib/**/components/Input/PhoneNumberInput/PhoneNumberInput.native.js",
+    "./build/lib/**/utils/bladeCoverage.js",
+    "./build/lib/**/node_modules/**",
+    "./build/lib/**/_virtual/**"
+  ],
   "keywords": [
     "design system",
     "react",


### PR DESCRIPTION
## Problem

`packages/blade/package.json` has no `sideEffects` field. Without it, webpack and Turbopack must assume **every one of the ~2,400 emitted modules has import-time side effects**, so they cannot prune anything out of our `export *` barrels. `src/components/index.ts` is 84 wildcard re-exports reaching ~89% of the component source tree — so importing one component pulls in most of the library.

This shows up badly in Next.js + Turbopack, where our initial bundle is dominated by Blade.

The library is already *substantively* side-effect free — the `assignWithoutSideEffects` work in #1045 is thoroughly applied (588 files, **zero** direct `.displayName =` / `.componentId =` assignments). But that work only helps *within* a module the bundler has already decided to include; `/*#__PURE__*/` can't rescue a module that was never prunable in the first place. The missing `sideEffects` field nullifies it at the module-graph level.

## Change

One field, 11 lines. An explicit **allowlist** of the modules that genuinely do have import-time side effects:

| entry | why |
|---|---|
| `*.css`, `./fonts.css` | consumers do `import '@razorpay/blade/fonts.css'` (documented in `Installation.mdx:181`) — binds nothing, so a bare `false` would delete it |
| `DatePicker/utils.js`, `DatePicker/shiftTimezone.js`, `DatePicker/DatePicker.native.js` | `dayjs.extend()` mutates a shared singleton |
| `PhoneNumberInput.native.js` | three `@formatjs` polyfills patching global `Intl` |
| `utils/bladeCoverage.js` | CJS entry, top-level `module.exports` |
| `node_modules/**`, `_virtual/**` | inlined recharts/d3/immer/redux have real module-scope effects (`startListening`, `defaultLocale()`, `define()`); since they're emitted *inside* our package, our flag governs them |

Result: 1,405 of 6,518 files stay side-effectful, **~78% become prunable**.

> [!IMPORTANT]
> This needs to stay an allowlist. A bare `"sideEffects": false` would let bundlers delete the `fonts.css` import and the `dayjs.extend()` registrations — both fail **silently** at runtime (`dayjs(x).tz()` and custom-format parsing just stop working). Happy to add a lint guard if you'd like one.

## How to test / verify

No build-behaviour change — this field is metadata consumed by downstream bundlers only, so CI should be unaffected. I verified against the **published `12.113.3` build** with esbuild (which honours `sideEffects`), toggling only the field:

```
A. Bundle size: import { Button } from '@razorpay/blade/components'
   before   1,264,595 bytes   1576 blade modules
   after       60,906 bytes     51 blade modules      ← 95.2% smaller

B. Correctness: import { DatePicker }  →  all 3 dayjs.extend() calls retained   PASS
C. Correctness: import '@razorpay/blade/fonts.css'  →  retained (2,942 bytes)   PASS
```

To reproduce:
```bash
npm pack @razorpay/blade@12.113.3 && tar xzf razorpay-blade-*.tgz
# put it in node_modules/@razorpay/blade, then bundle with/without the field:
npx esbuild entry.js --bundle --format=esm --minify --outfile=out.js \
  --external:react --external:react-dom --external:styled-components   # ...and other peers
```

Checks I'd value from you, since you own the runtime surface:
- [ ] **RN / Metro** — Metro doesn't currently honour `sideEffects`, so this should be a no-op there. Worth a sanity run of the native Storybook.
- [ ] **SSR / Next.js app router** in a real consumer.
- [ ] **DatePicker + PhoneNumberInput smoke test** in a *consumer* build (not Storybook) — these are the two components the allowlist protects.
- [ ] Anything in the publish pipeline that rewrites `package.json` and might drop the field.

## Not included (for discussion)

While investigating I found two related things I deliberately left **out** of this PR, since they're your call:

1. **`treeshake: false` in `rollup.config.mjs`** leaves ~3,711 orphan barrel imports in the shipped output (e.g. `Button.js` contains a redundant `import '../BaseButton/index.js'`; 453 files bare-import the `useIconProps` barrel, 463 the `_Svg` barrel). This PR makes them harmless — once modules are declared side-effect free, consumers drop them. Flipping `treeshake` would remove them at publish time too, but the comment at `rollup.config.mjs:176-183` documents concrete past breakage (`tokens/global/motion.ts` losing `delay`/`duration`), so I didn't touch it. **Is that history still load-bearing?**

2. **`recharts` is excluded from externals** at `rollup.config.mjs:56` and isn't a peer dep, so it's inlined into our build — ~7.9 MB of `node_modules/` (recharts, d3-*, immer, redux, victory-vendor) plus 1,100 `_virtual/` CJS shims inside the package. Making it external would shrink the package substantially and let its own `sideEffects` apply, but it's a breaking change needing a major. **Was the inlining deliberate?**

Also worth considering separately: per-component subpath exports (`./components/*`) — `preserveModules` already emits the files, the `exports` allowlist is the only thing blocking them.

Happy to split, adjust, or drop any of this — I'm a consumer rather than an owner here, so please push back where I've missed context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
