### PR TITLE
chore: add reinstall script to recover from yarn linking crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "publish-npm": "node ./scripts/publishToNpm.js",
     "release": "node ./scripts/generateGitHubRegistryNpmrc.js && changeset publish",
     "postinstall": "yarn build:eslint-plugin-blade",
+    "reinstall": "rm -rf packages/blade-core/node_modules packages/blade-svelte/node_modules && yarn install",
     "build": "npm-run-all --parallel build:*",
     "build:blade": "lerna run --scope @razorpay/blade build",
     "build:blade-core": "lerna run --scope @razorpay/blade-core build",


### PR DESCRIPTION
## Description

`yarn install` intermittently dies during `[4/5] Linking dependencies` with:

```
error An unexpected error occurred: "ENOENT: no such file or directory, lstat
'.../packages/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker'".
```

Once it starts, it is not self-healing — every retry fails identically, blocking installs and therefore Storybook.

**Root cause.** `packages/blade-svelte/node_modules/@razorpay/blade-core` is a symlink to `packages/blade-core`, and the root `package.json` sets `nohoist: ["**"]`. Yarn therefore plans a separate nested dependency tree for blade-core inside blade-svelte, but both trees resolve to the *same physical directory*. They disagree about where `estree-walker` belongs, so in a single run yarn writes a file via one path and deletes it as "extraneous" via the other, then crashes reading its own deletion:

```
20.2639  Copying ... -> packages/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker/...
20.3397  Removing extraneous file ".../blade-svelte/node_modules/@razorpay/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker"
21.2931  Error: ENOENT ... lstat 'packages/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker'
```

Any lockfile change re-triggers the cleanup phase and hence the crash, so it recurs on branch switches, pulls, and version bumps.

**Why this fix works.** Yarn's cleanup phase only ever deletes files that already existed when the install started. Emptying the two aliased packages beforehand means there is nothing to delete, so the collision cannot happen.

## Changes

- Add a root `reinstall` script: `rm -rf packages/blade-core/node_modules packages/blade-svelte/node_modules && yarn install`

## Additional Information

Deleting only the leftover `@vitest/mocker/node_modules` directory does **not** work — yarn recreates that nested copy during linking and collides again. Both packages' `node_modules` have to go.

This is a targeted alternative to wiping every `node_modules` in the repo: 909 MB instead of 2.7 GB, and roughly 70s instead of 3m19s against a warm yarn cache.

It is a plain `scripts` entry, so nothing changes for CI or for anyone who does not explicitly run it. The permanent structural fix would be removing `nohoist: ["**"]`, but React Native/Metro likely depends on it, so that is deliberately out of scope here.

Usage when an install fails:

```bash
yarn reinstall
```

## Component Checklist

Not applicable — repo tooling only, no component or published-package changes (the root package is private, so no changeset is needed).

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset

Made with [Cursor](https://cursor.com)