### PR TITLE
fix(Toast): native visual parity with web popup tokens + offsetBottom on native ToastContainer

### DIFF
--- a/.changeset/native-toast-popup-parity.md
+++ b/.changeset/native-toast-popup-parity.md
@@ -1,0 +1,8 @@
+---
+'@razorpay/blade': minor
+---
+
+fix(Toast): web visual parity for the native Toast + `offsetBottom` on native ToastContainer
+
+- Native `Toast` now uses the same `popup.background.*` / `popup.border.*` tokens as web (solid-looking saturated backgrounds with staticWhite content) instead of 9%-alpha `feedback.background.*.subtle` tints, which let underlying screen content bleed through the toast. Since RN has no `backdropFilter: blur()`, the semi-transparent popup token is backed by an opaque surface view (same workaround as `TooltipContentWrapper.native`).
+- Native `ToastContainer` now honors the existing web `offsetBottom` prop so apps can lift the toast stack above bottom tab bars and safe-area insets (previously hardcoded to `theme.spacing[8]` from the screen bottom).

--- a/packages/blade/src/components/Toast/Toast.native.tsx
+++ b/packages/blade/src/components/Toast/Toast.native.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated } from 'react-native';
+import { Animated, View } from 'react-native';
 import type { ToastProps } from './types';
 import { toastStore } from './useToast.native';
 import { Box } from '~components/Box';
 import { Button } from '~components/Button';
 import { IconButton } from '~components/Button/IconButton';
 import { Text } from '~components/Typography';
+import { useTheme } from '~components/BladeProvider';
+import getIn from '~utils/lodashButBetter/get';
+import { castNativeType } from '~utils';
 import {
   AlertOctagonIcon,
   AlertTriangleIcon,
@@ -41,6 +44,7 @@ const Toast = (
     onDismissButtonClick,
   } = props;
 
+  const { theme } = useTheme();
   const opacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(40)).current;
 
@@ -60,7 +64,19 @@ const Toast = (
   }, [isVisible, opacity, translateY]);
 
   const isPromotional = type === 'promotional';
-  const Icon = Leading ?? iconMap[color];
+  // Web parity: promotional toasts only render an explicitly-passed leading icon.
+  const Icon = isPromotional ? Leading : Leading ?? iconMap[color];
+
+  // Same tokens as Toast.web. Applied via theme lookup because native Box's
+  // runtime backgroundColor validation doesn't allow `popup.background.*`.
+  const backgroundColor = getIn(
+    theme.colors,
+    isPromotional ? 'popup.background.gray.moderate' : `popup.background.${color}.moderate`,
+  );
+  const borderColor = getIn(
+    theme.colors,
+    isPromotional ? 'popup.border.gray.moderate' : `popup.border.${color}.moderate`,
+  );
 
   // The public `ToastProps` types `event` as a web `MouseEvent` so consumers
   // can write platform-agnostic handlers. Native has no MouseEvent equivalent
@@ -83,69 +99,99 @@ const Toast = (
     action.onClick?.({ event: stubEvent, toastId: id ?? '' });
   };
 
+  const actionButton = action ? (
+    <Button
+      size="xsmall"
+      variant={isPromotional ? 'secondary' : 'tertiary'}
+      color={isPromotional ? 'primary' : 'white'}
+      isLoading={action.isLoading}
+      onClick={handleActionClick}
+    >
+      {action.text}
+    </Button>
+  ) : null;
+
   return (
     <Animated.View style={{ opacity, transform: [{ translateY }] }}>
-      <Box
-        // Native Box validates background tokens at runtime (rejects anything
-        // outside `transparent` / `surface.background.*` / `overlay.*` /
-        // `feedback.background.*`). Web's `popup.background.*` choices map to:
-        //   - promotional → `surface.background.gray.intense` (dark surface)
-        //   - color variants → `feedback.background.${color}.subtle`
-        backgroundColor={
-          isPromotional
-            ? 'surface.background.gray.intense'
-            : (`feedback.background.${color}.subtle` as 'feedback.background.positive.subtle')
-        }
-        borderRadius="medium"
-        padding="spacing.4"
-        flexDirection="row"
-        alignItems="center"
-        elevation="midRaised"
-        marginBottom="spacing.3"
+      <View
+        style={[
+          {
+            borderRadius: theme.border.radius.medium,
+            borderWidth: theme.border.width.thin,
+            borderColor,
+            marginBottom: theme.spacing[3],
+          },
+          castNativeType(theme.elevation.midRaised),
+        ]}
       >
-        <Box marginRight="spacing.3">
-          <Icon
-            size="medium"
-            color={
-              isPromotional
-                ? 'surface.icon.staticWhite.normal'
-                : (`feedback.icon.${color}.intense` as 'feedback.icon.positive.intense')
-            }
-          />
-        </Box>
-        <Box flex={1}>
-          {typeof content === 'string' ? (
-            <Text
-              size="medium"
-              color={isPromotional ? 'surface.text.staticWhite.normal' : 'surface.text.gray.normal'}
+        {/* popup.background.* tokens are semi-transparent — web pairs them with
+            backdropFilter blur, which RN doesn't support, so content would bleed
+            through. Back the toast with an opaque surface first (same workaround
+            as TooltipContentWrapper.native). */}
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            backgroundColor: theme.colors.surface.background.gray.intense,
+            borderRadius: theme.border.radius.medium,
+          }}
+        />
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor,
+            borderRadius: theme.border.radius.medium,
+            paddingHorizontal: theme.spacing[4],
+            paddingVertical: isPromotional ? theme.spacing[4] : theme.spacing[3],
+          }}
+        >
+          {Icon ? (
+            <Box
+              marginRight="spacing.3"
+              alignSelf={isPromotional ? 'flex-start' : 'center'}
+              marginTop={isPromotional ? 'spacing.1' : 'spacing.0'}
             >
-              {content}
-            </Text>
-          ) : (
-            content
-          )}
-        </Box>
-        {action ? (
-          <Box marginLeft="spacing.3">
-            <Button
-              size="small"
-              variant="tertiary"
-              isLoading={action.isLoading}
-              onClick={handleActionClick}
-            >
-              {action.text}
-            </Button>
+              <Icon
+                size="medium"
+                color={isPromotional ? 'surface.icon.gray.normal' : 'surface.icon.staticWhite.normal'}
+              />
+            </Box>
+          ) : null}
+          <Box flex={1}>
+            {typeof content === 'string' ? (
+              <Text
+                size="small"
+                color={isPromotional ? 'surface.text.gray.normal' : 'surface.text.staticWhite.normal'}
+              >
+                {content}
+              </Text>
+            ) : (
+              content
+            )}
+            {isPromotional && actionButton ? (
+              <Box marginTop="spacing.3" alignSelf="flex-start">
+                {actionButton}
+              </Box>
+            ) : null}
           </Box>
-        ) : null}
-        <Box marginLeft="spacing.2">
-          <IconButton
-            icon={CloseIcon}
-            size="small"
-            accessibilityLabel="Dismiss"
-            onClick={handleDismiss}
-          />
-        </Box>
-      </Box>
+          {!isPromotional && actionButton ? (
+            <Box marginLeft="spacing.3">{actionButton}</Box>
+          ) : null}
+          <Box marginLeft="spacing.2" alignSelf={isPromotional ? 'flex-start' : 'center'}>
+            <IconButton
+              icon={CloseIcon}
+              size="small"
+              emphasis={isPromotional ? 'intense' : 'subtle'}
+              accessibilityLabel="Dismiss"
+              onClick={handleDismiss}
+            />
+          </Box>
+        </View>
+      </View>
     </Animated.View>
   );
 };

--- a/packages/blade/src/components/Toast/Toast.native.tsx
+++ b/packages/blade/src/components/Toast/Toast.native.tsx
@@ -157,7 +157,9 @@ const Toast = (
             >
               <Icon
                 size="medium"
-                color={isPromotional ? 'surface.icon.gray.normal' : 'surface.icon.staticWhite.normal'}
+                color={
+                  isPromotional ? 'surface.icon.gray.normal' : 'surface.icon.staticWhite.normal'
+                }
               />
             </Box>
           ) : null}
@@ -165,7 +167,9 @@ const Toast = (
             {typeof content === 'string' ? (
               <Text
                 size="small"
-                color={isPromotional ? 'surface.text.gray.normal' : 'surface.text.staticWhite.normal'}
+                color={
+                  isPromotional ? 'surface.text.gray.normal' : 'surface.text.staticWhite.normal'
+                }
               >
                 {content}
               </Text>
@@ -178,9 +182,7 @@ const Toast = (
               </Box>
             ) : null}
           </Box>
-          {!isPromotional && actionButton ? (
-            <Box marginLeft="spacing.3">{actionButton}</Box>
-          ) : null}
+          {!isPromotional && actionButton ? <Box marginLeft="spacing.3">{actionButton}</Box> : null}
           <Box marginLeft="spacing.2" alignSelf={isPromotional ? 'flex-start' : 'center'}>
             <IconButton
               icon={CloseIcon}

--- a/packages/blade/src/components/Toast/ToastContainer.native.tsx
+++ b/packages/blade/src/components/Toast/ToastContainer.native.tsx
@@ -15,7 +15,18 @@ import { useTheme } from '~components/BladeProvider';
  * `useToast` external store via `useSyncExternalStore` and renders the
  * native `<Toast>` component for each visible toast.
  */
-const ToastContainer = (): React.ReactElement | null => {
+const ToastContainer = ({
+  offsetBottom,
+}: {
+  /**
+   * Distance of the toast stack from the bottom of the screen, in px.
+   * Use it to lift toasts above bottom navigation / tab bars + safe-area insets.
+   * Same prop as the web ToastContainer.
+   *
+   * @default theme.spacing[8]
+   */
+  offsetBottom?: number;
+}): React.ReactElement | null => {
   const { theme } = useTheme();
   const { toasts } = useToast();
 
@@ -27,7 +38,7 @@ const ToastContainer = (): React.ReactElement | null => {
         position: 'absolute',
         left: theme.spacing[5],
         right: theme.spacing[5],
-        bottom: theme.spacing[8],
+        bottom: offsetBottom ?? theme.spacing[8],
       }}
       pointerEvents="box-none"
     >

--- a/packages/blade/src/components/Toast/__tests__/__snapshots__/Toast.native.test.tsx.snap
+++ b/packages/blade/src/components/Toast/__tests__/__snapshots__/Toast.native.test.tsx.snap
@@ -22,24 +22,13 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
     }
   >
     <View
-      alignItems="center"
-      backgroundColor="feedback.background.positive.subtle"
-      borderRadius="medium"
-      data-blade-component="box"
-      elevation="midRaised"
-      flexDirection="row"
       style={
         [
           {
-            "alignItems": "center",
-            "backgroundColor": "hsla(150, 100%, 28%, 0.09)",
+            "borderColor": "hsla(150, 100%, 28%, 1)",
             "borderRadius": 12,
-            "flexDirection": "row",
+            "borderWidth": 1,
             "marginBottom": 8,
-            "paddingBottom": 12,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 12,
           },
           {
             "elevation": 16,
@@ -51,187 +40,43 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
             "shadowOpacity": 0.06,
             "shadowRadius": 4,
           },
-          undefined,
         ]
       }
     >
       <View
-        data-blade-component="box"
         style={
-          [
-            {
-              "marginRight": 8,
-            },
-          ]
-        }
-      >
-        <RNSVGSvgView
-          accessibilityElementsHidden={true}
-          align="xMidYMid"
-          bbHeight="16px"
-          bbWidth="16px"
-          data-blade-component="icon"
-          fill="none"
-          focusable={false}
-          height="16px"
-          importantForAccessibility="no-hide-descendants"
-          meetOrSlice={0}
-          minX={0}
-          minY={0}
-          style={
-            [
-              {
-                "backgroundColor": "transparent",
-                "borderWidth": 0,
-              },
-              [
-                {},
-              ],
-              {
-                "flex": 0,
-                "height": 16,
-                "width": 16,
-              },
-            ]
+          {
+            "backgroundColor": "hsla(0, 0%, 100%, 1)",
+            "borderRadius": 12,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
-          vbHeight={24}
-          vbWidth={24}
-          width="16px"
-        >
-          <RNSVGGroup
-            fill={null}
-            propList={
-              [
-                "fill",
-              ]
-            }
-          >
-            <RNSVGPath
-              d="M4.15845 7.14673C6.74812 4.11682 11.0222 3.15114 14.663 4.77337C15.1675 4.99815 15.7586 4.77141 15.9834 4.26694C16.2082 3.76247 15.9815 3.17129 15.477 2.94651C11.0272 0.963789 5.80325 2.14407 2.6381 5.84729C-0.527049 9.55051 -0.879431 14.8945 1.77205 18.9813C4.42353 23.0681 9.44725 24.9241 14.1189 23.5428C18.7905 22.1615 21.9972 17.8715 22 12.9999V12.0699C22 11.5177 21.5523 11.0699 21 11.0699C20.4477 11.0699 20 11.5177 20 12.0699V12.9994C19.9977 16.9852 17.3741 20.4948 13.5518 21.6249C9.72957 22.755 5.61926 21.2364 3.44986 17.8927C1.28047 14.549 1.56878 10.1766 4.15845 7.14673Z"
-              fill={
-                {
-                  "payload": 4278220091,
-                  "type": 0,
-                }
-              }
-              propList={
-                [
-                  "fill",
-                ]
-              }
-            />
-            <RNSVGPath
-              d="M22.7071 4.70705C23.0976 4.31652 23.0976 3.68336 22.7071 3.29283C22.3166 2.90231 21.6834 2.90231 21.2929 3.29283L11 13.5857L8.70711 11.2928C8.31658 10.9023 7.68342 10.9023 7.29289 11.2928C6.90237 11.6834 6.90237 12.3165 7.29289 12.707L10.2929 15.707C10.6834 16.0976 11.3166 16.0976 11.7071 15.707L22.7071 4.70705Z"
-              fill={
-                {
-                  "payload": 4278220091,
-                  "type": 0,
-                }
-              }
-              propList={
-                [
-                  "fill",
-                ]
-              }
-            />
-          </RNSVGGroup>
-        </RNSVGSvgView>
-      </View>
-      <View
-        data-blade-component="box"
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
         }
-      >
-        <Text
-          accessible={true}
-          color="surface.text.gray.normal"
-          data-blade-component="text"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          letterSpacing={50}
-          lineHeight={100}
-          style={
-            [
-              {
-                "color": "hsla(0, 0%, 2%, 1)",
-                "fontFamily": "Inter",
-                "fontSize": 14,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "letterSpacing": -0.18200000000000002,
-                "lineHeight": 20,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
-              },
-            ]
-          }
-        >
-          Saved successfully
-        </Text>
-      </View>
+      />
       <View
-        data-blade-component="box"
         style={
-          [
-            {
-              "marginLeft": 4,
-            },
-          ]
+          {
+            "alignItems": "center",
+            "backgroundColor": "hsla(150, 100%, 28%, 0.88)",
+            "borderRadius": 12,
+            "flexDirection": "row",
+            "paddingHorizontal": 12,
+            "paddingVertical": 8,
+          }
         }
       >
         <View
-          accessibilityLabel="Dismiss"
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          emphasis="intense"
-          focusable={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          alignSelf="center"
+          data-blade-component="box"
           style={
             [
               {
                 "alignSelf": "center",
+                "marginRight": 8,
+                "marginTop": 0,
               },
             ]
           }
@@ -239,12 +84,12 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
           <RNSVGSvgView
             accessibilityElementsHidden={true}
             align="xMidYMid"
-            bbHeight="12px"
-            bbWidth="12px"
+            bbHeight="16px"
+            bbWidth="16px"
             data-blade-component="icon"
             fill="none"
             focusable={false}
-            height="12px"
+            height="16px"
             importantForAccessibility="no-hide-descendants"
             meetOrSlice={0}
             minX={0}
@@ -260,14 +105,14 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
                 ],
                 {
                   "flex": 0,
-                  "height": 12,
-                  "width": 12,
+                  "height": 16,
+                  "width": 16,
                 },
               ]
             }
             vbHeight={24}
             vbWidth={24}
-            width="12px"
+            width="16px"
           >
             <RNSVGGroup
               fill={null}
@@ -278,10 +123,24 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
               }
             >
               <RNSVGPath
-                d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
+                d="M4.15845 7.14673C6.74812 4.11682 11.0222 3.15114 14.663 4.77337C15.1675 4.99815 15.7586 4.77141 15.9834 4.26694C16.2082 3.76247 15.9815 3.17129 15.477 2.94651C11.0272 0.963789 5.80325 2.14407 2.6381 5.84729C-0.527049 9.55051 -0.879431 14.8945 1.77205 18.9813C4.42353 23.0681 9.44725 24.9241 14.1189 23.5428C18.7905 22.1615 21.9972 17.8715 22 12.9999V12.0699C22 11.5177 21.5523 11.0699 21 11.0699C20.4477 11.0699 20 11.5177 20 12.0699V12.9994C19.9977 16.9852 17.3741 20.4948 13.5518 21.6249C9.72957 22.755 5.61926 21.2364 3.44986 17.8927C1.28047 14.549 1.56878 10.1766 4.15845 7.14673Z"
                 fill={
                   {
-                    "payload": 4284575093,
+                    "payload": 4294967295,
+                    "type": 0,
+                  }
+                }
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+              />
+              <RNSVGPath
+                d="M22.7071 4.70705C23.0976 4.31652 23.0976 3.68336 22.7071 3.29283C22.3166 2.90231 21.6834 2.90231 21.2929 3.29283L11 13.5857L8.70711 11.2928C8.31658 10.9023 7.68342 10.9023 7.29289 11.2928C6.90237 11.6834 6.90237 12.3165 7.29289 12.707L10.2929 15.707C10.6834 16.0976 11.3166 16.0976 11.7071 15.707L22.7071 4.70705Z"
+                fill={
+                  {
+                    "payload": 4294967295,
                     "type": 0,
                   }
                 }
@@ -293,6 +152,166 @@ exports[`<Toast /> (native) renders a positive informational toast 1`] = `
               />
             </RNSVGGroup>
           </RNSVGSvgView>
+        </View>
+        <View
+          data-blade-component="box"
+          style={
+            [
+              {
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
+              },
+            ]
+          }
+        >
+          <Text
+            accessible={true}
+            color="surface.text.staticWhite.normal"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={75}
+            style={
+              [
+                {
+                  "color": "hsla(0, 0%, 100%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.15600000000000003,
+                  "lineHeight": 17,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
+                },
+              ]
+            }
+          >
+            Saved successfully
+          </Text>
+        </View>
+        <View
+          alignSelf="center"
+          data-blade-component="box"
+          style={
+            [
+              {
+                "alignSelf": "center",
+                "marginLeft": 4,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Dismiss"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            emphasis="subtle"
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignSelf": "center",
+                },
+              ]
+            }
+          >
+            <RNSVGSvgView
+              accessibilityElementsHidden={true}
+              align="xMidYMid"
+              bbHeight="12px"
+              bbWidth="12px"
+              data-blade-component="icon"
+              fill="none"
+              focusable={false}
+              height="12px"
+              importantForAccessibility="no-hide-descendants"
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
+                [
+                  {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  [
+                    {},
+                  ],
+                  {
+                    "flex": 0,
+                    "height": 12,
+                    "width": 12,
+                  },
+                ]
+              }
+              vbHeight={24}
+              vbWidth={24}
+              width="12px"
+            >
+              <RNSVGGroup
+                fill={null}
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+              >
+                <RNSVGPath
+                  d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
+                  fill={
+                    {
+                      "payload": 2751463423,
+                      "type": 0,
+                    }
+                  }
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
         </View>
       </View>
     </View>
@@ -322,24 +341,13 @@ exports[`<Toast /> (native) renders a promotional toast 1`] = `
     }
   >
     <View
-      alignItems="center"
-      backgroundColor="surface.background.gray.intense"
-      borderRadius="medium"
-      data-blade-component="box"
-      elevation="midRaised"
-      flexDirection="row"
       style={
         [
           {
-            "alignItems": "center",
-            "backgroundColor": "hsla(0, 0%, 100%, 1)",
+            "borderColor": "hsla(0, 0%, 97%, 1)",
             "borderRadius": 12,
-            "flexDirection": "row",
+            "borderWidth": 1,
             "marginBottom": 8,
-            "paddingBottom": 12,
-            "paddingLeft": 12,
-            "paddingRight": 12,
-            "paddingTop": 12,
           },
           {
             "elevation": 16,
@@ -351,265 +359,193 @@ exports[`<Toast /> (native) renders a promotional toast 1`] = `
             "shadowOpacity": 0.06,
             "shadowRadius": 4,
           },
-          undefined,
         ]
       }
     >
       <View
-        data-blade-component="box"
         style={
-          [
-            {
-              "marginRight": 8,
-            },
-          ]
-        }
-      >
-        <RNSVGSvgView
-          accessibilityElementsHidden={true}
-          align="xMidYMid"
-          bbHeight="16px"
-          bbWidth="16px"
-          data-blade-component="icon"
-          fill="none"
-          focusable={false}
-          height="16px"
-          importantForAccessibility="no-hide-descendants"
-          meetOrSlice={0}
-          minX={0}
-          minY={0}
-          style={
-            [
-              {
-                "backgroundColor": "transparent",
-                "borderWidth": 0,
-              },
-              [
-                {},
-              ],
-              {
-                "flex": 0,
-                "height": 16,
-                "width": 16,
-              },
-            ]
+          {
+            "backgroundColor": "hsla(0, 0%, 100%, 1)",
+            "borderRadius": 12,
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
-          vbHeight={24}
-          vbWidth={24}
-          width="16px"
-        >
-          <RNSVGGroup
-            fill={null}
-            propList={
-              [
-                "fill",
-              ]
-            }
-          >
-            <RNSVGPath
-              d="M12 11C12.5523 11 13 11.4477 13 12V16C13 16.5523 12.5523 17 12 17C11.4477 17 11 16.5523 11 16V12C11 11.4477 11.4477 11 12 11Z"
-              fill={
-                {
-                  "payload": 4294967295,
-                  "type": 0,
-                }
-              }
-              propList={
-                [
-                  "fill",
-                ]
-              }
-            />
-            <RNSVGPath
-              d="M12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12Z"
-              fill={
-                {
-                  "payload": 4294967295,
-                  "type": 0,
-                }
-              }
-              propList={
-                [
-                  "fill",
-                ]
-              }
-            />
-            <RNSVGPath
-              clipRule={0}
-              d="M1 12C1 5.92487 5.92487 1 12 1C18.0751 1 23 5.92487 23 12C23 18.0751 18.0751 23 12 23C5.92487 23 1 18.0751 1 12ZM12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3Z"
-              fill={
-                {
-                  "payload": 4294967295,
-                  "type": 0,
-                }
-              }
-              fillRule={0}
-              propList={
-                [
-                  "fill",
-                  "fillRule",
-                ]
-              }
-            />
-          </RNSVGGroup>
-        </RNSVGSvgView>
-      </View>
-      <View
-        data-blade-component="box"
-        style={
-          [
-            {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-            },
-          ]
         }
-      >
-        <Text
-          accessible={true}
-          color="surface.text.staticWhite.normal"
-          data-blade-component="text"
-          fontFamily="text"
-          fontSize={100}
-          fontStyle="normal"
-          fontWeight="regular"
-          letterSpacing={50}
-          lineHeight={100}
-          style={
-            [
-              {
-                "color": "hsla(0, 0%, 100%, 1)",
-                "fontFamily": "Inter",
-                "fontSize": 14,
-                "fontStyle": "normal",
-                "fontWeight": "400",
-                "letterSpacing": -0.18200000000000002,
-                "lineHeight": 20,
-                "marginBottom": 0,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "marginTop": 0,
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 0,
-                "textDecorationLine": "none",
-              },
-            ]
-          }
-        >
-          New feature available
-        </Text>
-      </View>
+      />
       <View
-        data-blade-component="box"
         style={
-          [
-            {
-              "marginLeft": 4,
-            },
-          ]
+          {
+            "alignItems": "center",
+            "backgroundColor": "hsla(0, 0%, 100%, 0.94)",
+            "borderRadius": 12,
+            "flexDirection": "row",
+            "paddingHorizontal": 12,
+            "paddingVertical": 12,
+          }
         }
       >
         <View
-          accessibilityLabel="Dismiss"
-          accessibilityRole="button"
-          accessibilityState={
-            {
-              "busy": undefined,
-              "checked": undefined,
-              "disabled": undefined,
-              "expanded": undefined,
-              "selected": undefined,
-            }
-          }
-          accessibilityValue={
-            {
-              "max": undefined,
-              "min": undefined,
-              "now": undefined,
-              "text": undefined,
-            }
-          }
-          accessible={true}
-          collapsable={false}
-          emphasis="intense"
-          focusable={true}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
+          data-blade-component="box"
           style={
             [
               {
-                "alignSelf": "center",
+                "flexBasis": 0,
+                "flexGrow": 1,
+                "flexShrink": 1,
               },
             ]
           }
         >
-          <RNSVGSvgView
-            accessibilityElementsHidden={true}
-            align="xMidYMid"
-            bbHeight="12px"
-            bbWidth="12px"
-            data-blade-component="icon"
-            fill="none"
-            focusable={false}
-            height="12px"
-            importantForAccessibility="no-hide-descendants"
-            meetOrSlice={0}
-            minX={0}
-            minY={0}
+          <Text
+            accessible={true}
+            color="surface.text.gray.normal"
+            data-blade-component="text"
+            fontFamily="text"
+            fontSize={75}
+            fontStyle="normal"
+            fontWeight="regular"
+            letterSpacing={50}
+            lineHeight={75}
             style={
               [
                 {
-                  "backgroundColor": "transparent",
-                  "borderWidth": 0,
-                },
-                [
-                  {},
-                ],
-                {
-                  "flex": 0,
-                  "height": 12,
-                  "width": 12,
+                  "color": "hsla(0, 0%, 2%, 1)",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontStyle": "normal",
+                  "fontWeight": "400",
+                  "letterSpacing": -0.15600000000000003,
+                  "lineHeight": 17,
+                  "marginBottom": 0,
+                  "marginLeft": 0,
+                  "marginRight": 0,
+                  "marginTop": 0,
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 0,
+                  "textDecorationLine": "none",
                 },
               ]
             }
-            vbHeight={24}
-            vbWidth={24}
-            width="12px"
           >
-            <RNSVGGroup
-              fill={null}
-              propList={
+            New feature available
+          </Text>
+        </View>
+        <View
+          alignSelf="flex-start"
+          data-blade-component="box"
+          style={
+            [
+              {
+                "alignSelf": "flex-start",
+                "marginLeft": 4,
+              },
+            ]
+          }
+        >
+          <View
+            accessibilityLabel="Dismiss"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            emphasis="intense"
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              [
+                {
+                  "alignSelf": "center",
+                },
+              ]
+            }
+          >
+            <RNSVGSvgView
+              accessibilityElementsHidden={true}
+              align="xMidYMid"
+              bbHeight="12px"
+              bbWidth="12px"
+              data-blade-component="icon"
+              fill="none"
+              focusable={false}
+              height="12px"
+              importantForAccessibility="no-hide-descendants"
+              meetOrSlice={0}
+              minX={0}
+              minY={0}
+              style={
                 [
-                  "fill",
+                  {
+                    "backgroundColor": "transparent",
+                    "borderWidth": 0,
+                  },
+                  [
+                    {},
+                  ],
+                  {
+                    "flex": 0,
+                    "height": 12,
+                    "width": 12,
+                  },
                 ]
               }
+              vbHeight={24}
+              vbWidth={24}
+              width="12px"
             >
-              <RNSVGPath
-                d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
-                fill={
-                  {
-                    "payload": 4284575093,
-                    "type": 0,
-                  }
-                }
+              <RNSVGGroup
+                fill={null}
                 propList={
                   [
                     "fill",
                   ]
                 }
-              />
-            </RNSVGGroup>
-          </RNSVGSvgView>
+              >
+                <RNSVGPath
+                  d="M18.7071 6.70711C19.0976 6.31658 19.0976 5.68342 18.7071 5.29289C18.3166 4.90237 17.6834 4.90237 17.2929 5.29289L12 10.5858L6.70711 5.29289C6.31658 4.90237 5.68342 4.90237 5.29289 5.29289C4.90237 5.68342 4.90237 6.31658 5.29289 6.70711L10.5858 12L5.29289 17.2929C4.90237 17.6834 4.90237 18.3166 5.29289 18.7071C5.68342 19.0976 6.31658 19.0976 6.70711 18.7071L12 13.4142L17.2929 18.7071C17.6834 19.0976 18.3166 19.0976 18.7071 18.7071C19.0976 18.3166 19.0976 17.6834 18.7071 17.2929L13.4142 12L18.7071 6.70711Z"
+                  fill={
+                    {
+                      "payload": 4284575093,
+                      "type": 0,
+                    }
+                  }
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                />
+              </RNSVGGroup>
+            </RNSVGSvgView>
+          </View>
         </View>
       </View>
     </View>


### PR DESCRIPTION
## Summary

The native Toast shipped with `feedback.background.*.subtle` backgrounds — **9% alpha tints** designed for Alerts sitting on opaque cards. Floating over arbitrary screen content, everything underneath bleeds through the toast (screenshot reports from the Razorpay merchant app 3.0.0 tester rollout). Web Toast uses solid-looking `popup.background.*.moderate` tokens.

### Changes
- **Native `Toast` now mirrors `Toast.web` token-for-token**: `popup.background.{color}.moderate` / `popup.border.{color}.moderate` backgrounds + borders, staticWhite text/icons on color variants, gray-on-light promotional variant, web's action-button variants (`tertiary`/`white`, promo `secondary`/`primary`) and dismiss-button emphasis.
- **Opaque backing view** under the semi-transparent popup token — RN has no `backdropFilter: blur()`, so without it content still bleeds through at 88-94% alpha. Same workaround as `TooltipContentWrapper.native`.
- **Native `ToastContainer` implements the existing web `offsetBottom` prop** — previously hardcoded `bottom: theme.spacing[8]`, which pins toasts onto bottom tab bars / home-indicator safe areas with no recourse for consumers.

### Why popup tokens are applied via `getIn(theme.colors, …)`
Native Box's runtime backgroundColor validation rejects `popup.background.*` (the original implementation's comment says this is why it fell back to feedback tints). The colored layers are plain `View`s with theme lookups, matching the Tooltip native pattern.

### Testing
- `yarn types:typecheck:native` clean
- `yarn test:react-native Toast`: 7/7 pass (2 snapshots updated — the intended visual change)
- Consumer validation: Razorpay merchant app (RN 0.85) — the transparent-toast defect reported by testers reproduces with subtle tints and disappears with these tokens

### Consumer follow-up
The merchant app will pass `offsetBottom` (tab bar height + safe-area inset) from its root once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)