### PR TITLE
fix: portal target

### DIFF
--- a/.changeset/fix-portal-target.md
+++ b/.changeset/fix-portal-target.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-svelte": patch
+---
+
+fix: add optional `portalTarget` prop to BottomSheet and PhoneNumberInput for custom portal mounting

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -22,7 +22,6 @@
     bottomSheetGrabHandleFloatingClass,
     getBottomSheetTemplateClasses,
   } from '@razorpay/blade-core/styles';
-  import { portal } from '../../utils/portal';
   import {
     bottomSheetStack,
     addBottomSheetToStack,
@@ -33,6 +32,7 @@
   import type { BottomSheetProps, SnapPoints } from './types';
   import { computeMaxContent, computeSnapPointBounds } from './utils';
   import BottomSheetBackdrop from './BottomSheetBackdrop.svelte';
+  import { portal } from '../../utils/portal';
 
   /* Anchor structural classes against the Rollup tree-shaker — CSS modules
    * export ESM objects whose unused individual exports otherwise get
@@ -48,6 +48,7 @@
     snapPoints = [...BOTTOM_SHEET_DEFAULT_SNAP_POINTS] as SnapPoints,
     isDismissible = true,
     zIndex = BOTTOM_SHEET_Z_INDEX,
+    portalTarget,
     testID,
     ...rest
   }: BottomSheetProps = $props();
@@ -248,9 +249,24 @@
     }
   });
 
-  /* Track viewport height for snap-point math. */
+  /* Track viewport height for snap-point math — use portal target height when
+   * portaling into a bounded container (e.g. checkout phone frame). */
+  $effect(() => {
+    const target = portalTarget;
+    if (target) {
+      windowHeight = target.clientHeight;
+      const observer = new ResizeObserver(() => {
+        windowHeight = target.clientHeight;
+      });
+      observer.observe(target);
+      return () => observer.disconnect();
+    }
+    return undefined;
+  });
+
   onMount(() => {
     if (typeof window === 'undefined') return undefined;
+    if (portalTarget) return undefined;
     windowHeight = window.innerHeight;
     const handler = (): void => {
       windowHeight = window.innerHeight;
@@ -522,26 +538,34 @@
 </script>
 
 {#if isMounted}
-  <div use:portal={document.body}>
-    <BottomSheetBackdrop
-      isOpen={isVisible}
-      zIndex={bottomSheetZIndex}
-      {isDismissible}
-      onClose={close}
-    />
-    <div
-      class="{bottomSheetSurfaceClass} {surfaceExtraClasses}"
-      style={surfaceStyle}
-      data-state={surfaceState}
-      data-dragging={isDragging}
-      {...surfaceMetaAttrs}
-      {...surfaceA11yAttrs}
-      {...analyticsAttrs}
-    >
-      <div class={bottomSheetInnerWrapperClass}>
-        <div bind:this={grabHandleEl} class={grabHandleClasses} {...grabHandleMetaAttrs}></div>
-        {@render children()}
-      </div>
+  {#if portalTarget}
+    <div use:portal={portalTarget}>
+      {@render overlay()}
+    </div>
+  {:else}
+    {@render overlay()}
+  {/if}
+{/if}
+
+{#snippet overlay()}
+  <BottomSheetBackdrop
+    isOpen={isVisible}
+    zIndex={bottomSheetZIndex}
+    {isDismissible}
+    onClose={close}
+  />
+  <div
+    class="{bottomSheetSurfaceClass} {surfaceExtraClasses}"
+    style={surfaceStyle}
+    data-state={surfaceState}
+    data-dragging={isDragging}
+    {...surfaceMetaAttrs}
+    {...surfaceA11yAttrs}
+    {...analyticsAttrs}
+  >
+    <div class={bottomSheetInnerWrapperClass}>
+      <div bind:this={grabHandleEl} class={grabHandleClasses} {...grabHandleMetaAttrs}></div>
+      {@render children()}
     </div>
   </div>
-{/if}
+{/snippet}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -538,13 +538,9 @@
 </script>
 
 {#if isMounted}
-  {#if portalTarget}
-    <div use:portal={portalTarget}>
-      {@render overlay()}
-    </div>
-  {:else}
+  <div use:portal={portalTarget ?? document.body}>
     {@render overlay()}
-  {/if}
+  </div>
 {/if}
 
 {#snippet overlay()}

--- a/packages/blade-svelte/src/components/BottomSheet/types.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/types.ts
@@ -63,10 +63,11 @@ export interface BottomSheetProps extends StyledPropsBlade {
   zIndex?: number;
 
   /**
-   * Mounts the overlay (backdrop + surface) into this element instead of
-   * rendering inline. Use when the sheet is nested inside another overlay or
-   * an ancestor with `overflow: hidden` / `transform` (e.g. a phone-frame
-   * preview). Snap-point math uses the target's height when set.
+   * Mounts the overlay (backdrop + surface) into this element. Defaults to
+   * `document.body`. Use a custom target when the sheet is nested inside
+   * another overlay or an ancestor with `overflow: hidden` / `transform`
+   * (e.g. a phone-frame preview). Snap-point math uses the target's height
+   * when set.
    */
   portalTarget?: HTMLElement | null;
 

--- a/packages/blade-svelte/src/components/BottomSheet/types.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/types.ts
@@ -62,6 +62,14 @@ export interface BottomSheetProps extends StyledPropsBlade {
    */
   zIndex?: number;
 
+  /**
+   * Mounts the overlay (backdrop + surface) into this element instead of
+   * rendering inline. Use when the sheet is nested inside another overlay or
+   * an ancestor with `overflow: hidden` / `transform` (e.g. a phone-frame
+   * preview). Snap-point math uses the target's height when set.
+   */
+  portalTarget?: HTMLElement | null;
+
   /** Test ID applied to the surface element. */
   testID?: string;
 

--- a/packages/blade-svelte/src/components/Input/PhoneNumberInput/CountrySelector.svelte
+++ b/packages/blade-svelte/src/components/Input/PhoneNumberInput/CountrySelector.svelte
@@ -58,6 +58,7 @@
     onItemClick,
     flags,
     size,
+    portalTarget,
   }: CountrySelectorProps = $props();
 
   let isOpen = $state(false);
@@ -95,7 +96,7 @@
   </span>
 </button>
 
-<BottomSheet {isOpen} onDismiss={() => (isOpen = false)}>
+<BottomSheet {isOpen} onDismiss={() => (isOpen = false)} {portalTarget}>
   <BottomSheetHeader title="Select A Country" />
   <BottomSheetBody hasActionList>
     <ActionList selectionType="single" selectedValue={selectedCountry} onAction={handleSelect}>

--- a/packages/blade-svelte/src/components/Input/PhoneNumberInput/PhoneNumberInput.svelte
+++ b/packages/blade-svelte/src/components/Input/PhoneNumberInput/PhoneNumberInput.svelte
@@ -49,6 +49,7 @@
     allowedCountries,
     placeholder,
     id,
+    portalTarget,
     ...rest
   }: PhoneNumberInputProps = $props();
 
@@ -160,6 +161,7 @@
       {flags}
       {isDisabled}
       {selectedCountry}
+      {portalTarget}
       onItemClick={handleCountrySelect}
     />
   {/if}

--- a/packages/blade-svelte/src/components/Input/PhoneNumberInput/types.ts
+++ b/packages/blade-svelte/src/components/Input/PhoneNumberInput/types.ts
@@ -100,6 +100,11 @@ export interface PhoneNumberInputProps extends StyledPropsBlade, DataAnalyticsAt
   onClearButtonClick?: () => void;
   /** Optional stable HTML id for the underlying input. Auto-generated when omitted. */
   id?: string;
+  /**
+   * Portals the country-selector bottom sheet into this element. Pass the same
+   * target used by a parent `BottomSheet` when the input lives inside one.
+   */
+  portalTarget?: HTMLElement | null;
 }
 
 /** Imperative handle exposed via `bind:this`. */
@@ -124,4 +129,6 @@ export type CountrySelectorProps = {
   isDisabled?: boolean;
   /** Size of the trigger (drives flag size). */
   size: BaseInputSize;
+  /** Portals the country list bottom sheet into this element. */
+  portalTarget?: HTMLElement | null;
 };


### PR DESCRIPTION
## Summary
- Cherry-picks commit `61d1aa7` (fix: portal target) onto `master`.
- Adds portal target support to `BottomSheet` and `PhoneNumberInput` (`CountrySelector`) Svelte components, with corresponding `types.ts` updates.

## Changes
- `blade-svelte` BottomSheet: portal target handling.
- `blade-svelte` PhoneNumberInput / CountrySelector: pass through portal target.

## Test plan
- [ ] Verify BottomSheet renders into the correct portal target.
- [ ] Verify PhoneNumberInput country selector dropdown respects portal target.

Made with [Cursor](https://cursor.com)