### PR TITLE
fix(SpotlightPopoverTour): prevent scroll lock when anchor is taller than viewport

### DIFF
--- a/.changeset/spotlight-tour-oversized-anchor.md
+++ b/.changeset/spotlight-tour-oversized-anchor.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+Fixed `SpotlightPopoverTour` scrolling indefinitely and locking the page when a step's anchor is taller than the viewport (e.g. a large table). The tour now detects oversized anchors and scroll-aligns them to the top instead of trying to center them, so the page no longer freezes with the popover pushed off-screen.

--- a/packages/blade/src/components/SpotlightPopoverTour/Tour.web.tsx
+++ b/packages/blade/src/components/SpotlightPopoverTour/Tour.web.tsx
@@ -17,6 +17,7 @@ import type { SpotlightPopoverTourMaskRect, SpotlightPopoverTourProps } from './
 import { SpotlightPopoverTourMask } from './TourMask';
 import { transitionDelay } from './tourTokens';
 import { useTheme } from '~components/BladeProvider';
+import { isBrowser } from '~utils';
 import { useIsomorphicLayoutEffect } from '~utils/useIsomorphicLayoutEffect';
 
 const asHTMLElement = (el: TourElement | null): HTMLElement | null => el as HTMLElement | null;
@@ -130,6 +131,8 @@ const SpotlightPopoverTour = ({
   );
 
   const scrollToStep = useCallback(() => {
+    if (!isBrowser()) return;
+
     const ref = refIdMap.get(steps[delayedActiveStep]?.name);
     const el = asHTMLElement(ref?.current ?? null);
     if (!el) return;

--- a/packages/blade/src/components/SpotlightPopoverTour/Tour.web.tsx
+++ b/packages/blade/src/components/SpotlightPopoverTour/Tour.web.tsx
@@ -47,10 +47,12 @@ const SpotlightPopoverTour = ({
   const [isScrolling, setIsScrolling] = useState(false);
 
   const currentStepRef = refIdMap.get(steps[activeStep]?.name);
+  // Anchors taller than the viewport can never reach 50% visibility, so we also observe the
+  // 0% crossing as a fallback threshold for those cases (see scrollToStep below).
   const intersection = useIntersectionObserver(
     (currentStepRef as React.RefObject<Element> | undefined)!,
     {
-      threshold: 0.5,
+      threshold: [0, 0.5],
     },
   );
   // main step logic
@@ -132,13 +134,22 @@ const SpotlightPopoverTour = ({
     const el = asHTMLElement(ref?.current ?? null);
     if (!el) return;
 
-    // If the element is already in view, don't scroll
-    if (intersection?.isIntersecting) return;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    const isAnchorTallerThanViewport = el.getBoundingClientRect().height > viewportHeight;
+
+    // An anchor taller than the viewport can never satisfy the 0.5 threshold, so require only
+    // partial visibility (ratio > 0) for it instead of waiting on an unreachable isIntersecting.
+    const isVisibleEnough = isAnchorTallerThanViewport
+      ? (intersection?.intersectionRatio ?? 0) > 0
+      : Boolean(intersection?.isIntersecting);
+    if (isVisibleEnough) return;
 
     setIsScrolling(true);
     smoothScroll(el, {
       behavior: 'smooth',
-      block: 'center',
+      // Centering an anchor taller than the viewport pushes its edges (and the popover
+      // attached near them) outside the viewport, so align to the top instead.
+      block: isAnchorTallerThanViewport ? 'start' : 'center',
       inline: 'center',
     })
       .then(() => {
@@ -149,7 +160,7 @@ const SpotlightPopoverTour = ({
       .finally(() => {
         setIsScrolling(false);
       });
-  }, [delayedActiveStep, refIdMap, steps, updateMaskSize, intersection?.isIntersecting]);
+  }, [delayedActiveStep, refIdMap, steps, updateMaskSize, intersection]);
 
   // Update the size of the mask when the active step changes
   useIsomorphicLayoutEffect(() => {

--- a/packages/blade/src/components/SpotlightPopoverTour/docs/Tour.stories.tsx
+++ b/packages/blade/src/components/SpotlightPopoverTour/docs/Tour.stories.tsx
@@ -768,6 +768,120 @@ WithScrollablePage.parameters = {
   viewMode: 'story',
 };
 
+/**
+ * Reproduction for a reported bug: when the anchor (e.g. a large table) is taller than the
+ * viewport, it can never satisfy the 0.5 intersection threshold used internally by the tour.
+ * That causes the tour to keep calling `scrollIntoView({ block: 'center' })`, which can push the
+ * popover itself off-screen, while body scroll is locked and a full-screen mask blocks
+ * interaction — making the page feel frozen.
+ */
+export const WithLargeAnchor = () => {
+  const [activeStep, setActiveStep] = React.useState(0);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const steps = React.useMemo<SpotlightPopoverTourSteps>(
+    () => [
+      {
+        name: 'large-table',
+        title: 'Your Transactions',
+        content: () => {
+          return (
+            <Box>
+              <Text color="surface.text.gray.subtle">
+                This step is anchored to a table that is taller than the viewport, reproducing the
+                reported freeze/off-screen-popover issue.
+              </Text>
+            </Box>
+          );
+        },
+        placement: 'bottom',
+        footer: CustomTourFooter,
+      },
+      {
+        name: 'small-row',
+        title: 'A Single Row',
+        content: () => {
+          return (
+            <Box>
+              <Text color="surface.text.gray.subtle">
+                This step is anchored to a single row instead — it should behave normally.
+              </Text>
+            </Box>
+          );
+        },
+        placement: 'bottom',
+        footer: CustomTourFooter,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Box>
+      <Button
+        marginBottom="spacing.5"
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
+      >
+        {isOpen ? 'Tour In Progress' : 'Start Tour'}
+      </Button>
+      <SpotlightPopoverTour
+        steps={steps}
+        isOpen={isOpen}
+        activeStep={activeStep}
+        onFinish={() => {
+          setActiveStep(0);
+          setIsOpen(false);
+        }}
+        onOpenChange={({ isOpen }) => {
+          setIsOpen(isOpen);
+        }}
+        onStepChange={(step) => {
+          setActiveStep(step);
+        }}
+      >
+        <SpotlightPopoverTourStep name="large-table">
+          {/* Anchor is intentionally taller than any reasonable viewport (200vh) so it can
+              never reach 50% visibility, forcing the tour to repeatedly center-scroll it. */}
+          <Box
+            minHeight="200vh"
+            padding="spacing.4"
+            backgroundColor="surface.background.gray.intense"
+            borderWidth="thin"
+            borderColor="surface.border.gray.normal"
+          >
+            <Text weight="semibold" marginBottom="spacing.4">
+              Large Table (200vh tall — taller than the viewport)
+            </Text>
+            {Array.from({ length: 40 }).map((_, index) => (
+              <Box
+                key={index}
+                paddingY="spacing.3"
+                borderBottomWidth="thin"
+                borderColor="surface.border.gray.muted"
+              >
+                <Text>Row {index + 1}</Text>
+              </Box>
+            ))}
+          </Box>
+        </SpotlightPopoverTourStep>
+        <Box marginTop="spacing.9">
+          <SpotlightPopoverTourStep name="small-row">
+            <Box padding="spacing.4" backgroundColor="surface.background.gray.intense">
+              <Text>A small row anchor for comparison</Text>
+            </Box>
+          </SpotlightPopoverTourStep>
+        </Box>
+      </SpotlightPopoverTour>
+    </Box>
+  );
+};
+WithLargeAnchor.storyName = 'With Large Anchor (Bug Repro)';
+WithLargeAnchor.parameters = {
+  docs: { disable: true },
+  viewMode: 'story',
+};
+
 const InterruptibleTourFooter = ({
   activeStep,
   goToNext,


### PR DESCRIPTION
## Summary
- Fixes a bug reported in Subscriptions v2 where clicking "Take a tour" freezes the page: when a step's anchor (e.g. a large table) is taller than the viewport, it can never reach the hardcoded `0.5` intersection threshold, so the tour keeps calling `scrollIntoView({ block: 'center' })`. Combined with body scroll lock + full-screen mask, this pushes the popover off-screen with no way for the user to recover.
- `useIntersectionObserver` now also observes the `0` threshold as a fallback.
- `scrollToStep` detects anchors taller than the viewport and relaxes the visibility check (`intersectionRatio > 0` instead of `isIntersecting`), aligning them to the top (`block: 'start'`) instead of the center.
- Adds a `WithLargeAnchor` story (`SpotlightPopoverTour/docs/Tour.stories.tsx`) reproducing the bug with a 200vh-tall anchor, used for verification and as a regression guard.
- Adds a changeset.

## Root cause
`IntersectionObserver` only fires when the observed ratio crosses a specified `threshold`. With only `threshold: 0.5` set, an anchor that can never occupy 50% of the viewport (because it's taller than the viewport itself) never flips `isIntersecting` to `true`, so the tour's scroll-into-view effect kept re-firing with `block: 'center'`, moving the anchor's already-off-screen edges further out of view — while body scroll was locked, making the page feel frozen.

## Test plan
- [x] Added `WithLargeAnchor` story with a 200vh anchor to reproduce the bug
- [x] Verified via Storybook + agent-browser: before the fix, starting the tour scrolled the popover fully off-screen (footer/Next button unreachable) with scroll locked
- [x] After the fix: starting the tour keeps the anchor's top edge in view with the popover's footer/Next button visible and clickable; progressing to the second (normal-sized) step behaves normally
- [x] `yarn test:react SpotlightPopoverTour` — 2 suites / 6 tests / 3 snapshots, all passing, no regressions
- [x] `yarn typecheck` — passes (web + native)

🤖 Generated with [Claude Code](https://claude.com/claude-code)