### PR TITLE
fix(blade-svelte): constrain BottomSheet portalTarget to container bounds

### DIFF
--- a/.agents/reviews/pr-3877-review.md
+++ b/.agents/reviews/pr-3877-review.md
@@ -1,0 +1,39 @@
+# PR Review Report — PR #3877
+
+**PR:** fix(blade-svelte): constrain BottomSheet portalTarget to container bounds
+**Branch:** fix/bottomsheet-portal-target
+**Review URL:** https://github.com/razorpay/blade/pull/3877#pullrequestreview-4929435495
+**Date:** 2026-08-13
+
+## Review Status: `commented`
+
+## Summary
+
+Reviewed PR #3877 using the blade repo's `/review-pr` skill with `shouldReviewUI=true`, `shouldRunHeadedBrowser=false`, and `shouldSubmitReview=true`.
+
+## Critique Agents Spawned
+
+1. **code-quality-critique** — Reviewed code quality of changed files (1 issue: missing changeset)
+2. **api-decision-critique** — Reviewed API decisions (no issues found; `portalTarget` is an existing prop, no new API surface)
+3. **ui-critique** — Reviewed UI via Storybook using agent-browser (all checks passed)
+4. **filter-critique** — Deduplicated and filtered inline comments (kept the missing changeset comment)
+
+## UI Review
+
+| Check | State |
+|-------|-------|
+| BottomSheet With Portal Target | SUCCESS |
+| BottomSheet Default (regression check) | SUCCESS |
+
+- **With Portal Target**: Opened the story, clicked 'Open bottom sheet', and verified the BottomSheet surface and backdrop render inside the bounded 320x560 phone-frame container. Backdrop uses `position:absolute` (not `fixed`), confirming the `portalRoot` CSS wrapper works correctly.
+- **Default (regression check)**: Opened the default BottomSheet story, verified the sheet still renders full-viewport with `position:fixed`. Existing behavior is not broken by the portalTarget changes.
+
+## Inline Comments (after filtering)
+
+1. **Missing changeset** (minor, confidence: 9) — `packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte`
+   - This PR changes BottomSheet rendering behavior and adds a new public export (`bottomSheetPortalRootClass`) to blade-core, but no `.changeset` file was added.
+   - Suggestion: Add a `.changeset` file for `@razorpay/blade-svelte` (patch) describing the portalTarget positioning fix.
+
+## Changeset
+
+Missing — a `.changeset` file should be added for `@razorpay/blade-svelte` (patch) since this is a user-facing bug fix.

--- a/packages/blade-core/src/styles/BottomSheet/bottomSheet.module.css
+++ b/packages/blade-core/src/styles/BottomSheet/bottomSheet.module.css
@@ -7,6 +7,22 @@
  *   --bs-z-index   → z-index for surface and backdrop
  */
 
+/* ===== PORTAL ROOT ===== */
+/* Fills a custom portalTarget so surface/backdrop position against the
+ * container instead of the viewport (position: fixed → absolute). */
+.portalRoot {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.portalRoot .surface,
+.portalRoot .backdrop {
+  position: absolute;
+}
+
 /* ===== SURFACE ===== */
 .surface {
   position: fixed;

--- a/packages/blade-core/src/styles/BottomSheet/bottomSheet.ts
+++ b/packages/blade-core/src/styles/BottomSheet/bottomSheet.ts
@@ -85,6 +85,7 @@ export const getBottomSheetBodyClasses = cva(styles.body, {
  */
 export const bottomSheetSurfaceClass = styles.surface;
 export const bottomSheetBackdropClass = styles.backdrop;
+export const bottomSheetPortalRootClass = styles.portalRoot;
 export const bottomSheetInnerWrapperClass = styles.innerWrapper;
 export const bottomSheetGrabHandleClass = styles.grabHandle;
 export const bottomSheetGrabHandleFloatingClass = styles.grabHandleFloating;
@@ -116,6 +117,7 @@ export function getBottomSheetTemplateClasses(): Record<string, string> {
   return {
     surface: bottomSheetSurfaceClass,
     backdrop: bottomSheetBackdropClass,
+    portalRoot: bottomSheetPortalRootClass,
     innerWrapper: bottomSheetInnerWrapperClass,
     grabHandle: bottomSheetGrabHandleClass,
     grabHandleFloating: bottomSheetGrabHandleFloatingClass,

--- a/packages/blade-core/src/styles/BottomSheet/index.ts
+++ b/packages/blade-core/src/styles/BottomSheet/index.ts
@@ -8,6 +8,7 @@ export {
   getBottomSheetTemplateClasses,
   bottomSheetSurfaceClass,
   bottomSheetBackdropClass,
+  bottomSheetPortalRootClass,
   bottomSheetInnerWrapperClass,
   bottomSheetGrabHandleClass,
   bottomSheetGrabHandleFloatingClass,

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -459,6 +459,7 @@ export {
   getBottomSheetTemplateClasses,
   bottomSheetSurfaceClass,
   bottomSheetBackdropClass,
+  bottomSheetPortalRootClass,
   bottomSheetInnerWrapperClass,
   bottomSheetGrabHandleClass,
   bottomSheetGrabHandleFloatingClass,

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -88,6 +88,8 @@
   let productSelectedSim = $state<string | undefined>();
   let productSimError = $state<string | undefined>();
   let isNonDismissibleOpen = $state(false);
+  let isPortalTargetOpen = $state(false);
+  let portalTargetEl = $state<HTMLDivElement | null>(null);
 
   let searchInput: { focus: () => void; getInput: () => HTMLInputElement | null } | undefined =
     $state();
@@ -847,7 +849,81 @@
   {/snippet}
 </Story>
 
-<!-- Story 13: Non-Dismissible BottomSheet — locked open, must use footer buttons.
+<!-- Story 13: With Portal Target — mounts overlay into a bounded container. -->
+<Story name="With Portal Target">
+  {#snippet template()}
+    <div>
+      <Text marginBottom="spacing.4">
+        Pass portalTarget when the sheet sits inside a bounded container (phone preview, modal,
+        ancestor with overflow hidden). Overlay mounts into that element instead of document.body;
+        snap points use the container height.
+      </Text>
+
+      <div
+        bind:this={portalTargetEl}
+        style="
+          position: relative;
+          width: 320px;
+          height: 560px;
+          overflow: hidden;
+          border-radius: var(--radius-medium);
+          border: 2px solid var(--surface-border-gray-subtle);
+          background: var(--surface-background-gray-subtle);
+        "
+      >
+        <div
+          style="
+            padding: var(--spacing-5);
+            display: flex;
+            flex-direction: column;
+            gap: var(--spacing-4);
+            height: 100%;
+          "
+        >
+          <Heading size="small">Mobile checkout preview</Heading>
+          <Text color="surface.text.gray.muted" size="small">
+            Open the sheet — backdrop and surface stay inside this frame, not the Storybook canvas.
+          </Text>
+          <Button onClick={() => (isPortalTargetOpen = true)}>Open bottom sheet</Button>
+        </div>
+
+        <BottomSheet
+          isOpen={isPortalTargetOpen}
+          onDismiss={() => (isPortalTargetOpen = false)}
+          portalTarget={portalTargetEl}
+        >
+          {#snippet children()}
+            <BottomSheetHeader
+              title="Price summary"
+              subtitle="Snap points are relative to the phone frame height"
+            />
+            <BottomSheetBody>
+              {#snippet children()}
+                <div style="display: flex; flex-direction: column; gap: var(--spacing-4);">
+                  <div style="display: flex; justify-content: space-between;">
+                    <Text>Subtotal</Text>
+                    <Text weight="semibold">₹2,000</Text>
+                  </div>
+                  <div style="display: flex; justify-content: space-between;">
+                    <Text weight="semibold">Grand total</Text>
+                    <Text weight="semibold">₹2,000</Text>
+                  </div>
+                </div>
+              {/snippet}
+            </BottomSheetBody>
+            <BottomSheetFooter>
+              {#snippet children()}
+                <Button isFullWidth onClick={() => (isPortalTargetOpen = false)}>Continue</Button>
+              {/snippet}
+            </BottomSheetFooter>
+          {/snippet}
+        </BottomSheet>
+      </div>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 14: Non-Dismissible BottomSheet — locked open, must use footer buttons.
      The exported storyName in React is verbatim "Non-Dismissible BottomSheet" — DO NOT change. -->
 <Story name="Non-Dismissible BottomSheet">
   {#snippet template()}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -20,6 +20,7 @@
     bottomSheetInnerWrapperClass,
     bottomSheetGrabHandleClass,
     bottomSheetGrabHandleFloatingClass,
+    bottomSheetPortalRootClass,
     getBottomSheetTemplateClasses,
   } from '@razorpay/blade-core/styles';
   import {
@@ -538,9 +539,15 @@
 </script>
 
 {#if isMounted}
-  <div use:portal={portalTarget ?? document.body}>
-    {@render overlay()}
-  </div>
+  {#if portalTarget}
+    <div use:portal={portalTarget} class={bottomSheetPortalRootClass}>
+      {@render overlay()}
+    </div>
+  {:else}
+    <div use:portal={document.body}>
+      {@render overlay()}
+    </div>
+  {/if}
 {/if}
 
 {#snippet overlay()}


### PR DESCRIPTION
## Summary
- Fix `portalTarget` so BottomSheet backdrop and surface render inside the target container instead of the viewport
- Add `portalRoot` wrapper styles in blade-core that switch surface/backdrop from `position: fixed` to `position: absolute` when portaling into a bounded element
- Add a **With Portal Target** Storybook story demonstrating the phone-frame preview use case

## Context
`portalTarget` already moved overlay DOM into the target element, but surface/backdrop used `position: fixed`, so sheets still escaped bounded containers (e.g. checkout phone preview with `overflow: hidden`). Checkout worked only because `.phone-viewport` had `transform: translateZ(0)`.

## Test plan
- [ ] Open Storybook → **Components/BottomSheet → With Portal Target**
- [ ] Click **Open bottom sheet** — backdrop and sheet should stay inside the 320×560 phone frame
- [ ] Verify default BottomSheet stories (without `portalTarget`) still open full-viewport as before
- [ ] Verify checkout playground bottom sheets still work inside the phone preview


Made with [Cursor](https://cursor.com)