### PR TITLE
chore: add changeset for BottomSheet portalTarget fix (#3877)

### DIFF
--- a/.changeset/bottomsheet-portal-target-fix.md
+++ b/.changeset/bottomsheet-portal-target-fix.md
@@ -1,0 +1,8 @@
+---
+"@razorpay/blade-core": patch
+"@razorpay/blade-svelte": patch
+---
+
+fix(blade-svelte): constrain BottomSheet portalTarget to container bounds
+
+Fixed BottomSheet `portalTarget` so backdrop and surface render inside the target container instead of escaping to the viewport. Adds portal root wrapper styles in blade-core that switch surface/backdrop from `position: fixed` to `position: absolute` when portaling into a bounded element.


### PR DESCRIPTION
## Summary
- Add missing changeset for #3877 so `@razorpay/blade-core` and `@razorpay/blade-svelte` are included in the next release
- Patch bump for the BottomSheet `portalTarget` positioning fix merged in 303097a

## Context
#3877 merged without a changeset, so the fix is on `master` but was excluded from the current release PR (#3876). This changeset covers:
- `@razorpay/blade-svelte`: BottomSheet portalTarget renders backdrop/surface inside the target container
- `@razorpay/blade-core`: portal root wrapper styles for bounded portal targets

## Test plan
- [ ] Verify changeset-bot reports patch bumps for `@razorpay/blade-core` and `@razorpay/blade-svelte`
- [ ] After merge, confirm release PR (#3876 or successor) includes both packages

Made with [Cursor](https://cursor.com)