### PR TITLE
fix: scope nohoist to the blade workspace to stop recurring install crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "packages/blade-svelte"
     ],
     "nohoist": [
-      "**"
+      "@razorpay/blade/**"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## Description

`yarn install` fails on almost every pull with:

```
error An unexpected error occurred: "ENOENT: no such file or directory, lstat
'.../packages/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker'".
```

It is not self-healing — every retry fails identically, blocking installs and Storybook until `node_modules` is manually wiped. #3849 added a `reinstall` script, but that only treats the symptom. This fixes the cause.

**Root cause.** The root `package.json` set `nohoist: ["**"]`, added in April 2021 by `chore(restructure): move old blade to a workspace package` (#267) — years before `blade-core` and `blade-svelte` existed. It is needed for React Native/Metro in `packages/blade`, but as written it applied to *every* workspace.

That made yarn plan a separate nested dependency tree for blade-core inside blade-svelte. But `packages/blade-svelte/node_modules/@razorpay/blade-core` is a symlink to `packages/blade-core`, so the two trees were the *same physical directory* while disagreeing about where `estree-walker` belongs. In a single run yarn wrote a file via one path and deleted it as "extraneous" via the other, then crashed reading its own deletion:

```
20.2639  Copying ... -> packages/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker/...
20.3397  Removing extraneous file ".../blade-svelte/node_modules/@razorpay/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker"
21.2931  Error: ENOENT ... lstat 'packages/blade-core/node_modules/@vitest/mocker/node_modules/estree-walker'
```

**Why it fired on nearly every pull.** `packages/blade-core/package.json` gets a version bump on almost every release (`build: update version`), and `blade-svelte` depends on it (`"@razorpay/blade-core": ">=0.12.0"`). Each bump shifts the resolution graph, which re-runs yarn's cleanup phase — the phase that crashes.

**Fix.** Scope nohoist to the one workspace that needs it. React Native stays nohoisted under `packages/blade`; the other workspaces hoist normally, so the workspace symlink moves to the root and the duplicated nested tree disappears — the two aliased paths no longer exist.

Before / after:

| | before | after |
|---|---|---|
| `packages/blade/node_modules/react-native` | present | present (unchanged) |
| `packages/blade-svelte/node_modules/@razorpay/blade-core` | symlink to `packages/blade-core` (the alias) | gone |
| `node_modules/@razorpay/blade-core` | absent | symlink to `packages/blade-core` |

`yarn.lock` is unchanged by this — resolution is identical, only physical placement differs.

## Changes

- Root `package.json`: `nohoist` from `["**"]` to `["@razorpay/blade/**"]`

## Additional Information

Verified locally on a full clean install (all `node_modules` wiped):

- Clean `yarn install` succeeds (175s)
- Re-running `yarn install` is a clean no-op (`Already up-to-date`, 3.3s) — previously this is where it crashed
- **Regression test:** bumped `blade-core` to 0.12.1 to reproduce the release-bump trigger, then installed — succeeds in 29s, no ENOENT. This is the exact scenario that used to break every pull.
- `react-native` still resolves only under `packages/blade/node_modules`, confirming Metro's nohoist is preserved
- `yarn build:blade-core` passes
- `yarn build:blade-svelte` passes
- blade-svelte tests: 38/38 passing
- `yarn tsc:blade` passes for both web and native projects
- blade native Jest (`Button`): 113/113 tests, 95/95 snapshots passing
- Web Storybook boots with 1302 stories indexed

Worth a reviewer sanity check on iOS/Android simulators before merge, since I validated React Native via typecheck, Jest and resolution rather than a device build. The nohoist entry for `packages/blade` is untouched, so Metro's layout should be identical.

I left the `reinstall` script from #3849 in place as a general recovery escape hatch; it becomes unnecessary for this specific bug and can be removed separately if preferred.

## Component Checklist

Not applicable — build tooling only, no component or published-package changes (the root package is private, so no changeset is needed).

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset

Made with [Cursor](https://cursor.com)