### PR TITLE
fix(blade-mcp): define missing fetchers in TreeView async example

### DIFF
--- a/packages/blade-mcp/knowledgebase/components/TreeView.md
+++ b/packages/blade-mcp/knowledgebase/components/TreeView.md
@@ -301,6 +301,7 @@ function AsyncTree() {
   const [cities, setCities] = React.useState<string[]>([]);
   const [isLoadingChildren, setIsLoadingChildren] = React.useState(false);
   const [isLoadingMore, setIsLoadingMore] = React.useState(false);
+  const [hasMore, setHasMore] = React.useState(true);
 
   return (
     <TreeView selectionType="multiple">
@@ -322,16 +323,19 @@ function AsyncTree() {
         {cities.map((city) => (
           <TreeViewItem key={city} title={city} value={city.toLowerCase()} />
         ))}
-        <TreeViewLoadMore
-          isLoading={isLoadingMore}
-          onClick={() => {
-            setIsLoadingMore(true);
-            fetchMoreCities().then((moreCities) => {
-              setCities((previous) => [...previous, ...moreCities]);
-              setIsLoadingMore(false);
-            });
-          }}
-        />
+        {hasMore && (
+          <TreeViewLoadMore
+            isLoading={isLoadingMore}
+            onClick={() => {
+              setIsLoadingMore(true);
+              fetchMoreCities().then((moreCities) => {
+                setCities((previous) => [...previous, ...moreCities]);
+                setIsLoadingMore(false);
+                setHasMore(false);
+              });
+            }}
+          />
+        )}
       </TreeViewItem>
       <TreeViewItem title="Goa" value="goa" />
     </TreeView>

--- a/packages/blade-mcp/knowledgebase/components/TreeView.md
+++ b/packages/blade-mcp/knowledgebase/components/TreeView.md
@@ -293,6 +293,10 @@ function CityPicker() {
 import React from 'react';
 import { TreeView, TreeViewItem, TreeViewLoadMore } from '@razorpay/blade/components';
 
+// Stubbed data fetchers - replace with your real API calls
+const fetchCities = (): Promise<string[]> => Promise.resolve(['Bengaluru', 'Mysuru']);
+const fetchMoreCities = (): Promise<string[]> => Promise.resolve(['Hubli', 'Mangaluru']);
+
 function AsyncTree() {
   const [cities, setCities] = React.useState<string[]>([]);
   const [isLoadingChildren, setIsLoadingChildren] = React.useState(false);


### PR DESCRIPTION
The AsyncTree example called fetchCities() and fetchMoreCities() that were never defined, failing Knowledgebase Lint type-check (TS2552/TS2304) and turning master red. Add stubbed Promise<string[]> fetchers.

## Description

<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
