### PR TITLE
fix(blade-svelte): prevent BottomSheet focus from scrolling host content

### DIFF
--- a/.changeset/bottomsheet-prevent-scroll-focus.md
+++ b/.changeset/bottomsheet-prevent-scroll-focus.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade-svelte": patch
+---
+
+fix(blade-svelte): prevent BottomSheet focus from scrolling host content
+
+Use `focus({ preventScroll: true })` when moving focus into the sheet on open and when returning focus to the trigger on dismiss. Stops the browser from scrolling scrollable ancestors (e.g. Checkout modals) while preserving keyboard and screen-reader focus behavior.

--- a/packages/blade-mcp/knowledgebase/components/TreeView.md
+++ b/packages/blade-mcp/knowledgebase/components/TreeView.md
@@ -298,6 +298,14 @@ function AsyncTree() {
   const [isLoadingChildren, setIsLoadingChildren] = React.useState(false);
   const [isLoadingMore, setIsLoadingMore] = React.useState(false);
 
+  // Simulated API calls — replace with your real fetch logic
+  const fetchCities = async (): Promise<string[]> => {
+    return ['Bengaluru', 'Mysuru', 'Mangaluru'];
+  };
+  const fetchMoreCities = async (): Promise<string[]> => {
+    return ['Hubli', 'Belagavi'];
+  };
+
   return (
     <TreeView selectionType="multiple">
       <TreeViewItem

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -138,7 +138,10 @@
   function returnFocus(): void {
     if (!originalFocusEl) return;
     try {
-      originalFocusEl.focus();
+      /* `preventScroll` stops the browser scrolling the focus target into
+       * view — otherwise returning focus to a trigger inside a scrollable
+       * ancestor jumps the host content. Focus still moves for a11y. */
+      originalFocusEl.focus({ preventScroll: true });
     } catch {
       /* ignore — element may have been unmounted. */
     }
@@ -149,7 +152,12 @@
     const target = initialFocusRef ?? defaultFocusEl;
     if (!target) return;
     try {
-      target.focus();
+      /* `preventScroll` suppresses the native scroll-focused-element-into-view.
+       * The surface is fixed/absolute pinned to the bottom, so without this the
+       * browser scrolls the nearest scrollable ancestor of the portal target
+       * (e.g. a Checkout modal) and shoves the host content up. Focus still
+       * moves into the dialog, so screen-reader/keyboard behaviour is intact. */
+      target.focus({ preventScroll: true });
     } catch {
       /* ignore */
     }

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
@@ -9,10 +9,7 @@ function spyOnFocus(): ReturnType<typeof vi.spyOn> {
 }
 
 /* Find the options arg of the focus() call made against a specific element. */
-function focusOptionsFor(
-  spy: ReturnType<typeof vi.spyOn>,
-  el: Element,
-): FocusOptions | undefined {
+function focusOptionsFor(spy: ReturnType<typeof vi.spyOn>, el: Element): FocusOptions | undefined {
   const idx = spy.mock.contexts.indexOf(el);
   if (idx === -1) return undefined;
   return spy.mock.calls[idx][0] as FocusOptions | undefined;

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import BottomSheetFocusTestHarness from './BottomSheetFocusTestHarness.svelte';
+
+/* Spy on the prototype so the focus call is captured regardless of when the
+ * target element mounts (the sheet portals + defers focus across two rAFs). */
+function spyOnFocus(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(HTMLElement.prototype, 'focus');
+}
+
+/* Find the options arg of the focus() call made against a specific element. */
+function focusOptionsFor(
+  spy: ReturnType<typeof vi.spyOn>,
+  el: Element,
+): FocusOptions | undefined {
+  const idx = spy.mock.contexts.indexOf(el);
+  if (idx === -1) return undefined;
+  return spy.mock.calls[idx][0] as FocusOptions | undefined;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('<BottomSheet /> focus management', () => {
+  it('focuses the initial element with preventScroll on open', async () => {
+    const focusSpy = spyOnFocus();
+    render(BottomSheetFocusTestHarness, { props: { isOpen: true } });
+
+    const focusTarget = await screen.findByTestId('focus-target');
+
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(focusTarget));
+    expect(focusOptionsFor(focusSpy, focusTarget)).toEqual({ preventScroll: true });
+  });
+
+  it('returns focus to the trigger with preventScroll on dismiss', async () => {
+    const onDismiss = vi.fn();
+    const { rerender } = render(BottomSheetFocusTestHarness, {
+      props: { isOpen: false, onDismiss },
+    });
+
+    /* Trigger becomes the "original" focus element captured on open. */
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+
+    const focusSpy = spyOnFocus();
+    await rerender({ isOpen: true, onDismiss });
+
+    /* Wait until the open sequence has moved focus into the sheet — this
+     * guarantees `originalFocusEl` (the trigger) was captured before we
+     * dismiss, otherwise Escape races the deferred focus capture. */
+    const focusTarget = await screen.findByTestId('focus-target');
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(focusTarget));
+
+    /* Escape dismisses the top-most dismissible sheet → close() → returnFocus(). */
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(trigger));
+    expect(focusOptionsFor(focusSpy, trigger)).toEqual({ preventScroll: true });
+  });
+});

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheetFocusTestHarness.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheetFocusTestHarness.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import BottomSheet from '../BottomSheet.svelte';
+
+  let {
+    isOpen = false,
+    isDismissible = true,
+    onDismiss,
+  }: {
+    isOpen?: boolean;
+    isDismissible?: boolean;
+    onDismiss?: () => void;
+  } = $props();
+
+  /* Element the sheet should focus on open. Lives inside the sheet body and is
+   * wired via `initialFocusRef` so the test can assert `focus({ preventScroll })`
+   * without depending on the internal close-button markup. */
+  let focusEl = $state<HTMLElement | null>(null);
+</script>
+
+<button type="button" data-testid="trigger">open</button>
+
+<BottomSheet {isOpen} {isDismissible} {onDismiss} initialFocusRef={focusEl}>
+  {#snippet children()}
+    <button type="button" bind:this={focusEl} data-testid="focus-target">focus me</button>
+  {/snippet}
+</BottomSheet>


### PR DESCRIPTION
## Summary

- Use `focus({ preventScroll: true })` in Svelte `BottomSheet` when focusing the initial element on open and when returning focus to the trigger on dismiss
- Prevents the browser from scrolling scrollable ancestors (e.g. Checkout modals) while preserving keyboard and screen-reader focus behavior
- Adds Vitest coverage for open and dismiss focus paths via a small test harness
- Includes changeset for `@razorpay/blade-svelte` patch release

## Test plan

- [x] `yarn test BottomSheet` in `packages/blade-svelte`
- [ ] Open BottomSheet inside a scrollable modal and confirm host content no longer jumps on open/close
- [ ] Verify keyboard focus still moves into the sheet on open and back to the trigger on dismiss


Made with [Cursor](https://cursor.com)