### PR TITLE
fix(blade-svelte): export Link and CardHeaderLink prop types from barrel

### DIFF
--- a/.changeset/svelte-types-barrel-exports.md
+++ b/.changeset/svelte-types-barrel-exports.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade-svelte": patch
+---
+
+fix(blade-svelte): export Link and CardHeaderLink prop types from components barrel
+
+Export `LinkProps`, `BaseLinkProps`, and `CardHeaderLinkProps` from `@razorpay/blade-svelte/components` so consumers can import them without deep paths.

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -32,6 +32,8 @@ export { BaseIconButton } from './Button/IconButton/BaseIconButton';
 
 // Link
 export { default as Link } from './Link/Link.svelte';
+export type { LinkProps } from './Link/types';
+export type { BaseLinkProps } from './Link/BaseLink/types';
 
 // Spinner (alias to BaseSpinner for backward compatibility)
 export { default as Spinner } from './Spinner/BaseSpinner/BaseSpinner.svelte';
@@ -132,6 +134,7 @@ export type {
   CardHeaderLeadingProps,
   CardHeaderTrailingProps,
   CardHeaderIconButtonProps,
+  CardHeaderLinkProps,
   CardFooterProps,
   CardFooterAction,
   CardFooterLeadingProps,


### PR DESCRIPTION
## Summary

Follow-up to #3890. The svelte types cleanup moved Link and CardHeaderLink props into dedicated `types.ts` files, but a few types were not re-exported from the public `@razorpay/blade-svelte/components` barrel.

- Export `LinkProps` and `BaseLinkProps` from the components barrel
- Export `CardHeaderLinkProps` alongside sibling Card header prop types

## Test plan

- [ ] Verify `import type { LinkProps, BaseLinkProps, CardHeaderLinkProps } from '@razorpay/blade-svelte/components'` resolves in TypeScript
- [ ] CI passes


Made with [Cursor](https://cursor.com)