### PR TITLE
feat(BottomSheet): add showDragHandle prop to optionally hide drag handle

### DIFF
--- a/packages/blade/.changeset/bottomsheet-show-drag-handle.md
+++ b/packages/blade/.changeset/bottomsheet-show-drag-handle.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(BottomSheet): add `showDragHandle` prop to optionally hide the drag handle
+
+`BottomSheet` now accepts a `showDragHandle` boolean prop (default `true`). Set it to `false` to hide the drag handle (the pill affordance at the top of the sheet). On web this also removes the drag-to-move affordance since the handle is the drag surface; the sheet can still be dismissed via the backdrop, `esc`, or programmatically. On native, pan-to-close continues to work.

--- a/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.native.tsx
@@ -74,6 +74,7 @@ const _BottomSheet = ({
   initialFocusRef,
   zIndex = componentZIndices.bottomSheet,
   snapToContentHeight = false,
+  showDragHandle = true,
 }: BottomSheetProps): React.ReactElement => {
   const bottomSheetAndDropdownGlue = useBottomSheetAndDropdownGlue();
   const defaultInitialFocusRef = React.useRef<any>(null);
@@ -316,13 +317,15 @@ const _BottomSheet = ({
           setHeaderHeight(nativeEvent.layout.height);
         }}
       >
-        <BaseBox zIndex={bottomSheetZIndex}>
-          <BottomSheetGrabHandle />
-        </BaseBox>
+        {showDragHandle ? (
+          <BaseBox zIndex={bottomSheetZIndex}>
+            <BottomSheetGrabHandle />
+          </BaseBox>
+        ) : null}
         {header}
       </BaseBox>
     );
-  }, [isHeaderEmpty, bottomSheetZIndex, header]);
+  }, [isHeaderEmpty, bottomSheetZIndex, header, showDragHandle]);
 
   const isHeaderFloating = !hasBodyPadding && isHeaderEmpty;
   const contextValue = React.useMemo<BottomSheetContextProps>(

--- a/packages/blade/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -349,6 +349,11 @@ const BottomSheetTemplate: StoryFn<typeof BottomSheetComponent> = ({ ...args }) 
 
 export const Default = BottomSheetTemplate.bind({});
 
+export const WithoutDragHandle = BottomSheetTemplate.bind({});
+WithoutDragHandle.args = {
+  showDragHandle: false,
+};
+
 const WithHeaderFooterTemplate: StoryFn<any> = (args: StoryControlProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
 

--- a/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
+++ b/packages/blade/src/components/BottomSheet/BottomSheet.web.tsx
@@ -77,6 +77,7 @@ const _BottomSheet = ({
   snapPoints = [0.35, 0.5, 0.85],
   isDismissible = true,
   zIndex = componentZIndices.bottomSheet,
+  showDragHandle = true,
   ...dataAnalyticsProps
 }: BottomSheetProps): React.ReactElement => {
   const { theme } = useTheme();
@@ -532,12 +533,14 @@ const _BottomSheet = ({
         {...makeAnalyticsAttribute(dataAnalyticsProps)}
       >
         <BaseBox height="100%" display="flex" flexDirection="column">
-          <BottomSheetGrabHandle
-            ref={grabHandleRef}
-            isHeaderFloating={isHeaderFloating}
-            {...metaAttribute({ name: ComponentIds.BottomSheetGrabHandle })}
-            {...bind()}
-          />
+          {showDragHandle ? (
+            <BottomSheetGrabHandle
+              ref={grabHandleRef}
+              isHeaderFloating={isHeaderFloating}
+              {...metaAttribute({ name: ComponentIds.BottomSheetGrabHandle })}
+              {...bind()}
+            />
+          ) : null}
           {children}
         </BaseBox>
       </BottomSheetSurface>

--- a/packages/blade/src/components/BottomSheet/types.ts
+++ b/packages/blade/src/components/BottomSheet/types.ts
@@ -62,6 +62,16 @@ type BottomSheetProps = {
    * @default false
    */
   snapToContentHeight?: boolean;
+  /**
+   * Toggles the drag handle (the pill affordance rendered at the top of the sheet).
+   *
+   * Set to `false` to hide it. On web this also removes the drag-to-move affordance
+   * since the handle is the drag surface; the sheet can still be dismissed via the
+   * backdrop, `esc`, or programmatically. On native, pan-to-close still works.
+   *
+   * @default true
+   */
+  showDragHandle?: boolean;
 } & DataAnalyticsAttribute;
 
 type BottomSheetHeaderProps = Pick<


### PR DESCRIPTION
## Summary

Adds a `showDragHandle` boolean prop to `BottomSheet` so consumers can hide the drag handle (the pill affordance rendered at the top of the sheet, internally the "grab handle").

- `showDragHandle?: boolean` — **default `true`** (backwards compatible, handle shown as before).
- Wired across **web** (`BottomSheet.web.tsx`) and **native** (`BottomSheet.native.tsx`).
- Added a `WithoutDragHandle` Storybook story.
- Included a changeset (`minor`).

### API decision
Chose `showDragHandle` (positive `show*` prefix, `@default true`) to match Blade's existing chrome-toggle convention (`showCloseButton`, `showDivider`, `showBackButton`). Rejected the negative `hideDragHandle` (discouraged by AGENTS.md) and `showGrabHandle` — "drag handle" is the more discoverable public term while the internal `GrabHandle` naming stays an implementation detail (Blade already decouples this, e.g. `isContentPanningGestureEnabled`).

### Behavior notes
- **Web:** the handle is the drag surface, so hiding it also removes drag-to-move. The sheet can still be dismissed via backdrop, `esc`, or programmatically.
- **Native:** pan-to-close still works (Gorhom `enablePanDownToClose`); only the visual pill is hidden.

## Test plan
- [ ] `showDragHandle` control appears in Storybook autodocs and toggles the handle
- [ ] `WithoutDragHandle` story renders the sheet without the pill
- [ ] Default behavior unchanged (handle visible) on web + native
- [ ] Web: backdrop/esc dismissal still works with handle hidden
- [ ] Native: pan-to-close still works with handle hidden

Made with [Cursor](https://cursor.com)