### PR TITLE
fix(SpotlightPopoverTour, PopupArrow): revert the arrow tip radius and even out the arrow-to-spotlight gap

### DIFF
--- a/.changeset/spotlight-tour-radius-seam-tip.md
+++ b/.changeset/spotlight-tour-radius-seam-tip.md
@@ -2,7 +2,7 @@
 '@razorpay/blade': minor
 ---
 
-fix(SpotlightPopoverTour, PopupArrow): match the spotlight to the highlighted component, remove the popover's arrow seam, and round the arrow tip
+fix(SpotlightPopoverTour): match the spotlight to the highlighted component, remove the popover's arrow seam, and even out the arrow-to-spotlight gap
 
 Three visual fixes. All three apply to light and dark — none introduces a colour-scheme branch.
 
@@ -25,7 +25,7 @@ Because `SpotlightPopoverTourStep` clones its child to attach a ref, consumers c
 
 > React Native is intentionally left alone here. Its `PopupArrow` draws an opaque backing path (`surface.background.gray.intense`) beneath the fill and adds a stroke, so swapping the fill token alone does not make the arrow match the card — it only moves the mismatch (measured on the dark theme: from ~2/255 darker than the card to ~3/255 lighter). Fixing native means addressing that backing path, and is left as a follow-up.
 
-**3. `PopupArrow` — the arrow tip now reads as rounded.**
-`tipRadius` was set from `border.radius['2xsmall']` (2). `tipRadius` is a *ratio* rather than a px value, scaled against the arrow's own dimensions, so on a 22×12 arrow that blunted the tip by only 1.5px — invisible at 1x, leaving the tip looking like a hard point against the popup's rounded corners. Raised to `border.radius.xsmall` (4), the largest value that still leaves straight edges; the shape degenerates into a lens by 8.
+**3. `SpotlightPopoverTour` — the gap between the arrow tip and the spotlight is now the same on every step.**
+Nothing sets that gap directly; it falls out of two numbers measured from two different rectangles. `TourPopover` offsets the popup by `spacing[4] + ARROW_HEIGHT` (24px) so that, after the arrow's own 12px protrusion, the tip lands `GAP` (12px) from the anchor's edge — while `TourMask` draws the halo 6px past the traced element. The intended result is a constant 6px.
 
-> **⚠️ Visual change (no API break):** `PopupArrow` is shared, so this affects the arrows on `Popover` and `Tooltip` as well as `SpotlightPopoverTour`.
+That held only when both measured the same element, and they did not. The mask resolves the step's ref through `resolveSpotlightTarget` to trace the painted component, but `TourPopover` set its position reference to the raw ref — so any overhang between the wrapper and the component inside it was added straight to the gap. A step whose wrapper is stretched by a flex row (`alignItems="stretch"`) sat visibly further from its spotlight than a step whose wrapper happened to match its card. `resolveSpotlightTarget` moves into the shared web utils and both now resolve through it, so the gap no longer depends on how a consumer wraps their markup.

--- a/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.web.test.tsx.snap
+++ b/packages/blade/src/components/Popover/__tests__/__snapshots__/Popover.web.test.tsx.snap
@@ -360,13 +360,13 @@ exports[`<Popover /> should render 1`] = `
         >
           <path
             clip-path="url(#:r3:)"
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             fill="none"
             stroke="hsla(0, 0%, 97%, 1)"
             stroke-width="3"
           />
           <path
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             stroke="hsla(0, 0%, 100%, 0.94)"
           />
           <clippath
@@ -754,13 +754,13 @@ exports[`<Popover /> should render popover with custom zIndex 1`] = `
         >
           <path
             clip-path="url(#:rb:)"
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             fill="none"
             stroke="hsla(0, 0%, 97%, 1)"
             stroke-width="3"
           />
           <path
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             stroke="hsla(0, 0%, 100%, 0.94)"
           />
           <clippath
@@ -1212,13 +1212,13 @@ exports[`<Popover /> should render with title,footer 1`] = `
         >
           <path
             clip-path="url(#:r7:)"
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             fill="none"
             stroke="hsla(0, 0%, 97%, 1)"
             stroke-width="3"
           />
           <path
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             stroke="hsla(0, 0%, 100%, 0.94)"
           />
           <clippath

--- a/packages/blade/src/components/PopupArrow/PopupArrow.web.tsx
+++ b/packages/blade/src/components/PopupArrow/PopupArrow.web.tsx
@@ -17,12 +17,11 @@ const PopupArrow = React.forwardRef<SVGSVGElement, PopupArrowProps>(
         strokeWidth={strokeWidth ?? 0}
         /**
          * `tipRadius` is a ratio, not a px value — FloatingArrow scales it against the arrow's
-         * own width/height. At `2xsmall` (2) a 22x12 arrow is blunted by only 1.5px, which
-         * disappears into antialiasing at 1x and reads as a hard point next to the popup's
-         * rounded corners. `xsmall` (4) is the largest value that still leaves straight edges —
-         * the shape degenerates into a lens by 8.
+         * own width/height, so the rounding grows much faster than the token number suggests.
+         * `xsmall` (4) visibly bows the arrow's edges; `2xsmall` (2) softens the tip while
+         * keeping the sides straight.
          */
-        tipRadius={theme.border.radius.xsmall}
+        tipRadius={theme.border.radius['2xsmall']}
         style={{ ...style }}
       />
     );

--- a/packages/blade/src/components/SpotlightPopoverTour/Tour.web.tsx
+++ b/packages/blade/src/components/SpotlightPopoverTour/Tour.web.tsx
@@ -7,6 +7,8 @@ import { TourContext } from './TourContext';
 import type { TourElement } from './TourContext';
 import { TourPopover } from './TourPopover';
 import {
+  readBorderRadius,
+  resolveSpotlightTarget,
   smoothScroll,
   useDelayedState,
   useIntersectionObserver,
@@ -21,66 +23,6 @@ import { isBrowser } from '~utils';
 import { useIsomorphicLayoutEffect } from '~utils/useIsomorphicLayoutEffect';
 
 const asHTMLElement = (el: TourElement | null): HTMLElement | null => el as HTMLElement | null;
-
-const readBorderRadius = (el: HTMLElement): number => {
-  const { borderTopLeftRadius } = window.getComputedStyle(el);
-  const parsed = Number.parseFloat(borderTopLeftRadius);
-
-  if (Number.isNaN(parsed)) return 0;
-  // Percentage radii (e.g. `50%` on a circular avatar) resolve against the box itself.
-  if (borderTopLeftRadius.includes('%')) {
-    const { width, height } = el.getBoundingClientRect();
-    return (Math.min(width, height) * parsed) / 100;
-  }
-
-  return parsed;
-};
-
-// `getComputedStyle` reports unset properties as an empty string in some environments
-// (notably jsdom), so treat "unset" the same as "not painted" rather than as a value.
-const isPainted = (value: string): boolean =>
-  Boolean(value) && value !== 'none' && value !== 'transparent' && value !== 'rgba(0, 0, 0, 0)';
-
-/** Whether an element paints anything of its own, or is a bare layout shell. */
-const drawsOwnShape = (el: HTMLElement): boolean => {
-  const { borderTopWidth, backgroundColor, backgroundImage } = window.getComputedStyle(el);
-  return (
-    readBorderRadius(el) > 0 ||
-    Number.parseFloat(borderTopWidth) > 0 ||
-    isPainted(backgroundColor) ||
-    isPainted(backgroundImage)
-  );
-};
-
-/**
- * Resolves the element the spotlight should actually trace.
- *
- * `SpotlightPopoverTourStep` clones its child to attach a ref, so consumers commonly wrap
- * their UI in a layout element just to forward one. Measuring that wrapper is wrong twice
- * over: it has no corner radius to inherit, and a wrapper stretched by its parent's layout
- * (e.g. `alignItems="stretch"` in a flex row) is taller than the component inside it, which
- * makes the spotlight's padding look uneven — 6px on three sides and more at the bottom.
- *
- * So when the step's element paints nothing itself and simply wraps a single child that
- * fills it on at least one axis, we trace that child instead. The fill check keeps us from
- * shrinking onto an inner element that merely happens to be first — a wrapper around
- * narrower content is still measured as the wrapper.
- */
-const resolveSpotlightTarget = (element: HTMLElement): HTMLElement => {
-  if (drawsOwnShape(element)) return element;
-
-  const { children } = element;
-  if (children.length !== 1) return element;
-
-  const child = children[0] as HTMLElement;
-  const parentRect = element.getBoundingClientRect();
-  const childRect = child.getBoundingClientRect();
-  const fillsAnAxis =
-    Math.abs(childRect.width - parentRect.width) <= 1 ||
-    Math.abs(childRect.height - parentRect.height) <= 1;
-
-  return fillsAnAxis ? child : element;
-};
 
 const SpotlightPopoverTour = ({
   steps,

--- a/packages/blade/src/components/SpotlightPopoverTour/TourPopover.web.tsx
+++ b/packages/blade/src/components/SpotlightPopoverTour/TourPopover.web.tsx
@@ -19,6 +19,7 @@ import { PopoverContent } from '../Popover/PopoverContent';
 import { ARROW_HEIGHT, ARROW_WIDTH } from '../Popover/constants';
 import { PopoverContext } from '../Popover/PopoverContext';
 import { transitionDelay } from './tourTokens';
+import { resolveSpotlightTarget } from './utils';
 import { useTheme } from '~components/BladeProvider';
 import BaseBox from '~components/Box/BaseBox';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
@@ -125,8 +126,13 @@ const TourPopover = ({
   React.useLayoutEffect(() => {
     window.setTimeout(() => {
       if (!attachTo) return;
-      refs.setReference(attachTo.current);
-      refs.setPositionReference(attachTo.current);
+      const element = attachTo.current;
+      refs.setReference(element);
+      // The spotlight traces the painted component rather than the layout wrapper the step's
+      // ref happens to sit on, so `GAP` has to be measured from that same rectangle. Anchoring
+      // to the wrapper instead leaks its overhang — a wrapper stretched by a flex row is taller
+      // than the card inside it — into the gap between the arrow tip and the spotlight.
+      refs.setPositionReference(element ? resolveSpotlightTarget(element) : null);
     });
   }, [attachTo, refs, isOpen]);
 

--- a/packages/blade/src/components/SpotlightPopoverTour/__tests__/__snapshots__/Tour.web.test.tsx.snap
+++ b/packages/blade/src/components/SpotlightPopoverTour/__tests__/__snapshots__/Tour.web.test.tsx.snap
@@ -621,13 +621,13 @@ exports[`<Tour /> should render 1`] = `
         >
           <path
             clip-path="url(#:r7:)"
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             fill="none"
             stroke="hsla(0, 0%, 97%, 1)"
             stroke-width="3"
           />
           <path
-            d="M0,0 H22 L16.5,6 Q11,12 5.5,6 Z"
+            d="M0,0 H22 L13.75,9 Q11,12 8.25,9 Z"
             stroke="hsla(0, 0%, 100%, 0.94)"
           />
           <clippath

--- a/packages/blade/src/components/SpotlightPopoverTour/utils.native.ts
+++ b/packages/blade/src/components/SpotlightPopoverTour/utils.native.ts
@@ -37,4 +37,20 @@ const useLockBodyScroll = (_shouldLock: boolean): void => {
   // no-op — native uses useTourScrollLock
 };
 
-export { smoothScroll, useIntersectionObserver, useLockBodyScroll };
+/** @internal web-only — stubbed for native typecheck of shared imports */
+const readBorderRadius = (_el: HTMLElement): number => {
+  return 0;
+};
+
+/** @internal web-only — stubbed for native typecheck of shared imports */
+const resolveSpotlightTarget = (element: HTMLElement): HTMLElement => {
+  return element;
+};
+
+export {
+  smoothScroll,
+  useIntersectionObserver,
+  useLockBodyScroll,
+  readBorderRadius,
+  resolveSpotlightTarget,
+};

--- a/packages/blade/src/components/SpotlightPopoverTour/utils.ts
+++ b/packages/blade/src/components/SpotlightPopoverTour/utils.ts
@@ -128,6 +128,69 @@ function useIntersectionObserver(
   return entry;
 }
 
+const readBorderRadius = (el: HTMLElement): number => {
+  const { borderTopLeftRadius } = window.getComputedStyle(el);
+  const parsed = Number.parseFloat(borderTopLeftRadius);
+
+  if (Number.isNaN(parsed)) return 0;
+  // Percentage radii (e.g. `50%` on a circular avatar) resolve against the box itself.
+  if (borderTopLeftRadius.includes('%')) {
+    const { width, height } = el.getBoundingClientRect();
+    return (Math.min(width, height) * parsed) / 100;
+  }
+
+  return parsed;
+};
+
+// `getComputedStyle` reports unset properties as an empty string in some environments
+// (notably jsdom), so treat "unset" the same as "not painted" rather than as a value.
+const isPainted = (value: string): boolean =>
+  Boolean(value) && value !== 'none' && value !== 'transparent' && value !== 'rgba(0, 0, 0, 0)';
+
+/** Whether an element paints anything of its own, or is a bare layout shell. */
+const drawsOwnShape = (el: HTMLElement): boolean => {
+  const { borderTopWidth, backgroundColor, backgroundImage } = window.getComputedStyle(el);
+  return (
+    readBorderRadius(el) > 0 ||
+    Number.parseFloat(borderTopWidth) > 0 ||
+    isPainted(backgroundColor) ||
+    isPainted(backgroundImage)
+  );
+};
+
+/**
+ * Resolves the element a step should actually be measured against.
+ *
+ * `SpotlightPopoverTourStep` clones its child to attach a ref, so consumers commonly wrap
+ * their UI in a layout element just to forward one. Measuring that wrapper is wrong twice
+ * over: it has no corner radius to inherit, and a wrapper stretched by its parent's layout
+ * (e.g. `alignItems="stretch"` in a flex row) is taller than the component inside it, which
+ * makes the spotlight's padding look uneven — 6px on three sides and more at the bottom.
+ *
+ * So when the step's element paints nothing itself and simply wraps a single child that
+ * fills it on at least one axis, we trace that child instead. The fill check keeps us from
+ * shrinking onto an inner element that merely happens to be first — a wrapper around
+ * narrower content is still measured as the wrapper.
+ *
+ * Both the spotlight and the popover must resolve through this, or they anchor to different
+ * rectangles and the overhang between them shows up as an uneven arrow-to-spotlight gap.
+ */
+const resolveSpotlightTarget = (element: HTMLElement): HTMLElement => {
+  if (drawsOwnShape(element)) return element;
+
+  const { children } = element;
+  if (children.length !== 1) return element;
+
+  const child = children[0] as HTMLElement;
+  const parentRect = element.getBoundingClientRect();
+  const childRect = child.getBoundingClientRect();
+  const fillsAnAxis =
+    Math.abs(childRect.width - parentRect.width) <= 1 ||
+    Math.abs(childRect.height - parentRect.height) <= 1;
+
+  return fillsAnAxis ? child : element;
+};
+
 const useLockBodyScroll = (shouldLock: boolean) => {
   const scrollLockRef = useScrollLock({
     enabled: true,
@@ -153,4 +216,6 @@ export {
   smoothScroll,
   useIntersectionObserver,
   useLockBodyScroll,
+  readBorderRadius,
+  resolveSpotlightTarget,
 };

--- a/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
+++ b/packages/blade/src/components/Tooltip/__tests__/__snapshots__/Tooltip.web.test.tsx.snap
@@ -271,7 +271,7 @@ exports[`<Tooltip /> should render 1`] = `
           width="14"
         >
           <path
-            d="M0,0 H14 L10.5,4 Q7,8 3.5,4 Z"
+            d="M0,0 H14 L8.75,6 Q7,8 5.25,6 Z"
             stroke="none"
           />
           <clippath
@@ -552,7 +552,7 @@ exports[`<Tooltip /> should render tooltip with custom zIndex 1`] = `
           width="14"
         >
           <path
-            d="M0,0 H14 L10.5,4 Q7,8 3.5,4 Z"
+            d="M0,0 H14 L8.75,6 Q7,8 5.25,6 Z"
             stroke="none"
           />
           <clippath
@@ -857,7 +857,7 @@ exports[`<Tooltip /> should render with title 1`] = `
           width="14"
         >
           <path
-            d="M0,0 H14 L10.5,4 Q7,8 3.5,4 Z"
+            d="M0,0 H14 L8.75,6 Q7,8 5.25,6 Z"
             stroke="none"
           />
           <clippath


### PR DESCRIPTION
Stacked on #3895 — review that one first, this PR targets its branch.

## Summary

**1. Reverted the arrow tip radius back to `2xsmall`.** In practice `xsmall` read as too rounded. `tipRadius` is a ratio scaled against the arrow's own width and height, so the effect grows much faster than the token number suggests — at `xsmall` it bows the arrow's straight edges rather than just blunting the tip. Reverting also takes the `Popover` and `Tooltip` snapshots back to their pre-existing output, so this stack no longer touches those two components at all.

The seam fix from #3895 is untouched and retained — matching the arrow's fill token and continuing the outline across the join was the right call, and it is what makes the body and the arrow read as one container.

**2. Evened out the gap between the arrow tip and the spotlight.** Nothing sets that gap directly. `TourPopover` offsets the popup by `spacing[4] + ARROW_HEIGHT` (24px) so that, after the arrow's own 12px protrusion, the tip lands `GAP` (12px) from the anchor's edge, while `TourMask` draws the halo 6px past the traced element — an intended constant 6px.

That only holds if both measure the same element, and they did not. The mask resolves the step's ref through `resolveSpotlightTarget` to trace the painted component, but `TourPopover` set its position reference to the raw ref. Any overhang between the wrapper and the component inside it was added straight to the gap, so a step whose wrapper is stretched by a flex row (`alignItems="stretch"`) sat visibly further from its spotlight than a step whose wrapper happened to match its card. `resolveSpotlightTarget` moves into the shared web utils and both sides now resolve through it.

Only `setPositionReference` uses the resolved element; `setReference` stays on the original step element, since that one is the interaction and focus target rather than the geometry source.

## Test plan

- [x] `yarn test:react SpotlightPopoverTour Popover Tooltip` — 46 tests pass
- [x] `Popover` and `Tooltip` snapshots verified byte-identical to `master`
- [x] Typecheck clean for every touched file
- [x] Storybook: step through the `SpotlightPopoverTour` default story and confirm the arrow sits the same distance from the spotlight on the Refunds step (stretched wrapper) as on the Disputes step
- [x] Confirm the arrow tip rounding matches the pre-#3895 appearance

## Notes

- The changeset from #3895 is edited rather than added to, so the merged changelog describes what actually ships. Its third section no longer claims the tip was rounded, and now documents the gap fix instead.
- React Native is unchanged. Its tour has no equivalent target resolution, so this mismatch cannot arise there in the same form.
- `TourMask`'s `padding` prop still means "total added across both axes" rather than per-side, so `spacing[4]` reads as 12 but paints 6. Left alone deliberately, but it is the remaining reason the numbers do not visually cancel.

Made with [Cursor](https://cursor.com)