### PR TITLE
feat(blade-svelte): add showDragHandle prop to BottomSheet to optionally hide drag handle

### DIFF
--- a/.changeset/blade-svelte-bottomsheet-show-drag-handle.md
+++ b/.changeset/blade-svelte-bottomsheet-show-drag-handle.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': minor
+---
+
+feat(blade-svelte): add `showDragHandle` prop to BottomSheet to optionally hide the drag handle
+
+`BottomSheet` now accepts a `showDragHandle` boolean prop (default `true`). Set it to `false` to hide the drag handle (the pill affordance at the top of the sheet). Since the handle is the drag surface, hiding it also removes the drag-to-move affordance; the sheet can still be dismissed via the backdrop, `esc`, or programmatically.

--- a/.changeset/blade-svelte-bottomsheet-show-drag-handle.md
+++ b/.changeset/blade-svelte-bottomsheet-show-drag-handle.md
@@ -4,4 +4,4 @@
 
 feat(blade-svelte): add `showDragHandle` prop to BottomSheet to optionally hide the drag handle
 
-`BottomSheet` now accepts a `showDragHandle` boolean prop (default `true`). Set it to `false` to hide the drag handle (the pill affordance at the top of the sheet). Since the handle is the drag surface, hiding it also removes the drag-to-move affordance; the sheet can still be dismissed via the backdrop, `esc`, or programmatically.
+`BottomSheet` now accepts a `showDragHandle` boolean prop (default `true`). Set it to `false` to hide the drag handle (the pill affordance at the top of the sheet) and disable drag-to-move/dismiss gestures — useful for desktop flows where dragging is not expected. The sheet can still be dismissed via the backdrop, `esc`, or programmatically.

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -13,6 +13,7 @@
       isOpen: undefined,
       snapPoints: undefined,
       isDismissible: true,
+      showDragHandle: true,
       title: 'Address Details',
       subtitle: 'Saving addresses will improve your checkout experience',
       showBackButton: false,
@@ -23,6 +24,7 @@
       onDismiss: { table: { disable: true } },
       initialFocusRef: { table: { disable: true } },
       isDismissible: { control: 'boolean' },
+      showDragHandle: { control: 'boolean' },
       zIndex: { control: 'number' },
       title: {
         control: 'text',
@@ -64,6 +66,7 @@
 
   /* Default story state (one bucket per story to keep them independent). */
   let isDefaultOpen = $state(false);
+  let isDragHandleOpen = $state(false);
   let isHeaderFooterOpen = $state(false);
   let isSingleSelectOpen = $state(false);
   let isDropdownButtonOpen = $state(false);
@@ -298,6 +301,37 @@
                 </Checkbox>
                 <Button>Continue</Button>
               </div>
+            {/snippet}
+          </BottomSheetFooter>
+        {/snippet}
+      </BottomSheet>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story: Without Drag Handle — hides the drag handle pill via showDragHandle={false}. -->
+<Story name="Without Drag Handle">
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isDragHandleOpen = true)}>Open</Button>
+      <BottomSheet
+        isOpen={isDragHandleOpen}
+        onDismiss={() => (isDragHandleOpen = false)}
+        showDragHandle={false}
+      >
+        {#snippet children()}
+          <BottomSheetHeader title="Terms & Conditions" subtitle="No drag handle is shown." />
+          <BottomSheetBody>
+            {#snippet children()}
+              <Text>
+                The drag handle (grab handle pill) is hidden. The sheet can still be dismissed via
+                the backdrop or the escape key.
+              </Text>
+            {/snippet}
+          </BottomSheetBody>
+          <BottomSheetFooter>
+            {#snippet children()}
+              <Button isFullWidth onClick={() => (isDragHandleOpen = false)}>Continue</Button>
             {/snippet}
           </BottomSheetFooter>
         {/snippet}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -66,7 +66,7 @@
 
   /* Default story state (one bucket per story to keep them independent). */
   let isDefaultOpen = $state(false);
-  let isDragHandleOpen = $state(false);
+  let isWithoutDragHandleOpen = $state(false);
   let isHeaderFooterOpen = $state(false);
   let isSingleSelectOpen = $state(false);
   let isDropdownButtonOpen = $state(false);
@@ -309,14 +309,14 @@
   {/snippet}
 </Story>
 
-<!-- Story: Without Drag Handle — hides the drag handle pill via showDragHandle={false}. -->
+<!-- Without Drag Handle — hides the handle and disables drag gestures via showDragHandle={false}. -->
 <Story name="Without Drag Handle">
   {#snippet template()}
     <div>
-      <Button onClick={() => (isDragHandleOpen = true)}>Open</Button>
+      <Button onClick={() => (isWithoutDragHandleOpen = true)}>Open</Button>
       <BottomSheet
-        isOpen={isDragHandleOpen}
-        onDismiss={() => (isDragHandleOpen = false)}
+        isOpen={isWithoutDragHandleOpen}
+        onDismiss={() => (isWithoutDragHandleOpen = false)}
         showDragHandle={false}
       >
         {#snippet children()}
@@ -324,14 +324,14 @@
           <BottomSheetBody>
             {#snippet children()}
               <Text>
-                The drag handle (grab handle pill) is hidden. The sheet can still be dismissed via
-                the backdrop or the escape key.
+                The drag handle is hidden and drag-to-move/dismiss is disabled. Dismiss via the
+                backdrop, escape key, or the Continue button below.
               </Text>
             {/snippet}
           </BottomSheetBody>
           <BottomSheetFooter>
             {#snippet children()}
-              <Button isFullWidth onClick={() => (isDragHandleOpen = false)}>Continue</Button>
+              <Button isFullWidth onClick={() => (isWithoutDragHandleOpen = false)}>Continue</Button>
             {/snippet}
           </BottomSheetFooter>
         {/snippet}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -51,6 +51,7 @@
     zIndex = BOTTOM_SHEET_Z_INDEX,
     portalTarget,
     testID,
+    showDragHandle = true,
     ...rest
   }: BottomSheetProps = $props();
 
@@ -575,7 +576,9 @@
     {...analyticsAttrs}
   >
     <div class={bottomSheetInnerWrapperClass}>
-      <div bind:this={grabHandleEl} class={grabHandleClasses} {...grabHandleMetaAttrs}></div>
+      {#if showDragHandle}
+        <div bind:this={grabHandleEl} class={grabHandleClasses} {...grabHandleMetaAttrs}></div>
+      {/if}
       {@render children()}
     </div>
   </div>

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -50,8 +50,8 @@
     isDismissible = true,
     zIndex = BOTTOM_SHEET_Z_INDEX,
     portalTarget,
-    testID,
     showDragHandle = true,
+    testID,
     ...rest
   }: BottomSheetProps = $props();
 
@@ -429,8 +429,11 @@
   /* Wire `DragGesture` instances reactively. We attach to the same elements
    * React binds: the grab handle (with no `args`, so `isContentDragging` is
    * false) and the body's scroll element (with `isContentDragging: true`).
+   * Both are skipped when `showDragHandle` is false — desktop flows that hide
+   * the handle should not expose drag-to-move/dismiss either.
    * `from` is a getter so each drag-start picks up the *current* `positionY`. */
   $effect(() => {
+    if (!showDragHandle) return undefined;
     if (!grabHandleEl) return undefined;
     if (!isOnTopOfStack || !isOpen) return undefined;
     const gesture = new DragGesture(
@@ -448,6 +451,7 @@
   });
 
   $effect(() => {
+    if (!showDragHandle) return undefined;
     if (!scrollEl) return undefined;
     if (!isOnTopOfStack || !isOpen) return undefined;
     const gesture = new DragGesture(

--- a/packages/blade-svelte/src/components/BottomSheet/types.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/types.ts
@@ -73,9 +73,10 @@ export interface BottomSheetProps extends StyledPropsBlade {
 
   /**
    * Toggles the drag handle (the pill affordance rendered at the top of the
-   * sheet). Set to `false` to hide it. Since the handle is the drag surface,
-   * hiding it also removes the drag-to-move affordance; the sheet can still be
-   * dismissed via the backdrop, `esc`, or programmatically.
+   * sheet) and drag-to-move/dismiss gestures. Set to `false` for desktop flows
+   * where dragging is not expected — this hides the handle and disables all
+   * sheet drag gestures. The sheet can still be dismissed via the backdrop,
+   * `esc`, or programmatically.
    *
    * @default true
    */

--- a/packages/blade-svelte/src/components/BottomSheet/types.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/types.ts
@@ -71,6 +71,16 @@ export interface BottomSheetProps extends StyledPropsBlade {
    */
   portalTarget?: HTMLElement | null;
 
+  /**
+   * Toggles the drag handle (the pill affordance rendered at the top of the
+   * sheet). Set to `false` to hide it. Since the handle is the drag surface,
+   * hiding it also removes the drag-to-move affordance; the sheet can still be
+   * dismissed via the backdrop, `esc`, or programmatically.
+   *
+   * @default true
+   */
+  showDragHandle?: boolean;
+
   /** Test ID applied to the surface element. */
   testID?: string;
 


### PR DESCRIPTION
## Summary

Ports the React `showDragHandle` API to the Svelte `BottomSheet` (`@razorpay/blade-svelte`). Consumers can now hide the drag handle (the pill affordance at the top of the sheet, internally the "grab handle").

- `showDragHandle?: boolean` — **default `true`** (backwards compatible, handle shown as before).
- Grab handle `<div>` is wrapped in `{#if showDragHandle}`; the drag/measure `$effect`s already guard on `grabHandleEl`, so they no-op cleanly when it isn't rendered.
- Added a Storybook `showDragHandle` boolean control (Playground) + a dedicated `Without Drag Handle` story.
- Included a changeset (`minor`).

### API decision
Mirrors the React PR ([#3896](https://github.com/razorpay/blade/pull/3896)) for cross-framework parity: positive `show*` prefix, `@default true`, "drag handle" as the public term while internal `GrabHandle` naming stays an implementation detail.

### Behavior notes
- The handle is the drag surface, so hiding it also removes drag-to-move. The sheet can still be dismissed via backdrop, `esc`, or programmatically.

## Test plan
- [ ] `showDragHandle` control appears in Storybook and toggles the handle
- [ ] `Without Drag Handle` story renders the sheet without the pill
- [ ] Default behavior unchanged (handle visible)
- [ ] Backdrop/esc dismissal still works with handle hidden
- [ ] `yarn svelte-check` passes (0 errors)

Made with [Cursor](https://cursor.com)