### PR TITLE
feat(FloatingActionButton): add FloatingActionButton component

### DIFF
--- a/.changeset/floating-action-button.md
+++ b/.changeset/floating-action-button.md
@@ -1,0 +1,8 @@
+---
+'@razorpay/blade': minor
+'@razorpay/blade-mcp': minor
+---
+
+feat(FloatingActionButton): add FloatingActionButton component
+
+Adds `FloatingActionButton`, a persistent pill-shaped button anchored to the bottom of the viewport for the single most important action on a screen. It supports `primary`, `white` and `black` colors, anchors via `placement` (`bottom-end`, `bottom-start`, `bottom`) with a configurable `offset` and `zIndex`, and renders either an icon with a short label or an icon on its own, in which case `accessibilityLabel` is required. Positioning is `fixed` on web and `absolute` with safe-area insets on React Native.

--- a/packages/blade-mcp/knowledgebase/components/FloatingActionButton.md
+++ b/packages/blade-mcp/knowledgebase/components/FloatingActionButton.md
@@ -1,0 +1,228 @@
+## Component Name
+
+FloatingActionButton
+
+## Description
+
+FloatingActionButton is a persistent, elevated button anchored to the bottom of the viewport, used for the single most important action on a screen. It stays in place while the page scrolls, so the primary action remains reachable at all times. It renders as a pill with a drop shadow and always carries an icon, optionally alongside a short label. On React Native it automatically respects the device's safe-area insets.
+
+## Important Constraints
+
+- `icon` is required — a `FloatingActionButton` is never text-only
+- When `children` is omitted the button is icon-only, and `accessibilityLabel` becomes required
+- There is no `size` or `variant` prop — the button always renders at the `large` size with a `primary` emphasis
+- Only one `FloatingActionButton` should be rendered per screen
+- The button positions itself, so it does not need to be wrapped in a positioned `Box`
+
+## TypeScript Types
+
+The following types represent the props that the FloatingActionButton component accepts.
+
+```typescript
+/**
+ * Corner of the viewport the button is anchored to.
+ *
+ * Values mirror `Popover`'s `placement`, where the unsuffixed value is centered
+ * and `start` / `end` name the inline edges.
+ */
+type FloatingActionButtonPlacement = 'bottom-end' | 'bottom-start' | 'bottom';
+
+type FloatingActionButtonCommonProps = {
+  /**
+   * Icon rendered inside the button.
+   *
+   * Accepts an icon component from blade.
+   */
+  icon: IconComponent;
+
+  /**
+   * Color of the button.
+   *
+   * @default 'primary'
+   */
+  color?: 'primary' | 'white' | 'black';
+
+  /**
+   * Corner of the viewport the button is anchored to.
+   *
+   * @default 'bottom-end'
+   */
+  placement?: FloatingActionButtonPlacement;
+
+  /**
+   * Distance between the button and the edges it is anchored to.
+   *
+   * @default 'spacing.5'
+   */
+  offset?: SpacingValueType;
+
+  /**
+   * zIndex of the button.
+   *
+   * Defaults to a value that sits above page content but below `BottomNav`,
+   * `BottomSheet` and `Modal`.
+   *
+   * @default 99
+   */
+  zIndex?: number;
+
+  /**
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Shows a spinner in place of the button's content.
+   *
+   * @default false
+   */
+  isLoading?: boolean;
+
+  /**
+   * Automatically renders the button with an `a` tag with `href` on web.
+   */
+  href?: string;
+
+  /**
+   * anchor target attribute
+   *
+   * Should only be used alongside `href`
+   */
+  target?: string;
+
+  /**
+   * anchor rel attribute
+   *
+   * Should only be used alongside `href`
+   */
+  rel?: string;
+
+  /**
+   * @default 'button'
+   */
+  type?: 'button' | 'reset' | 'submit';
+
+  onClick?: (event: React.MouseEvent<HTMLButtonElement> | GestureResponderEvent) => void;
+} & TestID &
+  StyledPropsBlade &
+  DataAnalyticsAttribute &
+  BladeCommonEvents;
+
+/**
+ * With a label, `accessibilityLabel` is optional since the label already names
+ * the action.
+ */
+type FloatingActionButtonWithLabelProps = FloatingActionButtonCommonProps & {
+  children: StringChildrenType;
+  accessibilityLabel?: string;
+};
+
+/**
+ * Without a label the button is a bare icon, so it is unusable with a screen
+ * reader unless `accessibilityLabel` names the action.
+ */
+type FloatingActionButtonIconOnlyProps = FloatingActionButtonCommonProps & {
+  children?: undefined;
+  accessibilityLabel: string;
+};
+
+type FloatingActionButtonProps =
+  | FloatingActionButtonWithLabelProps
+  | FloatingActionButtonIconOnlyProps;
+```
+
+## Usage Guidelines
+
+**Do**
+
+- Use `FloatingActionButton` for the single most important action on a screen, such as creating a new record.
+- Always pass `accessibilityLabel` when rendering the icon-only form, so screen readers can name the action.
+- Keep the label to one or two words — the button floats over content, so it should stay compact.
+- Raise `offset` when the button would otherwise overlap fixed content at the bottom of the page.
+- Use `color="white"` or `color="black"` when the button sits over a colored or image background that the `primary` blue would not read against.
+
+**Don't**
+
+- Don't render more than one `FloatingActionButton` on a screen — it dilutes the "single most important action" intent.
+- Don't use it for destructive actions such as delete — it is too easy to hit by accident.
+- Don't use it for secondary or tertiary actions; use `Button` inline in the page instead.
+- Don't wrap it in a positioned `Box` or override `position` through styled props — the component anchors itself.
+- Don't pass a long sentence as `children` — the pill grows with the label and will cover page content.
+- Don't pair it with `BottomNav` at the same `placement` without raising `offset`, or the two will overlap.
+
+## Example
+
+This example shows a transactions screen with a labelled FloatingActionButton for the primary action, and an icon-only variant anchored to the opposite corner.
+
+```tsx
+import React, { useState } from 'react';
+import {
+  FloatingActionButton,
+  Box,
+  Text,
+  Heading,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  PlusIcon,
+  MessageSquareIcon,
+} from '@razorpay/blade/components';
+
+const TransactionsScreen = (): React.ReactElement => {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+
+  return (
+    <Box minHeight="100vh" padding="spacing.6" backgroundColor="surface.background.gray.subtle">
+      <Heading size="large">Transactions</Heading>
+
+      {/* Long page content the button floats over while scrolling */}
+      {Array.from({ length: 20 }).map((_, index) => (
+        <Box
+          key={index}
+          padding="spacing.5"
+          marginTop="spacing.4"
+          backgroundColor="surface.background.gray.intense"
+          borderRadius="medium"
+        >
+          <Text>Transaction #{index + 1}</Text>
+        </Box>
+      ))}
+
+      {/* Primary action — labelled, anchored bottom-right */}
+      <FloatingActionButton
+        icon={PlusIcon}
+        onClick={() => setIsCreateOpen(true)}
+        testID="create-payment-fab"
+        data-analytics="create-payment"
+      >
+        Create
+      </FloatingActionButton>
+
+      {/* Support entry point — icon-only, so accessibilityLabel is required */}
+      <FloatingActionButton
+        icon={MessageSquareIcon}
+        color="white"
+        placement="bottom-start"
+        accessibilityLabel="Chat with support"
+        onClick={() => console.log('open support chat')}
+      />
+
+      <Modal isOpen={isCreateOpen} onDismiss={() => setIsCreateOpen(false)}>
+        <ModalHeader title="Create payment" />
+        <ModalBody>
+          <Text>Payment creation form goes here.</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="tertiary" onClick={() => setIsCreateOpen(false)}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </Box>
+  );
+};
+
+export default TransactionsScreen;
+```

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -25,7 +25,7 @@ import type { DotNotationToken } from '~utils/lodashButBetter/get';
 import getIn from '~utils/lodashButBetter/get';
 import type { BaseLinkProps } from '~components/Link/BaseLink';
 import type { Theme } from '~components/BladeProvider';
-import type { IconComponent } from '~components/Icons';
+import type { IconComponent, IconSize } from '~components/Icons';
 import type { Platform } from '~utils';
 import { isReactNative } from '~utils';
 import type { StyledPropsBlade } from '~components/Box/styledProps';
@@ -34,6 +34,7 @@ import { getStyledProps } from '~components/Box/styledProps';
 import { BaseText } from '~components/Typography/BaseText';
 import { useTheme } from '~components/BladeProvider';
 import { announce } from '~components/LiveAnnouncer';
+import type { BaseSpinnerProps } from '~components/Spinner/BaseSpinner';
 import { BaseSpinner } from '~components/Spinner/BaseSpinner';
 import type { BaseBoxProps } from '~components/Box/BaseBox';
 import BaseBox from '~components/Box/BaseBox';
@@ -87,7 +88,28 @@ type BaseButtonCommonProps = {
     | 'notice'
     | 'information'
     | 'neutral'
-    | 'transparent';
+    | 'transparent'
+    /**
+     * Only supported with `variant="primary"`. Consumed by FloatingActionButton
+     * and intentionally not exposed on `Button`.
+     */
+    | 'black';
+  /**
+   * Overrides the size-derived border radius. Used by FloatingActionButton to
+   * render a pill. `round` is excluded because a percentage radius distorts on
+   * a non-square button.
+   */
+  _borderRadius?: Exclude<keyof Theme['border']['radius'], 'round'>;
+  /**
+   * Overrides the size-derived icon size. Used by FloatingActionButton, whose
+   * icon is larger than a `size="large"` Button's.
+   */
+  _iconSize?: IconSize;
+  /**
+   * Overrides the color of the loading spinner. Used by FloatingActionButton,
+   * whose contrast requirements differ from `Button`'s.
+   */
+  _spinnerColor?: BaseSpinnerProps['color'];
 } & TestID &
   StyledPropsBlade &
   BladeCommonEvents;
@@ -119,6 +141,47 @@ type BaseButtonColorTokenModifiers = {
   color: BaseButtonProps['color'];
 };
 
+/**
+ * `white`, `black` and `transparent` are not feedback colors, so the token
+ * factories are still called with `primary` and the value is looked up under its
+ * own key instead of under `base`.
+ */
+const isStaticOrTransparentColor = (
+  color: BaseButtonProps['color'],
+): color is 'white' | 'black' | 'transparent' =>
+  color === 'white' || color === 'black' || color === 'transparent';
+
+const getSpinnerColor = ({
+  variant,
+  color,
+}: {
+  variant: NonNullable<BaseButtonProps['variant']>;
+  color: NonNullable<BaseButtonProps['color']>;
+}): BaseSpinnerProps['color'] => {
+  // `black` only exists as a primary button, so it is looked up separately from
+  // the colors that carry a full variant record.
+  if (color === 'black') {
+    return spinnerColor.black.primary;
+  }
+
+  if (color !== 'primary' && color !== 'transparent' && color in spinnerColor) {
+    return spinnerColor[color as Exclude<keyof typeof spinnerColor, 'base' | 'black'>][
+      variant as 'primary' | 'secondary'
+    ];
+  }
+
+  return spinnerColor.base[variant];
+};
+
+const assertBlackIsPrimary = (variant: NonNullable<BaseButtonProps['variant']>): void => {
+  if (variant !== 'primary') {
+    throwBladeError({
+      moduleName: 'BaseButton',
+      message: `Black color can only be used with primary variant but received "${variant}"`,
+    });
+  }
+};
+
 const getRenderElement = (href?: string): 'a' | 'button' | undefined => {
   if (isReactNative()) {
     return undefined; // as property doesn't work with react native
@@ -138,13 +201,18 @@ export const getBackgroundColorToken = ({
 }: BaseButtonColorTokenModifiers) => {
   const _state = state === 'focus' || state === 'hover' ? 'highlighted' : state;
 
-  // For white and transparent colors, we use 'primary' as the base color
-  // since the actual token lookup uses the white/transparent specific paths
-  const gradientColor = color === 'white' || color === 'transparent' || !color ? 'primary' : color;
+  // For white, black and transparent colors, we use 'primary' as the base color
+  // since the actual token lookup uses the white/black/transparent specific paths
+  const gradientColor = isStaticOrTransparentColor(color) || !color ? 'primary' : color;
   const tokens = backgroundGradient(gradientColor);
 
   if (color === 'white') {
     return tokens.white[variant][_state];
+  }
+
+  if (color === 'black') {
+    assertBlackIsPrimary(variant);
+    return tokens.black.primary[_state];
   }
 
   if (color === 'transparent') {
@@ -173,11 +241,16 @@ export const getBoxShadowToken = ({
   color,
 }: BaseButtonColorTokenModifiers): ButtonBoxShadow => {
   const _state = state === 'focus' || state === 'hover' ? 'highlighted' : state;
-  const tokenColor = color === 'white' || color === 'transparent' || !color ? 'primary' : color;
+  const tokenColor = isStaticOrTransparentColor(color) || !color ? 'primary' : color;
   const tokens = boxShadow(tokenColor);
 
   if (color === 'white') {
     return tokens.white[variant][_state];
+  }
+
+  if (color === 'black') {
+    assertBlackIsPrimary(variant);
+    return tokens.black.primary[_state];
   }
 
   if (color === 'transparent') {
@@ -205,6 +278,11 @@ export const getTextColorToken = ({
 
   if (color === 'white') {
     return tokens.white[variant][_state];
+  }
+
+  if (color === 'black') {
+    assertBlackIsPrimary(variant);
+    return tokens.black.primary[_state];
   }
 
   if (color === 'transparent') {
@@ -237,6 +315,8 @@ const getProps = ({
   variant,
   color,
   hasIcon,
+  _borderRadius,
+  _iconSize,
 }: {
   buttonTypographyTokens: ButtonTypography;
   childrenString?: string;
@@ -246,6 +326,8 @@ const getProps = ({
   size: NonNullable<BaseButtonProps['size']>;
   variant: NonNullable<BaseButtonProps['variant']>;
   color: BaseButtonProps['color'];
+  _borderRadius?: BaseButtonCommonProps['_borderRadius'];
+  _iconSize?: BaseButtonCommonProps['_iconSize'];
 }): BaseButtonStyleProps => {
   if (
     variant === 'tertiary' &&
@@ -367,7 +449,9 @@ const getProps = ({
   };
 
   const props: BaseButtonStyleProps = {
-    iconSize: isIconOnly ? buttonIconOnlySizeToIconSizeMap[size] : buttonSizeToIconSizeMap[size],
+    iconSize:
+      _iconSize ??
+      (isIconOnly ? buttonIconOnlySizeToIconSizeMap[size] : buttonSizeToIconSizeMap[size]),
     spinnerSize: buttonSizeToSpinnerSizeMap[size],
     fontSize: buttonTypographyTokens.fonts.size[size],
     lineHeight: buttonTypographyTokens.lineHeights[size],
@@ -417,7 +501,7 @@ const getProps = ({
     ),
     focusBoxShadow: getBoxShadow('focus', color),
     focusRingColor: getIn(theme.colors, 'surface.border.primary.muted'),
-    borderRadius: makeBorderSize(theme.border.radius[buttonBorderRadius[size]]),
+    borderRadius: makeBorderSize(theme.border.radius[_borderRadius ?? buttonBorderRadius[size]]),
     motionDuration: 'duration.xquick',
     motionEasing: 'easing.standard',
     ...(isReactNative() && !isDisabled ? getNativeShadowColors(color) : {}),
@@ -484,6 +568,9 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
     accessibilityProps,
     onTouchEnd,
     onTouchStart,
+    _borderRadius,
+    _iconSize,
+    _spinnerColor,
     ...rest
   },
   ref,
@@ -577,6 +664,8 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
     theme,
     color: buttonGroupProps.color ?? color,
     hasIcon: Boolean(Icon),
+    _borderRadius,
+    _iconSize,
   });
 
   const renderElement = React.useMemo(() => getRenderElement(href), [href]);
@@ -779,13 +868,7 @@ const _BaseButton: React.ForwardRefRenderFunction<BladeElementRef, BaseButtonPro
             <BaseSpinner
               accessibilityLabel="Loading"
               size={spinnerSize}
-              color={
-                color && color !== 'primary' && color !== 'transparent' && color in spinnerColor
-                  ? spinnerColor[color as keyof typeof spinnerColor][
-                      variant as 'primary' | 'secondary'
-                    ]
-                  : spinnerColor.base[variant]
-              }
+              color={_spinnerColor ?? getSpinnerColor({ variant, color })}
             />
           </BaseBox>
         ) : null}

--- a/packages/blade/src/components/Button/BaseButton/buttonTokens.ts
+++ b/packages/blade/src/components/Button/BaseButton/buttonTokens.ts
@@ -62,6 +62,15 @@ const backgroundGradient = (color: FeedbackColors | 'primary') => {
         disabled: 'interactive.background.gray.disabled',
       },
     },
+    // Only the `primary` emphasis exists in the design for the black color, which
+    // is currently used by FloatingActionButton and is not exposed on `Button`.
+    black: {
+      primary: {
+        default: 'interactive.background.staticBlack.default',
+        highlighted: 'interactive.background.staticBlack.highlighted',
+        disabled: 'interactive.background.staticBlack.fadedHighlighted',
+      },
+    },
   } as const;
 };
 
@@ -89,6 +98,7 @@ const boxShadow = (
     'primary' | 'secondary' | 'tertiary',
     Record<'default' | 'highlighted' | 'disabled', ButtonBoxShadow>
   >;
+  black: Record<'primary', Record<'default' | 'highlighted' | 'disabled', ButtonBoxShadow>>;
 } => {
   return {
     base: {
@@ -174,6 +184,23 @@ const boxShadow = (
         disabled: [{ y: 0, blur: 0, spread: 1, color: 'interactive.border.staticWhite.disabled' }],
       },
     },
+    black: {
+      primary: {
+        default: [
+          { y: -1.5, blur: 0, spread: 0, color: 'interactive.border.staticBlack.highlighted' },
+          { y: 0, blur: 0, spread: 0.5, color: 'interactive.border.staticBlack.highlighted' },
+          { y: 1.5, blur: 0, spread: 0, color: 'interactive.border.staticWhite.fadedHighlighted' },
+          { y: -2, blur: 0, spread: 0, color: 'interactive.border.staticWhite.fadedHighlighted' },
+        ],
+        highlighted: [
+          { y: -1.5, blur: 0, spread: 0, color: 'interactive.border.staticBlack.highlighted' },
+          { y: 0, blur: 0, spread: 0.5, color: 'interactive.border.staticBlack.highlighted' },
+          { y: 1.5, blur: 0, spread: 0, color: 'interactive.border.staticWhite.fadedHighlighted' },
+          { y: -2, blur: 0, spread: 0, color: 'interactive.border.staticWhite.fadedHighlighted' },
+        ],
+        disabled: [],
+      },
+    },
   };
 };
 
@@ -208,6 +235,13 @@ const textColor = (property: 'icon' | 'text') => {
         disabled: `interactive.${property}.staticWhite.disabled`,
       },
       tertiary: {
+        default: `interactive.${property}.staticWhite.normal`,
+        highlighted: `interactive.${property}.staticWhite.normal`,
+        disabled: `interactive.${property}.staticWhite.disabled`,
+      },
+    },
+    black: {
+      primary: {
         default: `interactive.${property}.staticWhite.normal`,
         highlighted: `interactive.${property}.staticWhite.normal`,
         disabled: `interactive.${property}.staticWhite.disabled`,
@@ -345,6 +379,9 @@ const spinnerColor = {
     primary: 'white',
     secondary: 'white',
     tertiary: 'white',
+  },
+  black: {
+    primary: 'white',
   },
   positive: {
     primary: 'positive',

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButton.stories.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButton.stories.tsx
@@ -1,0 +1,180 @@
+import type { StoryFn, Meta } from '@storybook/react-vite';
+import { Title } from '@storybook/addon-docs/blocks';
+import React from 'react';
+import { FloatingActionButton as FloatingActionButtonComponent } from './FloatingActionButton';
+import type { FloatingActionButtonProps } from './types';
+import { Sandbox } from '~utils/storybook/Sandbox';
+import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
+import { getStyledPropsArgTypes } from '~components/Box/BaseBox/storybookArgTypes';
+import { Box } from '~components/Box';
+import { Text } from '~components/Typography';
+import { PlusIcon, EditIcon, MessageSquareIcon } from '~components/Icons';
+import { Alert } from '~components/Alert';
+
+const Page = (): React.ReactElement => {
+  return (
+    <StoryPageWrapper
+      componentName="FloatingActionButton"
+      componentDescription="A persistent, elevated button anchored to the bottom of the viewport, used for the single most important action on a screen. Use it for one action only — it is not a replacement for Button."
+      figmaURL="https://www.figma.com/design/jubmQL9Z8V7881ayUD95ps/Blade-DSL?node-id=125809-2463"
+    >
+      <Title>Usage</Title>
+      <Alert
+        color="information"
+        title="Positioning"
+        description="FloatingActionButton anchors itself to the viewport, so it does not need a wrapper to position it. On React Native it is absolutely positioned and automatically clears the bottom safe area, so mount it inside a parent that fills the screen. The stories below are pinned inside a demo surface so they stay next to their labels."
+        isFullWidth
+        isDismissible={false}
+      />
+      <Sandbox>
+        {`
+          import { FloatingActionButton, PlusIcon } from '@razorpay/blade/components';
+
+          function App() {
+            return (
+              <FloatingActionButton
+                icon={PlusIcon}
+                onClick={() => console.log('Create payment')}
+              >
+                Create payment
+              </FloatingActionButton>
+            )
+          }
+
+          export default App;
+        `}
+      </Sandbox>
+    </StoryPageWrapper>
+  );
+};
+
+export default {
+  title: 'Components/FloatingActionButton',
+  component: FloatingActionButtonComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    ...getStyledPropsArgTypes(),
+    icon: {
+      control: { disable: true },
+    },
+  },
+  args: {
+    icon: PlusIcon,
+    children: 'Create payment',
+  },
+  parameters: {
+    docs: {
+      page: Page,
+    },
+  },
+} as Meta<FloatingActionButtonProps>;
+
+/**
+ * The button anchors itself to the viewport, which in a docs iframe means it
+ * escapes its story and overlaps its neighbours. Zeroing every inset returns it
+ * to normal flow so a matrix of variants can be laid out side by side.
+ */
+const inlineDemoProps = {
+  position: 'relative',
+  top: 'spacing.0',
+  right: 'spacing.0',
+  bottom: 'spacing.0',
+  left: 'spacing.0',
+} as const;
+
+/**
+ * A positioned surface that acts as the viewport for stories which do need to
+ * demonstrate real anchoring.
+ */
+const DemoViewport = ({ children }: { children: React.ReactNode }): React.ReactElement => (
+  <Box
+    height="160px"
+    borderRadius="medium"
+    backgroundColor="surface.background.gray.moderate"
+    overflow="hidden"
+    position="relative"
+  >
+    {children}
+  </Box>
+);
+
+const FloatingActionButtonTemplate: StoryFn<typeof FloatingActionButtonComponent> = (args) => (
+  <DemoViewport>
+    <FloatingActionButtonComponent {...args} position="absolute" />
+  </DemoViewport>
+);
+
+export const Default = FloatingActionButtonTemplate.bind({});
+Default.storyName = 'Default';
+
+export const IconOnly = FloatingActionButtonTemplate.bind({});
+IconOnly.storyName = 'Icon Only';
+IconOnly.args = {
+  children: undefined,
+  accessibilityLabel: 'Create payment',
+};
+
+export const Colors = (): React.ReactElement => (
+  <Box display="flex" flexDirection="column" gap="spacing.5">
+    {(['primary', 'white', 'black'] as const).map((color) => (
+      <Box key={color} display="flex" flexDirection="column" gap="spacing.3">
+        <Text weight="semibold">{color}</Text>
+        <Box
+          padding="spacing.5"
+          borderRadius="medium"
+          backgroundColor={
+            color === 'white'
+              ? 'surface.background.primary.intense'
+              : 'surface.background.gray.moderate'
+          }
+          display="flex"
+          flexDirection="row"
+          gap="spacing.5"
+          alignItems="center"
+        >
+          <FloatingActionButtonComponent icon={EditIcon} color={color} {...inlineDemoProps}>
+            Edit invoice
+          </FloatingActionButtonComponent>
+          <FloatingActionButtonComponent
+            icon={EditIcon}
+            color={color}
+            accessibilityLabel="Edit invoice"
+            {...inlineDemoProps}
+          />
+        </Box>
+      </Box>
+    ))}
+  </Box>
+);
+
+export const States = (): React.ReactElement => (
+  <Box display="flex" flexDirection="row" gap="spacing.5" alignItems="center" flexWrap="wrap">
+    <FloatingActionButtonComponent icon={MessageSquareIcon} {...inlineDemoProps}>
+      Default
+    </FloatingActionButtonComponent>
+    <FloatingActionButtonComponent icon={MessageSquareIcon} isLoading {...inlineDemoProps}>
+      Loading
+    </FloatingActionButtonComponent>
+    <FloatingActionButtonComponent icon={MessageSquareIcon} isDisabled {...inlineDemoProps}>
+      Disabled
+    </FloatingActionButtonComponent>
+  </Box>
+);
+
+export const Placement = (): React.ReactElement => (
+  <Box display="flex" flexDirection="column" gap="spacing.5">
+    {(['bottom-start', 'bottom', 'bottom-end'] as const).map((placement) => (
+      <Box key={placement} display="flex" flexDirection="column" gap="spacing.3">
+        <Text weight="semibold">{placement}</Text>
+        <DemoViewport>
+          <FloatingActionButtonComponent
+            icon={PlusIcon}
+            placement={placement}
+            accessibilityLabel="Create payment"
+            position="absolute"
+          />
+        </DemoViewport>
+      </Box>
+    ))}
+  </Box>
+);

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButton.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButton.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { FloatingActionButtonContainer } from './FloatingActionButtonContainer';
+import type { FloatingActionButtonProps } from './types';
+import BaseButton from '~components/Button/BaseButton';
+import { componentZIndices } from '~utils/componentZIndices';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import type { BladeElementRef } from '~utils/types';
+
+/**
+ * The shared spinner map would render a white spinner on the white button, where
+ * it is invisible.
+ */
+const colorToSpinnerColor = {
+  primary: 'white',
+  black: 'white',
+  white: 'neutral',
+} as const;
+
+/**
+ * ### FloatingActionButton component
+ *
+ * A persistent, elevated button anchored to the bottom of the viewport, used for the single most important action on a screen.
+ *
+ * ---
+ *
+ * #### Usage
+ *
+ * ```jsx
+ * <FloatingActionButton icon={PlusIcon} onClick={() => createPayment()}>
+ *   Create payment
+ * </FloatingActionButton>
+ *
+ * // icon-only, accessibilityLabel is required
+ * <FloatingActionButton
+ *   icon={PlusIcon}
+ *   accessibilityLabel="Create payment"
+ *   onClick={() => createPayment()}
+ * />
+ * ```
+ *
+ * Checkout {@link https://blade.razorpay.com/?path=/docs/components-floatingactionbutton--docs FloatingActionButton Documentation}
+ */
+const _FloatingActionButton: React.ForwardRefRenderFunction<
+  BladeElementRef,
+  FloatingActionButtonProps
+> = (
+  {
+    children,
+    icon,
+    color = 'primary',
+    placement = 'bottom-end',
+    offset = 'spacing.5',
+    zIndex = componentZIndices.fab,
+    isDisabled = false,
+    isLoading = false,
+    href,
+    target,
+    rel,
+    type = 'button',
+    accessibilityLabel,
+    onClick,
+    onBlur,
+    onFocus,
+    onMouseLeave,
+    onMouseMove,
+    onMouseDown,
+    onPointerDown,
+    onPointerEnter,
+    onTouchStart,
+    onTouchEnd,
+    testID,
+    ...rest
+  },
+  ref,
+) => {
+  return (
+    <FloatingActionButtonContainer
+      placement={placement}
+      offset={offset}
+      zIndex={zIndex}
+      testID={testID}
+      {...rest}
+    >
+      <BaseButton
+        ref={ref}
+        icon={icon}
+        variant="primary"
+        color={color}
+        size="large"
+        _borderRadius="max"
+        _iconSize="xlarge"
+        _spinnerColor={colorToSpinnerColor[color]}
+        accessibilityProps={{ label: accessibilityLabel }}
+        href={href}
+        target={target}
+        rel={rel}
+        type={type}
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        onClick={onClick}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onMouseLeave={onMouseLeave}
+        onMouseMove={onMouseMove}
+        onMouseDown={onMouseDown}
+        onPointerDown={onPointerDown}
+        onPointerEnter={onPointerEnter}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+      >
+        {children}
+      </BaseButton>
+    </FloatingActionButtonContainer>
+  );
+};
+
+const FloatingActionButton = assignWithoutSideEffects(React.forwardRef(_FloatingActionButton), {
+  displayName: 'FloatingActionButton',
+  componentId: 'FloatingActionButton',
+});
+
+export { FloatingActionButton };

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButtonContainer.native.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButtonContainer.native.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { FloatingActionButtonContainerProps } from './types';
+import BaseBox from '~components/Box/BaseBox';
+import { getStyledProps } from '~components/Box/styledProps';
+import { makeSpace } from '~utils/makeSpace';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+
+const placementToJustifyContent = {
+  'bottom-start': 'flex-start',
+  'bottom-end': 'flex-end',
+  bottom: 'center',
+} as const;
+
+/**
+ * Anchors the button to the bottom of the screen and owns its drop shadow.
+ *
+ * React Native has no `position: fixed`, so the button is absolutely positioned
+ * and is expected to be mounted inside a filling parent.
+ *
+ * The positioning is done with a full-width row rather than by setting `left` /
+ * `right` directly, because centering would otherwise need a percentage
+ * `translateX`, which React Native does not support reliably. The row is
+ * `pointerEvents="box-none"` so it does not swallow touches meant for the
+ * content behind it, and the drop shadow sits on the inner, button-sized box so
+ * it traces the pill rather than the row.
+ *
+ * The bottom safe-area inset is applied to the row so the `offset` is measured
+ * from the top of the home indicator / navigation bar rather than from the
+ * physical bottom of the screen.
+ */
+const FloatingActionButtonContainer = ({
+  children,
+  placement,
+  offset,
+  zIndex,
+  testID,
+  ...rest
+}: FloatingActionButtonContainerProps): React.ReactElement => {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <BaseBox
+      position="absolute"
+      bottom={makeSpace(insets.bottom)}
+      left="0px"
+      right="0px"
+      paddingLeft={offset}
+      paddingRight={offset}
+      paddingBottom={offset}
+      display="flex"
+      flexDirection="row"
+      justifyContent={placementToJustifyContent[placement]}
+      pointerEvents="box-none"
+      zIndex={zIndex}
+      {...metaAttribute({ testID, name: MetaConstants.FloatingActionButton })}
+      {...makeAnalyticsAttribute(rest)}
+      {...getStyledProps(rest)}
+    >
+      <BaseBox borderRadius="max" elevation="midRaised">
+        {children}
+      </BaseBox>
+    </BaseBox>
+  );
+};
+
+export { FloatingActionButtonContainer };

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButtonContainer.web.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButtonContainer.web.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import type { FloatingActionButtonContainerProps } from './types';
+import BaseBox from '~components/Box/BaseBox';
+import { getStyledProps } from '~components/Box/styledProps';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+
+/**
+ * Anchors the button to the viewport and owns its drop shadow.
+ *
+ * The shadow lives here rather than on `BaseButton` because `BaseButton`
+ * composes its inner shadows into a single `box-shadow` that is rewritten on
+ * `:hover`, `:active` and `:focus-visible` — appending an outer shadow there
+ * would mean re-appending it in every one of those states.
+ */
+const FloatingActionButtonContainer = ({
+  children,
+  placement,
+  offset,
+  zIndex,
+  testID,
+  ...rest
+}: FloatingActionButtonContainerProps): React.ReactElement => {
+  const isCentered = placement === 'bottom';
+
+  return (
+    <BaseBox
+      position="fixed"
+      bottom={offset}
+      left={isCentered ? '50%' : placement === 'bottom-start' ? offset : undefined}
+      right={placement === 'bottom-end' ? offset : undefined}
+      transform={isCentered ? 'translateX(-50%)' : undefined}
+      display="flex"
+      borderRadius="max"
+      elevation="midRaised"
+      zIndex={zIndex}
+      {...metaAttribute({ testID, name: MetaConstants.FloatingActionButton })}
+      {...makeAnalyticsAttribute(rest)}
+      {...getStyledProps(rest)}
+    >
+      {children}
+    </BaseBox>
+  );
+};
+
+export { FloatingActionButtonContainer };

--- a/packages/blade/src/components/FloatingActionButton/_KitchenSink.FloatingActionButton.stories.tsx
+++ b/packages/blade/src/components/FloatingActionButton/_KitchenSink.FloatingActionButton.stories.tsx
@@ -1,0 +1,31 @@
+import { composeStories } from '@storybook/react-vite';
+import * as floatingActionButtonStories from './FloatingActionButton.stories';
+import { Box } from '~components/Box';
+import { Heading } from '~components/Typography';
+
+const allStories = Object.values(composeStories(floatingActionButtonStories));
+
+export const FloatingActionButton = (): JSX.Element => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.4">
+      {allStories.map((Story) => {
+        return (
+          <>
+            <Heading>{Story.storyName}</Heading>
+            <Story />
+          </>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default {
+  title: 'Components/KitchenSink/FloatingActionButton',
+  component: FloatingActionButton,
+  parameters: {
+    // enable Chromatic's snapshotting only for kitchensink
+    chromatic: { disableSnapshot: false },
+    options: { showPanel: false },
+  },
+};

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.native.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.native.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { FloatingActionButton } from '../FloatingActionButton';
+import { PlusIcon } from '~components/Icons';
+import renderWithTheme from '~utils/testing/renderWithTheme.native';
+
+const SAFE_AREA_BOTTOM_INSET = 34;
+
+jest.mock('react-native-safe-area-context', () => ({
+  ...jest.requireActual('react-native-safe-area-context'),
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: SAFE_AREA_BOTTOM_INSET, left: 0 }),
+}));
+
+describe('<FloatingActionButton /> (native)', () => {
+  it('should render with a label', () => {
+    const { toJSON } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon}>Create payment</FloatingActionButton>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should render as an icon-only button when children is omitted', () => {
+    const { toJSON } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} accessibilityLabel="Create payment" />,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it.each(['primary', 'white', 'black'] as const)('should render %s color', (color) => {
+    const { toJSON } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} color={color}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should lift itself above the bottom safe area inset', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({
+      position: 'absolute',
+      bottom: SAFE_AREA_BOTTOM_INSET,
+    });
+  });
+
+  it('should align to the end of the row by default', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ justifyContent: 'flex-end' });
+  });
+
+  it.each([
+    ['bottom-start', 'flex-start'],
+    ['bottom', 'center'],
+    ['bottom-end', 'flex-end'],
+  ] as const)('should align %s to %s', (placement, justifyContent) => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} placement={placement} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ justifyContent });
+  });
+
+  it('should not swallow touches meant for the content behind it', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ pointerEvents: 'box-none' });
+  });
+
+  it('should call onClick when pressed', () => {
+    const onClick = jest.fn();
+    const { getByRole } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} onClick={onClick}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    fireEvent.press(getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onClick when disabled', () => {
+    const onClick = jest.fn();
+    const { getByRole } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} isDisabled onClick={onClick}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    fireEvent.press(getByRole('button'));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('should expose the accessibilityLabel of an icon-only button', () => {
+    const { getByLabelText } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} accessibilityLabel="Create payment" />,
+    );
+
+    expect(getByLabelText('Create payment')).toBeTruthy();
+  });
+});

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.ssr.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.ssr.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { FloatingActionButton } from '../FloatingActionButton';
+import { PlusIcon } from '~components/Icons';
+import renderWithSSR from '~utils/testing/renderWithSSR.web';
+
+describe('<FloatingActionButton />', () => {
+  it('should render FloatingActionButton ssr', () => {
+    const { container } = renderWithSSR(
+      <FloatingActionButton icon={PlusIcon}>Create payment</FloatingActionButton>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.web.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.web.test.tsx
@@ -1,0 +1,188 @@
+import userEvents from '@testing-library/user-event';
+import React from 'react';
+import { FloatingActionButton } from '../FloatingActionButton';
+import { PlusIcon } from '~components/Icons';
+import renderWithTheme from '~utils/testing/renderWithTheme';
+import assertAccessible from '~utils/testing/assertAccessible';
+import { componentZIndices } from '~utils/componentZIndices';
+
+describe('<FloatingActionButton />', () => {
+  it('should render with a label', () => {
+    const { container } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon}>Create payment</FloatingActionButton>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render as an icon-only button when children is omitted', () => {
+    const { container, getByRole } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} accessibilityLabel="Create payment" />,
+    );
+
+    expect(getByRole('button', { name: 'Create payment' })).toBeInTheDocument();
+    expect(container).toMatchSnapshot();
+  });
+
+  it.each(['primary', 'white', 'black'] as const)('should render %s color', (color) => {
+    const { container } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} color={color}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should anchor to the bottom end of the viewport by default', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({
+      position: 'fixed',
+      bottom: '16px',
+      right: '16px',
+    });
+  });
+
+  it('should anchor to the bottom start of the viewport', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} placement="bottom-start" testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ bottom: '16px', left: '16px' });
+  });
+
+  it('should center itself when placement is bottom', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} placement="bottom" testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ left: '50%', transform: 'translateX(-50%)' });
+  });
+
+  it('should apply the offset to the anchored edges', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} offset="spacing.9" testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ bottom: '40px', right: '40px' });
+  });
+
+  it('should default zIndex to the registered fab value', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ zIndex: `${componentZIndices.fab}` });
+  });
+
+  it('should let zIndex be overridden', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} zIndex={1234} testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ zIndex: '1234' });
+  });
+
+  it('should let styled-props override the placement', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} position="absolute" bottom="spacing.11" testID="fab">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveStyle({ position: 'absolute', bottom: '56px' });
+  });
+
+  it('should call onClick when clicked', async () => {
+    const user = userEvents.setup();
+    const onClick = jest.fn();
+
+    const { getByRole } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} onClick={onClick}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    await user.click(getByRole('button', { name: 'Create payment' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onClick when disabled', async () => {
+    const user = userEvents.setup();
+    const onClick = jest.fn();
+
+    const { getByRole } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} isDisabled onClick={onClick}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    await user.click(getByRole('button', { name: 'Create payment' }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('should render an anchor when href is passed', () => {
+    const { getByRole } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} href="/payments">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByRole('link', { name: 'Create payment' })).toHaveAttribute('href', '/payments');
+  });
+
+  it('should forward the ref to the button element', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+
+    renderWithTheme(
+      <FloatingActionButton ref={ref} icon={PlusIcon}>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(ref.current?.tagName).toBe('BUTTON');
+  });
+
+  it('should support data-analytics attributes', () => {
+    const { getByTestId } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} testID="fab" data-analytics-name="create-payment">
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(getByTestId('fab')).toHaveAttribute('data-analytics-name', 'create-payment');
+  });
+
+  it('should pass general a11y with a label', async () => {
+    const { container } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon}>Create payment</FloatingActionButton>,
+    );
+
+    await assertAccessible(container);
+  });
+
+  it('should pass general a11y when icon-only', async () => {
+    const { container } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} accessibilityLabel="Create payment" />,
+    );
+
+    await assertAccessible(container);
+  });
+});

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.native.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.native.test.tsx.snap
@@ -1,0 +1,2862 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FloatingActionButton /> (native) should render as an icon-only button when children is omitted 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    bottom="34px"
+    data-blade-component="floating-action-button"
+    display="flex"
+    flexDirection="row"
+    justifyContent="flex-end"
+    left="0px"
+    pointerEvents="box-none"
+    position="absolute"
+    right="0px"
+    style={
+      [
+        {
+          "bottom": 34,
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "left": 0,
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "pointerEvents": "box-none",
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 99,
+        },
+      ]
+    }
+    zIndex={99}
+  >
+    <View
+      borderRadius="max"
+      data-blade-component="base-box"
+      elevation="midRaised"
+      style={
+        [
+          {
+            "borderRadius": 9999,
+          },
+          {
+            "elevation": 16,
+            "shadowColor": "hsla(200, 10%, 18%, 1)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 0.06,
+            "shadowRadius": 4,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityLabel="Create payment"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        borderRadius={9999}
+        buttonPaddingBottom="0px"
+        buttonPaddingLeft="0px"
+        buttonPaddingRight="0px"
+        buttonPaddingTop="0px"
+        collapsable={false}
+        color="primary"
+        data-blade-component="button"
+        defaultBackgroundColor="hsla(218, 89%, 51%, 1)"
+        defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 89%, 51%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        focusBackgroundColor="hsla(218, 87%, 43%, 1)"
+        focusBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 87%, 43%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        focusRingColor="hsla(218, 89%, 51%, 0.18)"
+        focusable={true}
+        height="48px"
+        hoverBackgroundColor="hsla(218, 87%, 43%, 1)"
+        hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 87%, 43%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        hoverIconColor="hsla(0, 0%, 100%, 1)"
+        isFullWidth={false}
+        isLoading={false}
+        isPressed={false}
+        minHeight="48px"
+        motionDuration="duration.xquick"
+        motionEasing="easing.standard"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        size="large"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "hsla(218, 89%, 51%, 1)",
+              "borderColor": "black",
+              "borderRadius": 9999,
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "cursor": "pointer",
+              "display": "flex",
+              "flexDirection": "row",
+              "height": 48,
+              "justifyContent": "center",
+              "minHeight": 48,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+              "textDecorationColor": "black",
+              "textDecorationLine": "none",
+              "textDecorationStyle": "solid",
+              "width": 48,
+            },
+            {
+              "backgroundColor": "hsla(218, 89%, 51%, 1)",
+            },
+          ]
+        }
+        type="button"
+        width="48px"
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight="100%"
+            bbWidth="100%"
+            focusable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": "100%",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGDefs>
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="topFade-r1"
+                  x1="0"
+                  x2="0"
+                  y1="0"
+                  y2="1"
+                />
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="bottomFade-r1"
+                  x1="0"
+                  x2="0"
+                  y1="1"
+                  y2="0"
+                />
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="topMask-r1"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "topFade-r1",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="0"
+                  />
+                </RNSVGMask>
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="bottomMask-r1"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "bottomFade-r1",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="80%"
+                  />
+                </RNSVGMask>
+                <RNSVGRadialGradient
+                  cx={0}
+                  cy={0}
+                  fx={0}
+                  fy={0}
+                  gradient={
+                    [
+                      0,
+                      788529151,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={1}
+                  name="btnGlow-r1"
+                  rx={64}
+                  ry={64}
+                />
+              </RNSVGDefs>
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r1"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 788529151,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={7}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="topMask-r1"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 788529151,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={4}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4279461105,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={1}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r1"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4279129293,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={5}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={
+                  {
+                    "brushRef": "btnGlow-r1",
+                    "type": 1,
+                  }
+                }
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                width="100%"
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            isHidden={false}
+            justifyContent="center"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "justifyContent": "center",
+                  "zIndex": 1,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            zIndex={1}
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="24px"
+                bbWidth="24px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="24px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="24px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                    fill={
+                      {
+                        "payload": 4294967295,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`<FloatingActionButton /> (native) should render black color 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    bottom="34px"
+    data-blade-component="floating-action-button"
+    display="flex"
+    flexDirection="row"
+    justifyContent="flex-end"
+    left="0px"
+    pointerEvents="box-none"
+    position="absolute"
+    right="0px"
+    style={
+      [
+        {
+          "bottom": 34,
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "left": 0,
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "pointerEvents": "box-none",
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 99,
+        },
+      ]
+    }
+    zIndex={99}
+  >
+    <View
+      borderRadius="max"
+      data-blade-component="base-box"
+      elevation="midRaised"
+      style={
+        [
+          {
+            "borderRadius": 9999,
+          },
+          {
+            "elevation": 16,
+            "shadowColor": "hsla(200, 10%, 18%, 1)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 0.06,
+            "shadowRadius": 4,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        borderRadius={9999}
+        buttonPaddingBottom="0px"
+        buttonPaddingLeft="16px"
+        buttonPaddingRight="16px"
+        buttonPaddingTop="0px"
+        collapsable={false}
+        color="black"
+        data-blade-component="button"
+        defaultBackgroundColor="hsla(0, 0%, 0%, 1)"
+        defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
+        focusBackgroundColor="hsla(0, 0%, 0%, 1)"
+        focusBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
+        focusRingColor="hsla(218, 89%, 51%, 0.18)"
+        focusable={true}
+        hoverBackgroundColor="hsla(0, 0%, 0%, 1)"
+        hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
+        hoverIconColor="hsla(0, 0%, 100%, 1)"
+        isFullWidth={false}
+        isLoading={false}
+        isPressed={false}
+        minHeight="48px"
+        motionDuration="duration.xquick"
+        motionEasing="easing.standard"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        size="large"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "hsla(0, 0%, 0%, 1)",
+              "borderColor": "black",
+              "borderRadius": 9999,
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "cursor": "pointer",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "minHeight": 48,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 0,
+              "textDecorationColor": "black",
+              "textDecorationLine": "none",
+              "textDecorationStyle": "solid",
+              "width": "auto",
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 0%, 1)",
+            },
+          ]
+        }
+        type="button"
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight="100%"
+            bbWidth="100%"
+            focusable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": "100%",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGDefs>
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="topFade-r4"
+                  x1="0"
+                  x2="0"
+                  y1="0"
+                  y2="1"
+                />
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="bottomFade-r4"
+                  x1="0"
+                  x2="0"
+                  y1="1"
+                  y2="0"
+                />
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="topMask-r4"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "topFade-r4",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="0"
+                  />
+                </RNSVGMask>
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="bottomMask-r4"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "bottomFade-r4",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="80%"
+                  />
+                </RNSVGMask>
+                <RNSVGRadialGradient
+                  cx={0}
+                  cy={0}
+                  fx={0}
+                  fy={0}
+                  gradient={
+                    [
+                      0,
+                      788529151,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={1}
+                  name="btnGlow-r4"
+                  rx={64}
+                  ry={64}
+                />
+              </RNSVGDefs>
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r4"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 1392508927,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={7}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="topMask-r4"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 1392508927,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={4}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4278190080,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={1}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r4"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4278190080,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={5}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={
+                  {
+                    "brushRef": "btnGlow-r4",
+                    "type": 1,
+                  }
+                }
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                width="100%"
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            isHidden={false}
+            justifyContent="center"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "justifyContent": "center",
+                  "zIndex": 1,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            zIndex={1}
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="24px"
+                bbWidth="24px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="24px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="24px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                    fill={
+                      {
+                        "payload": 4294967295,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <Text
+              accessible={true}
+              color="interactive.text.staticWhite.normal"
+              data-blade-component="base-text"
+              fontSize={200}
+              fontWeight="medium"
+              lineHeight={200}
+              marginX="spacing.2"
+              style={
+                [
+                  {
+                    "color": "hsla(0, 0%, 100%, 1)",
+                    "fontFamily": "Inter",
+                    "fontSize": 16,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 0,
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textAlign": "center",
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+              textAlign="center"
+            >
+              Create payment
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`<FloatingActionButton /> (native) should render primary color 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    bottom="34px"
+    data-blade-component="floating-action-button"
+    display="flex"
+    flexDirection="row"
+    justifyContent="flex-end"
+    left="0px"
+    pointerEvents="box-none"
+    position="absolute"
+    right="0px"
+    style={
+      [
+        {
+          "bottom": 34,
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "left": 0,
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "pointerEvents": "box-none",
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 99,
+        },
+      ]
+    }
+    zIndex={99}
+  >
+    <View
+      borderRadius="max"
+      data-blade-component="base-box"
+      elevation="midRaised"
+      style={
+        [
+          {
+            "borderRadius": 9999,
+          },
+          {
+            "elevation": 16,
+            "shadowColor": "hsla(200, 10%, 18%, 1)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 0.06,
+            "shadowRadius": 4,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        borderRadius={9999}
+        buttonPaddingBottom="0px"
+        buttonPaddingLeft="16px"
+        buttonPaddingRight="16px"
+        buttonPaddingTop="0px"
+        collapsable={false}
+        color="primary"
+        data-blade-component="button"
+        defaultBackgroundColor="hsla(218, 89%, 51%, 1)"
+        defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 89%, 51%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        focusBackgroundColor="hsla(218, 87%, 43%, 1)"
+        focusBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 87%, 43%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        focusRingColor="hsla(218, 89%, 51%, 0.18)"
+        focusable={true}
+        hoverBackgroundColor="hsla(218, 87%, 43%, 1)"
+        hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 87%, 43%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        hoverIconColor="hsla(0, 0%, 100%, 1)"
+        isFullWidth={false}
+        isLoading={false}
+        isPressed={false}
+        minHeight="48px"
+        motionDuration="duration.xquick"
+        motionEasing="easing.standard"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        size="large"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "hsla(218, 89%, 51%, 1)",
+              "borderColor": "black",
+              "borderRadius": 9999,
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "cursor": "pointer",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "minHeight": 48,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 0,
+              "textDecorationColor": "black",
+              "textDecorationLine": "none",
+              "textDecorationStyle": "solid",
+              "width": "auto",
+            },
+            {
+              "backgroundColor": "hsla(218, 89%, 51%, 1)",
+            },
+          ]
+        }
+        type="button"
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight="100%"
+            bbWidth="100%"
+            focusable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": "100%",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGDefs>
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="topFade-r2"
+                  x1="0"
+                  x2="0"
+                  y1="0"
+                  y2="1"
+                />
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="bottomFade-r2"
+                  x1="0"
+                  x2="0"
+                  y1="1"
+                  y2="0"
+                />
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="topMask-r2"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "topFade-r2",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="0"
+                  />
+                </RNSVGMask>
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="bottomMask-r2"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "bottomFade-r2",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="80%"
+                  />
+                </RNSVGMask>
+                <RNSVGRadialGradient
+                  cx={0}
+                  cy={0}
+                  fx={0}
+                  fy={0}
+                  gradient={
+                    [
+                      0,
+                      788529151,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={1}
+                  name="btnGlow-r2"
+                  rx={64}
+                  ry={64}
+                />
+              </RNSVGDefs>
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r2"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 788529151,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={7}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="topMask-r2"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 788529151,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={4}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4279461105,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={1}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r2"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4279129293,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={5}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={
+                  {
+                    "brushRef": "btnGlow-r2",
+                    "type": 1,
+                  }
+                }
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                width="100%"
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            isHidden={false}
+            justifyContent="center"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "justifyContent": "center",
+                  "zIndex": 1,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            zIndex={1}
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="24px"
+                bbWidth="24px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="24px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="24px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                    fill={
+                      {
+                        "payload": 4294967295,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <Text
+              accessible={true}
+              color="interactive.text.onPrimary.normal"
+              data-blade-component="base-text"
+              fontSize={200}
+              fontWeight="medium"
+              lineHeight={200}
+              marginX="spacing.2"
+              style={
+                [
+                  {
+                    "color": "hsla(0, 0%, 100%, 1)",
+                    "fontFamily": "Inter",
+                    "fontSize": 16,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 0,
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textAlign": "center",
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+              textAlign="center"
+            >
+              Create payment
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`<FloatingActionButton /> (native) should render white color 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    bottom="34px"
+    data-blade-component="floating-action-button"
+    display="flex"
+    flexDirection="row"
+    justifyContent="flex-end"
+    left="0px"
+    pointerEvents="box-none"
+    position="absolute"
+    right="0px"
+    style={
+      [
+        {
+          "bottom": 34,
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "left": 0,
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "pointerEvents": "box-none",
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 99,
+        },
+      ]
+    }
+    zIndex={99}
+  >
+    <View
+      borderRadius="max"
+      data-blade-component="base-box"
+      elevation="midRaised"
+      style={
+        [
+          {
+            "borderRadius": 9999,
+          },
+          {
+            "elevation": 16,
+            "shadowColor": "hsla(200, 10%, 18%, 1)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 0.06,
+            "shadowRadius": 4,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        borderRadius={9999}
+        buttonPaddingBottom="0px"
+        buttonPaddingLeft="16px"
+        buttonPaddingRight="16px"
+        buttonPaddingTop="0px"
+        collapsable={false}
+        color="white"
+        data-blade-component="button"
+        defaultBackgroundColor="hsla(0, 0%, 100%, 1)"
+        defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 0.18), inset 0 0px 0px 0.5px hsla(0, 0%, 100%, 1)"
+        focusBackgroundColor="hsla(0, 0%, 100%, 0.8)"
+        focusBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 0.18), inset 0 0px 0px 0.5px hsla(0, 0%, 100%, 1)"
+        focusRingColor="hsla(218, 89%, 51%, 0.18)"
+        focusable={true}
+        hoverBackgroundColor="hsla(0, 0%, 100%, 0.8)"
+        hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 0.18), inset 0 0px 0px 0.5px hsla(0, 0%, 100%, 1)"
+        hoverIconColor="hsla(0, 0%, 0%, 0.72)"
+        isFullWidth={false}
+        isLoading={false}
+        isPressed={false}
+        minHeight="48px"
+        motionDuration="duration.xquick"
+        motionEasing="easing.standard"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        size="large"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "hsla(0, 0%, 100%, 1)",
+              "borderColor": "black",
+              "borderRadius": 9999,
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "cursor": "pointer",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "minHeight": 48,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 0,
+              "textDecorationColor": "black",
+              "textDecorationLine": "none",
+              "textDecorationStyle": "solid",
+              "width": "auto",
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 100%, 1)",
+            },
+          ]
+        }
+        type="button"
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight="100%"
+            bbWidth="100%"
+            focusable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": "100%",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGDefs>
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="topFade-r3"
+                  x1="0"
+                  x2="0"
+                  y1="0"
+                  y2="1"
+                />
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="bottomFade-r3"
+                  x1="0"
+                  x2="0"
+                  y1="1"
+                  y2="0"
+                />
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="topMask-r3"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "topFade-r3",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="0"
+                  />
+                </RNSVGMask>
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="bottomMask-r3"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "bottomFade-r3",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="80%"
+                  />
+                </RNSVGMask>
+                <RNSVGRadialGradient
+                  cx={0}
+                  cy={0}
+                  fx={0}
+                  fy={0}
+                  gradient={
+                    [
+                      0,
+                      788529151,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={1}
+                  name="btnGlow-r3"
+                  rx={64}
+                  ry={64}
+                />
+              </RNSVGDefs>
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4294967295,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={1}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r3"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 771751936,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={5}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={
+                  {
+                    "brushRef": "btnGlow-r3",
+                    "type": 1,
+                  }
+                }
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                width="100%"
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            isHidden={false}
+            justifyContent="center"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "justifyContent": "center",
+                  "zIndex": 1,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            zIndex={1}
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="24px"
+                bbWidth="24px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="24px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="24px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                    fill={
+                      {
+                        "payload": 3087007744,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <Text
+              accessible={true}
+              color="interactive.text.staticBlack.muted"
+              data-blade-component="base-text"
+              fontSize={200}
+              fontWeight="medium"
+              lineHeight={200}
+              marginX="spacing.2"
+              style={
+                [
+                  {
+                    "color": "hsla(0, 0%, 0%, 0.72)",
+                    "fontFamily": "Inter",
+                    "fontSize": 16,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 0,
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textAlign": "center",
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+              textAlign="center"
+            >
+              Create payment
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`<FloatingActionButton /> (native) should render with a label 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    bottom="34px"
+    data-blade-component="floating-action-button"
+    display="flex"
+    flexDirection="row"
+    justifyContent="flex-end"
+    left="0px"
+    pointerEvents="box-none"
+    position="absolute"
+    right="0px"
+    style={
+      [
+        {
+          "bottom": 34,
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "left": 0,
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "pointerEvents": "box-none",
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 99,
+        },
+      ]
+    }
+    zIndex={99}
+  >
+    <View
+      borderRadius="max"
+      data-blade-component="base-box"
+      elevation="midRaised"
+      style={
+        [
+          {
+            "borderRadius": 9999,
+          },
+          {
+            "elevation": 16,
+            "shadowColor": "hsla(200, 10%, 18%, 1)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 0.06,
+            "shadowRadius": 4,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        borderRadius={9999}
+        buttonPaddingBottom="0px"
+        buttonPaddingLeft="16px"
+        buttonPaddingRight="16px"
+        buttonPaddingTop="0px"
+        collapsable={false}
+        color="primary"
+        data-blade-component="button"
+        defaultBackgroundColor="hsla(218, 89%, 51%, 1)"
+        defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 89%, 51%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        focusBackgroundColor="hsla(218, 87%, 43%, 1)"
+        focusBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 87%, 43%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        focusRingColor="hsla(218, 89%, 51%, 0.18)"
+        focusable={true}
+        hoverBackgroundColor="hsla(218, 87%, 43%, 1)"
+        hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(218, 87%, 43%, 1), inset 0 0px 0px 0.5px hsla(218, 87%, 43%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+        hoverIconColor="hsla(0, 0%, 100%, 1)"
+        isFullWidth={false}
+        isLoading={false}
+        isPressed={false}
+        minHeight="48px"
+        motionDuration="duration.xquick"
+        motionEasing="easing.standard"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        size="large"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "hsla(218, 89%, 51%, 1)",
+              "borderColor": "black",
+              "borderRadius": 9999,
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "cursor": "pointer",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "minHeight": 48,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 0,
+              "textDecorationColor": "black",
+              "textDecorationLine": "none",
+              "textDecorationStyle": "solid",
+              "width": "auto",
+            },
+            {
+              "backgroundColor": "hsla(218, 89%, 51%, 1)",
+            },
+          ]
+        }
+        type="button"
+      >
+        <View
+          pointerEvents="none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <RNSVGSvgView
+            bbHeight="100%"
+            bbWidth="100%"
+            focusable={false}
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "flex": 0,
+                  "height": "100%",
+                  "width": "100%",
+                },
+              ]
+            }
+          >
+            <RNSVGGroup
+              fill={
+                {
+                  "payload": 4278190080,
+                  "type": 0,
+                }
+              }
+            >
+              <RNSVGDefs>
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="topFade-r0"
+                  x1="0"
+                  x2="0"
+                  y1="0"
+                  y2="1"
+                />
+                <RNSVGLinearGradient
+                  gradient={
+                    [
+                      0,
+                      -1,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={0}
+                  name="bottomFade-r0"
+                  x1="0"
+                  x2="0"
+                  y1="1"
+                  y2="0"
+                />
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="topMask-r0"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "topFade-r0",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="0"
+                  />
+                </RNSVGMask>
+                <RNSVGMask
+                  fill={
+                    {
+                      "payload": 4278190080,
+                      "type": 0,
+                    }
+                  }
+                  height="100%"
+                  maskContentUnits={1}
+                  maskUnits={0}
+                  name="bottomMask-r0"
+                  width="100%"
+                  x="0%"
+                  y="0%"
+                >
+                  <RNSVGRect
+                    fill={
+                      {
+                        "brushRef": "bottomFade-r0",
+                        "type": 1,
+                      }
+                    }
+                    height="20%"
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                    width="100%"
+                    x="0"
+                    y="80%"
+                  />
+                </RNSVGMask>
+                <RNSVGRadialGradient
+                  cx={0}
+                  cy={0}
+                  fx={0}
+                  fy={0}
+                  gradient={
+                    [
+                      0,
+                      788529151,
+                      1,
+                      16777215,
+                    ]
+                  }
+                  gradientTransform={null}
+                  gradientUnits={1}
+                  name="btnGlow-r0"
+                  rx={64}
+                  ry={64}
+                />
+              </RNSVGDefs>
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r0"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 788529151,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={7}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="topMask-r0"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 788529151,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={4}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4279461105,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={1}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={null}
+                height="100%"
+                mask="bottomMask-r0"
+                propList={
+                  [
+                    "fill",
+                    "stroke",
+                    "strokeWidth",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                stroke={
+                  {
+                    "payload": 4279129293,
+                    "type": 0,
+                  }
+                }
+                strokeWidth={5}
+                width="100%"
+                x={0}
+                y={0}
+              />
+              <RNSVGRect
+                fill={
+                  {
+                    "brushRef": "btnGlow-r0",
+                    "type": 1,
+                  }
+                }
+                height="100%"
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+                rx={9999}
+                ry={9999}
+                width="100%"
+                x={0}
+                y={0}
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            isHidden={false}
+            justifyContent="center"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "justifyContent": "center",
+                  "zIndex": 1,
+                },
+                {
+                  "opacity": 1,
+                },
+              ]
+            }
+            zIndex={1}
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="24px"
+                bbWidth="24px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="24px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="24px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                    fill={
+                      {
+                        "payload": 4294967295,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <Text
+              accessible={true}
+              color="interactive.text.onPrimary.normal"
+              data-blade-component="base-text"
+              fontSize={200}
+              fontWeight="medium"
+              lineHeight={200}
+              marginX="spacing.2"
+              style={
+                [
+                  {
+                    "color": "hsla(0, 0%, 100%, 1)",
+                    "fontFamily": "Inter",
+                    "fontSize": 16,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 0,
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textAlign": "center",
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+              textAlign="center"
+            >
+              Create payment
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.ssr.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.ssr.test.tsx.snap
@@ -1,0 +1,208 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FloatingActionButton /> should render FloatingActionButton ssr 1`] = `"<div id="root"><div elevation="midRaised" data-blade-component="floating-action-button" class="BaseBox-bksIuc fYuIPl"><button type="button" data-blade-component="button" role="button" class="StyledBaseButtonweb__StyledBaseButton-sc-26bt38-0 iPGJsR"><div data-blade-component="base-box" class="BaseBox-bksIuc AnimatedButtonContentweb__AnimatedButtonContent-sc-1fkx0t6-0  gYMLpr"><div data-blade-component="base-box" class="BaseBox-bksIuc BaseButton__ButtonContent-zf1huq-0 jbTreI cdAugm"><div data-blade-component="base-box" class="BaseBox-bksIuc juovFm"><svg aria-hidden="true" data-blade-component="icon" height="24px" viewBox="0 0 24 24" width="24px" fill="none" class="Svgweb__StyledSvg-vcmjs8-0"><path d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z" fill="hsla(0, 0%, 100%, 1)" data-blade-component="svg-path"></path></svg></div><div class="StyledBaseText-foUshD ctKyJS" data-blade-component="base-text">Create payment</div></div></div></button></div></div>"`;
+
+exports[`<FloatingActionButton /> should render FloatingActionButton ssr 2`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  width: auto;
+  cursor: pointer;
+  background-color: hsla(218,89%,51%,1);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,89%,51%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: radial-gradient(72px 72px at var(--mouse-x,0%) var(--mouse-y,0%),hsla(0,0%,100%,0.18) 0%,transparent 100%);
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(218,87%,43%,1);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  margin-right: 4px;
+  margin-left: 4px;
+}
+
+.c4.c4.c4.c4.c4 {
+  opacity: 1;
+}
+
+<div
+  id="root"
+>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      class="c1"
+      data-blade-component="button"
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3 c4"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c5"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 100%, 1)"
+              />
+            </svg>
+          </div>
+          <div
+            class="c6"
+            data-blade-component="base-text"
+          >
+            Create payment
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.web.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.web.test.tsx.snap
@@ -1,0 +1,992 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FloatingActionButton /> should render as an icon-only button when children is omitted 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  height: 48px;
+  width: 48px;
+  cursor: pointer;
+  background-color: hsla(218,89%,51%,1);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,89%,51%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: radial-gradient(72px 72px at var(--mouse-x,0%) var(--mouse-y,0%),hsla(0,0%,100%,0.18) 0%,transparent 100%);
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(218,87%,43%,1);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c4.c4.c4.c4.c4 {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      aria-label="Create payment"
+      class="c1"
+      data-blade-component="button"
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3 c4"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c5"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 100%, 1)"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<FloatingActionButton /> should render black color 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  width: auto;
+  cursor: pointer;
+  background-color: hsla(0,0%,0%,1);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: radial-gradient(72px 72px at var(--mouse-x,0%) var(--mouse-y,0%),hsla(0,0%,100%,0.18) 0%,transparent 100%);
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(0,0%,0%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(0,0%,0%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(0,0%,0%,1);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  margin-right: 4px;
+  margin-left: 4px;
+}
+
+.c4.c4.c4.c4.c4 {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      class="c1"
+      data-blade-component="button"
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3 c4"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c5"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 100%, 1)"
+              />
+            </svg>
+          </div>
+          <div
+            class="c6"
+            data-blade-component="base-text"
+          >
+            Create payment
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<FloatingActionButton /> should render primary color 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  width: auto;
+  cursor: pointer;
+  background-color: hsla(218,89%,51%,1);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,89%,51%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: radial-gradient(72px 72px at var(--mouse-x,0%) var(--mouse-y,0%),hsla(0,0%,100%,0.18) 0%,transparent 100%);
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(218,87%,43%,1);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  margin-right: 4px;
+  margin-left: 4px;
+}
+
+.c4.c4.c4.c4.c4 {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      class="c1"
+      data-blade-component="button"
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3 c4"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c5"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 100%, 1)"
+              />
+            </svg>
+          </div>
+          <div
+            class="c6"
+            data-blade-component="base-text"
+          >
+            Create payment
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<FloatingActionButton /> should render white color 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  width: auto;
+  cursor: pointer;
+  background-color: hsla(0,0%,100%,1);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.18),inset 0 0px 0px 0.5px hsla(0,0%,100%,1);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: radial-gradient(72px 72px at var(--mouse-x,0%) var(--mouse-y,0%),hsla(0,0%,100%,0.18) 0%,transparent 100%);
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(0,0%,100%,0.8);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.18),inset 0 0px 0px 0.5px hsla(0,0%,100%,1);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(0,0%,100%,0.8);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.18),inset 0 0px 0px 0.5px hsla(0,0%,100%,1);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(0,0%,100%,0.8);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.18),inset 0 0px 0px 0.5px hsla(0,0%,100%,1);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,0%,0.72);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  margin-right: 4px;
+  margin-left: 4px;
+}
+
+.c4.c4.c4.c4.c4 {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      class="c1"
+      data-blade-component="button"
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3 c4"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c5"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 0%, 0.72)"
+              />
+            </svg>
+          </div>
+          <div
+            class="c6"
+            data-blade-component="base-text"
+          >
+            Create payment
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<FloatingActionButton /> should render with a label 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  width: auto;
+  cursor: pointer;
+  background-color: hsla(218,89%,51%,1);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,89%,51%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: radial-gradient(72px 72px at var(--mouse-x,0%) var(--mouse-y,0%),hsla(0,0%,100%,0.18) 0%,transparent 100%);
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(218,87%,43%,1);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(218,87%,43%,1);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(218,87%,43%,1),inset 0 0px 0px 0.5px hsla(218,87%,43%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  margin-right: 4px;
+  margin-left: 4px;
+}
+
+.c4.c4.c4.c4.c4 {
+  opacity: 1;
+}
+
+<div>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      class="c1"
+      data-blade-component="button"
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3 c4"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c5"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 100%, 1)"
+              />
+            </svg>
+          </div>
+          <div
+            class="c6"
+            data-blade-component="base-text"
+          >
+            Create payment
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;

--- a/packages/blade/src/components/FloatingActionButton/_decisions/decisions.md
+++ b/packages/blade/src/components/FloatingActionButton/_decisions/decisions.md
@@ -1,0 +1,153 @@
+# FloatingActionButton: Design Decisions
+
+A floating action button (FAB) is a persistent, elevated button that sits above the page content and exposes the single most important action on a screen. It is not a replacement for a regular `Button`.
+
+Design: [Blade DSL — FAB v1.0](https://www.figma.com/design/jubmQL9Z8V7881ayUD95ps/Blade-DSL?node-id=125809-2463)
+
+## Why it is built on top of `BaseButton`
+
+The Figma spec is, geometrically and tonally, `Button` at `size="large"` with two additions: a pill radius and an outer drop shadow. Every other value already exists in `buttonTokens.ts`:
+
+| Spec value                             | Existing token                              |
+| -------------------------------------- | ------------------------------------------- |
+| 48px height                            | `minHeight.large` (`size[48]`)               |
+| 16px horizontal padding                | `buttonPadding.large.left/right` (`spacing[5]`) |
+| 24px icon                              | `buttonIconOnlySizeToIconSizeMap.large`      |
+| 48x48 icon-only circle                 | `buttonIconOnlyHeightWidth.large`            |
+| `Body/LargeMedium` label               | `typography.fonts.size.large` (`200`)        |
+| Inner "3D" border/highlight shadows    | `boxShadow()` (`_components/Button/*` effect styles) |
+
+Reimplementing these in a standalone component would have duplicated the press animation, the loading state, the native SVG inset-shadow overlay, the link handling and the analytics wiring — and would have let the FAB drift away from `Button` whenever the shared token map changes. So `FloatingActionButton` renders `BaseButton` with `variant="primary"` and `size="large"` and adds only what the spec actually introduces.
+
+`BaseButton` gained three private props for this (it is an internal component, so this follows the existing `_isNestedDropdown` / `isInsideFullWidthButtonGroup` convention):
+
+- `_borderRadius` — overrides the size-derived radius so the FAB can use `border.radius.max`.
+- `_spinnerColor` — overrides the loading spinner colour, because the FAB's contrast requirements differ from `Button`'s (see below).
+- `color="black"` — a new value in the internal colour union, additive to the shared token maps.
+
+## Why `elevation` lives on a wrapper, not on the button
+
+In Figma the `elevation/midRaised` drop shadow sits on an outer `root` node, while the clipped, radius-`max` node is its child `wrapper`. The implementation mirrors this exactly, and it has to:
+
+- On web, `BaseButton` composes its inner shadows into a single `box-shadow` declaration that is rewritten on `:hover`, `:active` and `:focus-visible`. Appending a drop shadow there would mean re-appending it in all four places, and the focus ring already prepends its own layer.
+- On native, `BaseButton` sets `overflow: 'hidden'` and simulates inset shadows with an SVG overlay. A `shadowOffset` on that same view is clipped on Android and fights the overlay on iOS.
+
+So the container owns the drop shadow and the button owns its own inner shadows, with no interaction between the two.
+
+## Why placement is part of the component
+
+A FAB is defined by where it sits, so shipping only the pill would push identical `position: fixed` boilerplate — plus safe-area handling on native — into every consumer. `BottomNav` set the precedent for a viewport-anchored Blade component, and `FloatingActionButton` follows it: `position: fixed` on web, `position: 'absolute'` plus `useSafeAreaInsets()` on native, and a `zIndex` prop defaulting to a registered value in `componentZIndices`.
+
+`placement` is named to match `Popover`, `Menu` and `Tooltip` rather than `position`, which is already taken as a CSS styled prop on every Blade component. Its values (`bottom`, `bottom-start`, `bottom-end`) are spelled exactly as `Popover`'s, so the unsuffixed value is the centered one. Blade has no direction context today, so these resolve to physical `left`/`right`; the `start`/`end` naming is chosen so the API does not have to change if RTL support lands.
+
+`fab: 99` was chosen so the FAB sits above page content but *below* `bottomSheet`, `bottomNav` and `topnav` (all `100`) — a sheet or nav sliding over the FAB is the correct behaviour — and far below `modal` (`1000`) and `popover`/`tooltip` (`1100`).
+
+## API
+
+```jsx
+import { FloatingActionButton } from '@razorpay/blade/components';
+import { PlusIcon } from '@razorpay/blade/components';
+
+// with a label
+<FloatingActionButton icon={PlusIcon} onClick={createPayment}>
+  Create payment
+</FloatingActionButton>
+
+// icon-only, so accessibilityLabel is required by the type
+<FloatingActionButton icon={PlusIcon} accessibilityLabel="Create payment" onClick={createPayment} />
+```
+
+### Props
+
+```ts
+type FloatingActionButtonProps = {
+  /**
+   * Icon rendered inside the button. Required — a FAB always carries an icon.
+   */
+  icon: IconComponent;
+
+  /**
+   * Label of the button. When omitted, the FAB renders as a 48x48 circle.
+   */
+  children?: StringChildrenType;
+
+  /**
+   * Accessibility label. Required when `children` is omitted.
+   */
+  accessibilityLabel?: string;
+
+  /**
+   * @default 'primary'
+   */
+  color?: 'primary' | 'white' | 'black';
+
+  /**
+   * Corner of the viewport the button is anchored to.
+   *
+   * @default 'bottom-end'
+   */
+  placement?: 'bottom-end' | 'bottom-start' | 'bottom';
+
+  /**
+   * Distance from the anchored edges.
+   *
+   * @default 'spacing.5'
+   */
+  offset?: SpacingValueType;
+
+  /**
+   * @default componentZIndices.fab (99)
+   */
+  zIndex?: number;
+
+  isDisabled?: boolean;
+  isLoading?: boolean;
+
+  href?: string;
+  target?: string;
+  rel?: string;
+
+  /**
+   * @default 'button'
+   */
+  type?: 'button' | 'reset' | 'submit';
+
+  onClick?: Platform.Select<{
+    native: (event: GestureResponderEvent) => void;
+    web: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  }>;
+} & TestID &
+  StyledPropsBlade &
+  DataAnalyticsAttribute &
+  BladeCommonEvents;
+```
+
+### Decisions on individual props
+
+**`icon` is required.** Unlike `Button`, where the icon is optional and `children` carries the meaning, a FAB is an icon-first affordance — every variant in the spec has one. Making it required removes a meaningless state (a floating pill with only text) instead of documenting against it.
+
+**Icon-only is expressed by omitting `children`, not by a boolean.** `Button` already derives its icon-only geometry from the absence of text, and a `isIconOnly` flag would let callers write `isIconOnly` alongside `children` and get a contradiction the type system can't catch. The props are a discriminated union, so omitting `children` makes `accessibilityLabel` mandatory — an icon-only FAB is unusable with a screen reader otherwise. Pair it with a `Tooltip` for sighted users.
+
+**No `size` prop.** The spec has exactly one size. Adding a scale we cannot point at in the design would be speculative, and it is a backwards-compatible addition later if design defines one.
+
+**No `variant` prop.** All three colours in the spec are the `primary` emphasis; `secondary`/`tertiary` FABs do not exist. `color` alone therefore covers the full matrix.
+
+**`color` uses `black`, not `staticBlack`.** `Button` already exposes `white` (not `staticWhite`) for the equivalent token family, so `black` keeps the two components readable side by side. The value stays internal to `BaseButton` — it is deliberately *not* added to `Button`'s public colour union, since design has not specified a black `Button`.
+
+**`offset` is a single token rather than per-axis.** It covers the common case, and `StyledPropsBlade` is applied after the placement styles, so a caller needing asymmetric offsets (for example clearing a `BottomNav`) can pass `bottom="spacing.10"` directly without a second offset API.
+
+**Spinner colour is set explicitly per FAB colour.** `BaseButton`'s shared `spinnerColor` map would render a white spinner on the white FAB, which is invisible. The FAB passes `white` for `primary` and `black`, and `neutral` for `white`, matching the spec's loading state. This is scoped to the FAB rather than fixed in the shared map, which would change `Button`'s appearance.
+
+## Accessibility
+
+- Renders a real `button` (or `a` when `href` is set) through `BaseButton`, so it is keyboard reachable and exposes the native role.
+- `accessibilityLabel` is required by the type for icon-only FABs.
+- The loading state announces via `LiveAnnouncer`, inherited from `BaseButton`.
+- Because the FAB is fixed to the viewport, it is placed at the end of the DOM by the consumer's own layout; it is not portalled, so it keeps its position in the tab order relative to where it is mounted.
+
+## Out of scope for v1
+
+- **Speed dial / FAB menu** — a FAB that expands into multiple actions. Not in the spec.
+- **Collapse-to-icon on scroll** — the spec has labelled and icon-only as independent variants with no transition between them.
+- **Entry/exit animation.**
+- **Automatic `BottomNav` clearance** — consumers offset the FAB themselves, since whether the two coexist is a product decision.

--- a/packages/blade/src/components/FloatingActionButton/index.ts
+++ b/packages/blade/src/components/FloatingActionButton/index.ts
@@ -1,0 +1,2 @@
+export { FloatingActionButton } from './FloatingActionButton';
+export type { FloatingActionButtonProps, FloatingActionButtonPlacement } from './types';

--- a/packages/blade/src/components/FloatingActionButton/types.ts
+++ b/packages/blade/src/components/FloatingActionButton/types.ts
@@ -1,0 +1,136 @@
+import type React from 'react';
+import type { GestureResponderEvent } from 'react-native';
+import type { BaseButtonProps } from '~components/Button/BaseButton/BaseButton';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import type { IconComponent } from '~components/Icons';
+import type { BladeCommonEvents } from '~components/types';
+import type { Platform } from '~utils';
+import type { DataAnalyticsAttribute, StringChildrenType, TestID } from '~utils/types';
+import type { SpacingValueType } from '~components/Box/BaseBox/types';
+
+/**
+ * Values mirror `Popover`'s `placement`, where the unsuffixed value is centered
+ * and `start` / `end` name the inline edges.
+ */
+type FloatingActionButtonPlacement = 'bottom-end' | 'bottom-start' | 'bottom';
+
+type FloatingActionButtonCommonProps = {
+  /**
+   * Icon rendered inside the button.
+   *
+   * Accepts an icon component from blade.
+   */
+  icon: IconComponent;
+
+  /**
+   * Color of the button.
+   *
+   * @default 'primary'
+   */
+  color?: 'primary' | 'white' | 'black';
+
+  /**
+   * Corner of the viewport the button is anchored to.
+   *
+   * @default 'bottom-end'
+   */
+  placement?: FloatingActionButtonPlacement;
+
+  /**
+   * Distance between the button and the edges it is anchored to.
+   *
+   * @default 'spacing.5'
+   */
+  offset?: SpacingValueType;
+
+  /**
+   * zIndex of the button.
+   *
+   * Defaults to a value that sits above page content but below `BottomNav`,
+   * `BottomSheet` and `Modal`.
+   *
+   * @default 99
+   */
+  zIndex?: number;
+
+  /**
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Shows a spinner in place of the button's content.
+   *
+   * @default false
+   */
+  isLoading?: boolean;
+
+  /**
+   * Automatically renders the button with an `a` tag with `href` on web.
+   */
+  href?: BaseButtonProps['href'];
+
+  /**
+   * anchor target attribute
+   *
+   * Should only be used alongside `href`
+   */
+  target?: BaseButtonProps['target'];
+
+  /**
+   * anchor rel attribute
+   *
+   * Should only be used alongside `href`
+   */
+  rel?: BaseButtonProps['rel'];
+
+  /**
+   * @default 'button'
+   */
+  type?: 'button' | 'reset' | 'submit';
+
+  onClick?: Platform.Select<{
+    native: (event: GestureResponderEvent) => void;
+    web: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  }>;
+} & TestID &
+  StyledPropsBlade &
+  DataAnalyticsAttribute &
+  BladeCommonEvents;
+
+/*
+  With a label, `accessibilityLabel` is optional since the label already names
+  the action.
+*/
+type FloatingActionButtonWithLabelProps = FloatingActionButtonCommonProps & {
+  children: StringChildrenType;
+  accessibilityLabel?: string;
+};
+
+/*
+  Without a label the button is a bare icon, so it is unusable with a screen
+  reader unless `accessibilityLabel` names the action.
+*/
+type FloatingActionButtonIconOnlyProps = FloatingActionButtonCommonProps & {
+  children?: undefined;
+  accessibilityLabel: string;
+};
+
+type FloatingActionButtonProps =
+  | FloatingActionButtonWithLabelProps
+  | FloatingActionButtonIconOnlyProps;
+
+type FloatingActionButtonContainerProps = {
+  children: React.ReactNode;
+  placement: FloatingActionButtonPlacement;
+  offset: SpacingValueType;
+  zIndex: number;
+} & TestID &
+  StyledPropsBlade &
+  DataAnalyticsAttribute;
+
+export type {
+  FloatingActionButtonProps,
+  FloatingActionButtonPlacement,
+  FloatingActionButtonContainerProps,
+};

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -33,6 +33,7 @@ export * from './Elevate';
 export * from './EmptyState';
 export * from './Fade';
 export * from './FileUpload';
+export * from './FloatingActionButton';
 export * from './Icons';
 export * from './InfoGroup';
 export * from './Indicator';

--- a/packages/blade/src/utils/componentZIndices.ts
+++ b/packages/blade/src/utils/componentZIndices.ts
@@ -1,5 +1,6 @@
 // TODO: Move these properly to tokens at some point
 export const componentZIndices = {
+  fab: 99, // should be behind bottomNav and bottomSheet, which are allowed to cover it
   bottomSheet: 100,
   bottomNav: 100, // should be behind drawer since sidenav opens in drawer in mobile
   modal: 1000,

--- a/packages/blade/src/utils/metaAttribute/metaConstants.ts
+++ b/packages/blade/src/utils/metaAttribute/metaConstants.ts
@@ -58,6 +58,7 @@ export const MetaConstants = {
   FileUploadItem: 'file-upload-item',
   FileUploadLabel: 'file-upload-label',
   FilterChipGroup: 'filter-chip-group',
+  FloatingActionButton: 'floating-action-button',
   Icon: 'icon',
   IconButton: 'icon-button',
   InfoGroup: 'info-group',

--- a/packages/blade/src/utils/storybook/componentStatusData.ts
+++ b/packages/blade/src/utils/storybook/componentStatusData.ts
@@ -1371,6 +1371,21 @@ const componentData: ComponentStatusDataType = [
       },
     },
   },
+  {
+    name: 'FloatingActionButton',
+    description:
+      'FloatingActionButton is a persistent, elevated button anchored to the bottom of the viewport, used for the single most important action on a screen.',
+    platform: 'all',
+    frameworks: {
+      react: {
+        status: 'in-development',
+        storybookLink: 'Components/FloatingActionButton',
+      },
+      svelte: {
+        status: 'to-be-decided',
+      },
+    },
+  },
 ];
 
 export type { ComponentStatuses, ComponentStatusDataType, FrameworkStatus };


### PR DESCRIPTION
## Summary

Adds `FloatingActionButton`, a persistent pill-shaped button anchored to the bottom of the viewport for the single most important action on a screen. Built from the [Figma frame](https://www.figma.com/design/jubmQL9Z8V7881ayUD95ps/Blade-DSL?node-id=125809-2463).

- Renders either an icon with a short label or an icon on its own. The prop types are a discriminated union, so omitting `children` makes `accessibilityLabel` required rather than merely recommended.
- Anchors via `placement` (`bottom-end`, `bottom-start`, `bottom`) with configurable `offset` and `zIndex`. The values mirror `Popover`'s naming, where the unsuffixed value is centred and `start`/`end` name the inline edges — this future-proofs for RTL without implying Blade supports it today.
- Positioning is `fixed` on web and `absolute` with `useSafeAreaInsets()` on React Native, following `BottomNav`'s precedent. On native the outer strip uses `pointerEvents="box-none"` so it doesn't swallow touches meant for content behind it.
- Colors are `primary`, `white` and `black`. There is no `size` or `variant` prop — the button is always `large` with a `primary` emphasis, matching the design.
- Registered `fab: 99` in `componentZIndices`, which sits above page content but below `BottomNav`, `BottomSheet` and `Modal`.

### Why BaseButton grew three private props

The component delegates to `BaseButton` instead of restyling a `Button`, which keeps all the interaction, loading and link behaviour shared. That needed three internal overrides:

- `_borderRadius` — applies `border.radius.max` for the pill. `round` is excluded from its type because a percentage radius distorts on a non-square button.
- `_iconSize` — the design's icon is 24px (`xlarge`), larger than a `size="large"` Button's 16px.
- `_spinnerColor` — the shared spinner map would render a white spinner on the white button, where it is invisible.

A `black` color was also added to the button token maps. It exists only as a `primary` emphasis, matching the design, and is deliberately not exposed on `Button`; `BaseButton` throws in dev if it's paired with another variant. Its four inner shadows were verified directly against Figma's `_components/Button/Black/Primary/Default` effect style.

## Depends on #3903

That PR fixes the white primary button's border shadow, and `FloatingActionButton` reads the same `boxShadow().white.primary` entry, so it inherits the fix for free on both platforms — no shared abstraction is needed beyond `buttonTokens.ts`.

The two branches merge cleanly (#3903 edits two color strings inside `white.primary`; this branch adds a sibling `black` key ~25 lines below), **but the FAB snapshots here hard-code the pre-fix value** `hsla(0,0%,100%,1)`. Git won't flag that, so whichever PR lands second leaves master with a failing FAB test. **Please merge #3903 first**, after which this branch will be rebased and its snapshots regenerated.

## Test plan

- [x] `yarn test:react` — 151 passed across `Button`, `ButtonGroup`, `IconButton`, `BaseButton` and `FloatingActionButton`
- [x] `yarn test:react-native` — 124 passed across the same set
- [x] Both suites run with `--ci` so snapshots can't be silently rewritten, confirming the `BaseButton` changes are additive and move no existing snapshot
- [x] `yarn lint:blade` clean on all changed files
- [x] `yarn typecheck` reports nothing in the new source
- [x] Reviewed in Storybook against the Figma frame
- [ ] Re-verify the white variant after #3903 lands and snapshots are regenerated

### Known deviation

Figma's `elevation/midRaised` is a drop shadow at offset-y 12 / blur 16, but Blade's `elevation.midRaised` token renders offset-y 16 / blur 12 — the two values are transposed. I used the semantic token so the FAB stays consistent with every other elevated Blade surface. If that transposition is itself a token bug it deserves its own fix at the token layer rather than a local override here.

Made with Cursor

Made with [Cursor](https://cursor.com)