### PR TITLE
fix(blade-svelte): input focus ring transition flashes solid outline

### DIFF
--- a/.changeset/fix-svelte-input-focus-ring.md
+++ b/.changeset/fix-svelte-input-focus-ring.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-core": patch
+---
+
+fix(blade-svelte): prevent solid outline flash on input focus by transitioning only outline-width

--- a/packages/blade-core/src/styles/Input/baseInput.module.css
+++ b/packages/blade-core/src/styles/Input/baseInput.module.css
@@ -55,8 +55,12 @@
 
 .focus-ring-wrapper:focus-within {
   outline: 4px solid var(--surface-border-primary-muted);
-  outline-offset: 0px;
-  transition-property: outline;
+  outline-offset: 1px;
+  /* Transition only outline-width: transitioning the full `outline` shorthand
+   * also animates outline-color from the resting `currentcolor` (dark) to the
+   * muted ring color, which flashes a solid dark outline on focus before it
+   * settles. Animating width alone grows the ring in cleanly (mirrors React). */
+  transition-property: outline-width;
   transition-duration: var(--duration-xgentle);
   transition-timing-function: var(--easing-emphasized);
 }


### PR DESCRIPTION
## Summary
- Fixed text input focus ring animation in `blade-svelte`: on focus, a solid dark outline flashed in first, then the muted focus ring transitioned in.
- Root cause: `.focus-ring-wrapper:focus-within` used `transition-property: outline` (the shorthand). This animates `outline-color` from the resting `currentcolor` (dark) to the muted ring color, while `outline-style` flips to `solid` instantly — producing a solid dark outline flash before the color settled.
- Fix mirrors the React reference (`getFocusRingStyles.web.ts`): transition only `outline-width` so color/style apply instantly and only the width grows in. Also aligned `outline-offset` to `1px` for parity.

## Test plan
- [ ] Focus a TextInput in Storybook — focus ring grows in cleanly with no solid dark outline flash
- [ ] Verify blur transition still behaves correctly
- [ ] Verify error/disabled states unaffected
- [ ] Cross-check against React blade TextInput focus behavior for parity

Made with [Cursor](https://cursor.com)