### PR TITLE
feat(blade-svelte): Modal component

### DIFF
--- a/packages/blade-core/src/styles/Modal/index.ts
+++ b/packages/blade-core/src/styles/Modal/index.ts
@@ -1,0 +1,22 @@
+export {
+  MODAL_Z_INDEX,
+  getModalSurfaceClasses,
+  getModalBodyClasses,
+  getModalTemplateClasses,
+  modalWrapperClass,
+  modalBackdropClass,
+  modalHeaderClass,
+  modalEmptyHeaderCapsuleClass,
+  modalHeaderContentClass,
+  modalHeaderLeadingClass,
+  modalHeaderTitleBlockClass,
+  modalHeaderTitleRowClass,
+  modalHeaderTrailingClass,
+  modalCloseButtonClass,
+  modalHeaderCloseButtonClass,
+  modalHeaderDividerClass,
+  modalFooterClass,
+  modalFooterDividerClass,
+  modalFooterInnerClass,
+} from './modal';
+export type { ModalSize, ModalBodyPadding } from './modal';

--- a/packages/blade-core/src/styles/Modal/modal.module.css
+++ b/packages/blade-core/src/styles/Modal/modal.module.css
@@ -1,0 +1,242 @@
+/* Modal — surface, backdrop, header, body, footer.
+ *
+ * Mirrors the React Modal styles in blade/src/components/Modal/. The surface
+ * centers in the viewport for non-`full` sizes (top/left 50% + translate) and
+ * switches to a fixed 8px inset for `size="full"`. Enter/exit is driven by the
+ * `data-state="open|closed"` attribute set from the Svelte component:
+ *   opacity + scale transform on the surface, opacity on the backdrop.
+ *
+ * The wrapper receives the z-index via an inline `--modal-z-index` CSS var. */
+
+/* ===== WRAPPER ===== */
+.wrapper {
+  position: fixed;
+  z-index: var(--modal-z-index, 1000);
+}
+
+/* ===== BACKDROP ===== */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: var(--overlay-background-subtle);
+  opacity: 0;
+  pointer-events: none;
+
+  transition-property: opacity;
+  transition-duration: var(--duration-moderate);
+  transition-timing-function: var(--easing-exit);
+}
+
+.backdrop[data-state='open'] {
+  opacity: 1;
+  pointer-events: all;
+  transition-timing-function: var(--easing-entrance);
+}
+
+/* ===== SURFACE ===== */
+.surface {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 320px;
+  border-radius: var(--border-radius-large);
+  box-shadow: var(--elevation-high-raised);
+  background-color: var(--popup-background-gray-subtle);
+
+  opacity: 0;
+
+  will-change: transform, opacity;
+  transition-property: opacity, transform;
+  transition-duration: var(--duration-moderate);
+  transition-timing-function: var(--easing-exit);
+}
+
+/* Non-full sizes center in the viewport and animate a scale-in. */
+.surface:not(.sizeFull) {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  max-height: 80vh;
+  width: calc(100vw - 48px);
+}
+
+.surface:not(.sizeFull)[data-state='open'] {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+  transition-timing-function: var(--easing-entrance);
+}
+
+.sizeSmall {
+  max-width: 400px;
+}
+
+.sizeMedium {
+  max-width: 760px;
+}
+
+.sizeLarge {
+  max-width: 1024px;
+}
+
+/* `full` pins to a fixed 8px inset with no transform (only opacity animates). */
+.sizeFull {
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  width: calc(100vw - 16px);
+  max-width: 100%;
+  max-height: 100vh;
+  transform: none;
+}
+
+.sizeFull[data-state='open'] {
+  opacity: 1;
+  transition-timing-function: var(--easing-entrance);
+}
+
+/* ===== HEADER ===== */
+.header {
+  flex-shrink: 0;
+}
+
+/* Empty header renders only a floating close-button capsule anchored top-right. */
+.emptyHeaderCapsule {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: var(--spacing-5);
+  right: var(--spacing-5);
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  background-color: var(--popup-background-gray-subtle);
+  border-radius: var(--border-radius-max);
+  z-index: 1;
+}
+
+.headerContent {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: var(--spacing-5);
+  gap: var(--spacing-3);
+}
+
+.headerLeading {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+}
+
+.headerTitleBlock {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.headerTitleRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.headerTrailing {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: var(--border-radius-max);
+  color: var(--interactive-icon-gray-muted);
+  flex-shrink: 0;
+  transition-property: color;
+  transition-duration: var(--duration-xquick);
+  transition-timing-function: var(--easing-standard);
+}
+
+.closeButton:hover:not([disabled]),
+.closeButton:active {
+  color: var(--interactive-icon-gray-subtle);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--interactive-border-primary-default, hsla(218, 89%, 51%, 1));
+  outline-offset: 2px;
+  color: var(--interactive-icon-gray-subtle);
+}
+
+.headerCloseButton {
+  margin-left: var(--spacing-3);
+}
+
+.headerDivider {
+  border-bottom-width: var(--border-width-thin);
+  border-bottom-style: solid;
+  border-bottom-color: var(--surface-border-gray-muted);
+  width: 100%;
+}
+
+/* ===== BODY ===== */
+.body {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.bodyPaddingDefault {
+  padding: var(--spacing-6);
+}
+
+.bodyPaddingZero {
+  padding: var(--spacing-0);
+}
+
+.bodyHasHeight {
+  height: var(--modal-body-height);
+}
+
+/* ===== FOOTER ===== */
+.footer {
+  flex-shrink: 0;
+  width: 100%;
+  margin-top: auto;
+}
+
+.footerDivider {
+  border-top-width: var(--border-width-thin);
+  border-top-style: solid;
+  border-top-color: var(--surface-border-gray-muted);
+  width: 100%;
+}
+
+.footerInner {
+  padding: var(--spacing-5);
+}
+
+@media (min-width: 768px) {
+  .headerContent {
+    padding: var(--spacing-6);
+  }
+
+  .footerInner {
+    padding: var(--spacing-6);
+  }
+}

--- a/packages/blade-core/src/styles/Modal/modal.ts
+++ b/packages/blade-core/src/styles/Modal/modal.ts
@@ -1,0 +1,98 @@
+import { cva } from 'class-variance-authority';
+// @ts-expect-error - CSS modules may not have type definitions in build
+import styles from './modal.module.css';
+
+/**
+ * Default z-index for the Modal. Mirrors React's `componentZIndices.modal`.
+ * Exposed alongside the CVA like `BOTTOM_SHEET_Z_INDEX`.
+ */
+export const MODAL_Z_INDEX = 1000;
+
+export type ModalSize = 'small' | 'medium' | 'large' | 'full';
+export type ModalBodyPadding = 'spacing.0' | 'spacing.6';
+
+/**
+ * CVA wrapper for the Modal surface. `size` selects the max-width (and, for
+ * `full`, switches from the centered model to a fixed inset). The open/closed
+ * animation is handled in CSS via the `data-state` attribute.
+ */
+export const getModalSurfaceClasses = cva(styles.surface, {
+  variants: {
+    size: {
+      small: styles.sizeSmall,
+      medium: styles.sizeMedium,
+      large: styles.sizeLarge,
+      full: styles.sizeFull,
+    },
+  },
+  defaultVariants: {
+    size: 'small',
+  },
+});
+
+/**
+ * CVA wrapper for the Modal body. `padding` toggles between the default
+ * `spacing.6` and `spacing.0`; `hasHeight` applies an explicit height fed via
+ * the `--modal-body-height` CSS variable.
+ */
+export const getModalBodyClasses = cva(styles.body, {
+  variants: {
+    padding: {
+      'spacing.0': styles.bodyPaddingZero,
+      'spacing.6': styles.bodyPaddingDefault,
+    },
+    hasHeight: {
+      true: styles.bodyHasHeight,
+      false: null,
+    },
+  },
+  defaultVariants: {
+    padding: 'spacing.6',
+    hasHeight: false,
+  },
+});
+
+/* Structural class names — exported individually so Svelte templates can
+ * reference them and the bundler keeps them. Calling
+ * `getModalTemplateClasses()` from the component anchors them against
+ * tree-shaking (CSS modules export ESM objects whose unused members are
+ * otherwise dropped). */
+export const modalWrapperClass = styles.wrapper;
+export const modalBackdropClass = styles.backdrop;
+export const modalHeaderClass = styles.header;
+export const modalEmptyHeaderCapsuleClass = styles.emptyHeaderCapsule;
+export const modalHeaderContentClass = styles.headerContent;
+export const modalHeaderLeadingClass = styles.headerLeading;
+export const modalHeaderTitleBlockClass = styles.headerTitleBlock;
+export const modalHeaderTitleRowClass = styles.headerTitleRow;
+export const modalHeaderTrailingClass = styles.headerTrailing;
+export const modalCloseButtonClass = styles.closeButton;
+export const modalHeaderCloseButtonClass = styles.headerCloseButton;
+export const modalHeaderDividerClass = styles.headerDivider;
+export const modalFooterClass = styles.footer;
+export const modalFooterDividerClass = styles.footerDivider;
+export const modalFooterInnerClass = styles.footerInner;
+
+/**
+ * Aggregated class lookup. The Svelte component calls this to keep the CSS
+ * imports alive against the bundler's tree-shaker.
+ */
+export function getModalTemplateClasses(): Record<string, string> {
+  return {
+    wrapper: modalWrapperClass,
+    backdrop: modalBackdropClass,
+    header: modalHeaderClass,
+    emptyHeaderCapsule: modalEmptyHeaderCapsuleClass,
+    headerContent: modalHeaderContentClass,
+    headerLeading: modalHeaderLeadingClass,
+    headerTitleBlock: modalHeaderTitleBlockClass,
+    headerTitleRow: modalHeaderTitleRowClass,
+    headerTrailing: modalHeaderTrailingClass,
+    closeButton: modalCloseButtonClass,
+    headerCloseButton: modalHeaderCloseButtonClass,
+    headerDivider: modalHeaderDividerClass,
+    footer: modalFooterClass,
+    footerDivider: modalFooterDividerClass,
+    footerInner: modalFooterInnerClass,
+  } as const;
+}

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -484,6 +484,28 @@ export {
   bottomSheetBodyClass,
 } from './BottomSheet';
 export type { BottomSheetBodyPadding, BottomSheetBodyOverflow } from './BottomSheet';
+export {
+  MODAL_Z_INDEX,
+  getModalSurfaceClasses,
+  getModalBodyClasses,
+  getModalTemplateClasses,
+  modalWrapperClass,
+  modalBackdropClass,
+  modalHeaderClass,
+  modalEmptyHeaderCapsuleClass,
+  modalHeaderContentClass,
+  modalHeaderLeadingClass,
+  modalHeaderTitleBlockClass,
+  modalHeaderTitleRowClass,
+  modalHeaderTrailingClass,
+  modalCloseButtonClass,
+  modalHeaderCloseButtonClass,
+  modalHeaderDividerClass,
+  modalFooterClass,
+  modalFooterDividerClass,
+  modalFooterInnerClass,
+} from './Modal';
+export type { ModalSize, ModalBodyPadding } from './Modal';
 export { getTabsTemplateClasses } from './Tabs';
 export { getSegmentedControlTemplateClasses } from './SegmentedControl';
 export {

--- a/packages/blade-svelte/src/components/Modal/Modal.stories.svelte
+++ b/packages/blade-svelte/src/components/Modal/Modal.stories.svelte
@@ -1,0 +1,204 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Modal from './Modal.svelte';
+  import type { ModalProps } from './types';
+
+  /* Storybook title MUST match the React export verbatim:
+   *   blade/src/components/Modal/docs/SimpleModal.stories.tsx → 'Components/Modal/SimpleModal'. */
+  const { Story } = defineMeta({
+    title: 'Components/Modal/SimpleModal',
+    component: Modal,
+    tags: ['autodocs'],
+    args: {
+      size: 'medium',
+      isDismissible: true,
+    },
+    argTypes: {
+      isOpen: { table: { disable: true } },
+      children: { table: { disable: true } },
+      onDismiss: { table: { disable: true } },
+      initialFocusRef: { table: { disable: true } },
+      isDismissible: { control: 'boolean' },
+      zIndex: { control: 'number' },
+      size: {
+        control: 'select',
+        options: ['small', 'medium', 'large', 'full'],
+      },
+    },
+  } as Parameters<typeof defineMeta>[0] & { argTypes: Record<string, unknown> });
+</script>
+
+<script lang="ts">
+  import ModalHeader from './ModalHeader.svelte';
+  import ModalBody from './ModalBody.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import Button from '../Button/Button.svelte';
+  import Text from '../Typography/Text/Text.svelte';
+  import Alert from '../Alert/Alert.svelte';
+  import RadioGroup from '../Radio/RadioGroup.svelte';
+  import Radio from '../Radio/Radio.svelte';
+  import Skeleton from '../Skeleton/Skeleton.svelte';
+
+  let isPlaygroundOpen = $state(false);
+  let isSimpleOpen = $state(false);
+  let isNonDismissibleOpen = $state(false);
+  let isFullPageOpen = $state(false);
+  let isImageLoading = $state(true);
+</script>
+
+<!-- Playground — controls drive size + isDismissible. -->
+<Story name="Playground">
+  {#snippet template(args: ModalProps)}
+    <div>
+      <Button onClick={() => (isPlaygroundOpen = true)}>Open Modal</Button>
+      <Modal
+        {...args}
+        isOpen={isPlaygroundOpen}
+        onDismiss={() => (isPlaygroundOpen = false)}
+      >
+        {#snippet children()}
+          <ModalHeader
+            title="Address Details"
+            subtitle="Use the controls to tweak size and isDismissible"
+          />
+          <ModalBody>
+            {#snippet children()}
+              <Text>Modal body content goes here.</Text>
+            {/snippet}
+          </ModalBody>
+          <ModalFooter>
+            {#snippet children()}
+              <div style="display: flex; gap: var(--spacing-3); justify-content: flex-end; width: 100%;">
+                <Button variant="secondary" onClick={() => (isPlaygroundOpen = false)}>Cancel</Button>
+                <Button onClick={() => (isPlaygroundOpen = false)}>Confirm</Button>
+              </div>
+            {/snippet}
+          </ModalFooter>
+        {/snippet}
+      </Modal>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 1: Simple Modal. -->
+<Story name="Simple Modal">
+  {#snippet template(args: ModalProps)}
+    <div>
+      <Button onClick={() => (isSimpleOpen = true)}>Open Modal</Button>
+      <Modal
+        isOpen={isSimpleOpen}
+        onDismiss={() => (isSimpleOpen = false)}
+        size={args.size}
+      >
+        {#snippet children()}
+          <ModalHeader
+            title="Address Details"
+            subtitle="This example is created for Modal snapshot testing"
+          />
+          <ModalBody>
+            {#snippet children()}
+              <RadioGroup label="Addresses">
+                <Radio value="home">Home - 11850 Florida 24, Cedar Key, Florida</Radio>
+                <Radio value="office-1">Office - 2033 Florida 21, Cedar Key, Florida</Radio>
+                <Radio value="office-2">Work - 5938 New York, Main Street</Radio>
+              </RadioGroup>
+            {/snippet}
+          </ModalBody>
+          <ModalFooter>
+            {#snippet children()}
+              <div style="display: flex; gap: var(--spacing-3); justify-content: flex-end; width: 100%;">
+                <Button variant="secondary">Remove address</Button>
+                <Button>Add address</Button>
+              </div>
+            {/snippet}
+          </ModalFooter>
+        {/snippet}
+      </Modal>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 2: Non-Dismissible Modal. -->
+<Story name="Non-Dismissible Modal">
+  {#snippet template(args: ModalProps)}
+    <div>
+      <Button onClick={() => (isNonDismissibleOpen = true)}>Open Non-Dismissible Modal</Button>
+      <Modal isOpen={isNonDismissibleOpen} isDismissible={false} size={args.size}>
+        {#snippet children()}
+          <ModalHeader
+            title="Important Action Required"
+            subtitle="This modal requires explicit confirmation"
+          />
+          <ModalBody>
+            {#snippet children()}
+              <Alert
+                title="Notice"
+                description="This modal cannot be dismissed by clicking outside or pressing escape key."
+                color="notice"
+                isDismissible={false}
+                isFullWidth
+              />
+              <Text marginTop="spacing.4" color="surface.text.gray.subtle">
+                Try clicking outside the modal or pressing the escape key - it won't close. You must
+                click one of the buttons below to proceed.
+              </Text>
+            {/snippet}
+          </ModalBody>
+          <ModalFooter>
+            {#snippet children()}
+              <div style="display: flex; gap: var(--spacing-3); justify-content: flex-end; width: 100%;">
+                <Button variant="secondary" onClick={() => (isNonDismissibleOpen = false)}>Cancel</Button>
+                <Button onClick={() => (isNonDismissibleOpen = false)}>Confirm Action</Button>
+              </div>
+            {/snippet}
+          </ModalFooter>
+        {/snippet}
+      </Modal>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 3: Full Page Modal. -->
+<Story name="Full Page Modal" args={{ size: 'full' }}>
+  {#snippet template()}
+    <div>
+      <Button onClick={() => (isFullPageOpen = true)}>Open Modal</Button>
+      <Modal isOpen={isFullPageOpen} onDismiss={() => (isFullPageOpen = false)} size="full">
+        {#snippet children()}
+          <ModalHeader
+            title="Full Page Modal"
+            subtitle="This example is created for Full Page Modal"
+          />
+          <ModalBody height="100%" padding="spacing.0">
+            {#snippet children()}
+              <div style="position: relative; width: 100%; height: 100%;">
+                {#if isImageLoading}
+                  <div
+                    style="position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--surface-background-gray-intense);"
+                  >
+                    <Skeleton height="100%" width="100%" />
+                  </div>
+                {/if}
+                <img
+                  width="100%"
+                  height="100%"
+                  src="https://picsum.photos/1920/1080"
+                  alt="random"
+                  onload={() => (isImageLoading = false)}
+                  style={`display: ${isImageLoading ? 'none' : 'block'}`}
+                />
+              </div>
+            {/snippet}
+          </ModalBody>
+          <ModalFooter>
+            {#snippet children()}
+              <div style="display: flex; gap: var(--spacing-3); justify-content: flex-end; width: 100%;">
+                <Button isDisabled={isImageLoading}>Download</Button>
+              </div>
+            {/snippet}
+          </ModalFooter>
+        {/snippet}
+      </Modal>
+    </div>
+  {/snippet}
+</Story>

--- a/packages/blade-svelte/src/components/Modal/Modal.svelte
+++ b/packages/blade-svelte/src/components/Modal/Modal.svelte
@@ -10,6 +10,7 @@
     makeAccessible,
     makeAnalyticsAttribute,
     getStyledPropsClasses,
+    logger,
   } from '@razorpay/blade-core/utils';
   import {
     MODAL_Z_INDEX,
@@ -100,6 +101,9 @@
     }
 
     isVisible = false;
+    /* Return focus whenever isOpen flips to false, even when driven by the
+     * parent directly (not just via close()/onDismiss). */
+    returnFocus();
     if (isMounted) {
       unmountTimeoutId = setTimeout(() => {
         unmountTimeoutId = null;
@@ -132,6 +136,49 @@
         clearAllBodyScrollLocks();
       }
     };
+  });
+
+  let portalWrapperEl = $state<HTMLElement | null>(null);
+
+  /* Make background content inert (or aria-hidden as a fallback) while
+   * mounted, so background elements are not focusable/clickable and are
+   * hidden from assistive tech. Restored on unmount. */
+  $effect(() => {
+    if (!isMounted || typeof document === 'undefined' || !portalWrapperEl) return undefined;
+
+    const supportsInert = 'inert' in HTMLElement.prototype;
+    const siblings = Array.from(document.body.children).filter(
+      (el) => el !== portalWrapperEl,
+    ) as HTMLElement[];
+
+    siblings.forEach((el) => {
+      if (supportsInert) {
+        (el as HTMLElement & { inert: boolean }).inert = true;
+      } else {
+        el.setAttribute('aria-hidden', 'true');
+      }
+    });
+
+    return () => {
+      siblings.forEach((el) => {
+        if (supportsInert) {
+          (el as HTMLElement & { inert: boolean }).inert = false;
+        } else {
+          el.removeAttribute('aria-hidden');
+        }
+      });
+    };
+  });
+
+  /* APG requires dialogs to have an accessible name. */
+  $effect(() => {
+    if (isMounted && !accessibilityLabel) {
+      logger({
+        message: 'accessibilityLabel is required for Modal to be accessible.',
+        type: 'warn',
+        moduleName: 'Modal',
+      });
+    }
   });
 
   const FOCUSABLE_SELECTOR = [
@@ -217,7 +264,7 @@
 </script>
 
 {#if isMounted}
-  <div use:portal={document.body}>
+  <div bind:this={portalWrapperEl} use:portal={document.body}>
     <div class={modalWrapperClass} style={wrapperStyle} data-blade-component="modal-wrapper">
       <ModalBackdrop />
       <div

--- a/packages/blade-svelte/src/components/Modal/Modal.svelte
+++ b/packages/blade-svelte/src/components/Modal/Modal.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import {
+    disableBodyScroll,
+    enableBodyScroll,
+    clearAllBodyScrollLocks,
+  } from 'body-scroll-lock-upgrade';
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAccessible,
+    makeAnalyticsAttribute,
+    getStyledPropsClasses,
+  } from '@razorpay/blade-core/utils';
+  import {
+    MODAL_Z_INDEX,
+    getModalSurfaceClasses,
+    getModalTemplateClasses,
+    modalWrapperClass,
+  } from '@razorpay/blade-core/styles';
+  import { portal } from '../../utils/portal';
+  import ModalBackdrop from './ModalBackdrop.svelte';
+  import { setModalContext } from './modalContext';
+  import type { ModalContextValue } from './modalContext';
+  import type { ModalProps } from './types';
+
+  /* Anchor structural classes against the bundler's tree-shaker — CSS modules
+   * export ESM objects whose unused individual exports otherwise get dropped. */
+  void getModalTemplateClasses();
+
+  let {
+    isOpen = false,
+    children,
+    onDismiss,
+    isDismissible = true,
+    initialFocusRef = null,
+    size = 'small',
+    accessibilityLabel,
+    zIndex = MODAL_Z_INDEX,
+    testID,
+    ...rest
+  }: ModalProps = $props();
+
+  let surfaceEl = $state<HTMLElement | null>(null);
+  let defaultFocusEl = $state<HTMLElement | null>(null);
+  let originalFocusEl: HTMLElement | null = null;
+
+  /* Presence — DOM stays mounted past `isOpen=false` until the exit transition
+   * completes. Mirrors BottomSheet's pattern. */
+  let isMounted = $state(false);
+  let isVisible = $state(false);
+  let unmountTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  /* Allow ~320ms (--duration-moderate 280ms + buffer) for the exit transition
+   * before unmounting. */
+  const UNMOUNT_FALLBACK_MS = 320;
+
+  function returnFocus(): void {
+    if (!originalFocusEl) return;
+    try {
+      originalFocusEl.focus({ preventScroll: true });
+    } catch {
+      /* ignore — element may have been unmounted. */
+    }
+    originalFocusEl = null;
+  }
+
+  function focusOnInitialRef(): void {
+    const target = initialFocusRef ?? defaultFocusEl ?? surfaceEl;
+    if (!target) return;
+    try {
+      target.focus({ preventScroll: true });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function close(): void {
+    if (isDismissible) {
+      onDismiss?.();
+    }
+    returnFocus();
+  }
+
+  /* Sync controlled open state to internal presence/animation. */
+  $effect(() => {
+    if (unmountTimeoutId !== null) {
+      clearTimeout(unmountTimeoutId);
+      unmountTimeoutId = null;
+    }
+    if (isOpen) {
+      isMounted = true;
+      if (typeof document !== 'undefined') {
+        originalFocusEl = originalFocusEl ?? (document.activeElement as HTMLElement | null);
+      }
+      const rafId = requestAnimationFrame(() => {
+        isVisible = true;
+        /* Defer focus to after the close button has mounted. */
+        requestAnimationFrame(focusOnInitialRef);
+      });
+      return () => cancelAnimationFrame(rafId);
+    }
+
+    isVisible = false;
+    if (isMounted) {
+      unmountTimeoutId = setTimeout(() => {
+        unmountTimeoutId = null;
+        if (!isOpen) {
+          isMounted = false;
+        }
+      }, UNMOUNT_FALLBACK_MS);
+    }
+    return () => {
+      if (unmountTimeoutId !== null) {
+        clearTimeout(unmountTimeoutId);
+        unmountTimeoutId = null;
+      }
+    };
+  });
+
+  /* Body scroll lock while mounted. `body-scroll-lock-upgrade` gives us
+   * `reserveScrollBarGap: true` (no layout shift) — descendants of the target
+   * (the ModalBody) still scroll. */
+  $effect(() => {
+    if (!surfaceEl) return undefined;
+    const target = surfaceEl;
+    disableBodyScroll(target, { reserveScrollBarGap: true });
+    return () => enableBodyScroll(target);
+  });
+
+  $effect(() => {
+    return () => {
+      if (typeof document !== 'undefined') {
+        clearAllBodyScrollLocks();
+      }
+    };
+  });
+
+  const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ');
+
+  /* Escape dismisses (when dismissible); Tab is trapped within the surface. */
+  $effect(() => {
+    if (!isMounted) return undefined;
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === 'Escape') {
+        if (isDismissible) close();
+        return;
+      }
+      if (event.key !== 'Tab' || !surfaceEl) return;
+
+      const focusables = Array.from(
+        surfaceEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+
+      if (focusables.length === 0) {
+        event.preventDefault();
+        surfaceEl.focus({ preventScroll: true });
+        return;
+      }
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (active === first || !surfaceEl.contains(active)) {
+          event.preventDefault();
+          last.focus({ preventScroll: true });
+        }
+      } else if (active === last || !surfaceEl.contains(active)) {
+        event.preventDefault();
+        first.focus({ preventScroll: true });
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  });
+
+  /* Provide context to descendants. The getter returns the live state object so
+   * updates propagate automatically. */
+  const contextValue: ModalContextValue = {
+    isInsideModal: true,
+    get isOpen() {
+      return isVisible;
+    },
+    close,
+    get isDismissible() {
+      return isDismissible;
+    },
+    setDefaultFocusElement: (el: HTMLElement | null) => {
+      defaultFocusEl = el;
+    },
+  };
+  setModalContext(() => contextValue);
+
+  const styledProps = $derived(getStyledPropsClasses(rest));
+  const surfaceExtraClasses = $derived((styledProps.classes || []).filter(Boolean).join(' '));
+  const surfaceClasses = $derived(
+    [getModalSurfaceClasses({ size }), surfaceExtraClasses].filter(Boolean).join(' '),
+  );
+
+  const surfaceMetaAttrs = metaAttribute({ name: MetaConstants.Modal, testID });
+  const surfaceA11yAttrs = makeAccessible({
+    role: 'dialog',
+    modal: true,
+    label: accessibilityLabel,
+  });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+
+  const surfaceState = $derived(isVisible ? 'open' : 'closed');
+  const wrapperStyle = $derived(`--modal-z-index:${zIndex}`);
+</script>
+
+{#if isMounted}
+  <div use:portal={document.body}>
+    <div class={modalWrapperClass} style={wrapperStyle} data-blade-component="modal-wrapper">
+      <ModalBackdrop />
+      <div
+        bind:this={surfaceEl}
+        class={surfaceClasses}
+        tabindex="-1"
+        data-state={surfaceState}
+        {...surfaceMetaAttrs}
+        {...surfaceA11yAttrs}
+        {...analyticsAttrs}
+      >
+        {@render children()}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/packages/blade-svelte/src/components/Modal/ModalBackdrop.svelte
+++ b/packages/blade-svelte/src/components/Modal/ModalBackdrop.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { metaAttribute, MetaConstants } from '@razorpay/blade-core/utils';
+  import { modalBackdropClass } from '@razorpay/blade-core/styles';
+  import { getModalContext } from './modalContext';
+
+  const ctx = getModalContext();
+
+  function handleClick(): void {
+    if (ctx?.isDismissible) {
+      ctx.close();
+    }
+  }
+
+  const metaAttrs = metaAttribute({
+    name: MetaConstants.ModalBackdrop,
+    testID: MetaConstants.ModalBackdrop,
+  });
+  const dataState = $derived(ctx?.isOpen ? 'open' : 'closed');
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class={modalBackdropClass}
+  data-state={dataState}
+  onclick={handleClick}
+  {...metaAttrs}
+></div>

--- a/packages/blade-svelte/src/components/Modal/ModalBody.svelte
+++ b/packages/blade-svelte/src/components/Modal/ModalBody.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAnalyticsAttribute,
+  } from '@razorpay/blade-core/utils';
+  import { getModalBodyClasses } from '@razorpay/blade-core/styles';
+  import type { ModalBodyProps } from './types';
+
+  let {
+    children,
+    padding = 'spacing.6',
+    height,
+    testID,
+    ...rest
+  }: ModalBodyProps = $props();
+
+  const bodyClasses = $derived(getModalBodyClasses({ padding, hasHeight: Boolean(height) }));
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.ModalBody, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+
+  /* Explicit height is fed through a CSS custom property consumed by the
+   * `bodyHasHeight` class — keeps the free-form length string out of a CVA
+   * variant while avoiding a bare inline style declaration. */
+  const bodyStyle = $derived(height ? `--modal-body-height:${height}` : undefined);
+</script>
+
+<div class={bodyClasses} style={bodyStyle} {...metaAttrs} {...analyticsAttrs}>
+  {@render children()}
+</div>

--- a/packages/blade-svelte/src/components/Modal/ModalFooter.svelte
+++ b/packages/blade-svelte/src/components/Modal/ModalFooter.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAnalyticsAttribute,
+  } from '@razorpay/blade-core/utils';
+  import {
+    modalFooterClass,
+    modalFooterDividerClass,
+    modalFooterInnerClass,
+  } from '@razorpay/blade-core/styles';
+  import type { ModalFooterProps } from './types';
+
+  let { children, testID, ...rest }: ModalFooterProps = $props();
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.ModalFooter, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<div class={modalFooterClass} {...metaAttrs} {...analyticsAttrs}>
+  <div class={modalFooterDividerClass} role="separator"></div>
+  <div class={modalFooterInnerClass}>
+    {@render children()}
+  </div>
+</div>

--- a/packages/blade-svelte/src/components/Modal/ModalHeader.svelte
+++ b/packages/blade-svelte/src/components/Modal/ModalHeader.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAccessible,
+    makeAnalyticsAttribute,
+  } from '@razorpay/blade-core/utils';
+  import {
+    modalHeaderClass,
+    modalEmptyHeaderCapsuleClass,
+    modalHeaderContentClass,
+    modalHeaderLeadingClass,
+    modalHeaderTitleBlockClass,
+    modalHeaderTitleRowClass,
+    modalHeaderTrailingClass,
+    modalCloseButtonClass,
+    modalHeaderCloseButtonClass,
+    modalHeaderDividerClass,
+  } from '@razorpay/blade-core/styles';
+  import { CloseIcon } from '../Icons/CloseIcon';
+  import Text from '../Typography/Text/Text.svelte';
+  import { getModalContext } from './modalContext';
+  import type { ModalHeaderProps } from './types';
+
+  let {
+    title,
+    subtitle,
+    leading,
+    trailing,
+    titleSuffix,
+    testID,
+    ...rest
+  }: ModalHeaderProps = $props();
+
+  const ctx = getModalContext();
+
+  let closeButtonEl = $state<HTMLButtonElement | null>(null);
+
+  const isHeaderEmpty = $derived(!(title || subtitle || leading || trailing));
+  const isDismissible = $derived(ctx?.isDismissible ?? true);
+
+  /* Register the close button as the default focus target when dismissible.
+   * The parent uses this when `initialFocusRef` is null. */
+  $effect(() => {
+    if (closeButtonEl && isDismissible) {
+      ctx?.setDefaultFocusElement(closeButtonEl);
+      return () => {
+        ctx?.setDefaultFocusElement(null);
+      };
+    }
+    return undefined;
+  });
+
+  function handleClose(): void {
+    ctx?.close();
+  }
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.ModalHeader, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+
+  const closeButtonClasses = $derived(
+    [modalCloseButtonClass, modalHeaderCloseButtonClass].join(' '),
+  );
+</script>
+
+<div class={modalHeaderClass} {...metaAttrs} {...analyticsAttrs}>
+  {#if isHeaderEmpty}
+    {#if isDismissible}
+      <div class={modalEmptyHeaderCapsuleClass}>
+        <button
+          bind:this={closeButtonEl}
+          type="button"
+          class={modalCloseButtonClass}
+          onclick={handleClose}
+          {...makeAccessible({ label: 'Close' })}
+        >
+          <CloseIcon size="large" color="currentColor" />
+        </button>
+      </div>
+    {/if}
+  {:else}
+    <div class={modalHeaderContentClass}>
+      {#if leading}
+        <div class={modalHeaderLeadingClass}>
+          {@render leading()}
+        </div>
+      {/if}
+
+      <div class={modalHeaderTitleBlockClass}>
+        {#if title}
+          <div class={modalHeaderTitleRowClass}>
+            <Text
+              size="large"
+              weight="semibold"
+              marginTop="1px"
+              color="surface.text.gray.normal"
+              wordBreak="break-word"
+            >
+              {title}
+            </Text>
+            {#if titleSuffix}
+              {@render titleSuffix()}
+            {/if}
+          </div>
+        {/if}
+        {#if subtitle}
+          <Text variant="body" size="small" weight="regular" color="surface.text.gray.muted">
+            {subtitle}
+          </Text>
+        {/if}
+      </div>
+
+      {#if trailing}
+        <div class={modalHeaderTrailingClass}>
+          {@render trailing()}
+        </div>
+      {/if}
+
+      {#if isDismissible}
+        <button
+          bind:this={closeButtonEl}
+          type="button"
+          class={closeButtonClasses}
+          onclick={handleClose}
+          {...makeAccessible({ label: 'Close' })}
+        >
+          <CloseIcon size="large" color="currentColor" />
+        </button>
+      {/if}
+    </div>
+
+    <div class={modalHeaderDividerClass} role="separator"></div>
+  {/if}
+</div>

--- a/packages/blade-svelte/src/components/Modal/__tests__/Modal.test.ts
+++ b/packages/blade-svelte/src/components/Modal/__tests__/Modal.test.ts
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import ModalFocusTestHarness from './ModalFocusTestHarness.svelte';
+
+/* Spy on the prototype so the focus call is captured regardless of when the
+ * target element mounts (the modal portals + defers focus across two rAFs). */
+function spyOnFocus(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(HTMLElement.prototype, 'focus');
+}
+
+/* Find the options arg of the focus() call made against a specific element. */
+function focusOptionsFor(spy: ReturnType<typeof vi.spyOn>, el: Element): FocusOptions | undefined {
+  const idx = spy.mock.contexts.indexOf(el);
+  if (idx === -1) return undefined;
+  return spy.mock.calls[idx][0] as FocusOptions | undefined;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.querySelectorAll('[data-testid="outside"]').forEach((el) => el.remove());
+});
+
+/* jsdom has no layout engine — offsetParent is always null. The component's
+ * focusable-elements filter treats offsetParent !== null as "visible", so
+ * stub it for elements the trap needs to consider on-screen. */
+function stubVisible(el: HTMLElement): void {
+  Object.defineProperty(el, 'offsetParent', { get: () => document.body, configurable: true });
+}
+
+describe('<Modal /> focus management', () => {
+  it('focuses the initial element with preventScroll on open', async () => {
+    const focusSpy = spyOnFocus();
+    render(ModalFocusTestHarness, { props: { isOpen: true } });
+
+    const focusTarget = await screen.findByTestId('focus-target');
+
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(focusTarget));
+    expect(focusOptionsFor(focusSpy, focusTarget)).toEqual({ preventScroll: true });
+  });
+
+  it('returns focus to the trigger with preventScroll on dismiss via Escape', async () => {
+    const onDismiss = vi.fn();
+    const { rerender } = render(ModalFocusTestHarness, {
+      props: { isOpen: false, onDismiss },
+    });
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+
+    const focusSpy = spyOnFocus();
+    await rerender({ isOpen: true, onDismiss });
+
+    const focusTarget = await screen.findByTestId('focus-target');
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(focusTarget));
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => expect(onDismiss).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(trigger));
+    expect(focusOptionsFor(focusSpy, trigger)).toEqual({ preventScroll: true });
+  });
+
+  it('returns focus to the trigger when isOpen is flipped to false directly (controlled)', async () => {
+    const { rerender } = render(ModalFocusTestHarness, { props: { isOpen: false } });
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.focus();
+
+    const focusSpy = spyOnFocus();
+    await rerender({ isOpen: true });
+
+    const focusTarget = await screen.findByTestId('focus-target');
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(focusTarget));
+
+    /* Parent closes the modal directly, without going through onDismiss. */
+    await rerender({ isOpen: false });
+
+    await waitFor(() => expect(focusSpy.mock.contexts).toContain(trigger));
+    expect(focusOptionsFor(focusSpy, trigger)).toEqual({ preventScroll: true });
+  });
+
+  it('does nothing on Escape when not dismissible', async () => {
+    const onDismiss = vi.fn();
+    render(ModalFocusTestHarness, {
+      props: { isOpen: true, isDismissible: false, onDismiss },
+    });
+
+    await screen.findByTestId('focus-target');
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('wraps Tab from the last focusable back to the first', async () => {
+    render(ModalFocusTestHarness, { props: { isOpen: true } });
+
+    const focusTarget = await screen.findByTestId('focus-target');
+    const second = screen.getByTestId('second-focusable');
+    stubVisible(focusTarget);
+    stubVisible(second);
+    await waitFor(() => expect(document.activeElement).toBe(focusTarget));
+
+    second.focus();
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    expect(document.activeElement).toBe(focusTarget);
+  });
+
+  it('wraps Shift+Tab from the first focusable back to the last', async () => {
+    render(ModalFocusTestHarness, { props: { isOpen: true } });
+
+    const focusTarget = await screen.findByTestId('focus-target');
+    const second = screen.getByTestId('second-focusable');
+    stubVisible(focusTarget);
+    stubVisible(second);
+    await waitFor(() => expect(document.activeElement).toBe(focusTarget));
+
+    await fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(second);
+  });
+
+  it('marks background elements inert (or aria-hidden) while open, and restores them on close', async () => {
+    const outside = document.createElement('button');
+    outside.setAttribute('data-testid', 'outside');
+    document.body.appendChild(outside);
+
+    const supportsInert = 'inert' in HTMLElement.prototype;
+
+    const { rerender } = render(ModalFocusTestHarness, { props: { isOpen: true } });
+    await screen.findByTestId('focus-target');
+
+    await waitFor(() => {
+      if (supportsInert) {
+        expect((outside as HTMLElement & { inert: boolean }).inert).toBe(true);
+      } else {
+        expect(outside.getAttribute('aria-hidden')).toBe('true');
+      }
+    });
+
+    await rerender({ isOpen: false });
+
+    await waitFor(() => {
+      if (supportsInert) {
+        expect((outside as HTMLElement & { inert: boolean }).inert).toBe(false);
+      } else {
+        expect(outside.hasAttribute('aria-hidden')).toBe(false);
+      }
+    });
+  });
+
+  it('warns when accessibilityLabel is missing while open', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    render(ModalFocusTestHarness, { props: { isOpen: true, accessibilityLabel: '' } });
+
+    await screen.findByTestId('focus-target');
+    await waitFor(() =>
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('accessibilityLabel is required for Modal'),
+      ),
+    );
+  });
+});

--- a/packages/blade-svelte/src/components/Modal/__tests__/ModalFocusTestHarness.svelte
+++ b/packages/blade-svelte/src/components/Modal/__tests__/ModalFocusTestHarness.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Modal from '../Modal.svelte';
+
+  let {
+    isOpen = false,
+    isDismissible = true,
+    accessibilityLabel = 'Test modal',
+    onDismiss,
+  }: {
+    isOpen?: boolean;
+    isDismissible?: boolean;
+    accessibilityLabel?: string | undefined;
+    onDismiss?: () => void;
+  } = $props();
+
+  /* Element the modal should focus on open. Lives inside the surface and is
+   * wired via `initialFocusRef` so the test can assert `focus({ preventScroll })`
+   * without depending on the internal close-button markup. */
+  let focusEl = $state<HTMLElement | null>(null);
+</script>
+
+<button type="button" data-testid="trigger">open</button>
+
+<Modal {isOpen} {isDismissible} {accessibilityLabel} {onDismiss} initialFocusRef={focusEl}>
+  {#snippet children()}
+    <button type="button" bind:this={focusEl} data-testid="focus-target">focus me</button>
+    <button type="button" data-testid="second-focusable">second</button>
+  {/snippet}
+</Modal>

--- a/packages/blade-svelte/src/components/Modal/index.ts
+++ b/packages/blade-svelte/src/components/Modal/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Modal — a centered, portal-style overlay dialog exposing a header / body /
+ * footer composition. Focus trap + return focus, backdrop / escape dismissal,
+ * body scroll lock, and enter/exit animation are wired internally; consumers
+ * only manage `isOpen`.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import {
+ *     Modal,
+ *     ModalHeader,
+ *     ModalBody,
+ *     ModalFooter,
+ *     Button,
+ *   } from '@razorpay/blade-svelte/components';
+ *
+ *   let isOpen = $state(false);
+ * </script>
+ *
+ * <Button onClick={() => (isOpen = true)}>Open</Button>
+ * <Modal {isOpen} onDismiss={() => (isOpen = false)} size="medium">
+ *   {#snippet children()}
+ *     <ModalHeader title="Address Details" subtitle="Add a new address" />
+ *     <ModalBody>
+ *       {#snippet children()}
+ *         <p>Body content goes here.</p>
+ *       {/snippet}
+ *     </ModalBody>
+ *     <ModalFooter>
+ *       {#snippet children()}
+ *         <Button onClick={() => (isOpen = false)}>Done</Button>
+ *       {/snippet}
+ *     </ModalFooter>
+ *   {/snippet}
+ * </Modal>
+ * ```
+ */
+export { default as Modal } from './Modal.svelte';
+export { default as ModalHeader } from './ModalHeader.svelte';
+export { default as ModalBody } from './ModalBody.svelte';
+export { default as ModalFooter } from './ModalFooter.svelte';
+
+export type { ModalProps, ModalHeaderProps, ModalBodyProps, ModalFooterProps } from './types';

--- a/packages/blade-svelte/src/components/Modal/modalContext.ts
+++ b/packages/blade-svelte/src/components/Modal/modalContext.ts
@@ -1,0 +1,36 @@
+import { getContext, setContext } from 'svelte';
+
+/**
+ * Reactive context shared between `Modal` (provider) and its sub-components
+ * (`ModalHeader`, `ModalBody`, `ModalFooter`, `ModalBackdrop`).
+ *
+ * Mirrors React's `ModalContext`. Uses the getter pattern so the live state
+ * object is read on each access and updates propagate automatically.
+ */
+export type ModalContextValue = {
+  /** Marker — `true` whenever this context is provided. */
+  isInsideModal: true;
+  /** Live visibility state (`true` once the surface has begun fading in). */
+  isOpen: boolean;
+  /** Closes the modal (when `isDismissible`). */
+  close: () => void;
+  /** Mirrors `ModalProps.isDismissible`. */
+  isDismissible: boolean;
+  /**
+   * Default focus target — the close button on first paint. Sub-components
+   * (`ModalHeader`) register the close button via this setter so the parent's
+   * `initialFocusRef` fallback can focus it on open.
+   */
+  setDefaultFocusElement: (element: HTMLElement | null) => void;
+};
+
+const MODAL_CONTEXT_KEY = Symbol('modal-context');
+
+export function setModalContext(getter: () => ModalContextValue): void {
+  setContext(MODAL_CONTEXT_KEY, getter);
+}
+
+export function getModalContext(): ModalContextValue | undefined {
+  const getter = getContext<(() => ModalContextValue) | undefined>(MODAL_CONTEXT_KEY);
+  return getter?.();
+}

--- a/packages/blade-svelte/src/components/Modal/types.ts
+++ b/packages/blade-svelte/src/components/Modal/types.ts
@@ -1,0 +1,135 @@
+import type { Snippet } from 'svelte';
+import type { StyledPropsBlade } from '@razorpay/blade-core/utils';
+import type { ModalSize, ModalBodyPadding } from '@razorpay/blade-core/styles';
+
+export interface ModalProps extends StyledPropsBlade {
+  /**
+   * Children of the Modal — typically a `ModalHeader`, `ModalBody`, and/or
+   * `ModalFooter` rendered in that order.
+   */
+  children: Snippet;
+
+  /**
+   * Sets the modal to open or close.
+   *
+   * @default false
+   */
+  isOpen?: boolean;
+
+  /**
+   * Callback fired when the user clicks the close button, clicks the backdrop,
+   * or presses the escape key.
+   */
+  onDismiss?: () => void;
+
+  /**
+   * Whether the modal can be dismissed by clicking outside or pressing the
+   * escape key. When `false` the close button is hidden and the modal must be
+   * closed programmatically (typically via a footer button).
+   *
+   * @default true
+   */
+  isDismissible?: boolean;
+
+  /**
+   * Element that should receive keyboard focus when the modal opens. By default
+   * focus moves to the close button. Svelte callers pass the element obtained
+   * via `bind:this`.
+   *
+   * @default null
+   */
+  initialFocusRef?: HTMLElement | null;
+
+  /**
+   * Size of the modal.
+   *
+   * @default 'small'
+   */
+  size?: ModalSize;
+
+  /**
+   * Accessibility label for the modal dialog.
+   */
+  accessibilityLabel?: string;
+
+  /**
+   * Sets the z-index of the modal.
+   *
+   * @default 1000
+   */
+  zIndex?: number;
+
+  /** Test ID applied to the surface element. */
+  testID?: string;
+
+  /** Analytics data attributes. */
+  [key: `data-analytics-${string}`]: string;
+}
+
+export interface ModalHeaderProps extends StyledPropsBlade {
+  /** Header title text. */
+  title?: string;
+
+  /** Header subtitle text rendered below the title. */
+  subtitle?: string;
+
+  /**
+   * Leading slot rendered before the title (e.g. an icon).
+   * Pass a Svelte snippet.
+   */
+  leading?: Snippet;
+
+  /**
+   * Trailing slot rendered after the title (e.g. a `Badge`, `Text`, `Button`,
+   * or `Link`). Pass a Svelte snippet.
+   */
+  trailing?: Snippet;
+
+  /**
+   * Adornment rendered alongside the title (e.g. a `Counter`).
+   * Pass a Svelte snippet.
+   */
+  titleSuffix?: Snippet;
+
+  /** Test ID applied to the header element. */
+  testID?: string;
+
+  /** Analytics data attributes. */
+  [key: `data-analytics-${string}`]: string;
+}
+
+export interface ModalBodyProps extends StyledPropsBlade {
+  /** Body content. */
+  children: Snippet;
+
+  /**
+   * Equal padding applied on all sides of the body content. Only `spacing.0`
+   * and `spacing.6` are allowed deliberately.
+   *
+   * @default 'spacing.6'
+   */
+  padding?: ModalBodyPadding;
+
+  /**
+   * Explicit height for the body scroll container (e.g. `'100%'`). Accepts any
+   * CSS length string.
+   */
+  height?: string;
+
+  /** Test ID applied to the body element. */
+  testID?: string;
+
+  /** Analytics data attributes. */
+  [key: `data-analytics-${string}`]: string;
+}
+
+export interface ModalFooterProps extends StyledPropsBlade {
+  /** Footer content — typically `Button`s or other CTAs. */
+  children: Snippet;
+
+  /** Test ID applied to the footer element. */
+  testID?: string;
+
+  /** Analytics data attributes. */
+  [key: `data-analytics-${string}`]: string;
+}

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -280,6 +280,10 @@ export type {
   SnapPoints,
 } from './BottomSheet';
 
+// Modal
+export { Modal, ModalHeader, ModalBody, ModalFooter } from './Modal';
+export type { ModalProps, ModalHeaderProps, ModalBodyProps, ModalFooterProps } from './Modal';
+
 // SegmentedControl
 export { SegmentedControl, SegmentedControlItem } from './SegmentedControl';
 export type {


### PR DESCRIPTION
## Summary

- Adds `Modal` to `@razorpay/blade-svelte` with composable `ModalHeader`, `ModalBody`, and `ModalFooter` subcomponents
- Adds shared Modal styles and CVA helpers in `@razorpay/blade-core` (surface sizes, backdrop, enter/exit animation via `data-state`)
- Includes Storybook stories covering sizes, dismissible/non-dismissible flows, and header/footer variants

The Svelte Modal mirrors the React Modal API: focus trap + return focus, backdrop/escape dismissal, body scroll lock, and programmatic open/close via `isOpen`.

## Test plan

- [ ] Open Modal stories in blade-svelte Storybook and verify all size variants (`small`, `medium`, `large`, `full`)
- [ ] Confirm dismiss via backdrop click, Escape key, and close button when `isDismissible={true}`
- [ ] Confirm non-dismissible modal hides close button and ignores backdrop/Escape
- [ ] Verify focus moves into modal on open and returns on close
- [ ] Run `yarn test` in `packages/blade-svelte`


Made with [Cursor](https://cursor.com)