### PR TITLE
feat(tokens): harden the Figma token publishing pipeline

### DIFF
--- a/packages/blade/scripts/__tests__/tokenSerializer.web.test.ts
+++ b/packages/blade/scripts/__tests__/tokenSerializer.web.test.ts
@@ -1,0 +1,386 @@
+/* eslint-disable no-template-curly-in-string */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/**
+ * These cover the failure modes that reached review on the last Figma token push, so a regression
+ * shows up here instead of on a PR.
+ */
+const {
+  collectDeclarationComments,
+  collectFileBindings,
+  matchesSegmentPattern,
+  mergePreservedTokens,
+  scanDeclaration,
+  collectTokenPaths,
+  collectTokenPathsFromSource,
+  diffTokenPaths,
+  findUnresolvableValueRoots,
+  replaceDeclaration,
+  serializeTokens,
+  // eslint-disable-next-line import/no-commonjs
+} = require('../tokenSerializer');
+
+const EXPRESSION_ROOTS = ['globalColors', 'opacity'];
+
+const THEME_DECLARATION = /const colors: ColorsWithModes = \{(.|\n)+?\n\};/gm;
+
+const THEME_FILE = `import {
+  colors as globalColors,
+  opacity,
+  elevation as themeElevation,
+} from '~tokens/global';
+import type { ThemeTokens, ColorsWithModes } from './theme';
+import * as helpers from './helpers';
+import defaultExport from './defaultExport';
+
+const colors: ColorsWithModes = {
+  onLight: {
+    surface: {
+      background: {
+        primary: {
+          faint: 'transparent',
+          intense: globalColors.chromatic.azure[500],
+        },
+      },
+    },
+    overlay: {
+      background: {
+        subtle: \`hsla(0, 0%, 0%, \${opacity[8]})\`,
+      },
+    },
+  },
+};
+
+const bladeTheme: ThemeTokens = { colors };
+
+export default bladeTheme;
+`;
+
+describe('serializeTokens', () => {
+  it('writes each tagged value kind in the form the theme file expects', () => {
+    const serialized = serializeTokens(
+      {
+        faint: { k: 's', v: 'transparent' },
+        intense: { k: 'e', v: 'globalColors.chromatic.azure[500]' },
+        overlay: { k: 't', v: 'hsla(0, 0%, 0%, ${opacity[8]})' },
+      },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(serialized).toContain("faint: 'transparent',");
+    expect(serialized).toContain('intense: globalColors.chromatic.azure[500],');
+    expect(serialized).toContain('overlay: `hsla(0, 0%, 0%, ${opacity[8]})`,');
+  });
+
+  it('quotes untagged values whose root is not an importable expression', () => {
+    // the regression: the old serializer stripped quotes off every string, turning the literal
+    // 'transparent' into a bare identifier that threw a ReferenceError on import
+    const serialized = serializeTokens({ faint: 'transparent' }, EXPRESSION_ROOTS);
+
+    expect(serialized).toContain("faint: 'transparent',");
+    expect(serialized).not.toContain('faint: transparent,');
+  });
+
+  it('leaves untagged values whose root is an importable expression bare', () => {
+    const serialized = serializeTokens(
+      { intense: 'globalColors.chromatic.azure[500]' },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(serialized).toContain('intense: globalColors.chromatic.azure[500],');
+  });
+
+  it('preserves untagged template literal values', () => {
+    const serialized = serializeTokens(
+      { subtle: '`hsla(0, 0%, 0%, ${opacity[8]})`' },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(serialized).toContain('subtle: `hsla(0, 0%, 0%, ${opacity[8]})`,');
+  });
+
+  it('escapes quotes inside string values', () => {
+    expect(serializeTokens({ odd: { k: 's', v: "it's" } }, EXPRESSION_ROOTS)).toContain(
+      "odd: 'it\\'s',",
+    );
+  });
+
+  it('writes numeric and identifier keys bare and quotes anything else', () => {
+    const serialized = serializeTokens(
+      { 50: { k: 's', v: 'a' }, azure: { k: 's', v: 'b' }, 'a-b': { k: 's', v: 'c' } },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(serialized).toContain('50:');
+    expect(serialized).toContain('azure:');
+    expect(serialized).toContain('"a-b":');
+  });
+});
+
+describe('collectTokenPaths', () => {
+  it('returns sorted leaf paths and treats a tagged value as a leaf, not a group', () => {
+    const paths = collectTokenPaths({
+      onLight: {
+        surface: { background: { gray: { subtle: { k: 'e', v: 'globalColors.gray[100]' } } } },
+        transparent: { k: 's', v: 'transparent' },
+      },
+    });
+
+    expect(paths).toEqual(['onLight.surface.background.gray.subtle', 'onLight.transparent']);
+  });
+});
+
+describe('collectFileBindings', () => {
+  const bindings = collectFileBindings(THEME_FILE);
+
+  it.each([
+    ['a named import', 'opacity'],
+    ['an aliased named import', 'globalColors'],
+    ['a namespace import', 'helpers'],
+    ['a default import', 'defaultExport'],
+    ['a top level declaration', 'bladeTheme'],
+  ])('finds %s', (_label, name) => {
+    expect(bindings.has(name)).toBe(true);
+  });
+
+  it('skips type-only imports, which are erased at runtime', () => {
+    expect(bindings.has('ColorsWithModes')).toBe(false);
+    expect(bindings.has('ThemeTokens')).toBe(false);
+  });
+});
+
+describe('findUnresolvableValueRoots', () => {
+  it('reports a bare value the target file cannot resolve', () => {
+    const declarationSource = serializeTokens(
+      { faint: { k: 'e', v: 'transparent' }, muted: { k: 'e', v: 'someOtherRoot.x' } },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(findUnresolvableValueRoots({ fileContent: THEME_FILE, declarationSource })).toEqual([
+      'someOtherRoot',
+      'transparent',
+    ]);
+  });
+
+  it('reports rather than crashes on an index a Figma variable named `000` produces', () => {
+    // `[000]` is an octal literal, which strict mode rejects outright — the check used to throw
+    // and take the whole push down instead of naming the unresolvable root
+    const declarationSource = serializeTokens(
+      { subtle: { k: 'e', v: '_styles.button.primary.default[000]' } },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(findUnresolvableValueRoots({ fileContent: THEME_FILE, declarationSource })).toEqual([
+      '_styles',
+    ]);
+  });
+
+  it('accepts values rooted in identifiers the file imports or declares', () => {
+    const declarationSource = serializeTokens(
+      {
+        faint: { k: 's', v: 'transparent' },
+        intense: { k: 'e', v: 'globalColors.chromatic.azure[500]' },
+        subtle: { k: 't', v: 'hsla(0, 0%, 0%, ${opacity[8]})' },
+      },
+      EXPRESSION_ROOTS,
+    );
+
+    expect(findUnresolvableValueRoots({ fileContent: THEME_FILE, declarationSource })).toEqual([]);
+  });
+});
+
+describe('collectTokenPathsFromSource', () => {
+  it('reads the token paths already in a theme file', () => {
+    const { paths, matchCount } = collectTokenPathsFromSource(THEME_FILE, THEME_DECLARATION);
+
+    expect(matchCount).toBe(1);
+    expect(paths).toEqual([
+      'onLight.overlay.background.subtle',
+      'onLight.surface.background.primary.faint',
+      'onLight.surface.background.primary.intense',
+    ]);
+  });
+
+  it('reports the match count when the declaration is missing so the file is not written blind', () => {
+    expect(collectTokenPathsFromSource('const other = {};', THEME_DECLARATION).matchCount).toBe(0);
+  });
+});
+
+describe('replaceDeclaration', () => {
+  it('replaces a single declaration without treating `$` in values as a replacement pattern', () => {
+    const { content, matchCount } = replaceDeclaration({
+      fileContent: THEME_FILE,
+      declarationRegex: THEME_DECLARATION,
+      replacement: 'const colors: ColorsWithModes = {\n  a: `hsla(0, 0%, 0%, ${opacity[8]})`,\n};',
+    });
+
+    expect(matchCount).toBe(1);
+    expect(content).toContain('a: `hsla(0, 0%, 0%, ${opacity[8]})`,');
+  });
+
+  it('leaves the file untouched when the declaration does not match exactly once', () => {
+    const fileContent = `${THEME_FILE}\n${THEME_FILE}`;
+    const { content, matchCount } = replaceDeclaration({
+      fileContent,
+      declarationRegex: THEME_DECLARATION,
+      replacement: 'const colors: ColorsWithModes = {};',
+    });
+
+    expect(matchCount).toBe(2);
+    expect(content).toBe(fileContent);
+  });
+});
+
+describe('collectDeclarationComments', () => {
+  // Figma has no concept of a deprecated token, so `// @deprecated` lives only in the source and
+  // every regeneration used to drop it.
+  const COMMENTED_FILE = `const colors: ColorsWithModes = {
+  onLight: {
+    popup: {
+      // @deprecated
+      // Use popup.background.gray.subtle instead
+      subtle: globalColors.gray[100],
+    },
+    // this group is on its way out
+    legacy: {
+      intense: globalColors.gray[900],
+    },
+  },
+};
+`;
+
+  it('keys comment lines by the token path they sit above', () => {
+    expect(collectDeclarationComments(COMMENTED_FILE, THEME_DECLARATION)).toEqual({
+      'onLight.popup.subtle': ['// @deprecated', '// Use popup.background.gray.subtle instead'],
+      'onLight.legacy': ['// this group is on its way out'],
+    });
+  });
+
+  it('re-attaches them to the regenerated declaration', () => {
+    const comments = collectDeclarationComments(COMMENTED_FILE, THEME_DECLARATION);
+    const serialized = serializeTokens(
+      { onLight: { popup: { subtle: { k: 'e', v: 'globalColors.gray[100]' } } } },
+      EXPRESSION_ROOTS,
+      { comments },
+    );
+
+    expect(serialized).toContain('// @deprecated');
+    expect(serialized).toContain('// Use popup.background.gray.subtle instead');
+  });
+
+  it('drops comments for token paths the payload no longer has', () => {
+    const comments = collectDeclarationComments(COMMENTED_FILE, THEME_DECLARATION);
+    const serialized = serializeTokens(
+      { onLight: { popup: { moderate: { k: 'e', v: 'globalColors.gray[100]' } } } },
+      EXPRESSION_ROOTS,
+      { comments },
+    );
+
+    expect(serialized).not.toContain('@deprecated');
+  });
+});
+
+describe('mergePreservedTokens', () => {
+  // Figma only knows the tokens somebody authored there. Deprecated aliases are kept in code so
+  // consumers do not break, and a regeneration from the payload alone deletes them — which is
+  // exactly how `popup.[background|border].[subtle|intense]` vanished from a release.
+  const DEPRECATED_FILE = `const colors: ColorsWithModes = {
+  onLight: {
+    popup: {
+      background: {
+        // @deprecated
+        subtle: globalColors.gray[100],
+        gray: {
+          moderate: globalColors.gray[200],
+        },
+      },
+    },
+  },
+};
+`;
+
+  const payloadWithoutDeprecated = {
+    onLight: {
+      popup: { background: { gray: { moderate: { k: 'e', v: 'globalColors.gray[200]' } } } },
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  const scanned = () => scanDeclaration(DEPRECATED_FILE, THEME_DECLARATION);
+
+  it('carries a code-only token back in with its source text intact', () => {
+    const { values, childOrder } = scanned();
+    const { tree, preserved } = mergePreservedTokens({
+      tree: payloadWithoutDeprecated,
+      existingValues: values,
+      preservedPaths: ['*.popup.background.subtle'],
+      childOrder,
+    });
+
+    expect(preserved).toEqual(['onLight.popup.background.subtle']);
+    expect(serializeTokens(tree, EXPRESSION_ROOTS)).toContain('subtle: globalColors.gray[100],');
+  });
+
+  it('puts it back where it was rather than appending it to the group', () => {
+    const { values, childOrder, comments } = scanned();
+    const { tree } = mergePreservedTokens({
+      tree: payloadWithoutDeprecated,
+      existingValues: values,
+      preservedPaths: ['*.popup.background.subtle'],
+      childOrder,
+    });
+    const serialized = serializeTokens(tree, EXPRESSION_ROOTS, { comments });
+
+    // `subtle` came before `gray` in the file and has to stay there, or a no-op push shows up as
+    // a pile of moved lines
+    expect(serialized.indexOf('subtle:')).toBeLessThan(serialized.indexOf('gray:'));
+    expect(serialized).toContain('// @deprecated');
+  });
+
+  it('leaves the payload in charge wherever the payload has an opinion', () => {
+    const { values, childOrder } = scanned();
+    const { tree, preserved } = mergePreservedTokens({
+      tree: {
+        onLight: { popup: { background: { subtle: { k: 'e', v: 'globalColors.gray[900]' } } } },
+      },
+      existingValues: values,
+      preservedPaths: ['*.popup.background.subtle'],
+      childOrder,
+    });
+
+    expect(preserved).toEqual([]);
+    expect(serializeTokens(tree, EXPRESSION_ROOTS)).toContain('subtle: globalColors.gray[900],');
+  });
+
+  it('drops the token once its path is taken off the list', () => {
+    const { values, childOrder } = scanned();
+    const { tree, preserved } = mergePreservedTokens({
+      tree: payloadWithoutDeprecated,
+      existingValues: values,
+      preservedPaths: [],
+      childOrder,
+    });
+
+    expect(preserved).toEqual([]);
+    expect(serializeTokens(tree, EXPRESSION_ROOTS)).not.toContain('globalColors.gray[100]');
+  });
+});
+
+describe('matchesSegmentPattern', () => {
+  it.each([
+    ['onLight.popup.background.subtle', '*.popup.background.subtle', true],
+    ['onDark.popup.background.subtle', '*.popup.background.subtle', true],
+    ['onLight.popup.background.gray.subtle', '*.popup.background.subtle', false],
+    ['onLight.popup.border.subtle', '*.popup.background.subtle', false],
+  ])('%s vs %s -> %s', (path, pattern, expected) => {
+    expect(matchesSegmentPattern(path, pattern)).toBe(expected);
+  });
+});
+
+describe('diffTokenPaths', () => {
+  it('separates added from removed paths', () => {
+    expect(diffTokenPaths(['a.b', 'a.c'], ['a.c', 'a.d'])).toEqual({
+      added: ['a.d'],
+      removed: ['a.b'],
+    });
+  });
+});

--- a/packages/blade/scripts/tokenSerializer.js
+++ b/packages/blade/scripts/tokenSerializer.js
@@ -1,0 +1,427 @@
+/**
+ * Turning a Figma token payload into TypeScript source, and reading the source back.
+ *
+ * The old serializer stripped quotes off every string value with a blanket regex, which is how
+ * `faint: 'transparent'` shipped as a bare `transparent` identifier and threw a ReferenceError the
+ * moment the theme was imported. Values are now tagged by the plugin (expression / string /
+ * template) and, for payloads from older plugin builds, inferred from `expressionRoots` instead of
+ * assumed. Everything written is then read back and checked against the bindings the target file
+ * actually has.
+ */
+
+const IDENTIFIER_REGEX = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const NUMERIC_KEY_REGEX = /^\d+$/;
+
+// Value kinds emitted by the plugin. Short keys keep the gzipped workflow_dispatch payload small.
+const EXPRESSION = 'e'; // written bare:      globalColors.chromatic.azure[500]
+const STRING = 's'; // written quoted:    'transparent'
+const TEMPLATE = 't'; // written in backticks: `hsla(0, 0%, 0%, ${opacity[8]})`
+// Not emitted by the plugin. Source text lifted straight out of the file being rewritten, for
+// tokens that are preserved rather than regenerated.
+const RAW = 'r';
+
+const isPlainObject = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** A `{ k, v }` pair emitted by the plugin, as opposed to a nested token group. */
+const isTaggedValue = (value) =>
+  isPlainObject(value) && typeof value.k === 'string' && typeof value.v === 'string';
+
+const isLeaf = (value) => !isPlainObject(value) || isTaggedValue(value);
+
+const quote = (value) => `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+/** First identifier in a member expression: `globalColors.chromatic.azure[500]` -> `globalColors`. */
+const rootOf = (expression) => String(expression).split(/[.[(]/)[0].trim();
+
+/**
+ * Untagged values come from plugin builds predating value tagging. The workflow always runs the
+ * script from master while plugin builds are installed by hand, so those payloads stay in
+ * circulation and have to keep working — just without the guesswork that broke `transparent`.
+ */
+const serializeUntaggedValue = (value, expressionRoots) => {
+  const raw = String(value);
+  // Already-quoted forms carry their own kind: backticks a template, single quotes a string.
+  if (raw.startsWith('`') && raw.endsWith('`')) {
+    return raw;
+  }
+  if (raw.length > 1 && raw.startsWith("'") && raw.endsWith("'")) {
+    return raw;
+  }
+  // Otherwise infer it, which is all a payload from an older plugin build gives us to go on.
+  return expressionRoots.includes(rootOf(raw)) ? raw : quote(raw);
+};
+
+const serializeValue = (value, expressionRoots) => {
+  if (!isTaggedValue(value)) {
+    return serializeUntaggedValue(value, expressionRoots);
+  }
+  if (value.k === EXPRESSION || value.k === RAW) {
+    return value.v;
+  }
+  if (value.k === TEMPLATE) {
+    return `\`${value.v}\``;
+  }
+  return quote(value.v);
+};
+
+const serializeKey = (key) =>
+  IDENTIFIER_REGEX.test(key) || NUMERIC_KEY_REGEX.test(key) ? key : JSON.stringify(key);
+
+/**
+ * Serializes a token tree into a JS object literal. Output is re-formatted by prettier afterwards,
+ * so the indentation here only matters when a failure gets printed.
+ *
+ * `comments` re-attaches comment lines harvested from the file being overwritten, keyed by token
+ * path. Without it every push silently strips the `// @deprecated` markers that are the only
+ * warning consumers of those tokens get.
+ */
+const serializeTokens = (
+  tree,
+  expressionRoots = [],
+  { comments = {}, path = '', depth = 1 } = {},
+) => {
+  const pad = '  '.repeat(depth);
+  const closingPad = '  '.repeat(depth - 1);
+
+  const entries = Object.entries(tree).map(([key, value]) => {
+    const tokenPath = path ? `${path}.${key}` : key;
+    const serialized = isLeaf(value)
+      ? serializeValue(value, expressionRoots)
+      : serializeTokens(value, expressionRoots, { comments, path: tokenPath, depth: depth + 1 });
+
+    const attached = (comments[tokenPath] ?? []).map((comment) => `${pad}${comment}`);
+    return [...attached, `${pad}${serializeKey(key)}: ${serialized},`].join('\n');
+  });
+
+  return entries.length ? `{\n${entries.join('\n')}\n${closingPad}}` : '{}';
+};
+
+/** Every leaf path in a token tree, dotted and sorted, for diffing one payload against another. */
+const collectTokenPaths = (tree, prefix = '', collected = []) => {
+  for (const [key, value] of Object.entries(tree)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isLeaf(value)) {
+      collected.push(path);
+    } else {
+      collectTokenPaths(value, path, collected);
+    }
+  }
+  return collected.sort();
+};
+
+/**
+ * Identifiers that resolve at module scope in a source file: named/default/namespace imports and
+ * top-level declarations. Type-only imports are skipped — they are erased at runtime, so a value
+ * leaning on one still throws.
+ */
+const collectFileBindings = (fileContent) => {
+  const bindings = new Set();
+
+  const importRegex = /import\s+(type\s+)?([^;]+?)\s+from\s+['"][^'"]+['"]/g;
+  let match = importRegex.exec(fileContent);
+  while (match) {
+    const [, isTypeOnly, clause] = match;
+    if (!isTypeOnly) {
+      const namedBlock = /\{([^}]*)\}/.exec(clause);
+      if (namedBlock) {
+        namedBlock[1]
+          .split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+          .forEach((entry) => {
+            if (entry.startsWith('type ')) return;
+            const alias = /\sas\s+([A-Za-z_$][\w$]*)$/.exec(entry);
+            bindings.add(alias ? alias[1] : entry);
+          });
+      }
+      const namespaceImport = /\*\s+as\s+([A-Za-z_$][\w$]*)/.exec(clause);
+      if (namespaceImport) bindings.add(namespaceImport[1]);
+      const defaultImport = /^([A-Za-z_$][\w$]*)\s*(?:,|$)/.exec(clause.trim());
+      if (defaultImport) bindings.add(defaultImport[1]);
+    }
+    match = importRegex.exec(fileContent);
+  }
+
+  const declarationRegex = /^(?:export\s+)?(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/gm;
+  match = declarationRegex.exec(fileContent);
+  while (match) {
+    bindings.add(match[1]);
+    match = declarationRegex.exec(fileContent);
+  }
+
+  return bindings;
+};
+
+/**
+ * Proxy that records the property path it was walked down, so an object literal full of member
+ * expressions can be evaluated without the real modules being present. Also survives template
+ * literal interpolation.
+ */
+const makePathProxy = (path) =>
+  new Proxy(function pathProxy() {}, {
+    get(target, property) {
+      if (property === Symbol.toPrimitive) return () => path;
+      if (property === 'toString' || property === 'valueOf') return () => path;
+      if (typeof property === 'symbol') return undefined;
+      return makePathProxy(`${path}.${String(property)}`);
+    },
+    apply() {
+      return makePathProxy(path);
+    },
+  });
+
+const MAX_RESOLUTION_ATTEMPTS = 64;
+
+/**
+ * Evaluates an object literal with every free identifier stubbed out, returning both the resulting
+ * tree and the identifiers that were not in `availableRoots`. That second list is the check the old
+ * pipeline was missing: a non-empty result means the file references something it cannot resolve.
+ */
+const parseObjectLiteralSource = (source, availableRoots = []) => {
+  const roots = new Set(availableRoots.filter((name) => IDENTIFIER_REGEX.test(name)));
+  const missingRoots = [];
+
+  for (let attempt = 0; attempt < MAX_RESOLUTION_ATTEMPTS; attempt++) {
+    const names = [...roots];
+    try {
+      // Deliberately sloppy mode. A Figma variable named `000` produces `someToken[000]`, which
+      // strict mode rejects outright as an octal literal — crashing the push instead of reporting
+      // it. The numeric value is irrelevant here; only the leaf paths and the free identifiers are.
+      // eslint-disable-next-line no-new-func
+      const evaluate = new Function(...names, `return (${source});`);
+      return { tree: evaluate(...names.map((name) => makePathProxy(name))), missingRoots };
+    } catch (error) {
+      const undefinedIdentifier = /^([A-Za-z_$][\w$]*) is not defined$/.exec(error.message ?? '');
+      if (error instanceof ReferenceError && undefinedIdentifier) {
+        missingRoots.push(undefinedIdentifier[1]);
+        roots.add(undefinedIdentifier[1]);
+        continue;
+      }
+      throw new Error(`Could not parse the token declaration: ${error.message}`);
+    }
+  }
+
+  throw new Error(
+    `Gave up resolving the token declaration after ${MAX_RESOLUTION_ATTEMPTS} unresolved identifiers.`,
+  );
+};
+
+const extractDeclarationBody = (fileContent, declarationRegex) => {
+  const matches = fileContent.match(new RegExp(declarationRegex.source, declarationRegex.flags));
+  if (!matches || matches.length !== 1) {
+    return { body: null, matchCount: matches ? matches.length : 0 };
+  }
+  const openingBrace = matches[0].indexOf('{');
+  const closingBrace = matches[0].lastIndexOf('}');
+  return { body: matches[0].slice(openingBrace, closingBrace + 1), matchCount: 1 };
+};
+
+const COMMENT_LINE_REGEX = /^(\/\/|\/\*|\*)/;
+const GROUP_LINE_REGEX = /^([A-Za-z0-9_$]+|'[^']*'|"[^"]*"):\s*\{$/;
+const LEAF_LINE_REGEX = /^([A-Za-z0-9_$]+|'[^']*'|"[^"]*"):\s*(.+?),?$/;
+
+const unquoteKey = (key) => key.replace(/^['"]|['"]$/g, '');
+
+/**
+ * Reads a prettier-formatted declaration into two path-keyed maps: the comment lines sitting above
+ * each entry, and the raw source text of each leaf value.
+ *
+ * Both exist because Figma is not the whole story. It has no concept of a deprecated token, so
+ * `// @deprecated` and the tokens it marks live only in the source; a regeneration that does not
+ * carry them over deletes them.
+ */
+const scanDeclaration = (fileContent, declarationRegex) => {
+  const { body } = extractDeclarationBody(fileContent, declarationRegex);
+  if (!body) return { comments: {}, values: {} };
+
+  const comments = {};
+  const values = {};
+  /** Parent path -> child keys in the order the file lists them. */
+  const childOrder = {};
+  const stack = [];
+  let pending = [];
+
+  for (const rawLine of body.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line === '{') continue;
+
+    if (COMMENT_LINE_REGEX.test(line)) {
+      pending.push(line);
+      continue;
+    }
+
+    if (line === '}' || line === '},') {
+      stack.pop();
+      pending = [];
+      continue;
+    }
+
+    const group = GROUP_LINE_REGEX.exec(line);
+    const leaf = group ? null : LEAF_LINE_REGEX.exec(line);
+    const key = group ? unquoteKey(group[1]) : unquoteKey(leaf?.[1] ?? '');
+    if (!key) {
+      pending = [];
+      continue;
+    }
+
+    const parentPath = stack.join('.');
+    const path = [...stack, key].join('.');
+    childOrder[parentPath] = [...(childOrder[parentPath] ?? []), key];
+
+    if (pending.length) {
+      comments[path] = pending;
+      pending = [];
+    }
+    if (group) {
+      stack.push(key);
+    } else {
+      values[path] = leaf[2];
+    }
+  }
+
+  return { comments, values, childOrder };
+};
+
+/** Comment lines in a declaration, keyed by the token path they sit above. */
+const collectDeclarationComments = (fileContent, declarationRegex) => {
+  const { comments } = scanDeclaration(fileContent, declarationRegex);
+  return comments;
+};
+
+/** Segment-wise glob where `*` matches exactly one segment: `*.popup.background.subtle`. */
+const matchesSegmentPattern = (path, pattern) => {
+  const pathSegments = path.split('.');
+  const patternSegments = pattern.split('.');
+  if (pathSegments.length !== patternSegments.length) return false;
+  return patternSegments.every(
+    (segment, index) => segment === '*' || segment === pathSegments[index],
+  );
+};
+
+/**
+ * Carries tokens that exist in the file but not in the payload back into the tree.
+ *
+ * Figma only knows about tokens somebody authored there. Deprecated aliases are kept in code
+ * purely so consumers do not break, so a regeneration from Figma alone deletes them — which is
+ * how `popup.[background|border].[subtle|intense]` disappeared out from under a release.
+ *
+ * The existing source text is reinserted verbatim, so whatever the file already said stays true.
+ * A path the payload does define is left alone: Figma wins wherever Figma has an opinion.
+ */
+const mergePreservedTokens = ({ tree, existingValues, preservedPaths, childOrder = {} }) => {
+  const preserved = [];
+  if (!preservedPaths?.length) return { tree, preserved };
+
+  const merged = JSON.parse(JSON.stringify(tree));
+  const touchedParents = new Set();
+
+  for (const path of Object.keys(existingValues)) {
+    if (!preservedPaths.some((pattern) => matchesSegmentPattern(path, pattern))) continue;
+
+    const segments = path.split('.');
+    const leafKey = segments.pop();
+    let cursor = merged;
+    for (const segment of segments) {
+      if (!isPlainObject(cursor[segment])) cursor[segment] = {};
+      cursor = cursor[segment];
+    }
+    if (cursor[leafKey] !== undefined) continue;
+
+    cursor[leafKey] = { k: RAW, v: existingValues[path] };
+    touchedParents.add(segments.join('.'));
+    preserved.push(path);
+  }
+
+  // Inserting appends, which would shunt a preserved token to the bottom of its group and show up
+  // as a pile of moved lines on an otherwise no-op push. Put the affected groups back into the
+  // order the file already had.
+  for (const parentPath of touchedParents) {
+    const order = childOrder[parentPath];
+    if (!order?.length) continue;
+
+    const segments = parentPath ? parentPath.split('.') : [];
+    let cursor = merged;
+    for (const segment of segments) cursor = cursor[segment];
+
+    const reordered = {};
+    for (const key of order) if (key in cursor) reordered[key] = cursor[key];
+    for (const key of Object.keys(cursor)) if (!(key in reordered)) reordered[key] = cursor[key];
+
+    if (segments.length) {
+      let parent = merged;
+      for (const segment of segments.slice(0, -1)) parent = parent[segment];
+      parent[segments[segments.length - 1]] = reordered;
+    } else {
+      Object.keys(merged).forEach((key) => delete merged[key]);
+      Object.assign(merged, reordered);
+    }
+  }
+
+  return { tree: merged, preserved: preserved.sort() };
+};
+
+/** Token paths already present in a source file, for diffing against an incoming payload. */
+const collectTokenPathsFromSource = (fileContent, declarationRegex) => {
+  const { body, matchCount } = extractDeclarationBody(fileContent, declarationRegex);
+  if (!body) {
+    return { paths: [], matchCount };
+  }
+  const { tree } = parseObjectLiteralSource(body);
+  return { paths: collectTokenPaths(tree), matchCount };
+};
+
+/**
+ * The `transparent` check: every bare identifier the serialized declaration leans on has to be
+ * resolvable inside the file it is about to live in.
+ */
+const findUnresolvableValueRoots = ({ fileContent, declarationSource }) => {
+  const { missingRoots } = parseObjectLiteralSource(declarationSource, [
+    ...collectFileBindings(fileContent),
+  ]);
+  return [...new Set(missingRoots)].sort();
+};
+
+/**
+ * Replaces a declaration, reporting how many times it matched. A count other than 1 means the file
+ * drifted (renamed or reformatted declaration) and must not be written blind.
+ */
+const replaceDeclaration = ({ fileContent, declarationRegex, replacement }) => {
+  const regex = new RegExp(declarationRegex.source, declarationRegex.flags);
+  const matches = fileContent.match(regex) ?? [];
+  if (matches.length !== 1) {
+    return { content: fileContent, matchCount: matches.length };
+  }
+  // function form so `$&`/`$1` inside token values are not treated as replacement patterns
+  return { content: fileContent.replace(regex, () => replacement), matchCount: 1 };
+};
+
+const diffTokenPaths = (before, after) => {
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  return {
+    added: after.filter((path) => !beforeSet.has(path)),
+    removed: before.filter((path) => !afterSet.has(path)),
+  };
+};
+
+module.exports = {
+  EXPRESSION,
+  RAW,
+  STRING,
+  TEMPLATE,
+  collectDeclarationComments,
+  matchesSegmentPattern,
+  mergePreservedTokens,
+  scanDeclaration,
+  collectFileBindings,
+  collectTokenPaths,
+  collectTokenPathsFromSource,
+  diffTokenPaths,
+  extractDeclarationBody,
+  findUnresolvableValueRoots,
+  isTaggedValue,
+  parseObjectLiteralSource,
+  replaceDeclaration,
+  serializeTokens,
+};

--- a/packages/blade/scripts/tokenTargets.json
+++ b/packages/blade/scripts/tokenTargets.json
@@ -1,0 +1,99 @@
+{
+  "$comment": [
+    "Every place a Figma token payload has to land. `blade` and `blade-core` keep byte-identical",
+    "copies of the theme files, so a payload that only writes one of them leaves the other stale",
+    "and breaks the blade-core typecheck. Add a file here rather than in uploadTokens.js.",
+    "",
+    "`declaration` picks the exact statement inside each file that gets replaced. It is matched",
+    "as a regex against the file source and must match exactly once."
+  ],
+  "themes": {
+    "bladeTheme": {
+      "declaration": "const colors: ColorsWithModes = \\{(.|\\n)+?\\n\\};",
+      "replacement": "const colors: ColorsWithModes = {{SERIALIZED}};",
+      "files": [
+        "packages/blade/src/tokens/theme/bladeTheme.ts",
+        "packages/blade-core/src/tokens/theme/bladeTheme.ts"
+      ]
+    },
+    "bladeNeutralTheme": {
+      "declaration": "const colors: ColorsWithModes = \\{(.|\\n)+?\\n\\};",
+      "replacement": "const colors: ColorsWithModes = {{SERIALIZED}};",
+      "files": [
+        "packages/blade/src/tokens/theme/bladeNeutralTheme.ts",
+        "packages/blade-core/src/tokens/theme/bladeNeutralTheme.ts"
+      ]
+    }
+  },
+  "globalColors": {
+    "declaration": "export const colors: Color = \\{(.|\\n)+?\\n\\};",
+    "replacement": "export const colors: Color = {{SERIALIZED}};",
+    "files": [
+      "packages/blade/src/tokens/global/colors.ts",
+      "packages/blade-core/src/tokens/global/colors.ts"
+    ]
+  },
+
+  "$comment_expressionRoots": [
+    "Identifiers a token value is allowed to start with when it is written unquoted. Anything",
+    "else coming out of Figma is written as a string literal instead of a bare identifier —",
+    "this is what stops `faint: 'transparent'` from becoming `faint: transparent`."
+  ],
+  "expressionRoots": ["globalColors", "opacity"],
+
+  "$comment_preservedTokenPaths": [
+    "Tokens that live in code and not in Figma. A push regenerates the whole declaration from the",
+    "payload, so anything Figma has never heard of is deleted — which is how the deprecated popup",
+    "aliases were dropped out from under a release. Paths listed here keep whatever the file",
+    "already says, comments included.",
+    "",
+    "`*` matches exactly one segment, so the leading one covers both `onLight` and `onDark`.",
+    "A path Figma DOES define is not affected: the payload always wins where it has an opinion.",
+    "",
+    "Remove an entry here when the token is genuinely ready to go, and the next push deletes it."
+  ],
+  "preservedTokenPaths": [
+    "*.popup.background.subtle",
+    "*.popup.background.intense",
+    "*.popup.border.subtle",
+    "*.popup.border.intense"
+  ],
+
+  "$comment_referenceScanRoots": [
+    "Searched for the text of every token path this payload deletes, so a removal that still",
+    "has consumers (components, codemod maps, docs) blocks the PR instead of shipping broken."
+  ],
+  "referenceScanRoots": [
+    "packages/blade/src",
+    "packages/blade/codemods",
+    "packages/blade-core/src",
+    "packages/blade-svelte/src",
+    "packages/blade-mcp/knowledgebase"
+  ],
+  "referenceScanExtensions": [".ts", ".tsx", ".js", ".jsx", ".svelte", ".json", ".md", ".mdx"],
+
+  "verify": {
+    "typecheck": [
+      { "name": "@razorpay/blade", "cwd": "packages/blade", "command": "yarn typecheck" },
+      { "name": "@razorpay/blade-core", "cwd": "packages/blade-core", "command": "yarn typecheck" }
+    ],
+    "$comment_snapshots": [
+      "Token values are baked into component snapshots (BaseButton, Popover, Tabs, createTheme…),",
+      "so a token push always dirties them. Regenerate here instead of leaving it to review."
+    ],
+    "snapshots": [
+      {
+        "name": "web snapshots",
+        "cwd": "packages/blade",
+        "command": "cross-env FRAMEWORK=REACT yarn jest -c ./jest.web.config.js --updateSnapshot --forceExit --ci=false"
+      },
+      {
+        "name": "native snapshots",
+        "cwd": "packages/blade",
+        "command": "cross-env FRAMEWORK=REACT_NATIVE yarn jest -c ./jest.native.config.js --updateSnapshot --forceExit --ci=false"
+      }
+    ]
+  },
+
+  "changesetPackages": ["@razorpay/blade", "@razorpay/blade-core"]
+}

--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -1,15 +1,64 @@
+/**
+ * Writes a Figma token payload into the repo and opens a PR.
+ *
+ * Everything here that looks defensive is a bug that reached review on a previous token push:
+ * values written as bare identifiers that nothing imports, tokens silently deleted because Figma
+ * no longer had them, `blade-core` left stale because only `blade` was in the target list, and a
+ * PR opened before anything had been typechecked. The rule is now: find problems here, and if any
+ * survive, open the PR as a draft with them written down rather than looking mergeable.
+ */
+
 const fs = require('fs');
 const path = require('path');
 const zlib = require('zlib');
 const execa = require('execa');
 const randomNameGenerator = require('moniker');
 
+// eslint-disable-next-line import/extensions
+const targets = require('./tokenTargets.json');
+const {
+  collectTokenPaths,
+  collectTokenPathsFromSource,
+  diffTokenPaths,
+  findUnresolvableValueRoots,
+  mergePreservedTokens,
+  replaceDeclaration,
+  scanDeclaration,
+  serializeTokens,
+} = require('./tokenSerializer');
+
 const GITHUB_BOT_EMAIL = 'tools+cibot@razorpay.com';
 const GITHUB_BOT_USERNAME = 'rzpcibot';
 
-// The Figma plugin gzip + base64 encodes the tokens payload to stay under GitHub's
-// 65,535 character workflow_dispatch input limit. Decompress it here, falling back to
-// treating the argument as raw JSON for backward compatibility.
+const BLADE_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(BLADE_ROOT, '../..');
+
+const SERIALIZED_PLACEHOLDER = '{{SERIALIZED}}';
+
+// `--dry-run` writes and verifies the files but touches neither git nor GitHub, so a payload can
+// be replayed locally. The skip flags exist for that loop too — the full snapshot run is slow.
+const flags = process.argv.slice(3);
+const isDryRun = flags.includes('--dry-run');
+const skipTypecheck = flags.includes('--skip-typecheck');
+const skipSnapshots = flags.includes('--skip-snapshots');
+
+/** Problems that must not ship. A non-empty list downgrades the PR to a draft. */
+const blockers = [];
+/** Worth a reviewer's attention but not a reason to hold the push. */
+const warnings = [];
+
+const touchedFiles = new Set();
+/** Code-owned tokens carried over because the payload has never heard of them. */
+const preservedTokens = new Set();
+
+// ---------------------------------------------------------------------------------------------
+// payload
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * The plugin gzip + base64 encodes the payload to stay under GitHub's 65,535 character
+ * workflow_dispatch input limit. Older plugin builds send raw JSON.
+ */
 const parseTokensArg = (arg) => {
   try {
     return JSON.parse(zlib.gunzipSync(Buffer.from(arg, 'base64')).toString('utf8'));
@@ -18,94 +67,463 @@ const parseTokensArg = (arg) => {
   }
 };
 
-const uploadColorTokens = async () => {
-  try {
-    // 1. read the tokens object
-    const colorTokens = parseTokensArg(process.argv[2]);
+// ---------------------------------------------------------------------------------------------
+// writing
+// ---------------------------------------------------------------------------------------------
 
-    const themeColorTokensRegex = /const colors: ColorsWithModes = {(.|\n)+?};/gm;
-    // Each theme in the payload is written into its own source file.
-    const THEME_TARGETS = {
-      bladeTheme: 'src/tokens/theme/bladeTheme.ts',
-      bladeNeutralTheme: 'src/tokens/theme/bladeNeutralTheme.ts',
-    };
+const toRepoPath = (relativePath) => path.resolve(REPO_ROOT, relativePath);
 
-    for (const [themeName, themeModes] of Object.entries(colorTokens?.themeColorTokens ?? {})) {
-      const targetRelativePath = THEME_TARGETS[themeName];
-      if (!targetRelativePath) {
-        console.warn(
-          `No target file configured for theme: ${themeName}. Update THEME_TARGETS in scripts/uploadTokens.js.`,
-        );
-        continue;
-      }
-      if (
-        !Object.keys(themeModes?.onLight ?? {}).length ||
-        !Object.keys(themeModes?.onDark ?? {}).length
-      ) {
-        continue;
-      }
+/**
+ * Writes one serialized declaration into one file, and refuses to leave behind anything it cannot
+ * vouch for: the declaration has to match exactly once, and every bare identifier the new values
+ * lean on has to resolve inside that file.
+ *
+ * Returns the token paths the file held *before* the write, or null if nothing was written.
+ */
+const writeDeclaration = ({ relativePath, declarationRegex, replacementTemplate, tree }) => {
+  const absolutePath = toRepoPath(relativePath);
 
-      // 2. read the theme file
-      const themeFilePath = path.resolve(__dirname, '..', targetRelativePath);
-      const themeFileContent = fs.readFileSync(themeFilePath, 'utf8');
-
-      // 3. write the new tokens to the theme file
-      const updatedThemeColors = JSON.stringify(themeModes, null, 2)
-        .replace(/"([a-zA-Z_$][a-zA-Z0-9_$]*)":/g, '$1:') // Remove quotes only from valid JS identifiers
-        .replace(/"(\d+)":/g, '$1:') // Remove quotes from numeric keys
-        .replace(/: "([^"]+)"/g, ': $1'); // Remove quotes from values
-      const updatedThemeFile = themeFileContent.replace(
-        themeColorTokensRegex,
-        `const colors: ColorsWithModes = ${updatedThemeColors};`,
-      );
-      fs.writeFileSync(themeFilePath, updatedThemeFile);
-      // prettify the file
-      execa.commandSync(`yarn prettier --write ${targetRelativePath}`);
-    }
-
-    if (Object.keys(colorTokens?.globalColorTokens).length) {
-      const globalColorTokensRegex = /export const colors: Color = {(.|\n)+?};/gm;
-      // 2. read the bladeTheme File
-      const globalColorTokensPath = path.resolve(__dirname, '../src/tokens/global/colors.ts');
-      const globalColorTokensFile = fs.readFileSync(globalColorTokensPath, 'utf8');
-
-      // 3. write the new tokens to global colors file
-      const updatedGlobalColorTokens = JSON.stringify(colorTokens.globalColorTokens, null, 2)
-        .replace(/"([a-zA-Z_$][a-zA-Z0-9_$]*)":/g, '$1:') // Remove quotes only from valid JS identifiers
-        .replace(/"(\d+)":/g, '$1:') // Remove quotes from numeric keys
-        .replace(/: "([^"]+)"/g, ': $1'); // Remove quotes from values
-      const updatedGlobalColorTokensFile = globalColorTokensFile.replace(
-        globalColorTokensRegex,
-        `export const colors: Color = ${updatedGlobalColorTokens};`,
-      );
-      fs.writeFileSync(globalColorTokensPath, updatedGlobalColorTokensFile);
-      // prettify the file
-      execa.commandSync('yarn prettier --write src/tokens/global/colors.ts');
-    }
-
-    // 6. create branch
-    const branchName = randomNameGenerator
-      .generator([randomNameGenerator.verb, randomNameGenerator.noun])
-      .choose();
-    execa.commandSync(`git checkout -b ${branchName}`);
-    execa.commandSync(`git config user.email ${GITHUB_BOT_EMAIL}`);
-    execa.commandSync(`git config user.name ${GITHUB_BOT_USERNAME}`);
-
-    // 7. Commit all changes
-    execa.commandSync('git status');
-    execa.commandSync('git add -A');
-    execa.commandSync(`git commit -m feat(tokens):\\ add\\ new\\ tokens`, {
-      env: { HUSKY_SKIP_HOOKS: 1 },
-    });
-
-    // // 8. Raise a PR
-    execa.commandSync(`git push origin ${branchName}`);
-    execa.commandSync(
-      `gh pr create --title feat(tokens):\\ add\\ new\\ tokens --head ${branchName} --repo razorpay/blade --body This\\ PR\\ was\\ opened\\ by\\ the\\ Token\\ Upload\\ GitHub\\ action.\\ It\\ updates\\ source\\ token\\ files\\ based\\ on\\ the\\ payload\\ from\\ Figma\\ Plugin.`,
+  if (!fs.existsSync(absolutePath)) {
+    blockers.push(
+      `\`${relativePath}\` is listed in \`scripts/tokenTargets.json\` but does not exist, so the token push skipped it.`,
     );
+    return null;
+  }
+
+  const fileContent = fs.readFileSync(absolutePath, 'utf8');
+  const { paths: previousPaths, matchCount: previousMatchCount } = collectTokenPathsFromSource(
+    fileContent,
+    declarationRegex,
+  );
+
+  // Figma has no idea a token is deprecated, so the deprecated aliases and the `// @deprecated`
+  // markers above them live only in the source — and each mirror carries its own. Both are read
+  // back per file rather than letting a regeneration quietly drop them.
+  const { comments, values, childOrder } = scanDeclaration(fileContent, declarationRegex);
+  const { tree: mergedTree, preserved } = mergePreservedTokens({
+    tree,
+    existingValues: values,
+    preservedPaths: targets.preservedTokenPaths,
+    childOrder,
+  });
+  preserved.forEach((tokenPath) => preservedTokens.add(tokenPath));
+
+  const serialized = serializeTokens(mergedTree, targets.expressionRoots, { comments });
+
+  if (previousMatchCount !== 1) {
+    blockers.push(
+      `Expected exactly one token declaration in \`${relativePath}\` but found ${previousMatchCount}. The file was left untouched — check whether the declaration was renamed or reformatted, and update \`scripts/tokenTargets.json\`.`,
+    );
+    return null;
+  }
+
+  const { content, matchCount } = replaceDeclaration({
+    fileContent,
+    declarationRegex,
+    // function form so `$` sequences inside token values are not read as replacement patterns
+    replacement: replacementTemplate.replace(SERIALIZED_PLACEHOLDER, () => serialized),
+  });
+  if (matchCount !== 1) {
+    blockers.push(`Could not replace the token declaration in \`${relativePath}\`.`);
+    return null;
+  }
+
+  // this is the `faint: transparent` class of bug — a value that looks like a member expression
+  // but resolves to nothing, throwing the moment the theme is imported
+  const unresolvableRoots = findUnresolvableValueRoots({
+    fileContent: content,
+    declarationSource: serialized,
+  });
+  if (unresolvableRoots.length) {
+    blockers.push(
+      `\`${relativePath}\` would reference ${unresolvableRoots
+        .map((root) => `\`${root}\``)
+        .join(', ')}, which ${
+        unresolvableRoots.length === 1 ? 'is' : 'are'
+      } neither imported nor declared in that file. Either the Figma variable should resolve to a global token, or its value belongs in quotes as a plain string.`,
+    );
+    return null;
+  }
+
+  fs.writeFileSync(absolutePath, content);
+  touchedFiles.add(absolutePath);
+  return { previousPaths, mergedPaths: collectTokenPaths(mergedTree) };
+};
+
+/**
+ * Writes one token tree into every file that mirrors it. `blade` and `blade-core` hold identical
+ * copies of the theme files; writing only one of them is what left `blade-core` failing to
+ * typecheck on the last push.
+ */
+const writeTokenTree = ({ label, tree, config }) => {
+  const declarationRegex = new RegExp(config.declaration, 'gm');
+  let newPaths = collectTokenPaths(tree);
+
+  let previousPaths = null;
+  for (const relativePath of config.files) {
+    const written = writeDeclaration({
+      relativePath,
+      declarationRegex,
+      replacementTemplate: config.replacement,
+      tree,
+    });
+    if (!written) continue;
+
+    if (previousPaths && previousPaths.join('\n') !== written.previousPaths.join('\n')) {
+      warnings.push(
+        `The mirrored copies of \`${label}\` were out of sync before this push — \`${relativePath}\` held a different set of token paths than the file before it. Both have been overwritten with the Figma payload.`,
+      );
+    }
+    previousPaths = written.previousPaths;
+    // preserved tokens are part of what landed, so the diff must not call them removed
+    newPaths = written.mergedPaths;
+  }
+
+  return diffTokenPaths(previousPaths ?? newPaths, newPaths);
+};
+
+// ---------------------------------------------------------------------------------------------
+// checks
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Reduces a reported path to the text components actually write.
+ *
+ * Theme tokens are reported as `<theme>.<mode>.<rest>` but consumed as `theme.colors.<rest>`, so
+ * both prefixes come off. Global colors are reported and consumed under the same `globalColors.`
+ * root, so that one stays.
+ */
+const toSearchablePath = (tokenPaths) => [
+  ...new Set(tokenPaths.map((tokenPath) => tokenPath.replace(/^[\w$]+\.(onLight|onDark)\./, ''))),
+];
+
+/** A token path is written both ways in source: `azure.50` in Figma, `azure[50]` in code. */
+const searchVariantsFor = (tokenPath) => [tokenPath, tokenPath.replace(/\.(\d+)(?=\.|$)/g, '[$1]')];
+
+const walkFiles = (directory, extensions, collected = []) => {
+  if (!fs.existsSync(directory)) return collected;
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'build')
+        continue;
+      walkFiles(entryPath, extensions, collected);
+    } else if (extensions.includes(path.extname(entry.name))) {
+      collected.push(entryPath);
+    }
+  }
+  return collected;
+};
+
+/**
+ * A token that disappears from Figma is deleted from the source files, and that is exactly how the
+ * deprecated `popup.*` aliases were dropped out from under `Popover.native.tsx` and the
+ * brand-refresh codemod map. Anything still naming a removed token blocks the push.
+ */
+const findConsumersOfRemovedTokens = (removedPaths) => {
+  if (!removedPaths.length) return [];
+
+  const searchFiles = targets.referenceScanRoots
+    .flatMap((root) => walkFiles(toRepoPath(root), targets.referenceScanExtensions))
+    .filter((filePath) => !touchedFiles.has(filePath));
+
+  const searchTerms = removedPaths.map((tokenPath) => ({
+    tokenPath,
+    variants: searchVariantsFor(tokenPath),
+  }));
+
+  const consumers = [];
+  for (const filePath of searchFiles) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    for (const { tokenPath, variants } of searchTerms) {
+      if (variants.some((variant) => content.includes(variant))) {
+        consumers.push({ tokenPath, file: path.relative(REPO_ROOT, filePath) });
+      }
+    }
+  }
+  return consumers;
+};
+
+const runStep = ({ name, cwd, command }) => {
+  console.log(`\n▶ ${name}: ${command}`);
+  try {
+    execa.commandSync(command, { cwd: toRepoPath(cwd), stdio: 'inherit', shell: true });
+    return true;
   } catch (error) {
-    console.error(error);
-    process.exit(1);
+    blockers.push(`\`${name}\` failed (\`${command}\`). See the workflow logs for the output.`);
+    return false;
   }
 };
-uploadColorTokens();
+
+// ---------------------------------------------------------------------------------------------
+// reporting
+// ---------------------------------------------------------------------------------------------
+
+const bulletList = (items, emptyText) =>
+  items.length ? items.map((item) => `- ${item}`).join('\n') : emptyText;
+
+const collapsibleList = (title, items) => {
+  if (!items.length) return null;
+  return [
+    '<details>',
+    `<summary>${title} (${items.length})</summary>`,
+    '',
+    items.map((item) => `- \`${item}\``).join('\n'),
+    '',
+    '</details>',
+    '',
+  ].join('\n');
+};
+
+const buildPullRequestBody = ({ added, removed, consumers, report }) => {
+  const sections = [
+    'This PR was opened by the Token Upload GitHub action. It updates source token files based on the payload from the Figma plugin.',
+    '',
+  ];
+
+  if (blockers.length) {
+    sections.push(
+      '## ⛔️ Blocking',
+      '',
+      'Opened as a draft because the push could not verify itself. Fix these before marking it ready:',
+      '',
+      bulletList(blockers, ''),
+      '',
+    );
+  }
+
+  sections.push(
+    '## Token changes',
+    '',
+    `**${added.length}** added · **${removed.length}** removed`,
+    '',
+    collapsibleList('Added token paths', added),
+    collapsibleList('Removed token paths', removed),
+  );
+
+  if (removed.length) {
+    sections.push(
+      '> Removals happen when a token exists in code but not in the Figma payload. If a removal is not intentional, the Figma variable is probably missing or renamed rather than deliberately deleted.',
+      '',
+    );
+  }
+
+  if (preservedTokens.size) {
+    sections.push(
+      `${preservedTokens.size} code-owned token${
+        preservedTokens.size === 1 ? '' : 's'
+      } were kept as-is because Figma does not define them, per \`preservedTokenPaths\` in \`packages/blade/scripts/tokenTargets.json\`.`,
+      '',
+      collapsibleList('Preserved token paths', [...preservedTokens].sort()),
+    );
+  }
+
+  if (consumers.length) {
+    sections.push(
+      '## ⚠️ Removed tokens that still have consumers',
+      '',
+      bulletList(
+        consumers.map(({ tokenPath, file }) => `\`${tokenPath}\` — \`${file}\``),
+        '',
+      ),
+      '',
+    );
+  }
+
+  const pluginErrors = report?.errors ?? [];
+  const pluginWarnings = [...(report?.warnings ?? []), ...(report?.diagnostics ?? [])];
+
+  if (pluginErrors.length) {
+    sections.push('## Figma validation errors', '', bulletList(pluginErrors, ''), '');
+  }
+  if (pluginWarnings.length || warnings.length) {
+    sections.push('## Warnings', '', bulletList([...warnings, ...pluginWarnings], '_none_'), '');
+  }
+
+  // `''` entries are deliberate blank lines between markdown blocks, so only drop the nulls that
+  // an empty section returns
+  return sections.filter((section) => section !== null).join('\n');
+};
+
+/**
+ * Removing a token from the public `Colors` type breaks downstream compilation, so it is a major.
+ * Adding one is a minor. Deriving this stops the version from being argued out in review.
+ */
+const determineBump = ({ added, removed }) => {
+  if (removed.length) return 'major';
+  if (added.length) return 'minor';
+  return 'patch';
+};
+
+const writeChangeset = ({ branchName, added, removed }) => {
+  const bump = determineBump({ added, removed });
+  const plural = (count) => (count === 1 ? '' : 's');
+  const summary = [
+    'update design tokens from Figma',
+    '',
+    `Added ${added.length} token${plural(added.length)} and removed ${removed.length} token${plural(
+      removed.length,
+    )}.`,
+  ];
+
+  if (removed.length) {
+    summary.push(
+      '',
+      'Removed tokens are a breaking change for consumers referencing them:',
+      '',
+      ...removed.map((tokenPath) => `- \`${tokenPath}\``),
+    );
+  }
+
+  const frontmatter = targets.changesetPackages
+    .map((packageName) => `'${packageName}': ${bump}`)
+    .join('\n');
+  const changesetPath = toRepoPath(`.changeset/figma-token-push-${branchName}.md`);
+  fs.writeFileSync(changesetPath, `---\n${frontmatter}\n---\n\n${summary.join('\n')}\n`);
+  touchedFiles.add(changesetPath);
+};
+
+// ---------------------------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------------------------
+
+const uploadColorTokens = async () => {
+  const payload = parseTokensArg(process.argv[2]);
+  // A current plugin sends the tokens twice — tagged `{ k, v }` values and the flat-string shape
+  // older scripts read. Prefer the tagged ones; fall back for payloads from an older plugin build,
+  // where `serializeTokens` infers the kind from `expressionRoots` instead.
+  const themeColorTokens = payload?.taggedThemeColorTokens ?? payload?.themeColorTokens ?? {};
+  const globalColorTokens = payload?.taggedGlobalColorTokens ?? payload?.globalColorTokens ?? {};
+  const report = payload?.report;
+
+  // The plugin runs the same validations before publishing, but a payload from an older build
+  // arrives without a report — so its errors are surfaced rather than trusted to have been seen.
+  for (const error of report?.errors ?? []) {
+    blockers.push(`Figma validation: ${error}`);
+  }
+
+  let added = [];
+  let removed = [];
+
+  for (const [themeName, config] of Object.entries(targets.themes)) {
+    const tree = themeColorTokens[themeName];
+    const hasBothModes =
+      Object.keys(tree?.onLight ?? {}).length && Object.keys(tree?.onDark ?? {}).length;
+
+    if (!hasBothModes) {
+      // Skipping quietly is how a theme goes stale without anyone noticing.
+      blockers.push(
+        `The payload contained no usable tokens for \`${themeName}\` (both \`onLight\` and \`onDark\` are required), so ${config.files
+          .map((file) => `\`${file}\``)
+          .join(' and ')} still hold the previous values.`,
+      );
+      continue;
+    }
+
+    const diff = writeTokenTree({ label: themeName, tree, config });
+    added = [...added, ...diff.added.map((tokenPath) => `${themeName}.${tokenPath}`)];
+    removed = [...removed, ...diff.removed.map((tokenPath) => `${themeName}.${tokenPath}`)];
+  }
+
+  for (const themeName of Object.keys(themeColorTokens)) {
+    if (!targets.themes[themeName]) {
+      blockers.push(
+        `The payload contains a theme called \`${themeName}\` with no target files configured. Add it to \`packages/blade/scripts/tokenTargets.json\`, otherwise it is never written anywhere.`,
+      );
+    }
+  }
+
+  if (Object.keys(globalColorTokens).length) {
+    const diff = writeTokenTree({
+      label: 'globalColors',
+      tree: globalColorTokens,
+      config: targets.globalColors,
+    });
+    added = [...added, ...diff.added.map((tokenPath) => `globalColors.${tokenPath}`)];
+    removed = [...removed, ...diff.removed.map((tokenPath) => `globalColors.${tokenPath}`)];
+  } else {
+    warnings.push('The payload contained no global color tokens, so `colors.ts` was not touched.');
+  }
+
+  if (!touchedFiles.size) {
+    console.error('Nothing was written.');
+    blockers.forEach((blocker) => console.error(`- ${blocker}`));
+    process.exit(1);
+  }
+
+  // formatting first: everything after this reads the files back
+  execa.sync('yarn', ['prettier', '--write', ...touchedFiles], { cwd: BLADE_ROOT });
+
+  const consumers = findConsumersOfRemovedTokens(toSearchablePath(removed));
+  if (consumers.length) {
+    blockers.push(
+      `${consumers.length} reference${
+        consumers.length === 1 ? '' : 's'
+      } to removed tokens are still in the repo (listed below). Migrate them, or restore the tokens in Figma.`,
+    );
+  }
+
+  if (!skipTypecheck) {
+    targets.verify.typecheck.forEach(runStep);
+  }
+  if (!skipSnapshots) {
+    // token values are baked into component snapshots, so a push always dirties them
+    targets.verify.snapshots.forEach(runStep);
+  }
+
+  console.log(
+    `\n${added.length} token(s) added, ${removed.length} token(s) removed, ${preservedTokens.size} preserved.`,
+  );
+  warnings.forEach((warning) => console.warn(`⚠️  ${warning}`));
+  blockers.forEach((blocker) => console.error(`⛔️  ${blocker}`));
+
+  const body = buildPullRequestBody({ added, removed, consumers, report });
+
+  if (isDryRun) {
+    console.log(`\n--dry-run: files written, git and GitHub untouched.\n\n${body}`);
+    return;
+  }
+
+  const branchName = randomNameGenerator
+    .generator([randomNameGenerator.verb, randomNameGenerator.noun])
+    .choose();
+
+  writeChangeset({ branchName, added, removed });
+
+  execa.commandSync(`git checkout -b ${branchName}`, { cwd: REPO_ROOT });
+  execa.commandSync(`git config user.email ${GITHUB_BOT_EMAIL}`, { cwd: REPO_ROOT });
+  execa.commandSync(`git config user.name ${GITHUB_BOT_USERNAME}`, { cwd: REPO_ROOT });
+  execa.commandSync('git add -A', { cwd: REPO_ROOT });
+  execa.sync('git', ['commit', '-m', 'feat(tokens): update tokens from figma'], {
+    cwd: REPO_ROOT,
+    env: { HUSKY_SKIP_HOOKS: 1 },
+  });
+  execa.commandSync(`git push origin ${branchName}`, { cwd: REPO_ROOT });
+
+  const title = blockers.length
+    ? 'feat(tokens): update tokens from figma (needs attention)'
+    : 'feat(tokens): update tokens from figma';
+
+  execa.sync(
+    'gh',
+    [
+      'pr',
+      'create',
+      '--title',
+      title,
+      '--head',
+      branchName,
+      '--repo',
+      'razorpay/blade',
+      '--body',
+      body,
+      ...(blockers.length ? ['--draft'] : []),
+    ],
+    { cwd: REPO_ROOT, stdio: 'inherit' },
+  );
+};
+
+uploadColorTokens().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/plugin-figma-token-publisher/README.md
+++ b/packages/plugin-figma-token-publisher/README.md
@@ -10,5 +10,104 @@ This plugin is used to sync the tokens from Figma to Code.
 - Run `yarn build:watch` to start webpack in watch mode.
 - Open `Figma` -> `Plugins` -> `Development` -> `Import plugin from manifest...` and choose `manifest.json` file from this repo.
 
+## How a token push works
 
+The plugin is only the first half of the pipeline. The second half lives in
+`packages/blade/scripts` and runs inside the `blade-tokens-upload.yml` workflow.
 
+| Stage                                      | Where                                                     |
+| ------------------------------------------ | --------------------------------------------------------- |
+| Read Figma variables, validate, tag values | `src/plugin/makeColorTokens.ts`, `validateColorTokens.ts` |
+| gzip + base64, dispatch the workflow       | `src/app/api/api.ts`                                      |
+| Write source files, verify, open the PR    | `packages/blade/scripts/uploadTokens.js`                  |
+
+### The payload is sent in two shapes
+
+`app/api/api.ts` dispatches the workflow with `ref: 'master'`, so **the script that runs is always
+the one on `master`**, while the plugin build is installed by hand. The two halves version
+independently and the plugin cannot assume the script has caught up with it.
+
+So the payload carries the tokens twice:
+
+| Key                                                  | Read by                                       |
+| ---------------------------------------------------- | --------------------------------------------- |
+| `themeColorTokens` / `globalColorTokens`             | any script, including old ones — flat strings |
+| `taggedThemeColorTokens` / `taggedGlobalColorTokens` | a current script — `{ k, v }` values          |
+
+In the flat shape the quoting is baked into the string (backticks for a template, single quotes for
+a string, bare for an expression), because those scripts write the value out verbatim after
+stripping one layer of JSON quotes.
+
+**Any change to the payload shape has to keep the flat keys readable by the script on `master`.**
+Sending only a new shape takes down every push until the script lands.
+
+### Value tagging
+
+Figma variables become one of three things in TypeScript, and the plugin says which:
+
+| Kind | Written as         | Example                                |
+| ---- | ------------------ | -------------------------------------- |
+| `e`  | a bare expression  | `globalColors.chromatic.azure[500]`    |
+| `s`  | a quoted string    | `'transparent'`                        |
+| `t`  | a template literal | `` `hsla(0, 0%, 0%, ${opacity[8]})` `` |
+
+An alias is written bare only when it resolves to one of `expressionRoots` in
+`packages/blade/scripts/tokenTargets.json`. Everything else becomes a string. The write side then
+re-reads what it produced and fails if any bare value cannot be resolved from the imports of the
+file it landed in.
+
+### Adding a theme
+
+Two places, both of which will complain if you miss the other:
+
+1. `FIGMA_MODE_THEME_MAP` in `src/plugin/makeColorTokens.ts` — maps the Figma mode prefix
+   (`blade`, `bladeNeutral`) to the code theme name. An unmapped mode is reported as an error
+   rather than dropped.
+2. `themes` in `packages/blade/scripts/tokenTargets.json` — lists every file the theme is written
+   into. `blade` and `blade-core` keep identical copies, so both belong in the list. A theme in
+   the payload with no entry here blocks the push.
+
+### Tokens that live in code, not Figma
+
+A push regenerates the whole declaration from the payload, so a token Figma has never heard of is
+deleted. Deprecated aliases are exactly that — they are kept for consumers, not authored in Figma —
+which is how `popup.[background|border].[subtle|intense]` got dropped from a PR.
+
+`preservedTokenPaths` in `packages/blade/scripts/tokenTargets.json` lists the paths to carry over
+verbatim, comments included. `*` matches one segment, so a leading `*` covers both modes:
+
+```json
+"preservedTokenPaths": ["*.popup.background.subtle", "*.popup.border.subtle"]
+```
+
+A path Figma _does_ define is unaffected — the payload always wins where it has an opinion. When a
+token is genuinely ready to go, delete its line here and the next push removes it.
+
+This is not the plugin's concern: Figma has no way to express "deprecated but keep it", so the
+decision belongs on the code side.
+
+### What blocks a push
+
+The plugin refuses to publish, and the workflow opens the PR as a **draft** with the reasons in the
+body, when any of these hold:
+
+- a value would be written as a bare identifier the target file cannot resolve
+- a theme came back missing `onLight` or `onDark`
+- the two themes disagree on which token paths exist
+- a token removed from Figma is still referenced somewhere in the repo
+- typecheck or the snapshot run fails
+
+Removals, hardcoded colours, and emphasis groups where every level shares one value are reported
+as warnings rather than blocked.
+
+### Replaying a payload locally
+
+The plugin logs the payload it posts. Save it, then:
+
+```bash
+cd packages/blade
+node ./scripts/uploadTokens.js "$(cat payload.b64)" --dry-run --skip-typecheck --skip-snapshots
+```
+
+`--dry-run` writes the files and prints the PR body it would have used, but touches neither git nor
+GitHub. Drop the skip flags to run the full verification.

--- a/packages/plugin-figma-token-publisher/src/app/components/App.tsx
+++ b/packages/plugin-figma-token-publisher/src/app/components/App.tsx
@@ -1,12 +1,70 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import React, { useState } from 'react';
 import '../styles/ui.css';
 // eslint-disable-next-line import/extensions
 import 'figma-plugin-ds/dist/figma-plugin-ds.css';
 import { uploadTokens } from '../api/api';
 
+type TokenReport = {
+  errors: string[];
+  warnings: string[];
+  diagnostics: string[];
+};
+
+const EMPTY_REPORT: TokenReport = { errors: [], warnings: [], diagnostics: [] };
+
+/**
+ * Report messages carry token paths in backticks. Rendering them as text puts a wall of punctuation
+ * in front of the reader; as chips, the path is the thing the eye lands on.
+ */
+const withCodeChips = (message: string): ReactNode[] =>
+  message.split(/`([^`]+)`/g).map((part, index) =>
+    index % 2 ? (
+      // eslint-disable-next-line react/no-array-index-key
+      <code key={index} className="chip">
+        {part}
+      </code>
+    ) : (
+      part
+    ),
+  );
+
+const ReportSection = ({
+  title,
+  tone,
+  items,
+  defaultOpen,
+}: {
+  title: string;
+  tone: 'error' | 'warning' | 'info';
+  items: string[];
+  defaultOpen: boolean;
+}): ReactElement | null => {
+  if (!items.length) return null;
+
+  return (
+    <details className={`report report--${tone}`} open={defaultOpen}>
+      <summary className="report__summary">
+        <span className="report__title">{title}</span>
+        <span className="report__count">{items.length}</span>
+      </summary>
+      <ul className="report__list">
+        {items.map((item) => (
+          <li key={item} className="report__item">
+            {withCodeChips(item)}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+};
+
 const App = (): ReactElement => {
   const [colorTokens, setColorTokens] = useState({});
+  const [report, setReport] = useState<TokenReport>(EMPTY_REPORT);
+  // A clean run and a run that has not happened yet both have an empty report, but only one of
+  // them should say so.
+  const [hasGeneratedTokens, setHasGeneratedTokens] = useState(false);
   const [personalAccessToken, setPersonalAccessToken] = useState('');
   const [svgString, setSvgString] = React.useState('');
 
@@ -14,7 +72,14 @@ const App = (): ReactElement => {
     setPersonalAccessToken(event.target.value);
   };
 
+  // Publishing with known errors means the run either deletes tokens or writes values that throw
+  // on import. Both have shipped before; neither is worth a round trip through CI to discover.
+  const hasBlockingErrors = report.errors.length > 0;
+  const canPublish = !hasBlockingErrors && personalAccessToken.length > 0;
+  const reportItemCount = report.errors.length + report.warnings.length + report.diagnostics.length;
+
   const onCreate = React.useCallback(async () => {
+    if (hasBlockingErrors) return;
     await uploadTokens({
       orgName: 'razorpay',
       repoName: 'blade',
@@ -22,7 +87,7 @@ const App = (): ReactElement => {
       personalAccessToken,
       colorTokens,
     });
-  }, [colorTokens, personalAccessToken]);
+  }, [colorTokens, personalAccessToken, hasBlockingErrors]);
 
   const onCancel = React.useCallback(() => {
     // nosemgrep
@@ -33,7 +98,10 @@ const App = (): ReactElement => {
     window.onmessage = (event) => {
       const { type, data } = event.data.pluginMessage;
       if (type === 'export-color-tokens') {
-        setColorTokens(data);
+        const { report: tokenReport, ...tokens } = data;
+        setColorTokens({ ...tokens, report: tokenReport ?? EMPTY_REPORT });
+        setReport(tokenReport ?? EMPTY_REPORT);
+        setHasGeneratedTokens(true);
       }
       if (type === 'export-svg-icons') {
         const svg = data;
@@ -44,55 +112,78 @@ const App = (): ReactElement => {
   }, []);
 
   return (
-    <section className="container">
-      <p className="section-title">
-        To publish the generated tokens to your GitHub repository, you need a personal access token.
-        Don't have access token?
-        <span>
-          &nbsp;
+    <main className="app">
+      <div className="app__scroll">
+        <p className="intro">
+          Publishing needs a GitHub personal access token.{' '}
           <a
             href="https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages,read:repo_hook,write:packages"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Generate here
+            Generate one
           </a>
-        </span>
-      </p>
-      <label htmlFor="accesssTokenInput" className="label">
-        GitHub Personal Access Token
-      </label>
-      <input
-        id="accesssTokenInput"
-        className="input__field input__field--margin"
-        type="password"
-        placeholder="xxxxxx"
-        value={personalAccessToken}
-        onChange={handlePersonalAccessTokenChange}
-      />
-      <section className="container__button">
-        <button className="button button--primary" onClick={onCreate}>
-          Export Tokens
-        </button>
-        <button className="button button--secondary" onClick={onCancel}>
-          Cancel
-        </button>
-      </section>
-      {svgString ? (
-        <>
-          <label htmlFor="exportedIcons" className="label">
-            Exported Icons:
-          </label>
-          <textarea
-            id="exportedIcons"
-            className="input__field input__field--margin"
-            style={{ height: 200 }}
-            value={svgString}
-            readOnly
-          />
-        </>
-      ) : null}
-    </section>
+        </p>
+
+        <ReportSection
+          title="Fix before publishing"
+          tone="error"
+          items={report.errors}
+          defaultOpen
+        />
+        <ReportSection
+          title="Worth checking"
+          tone="warning"
+          items={report.warnings}
+          defaultOpen={!hasBlockingErrors}
+        />
+        <ReportSection title="Notes" tone="info" items={report.diagnostics} defaultOpen={false} />
+
+        {hasGeneratedTokens && !reportItemCount ? (
+          <p className="all-clear">✅ Tokens generated, nothing flagged.</p>
+        ) : null}
+
+        {svgString ? (
+          <>
+            <label htmlFor="exportedIcons" className="label">
+              Exported icons
+            </label>
+            <textarea id="exportedIcons" className="input__field" value={svgString} readOnly />
+          </>
+        ) : null}
+      </div>
+
+      <footer className="app__footer">
+        <label htmlFor="accesssTokenInput" className="label">
+          GitHub personal access token
+        </label>
+        <input
+          id="accesssTokenInput"
+          className="input__field"
+          type="password"
+          placeholder="xxxxxx"
+          value={personalAccessToken}
+          onChange={handlePersonalAccessTokenChange}
+        />
+        <div className="app__actions">
+          <button className="button button--secondary" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="button button--primary"
+            onClick={onCreate}
+            disabled={!canPublish}
+            title={
+              hasBlockingErrors
+                ? 'Resolve the errors above in Figma, then run the plugin again.'
+                : undefined
+            }
+          >
+            Export tokens
+          </button>
+        </div>
+      </footer>
+    </main>
   );
 };
 

--- a/packages/plugin-figma-token-publisher/src/app/styles/ui.css
+++ b/packages/plugin-figma-token-publisher/src/app/styles/ui.css
@@ -1,20 +1,65 @@
-.container {
-  margin: 10px 20px;
+/*
+ * The plugin window is small and the validation report can run long, so the layout is a scrolling
+ * body with the token field and buttons pinned to the bottom. Without the pin, a report of any
+ * length pushes the publish button out of reach.
+ */
+html,
+body,
+#react-page {
+  height: 100%;
+  margin: 0;
+}
+
+.app {
+  height: 100%;
   display: flex;
   flex-direction: column;
+  color: var(--figma-color-text, #000000);
 }
 
-.container__button {
+.app__scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 16px 8px;
+}
+
+.app__footer {
+  flex-shrink: 0;
+  padding: 12px 16px 16px;
+  border-top: 1px solid var(--figma-color-border, #e5e5e5);
+  background: var(--figma-color-bg, #ffffff);
+}
+
+.app__actions {
   display: flex;
-  flex-direction: row-reverse;
-  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
 }
 
-.input__field--margin {
-  margin-bottom: 40px !important;
+.intro {
+  margin: 0 0 16px;
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--figma-color-text-secondary, #666666);
+}
+
+.label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--figma-color-text, #000000a9) !important;
+}
+
+.input__field {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 textarea.input__field {
+  height: 180px;
   border: 1px solid var(--figma-color-border, #e5e5e5);
   resize: vertical;
   font-family: inherit;
@@ -27,21 +72,117 @@ textarea.input__field:focus {
   border-color: var(--figma-color-border-selected, #18a0fb);
 }
 
-.button {
-  margin-left: 20px;
+.button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
-.section-title {
-  display: block !important;
-  margin-bottom: 16px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--figma-color-text, #000000);
-  line-height: 20px;
-}
-
-.label {
+.all-clear {
+  margin: 0;
   font-size: 11px;
+  line-height: 17px;
+  color: var(--figma-color-text-secondary, #666666);
+}
+
+/* ── Validation report ─────────────────────────────────────────────────────────────────────── */
+/* Collapsible so a long list of advisories never hides the errors above it. */
+
+.report {
+  margin-bottom: 8px;
+  border-radius: 4px;
+  border: 1px solid;
+  font-size: 11px;
+  line-height: 17px;
+  overflow: hidden;
+}
+
+.report__summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.report__summary::-webkit-details-marker {
+  display: none;
+}
+
+/* disclosure triangle, rotated by the open state */
+.report__summary::before {
+  content: '';
+  flex-shrink: 0;
+  width: 0;
+  height: 0;
+  border-left: 4px solid currentColor;
+  border-top: 3.5px solid transparent;
+  border-bottom: 3.5px solid transparent;
+  opacity: 0.5;
+  transition: transform 100ms ease;
+}
+
+.report[open] > .report__summary::before {
+  transform: rotate(90deg);
+}
+
+.report__title {
+  flex: 1;
   font-weight: 600;
-  color: var(--figma-color-text, #000000a9) !important;
+}
+
+.report__count {
+  flex-shrink: 0;
+  min-width: 16px;
+  padding: 0 5px;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  background: var(--figma-color-bg, #ffffff);
+  opacity: 0.75;
+}
+
+.report__list {
+  margin: 0;
+  padding: 0 10px 10px 26px;
+}
+
+.report__item {
+  margin-bottom: 8px;
+  color: var(--figma-color-text-secondary, #333333);
+  overflow-wrap: anywhere;
+}
+
+.report__item:last-child {
+  margin-bottom: 0;
+}
+
+/* Token paths inside a message. Chips rather than raw backticks — the path is what is being
+   pointed at, so it should be the thing that reads first. */
+.chip {
+  padding: 1px 3px;
+  border: 1px solid var(--figma-color-border, #00000014);
+  border-radius: 3px;
+  background: var(--figma-color-bg, #ffffff);
+  font-family: 'SF Mono', ui-monospace, Menlo, Consolas, monospace;
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.report--error {
+  border-color: var(--figma-color-border-danger-strong, #f8b4ad);
+  background: var(--figma-color-bg-danger-tertiary, #fdeceb);
+}
+
+.report--warning {
+  border-color: var(--figma-color-border-warning-strong, #ffd966);
+  background: var(--figma-color-bg-warning-tertiary, #fff8e0);
+}
+
+.report--info {
+  border-color: var(--figma-color-border, #e5e5e5);
+  background: var(--figma-color-bg-secondary, #f5f5f5);
 }

--- a/packages/plugin-figma-token-publisher/src/plugin/getIcons.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/getIcons.ts
@@ -65,6 +65,8 @@ const getIcons = async (): Promise<void> => {
     type: 'export-svg-icons',
     data: svgStrings,
   });
+  // the exported SVG blob needs a readable textarea, not the default token-field sized window
+  figma.ui.resize(460, 560);
   figma.ui.show();
 };
 

--- a/packages/plugin-figma-token-publisher/src/plugin/index.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/index.ts
@@ -3,7 +3,9 @@ import getIcons from './getIcons';
 import makeColorTokens from './makeColorTokens';
 import makeDevTokenNames from './makeDevTokenNames';
 import showNotification from './showNotification';
-figma.showUI(__html__, { visible: false, width: 350, height: 250 });
+// Starting size for the token field and buttons alone. `makeColorTokens` grows the window when it
+// has a validation report to show.
+figma.showUI(__html__, { visible: false, width: 400, height: 260 });
 
 const runCommand = async (): Promise<void> => {
   if (figma.command === 'colorTokens') {

--- a/packages/plugin-figma-token-publisher/src/plugin/makeColorTokens.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/makeColorTokens.ts
@@ -4,17 +4,37 @@
 import setValue from '../utils/setValue';
 import { opacity as opacityTokens } from '../../../blade/src/tokens/global/opacity';
 import showNotification from './showNotification';
+import validateColorTokens from './validateColorTokens';
+import type {
+  LegacyThemeModes,
+  ThemeModes,
+  TokenPayload,
+  TokenReport,
+  TokenTree,
+  TokenValue,
+} from './tokenTypes';
+import { EXPRESSION, STRING, TEMPLATE, toLegacyTokenTree } from './tokenTypes';
 
 const THEME_TOKENS_COLLECTION = 'Blade Theme Tokens';
 
 const GLOBAL_TOKENS_COLLECTION = '_global-tokens';
 
-// Figma modes are named `<figmaThemePrefix>/<scheme>` (eg: blade/onLight, bladeNeutral/onDark).
-// This maps the Figma theme prefix to the corresponding code theme name.
+// Figma modes are named `<figmaThemePrefix><separator><scheme>` (eg: blade/onLight,
+// bladeNeutral - onDark). This maps the Figma theme prefix to the corresponding code theme name.
 const FIGMA_MODE_THEME_MAP: Record<string, string> = {
   blade: 'bladeTheme',
   bladeNeutral: 'bladeNeutralTheme',
 };
+
+// Identifiers a token value may be written unquoted against. They correspond to the imports the
+// theme files carry; anything else has to be a string literal or it throws on import.
+const EXPRESSION_ROOTS = ['globalColors', 'opacity'];
+
+// Values that are genuinely meant to be plain strings in the source, so no warning for them.
+const KNOWN_LITERAL_VALUES = ['transparent'];
+
+/** Collected while walking the Figma variables and carried through to the PR body. */
+let report: TokenReport = { errors: [], warnings: [], diagnostics: [] };
 
 const makeGlobalColorTokenName = (variableName: string): string => {
   return variableName.split('/').slice(1).join('.');
@@ -35,7 +55,31 @@ const makeThemeTokenName = (variableName: string, isValue = false): string => {
   return transformed;
 };
 
-const opacityMap = {};
+/**
+ * `-` becomes `.`, which nests the token one level deeper than its name reads. Reported separately
+ * from the transform so it is only raised for variables that actually reach the payload — the
+ * filtered ones (`_`, `❌`, `elevation`) are dropped before this runs.
+ */
+const reportStrayHyphen = (variableName: string): void => {
+  if (!variableName.replace('_global-colors', 'globalColors').includes('-')) return;
+  report.diagnostics.push(
+    `The Figma variable \`${variableName}\` contains a hyphen, which becomes a \`.\` in the token path. Rename it if that nesting was not intended.`,
+  );
+};
+
+/**
+ * The scheme is the fixed part of a mode name, so anchoring on it survives theme prefixes that
+ * themselves contain the separator (eg: `blade-neutral/onLight`).
+ */
+const parseModeName = (
+  modeName: string,
+): { figmaThemePrefix: string; scheme: keyof ThemeModes } | null => {
+  const match = /^(.*?)\s*[-/]\s*(onLight|onDark)$/.exec(modeName.trim());
+  if (!match) return null;
+  return { figmaThemePrefix: match[1], scheme: match[2] as keyof ThemeModes };
+};
+
+const opacityMap: Record<string, string> = {};
 for (const [key, value] of Object.entries(opacityTokens)) {
   opacityMap[value.toFixed(2)] = `\${opacity[${key}]}`;
 }
@@ -78,16 +122,65 @@ const rgbaToHsla = ({ r, g, b, a }: RGBA): string => {
   s = +(s * 100).toFixed(1);
   l = +(l * 100).toFixed(1);
 
-  return `hsla(${h}, ${Math.round(s)}%, ${Math.round(l)}%, ${opacityMap[a.toFixed(2)]})`;
+  // An alpha with no matching opacity token would otherwise interpolate as `undefined`.
+  const alpha = opacityMap[a.toFixed(2)];
+  if (!alpha) {
+    report.diagnostics.push(
+      `Alpha ${a.toFixed(
+        2,
+      )} has no matching token in \`opacity\`, so it was written as a raw number.`,
+    );
+  }
+
+  return `hsla(${h}, ${Math.round(s)}%, ${Math.round(l)}%, ${alpha ?? a.toFixed(2)})`;
 };
-const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
-  const themeColorTokens: Record<
-    string,
-    { onLight: Record<string, any>; onDark: Record<string, any> }
-  > = {
-    bladeTheme: { onLight: {}, onDark: {} },
-    bladeNeutralTheme: { onLight: {}, onDark: {} },
-  };
+
+/**
+ * An alias resolves to another variable's name. If that name starts with an identifier the theme
+ * files import, it is an expression; otherwise it is a plain string. Guessing this on the write
+ * side is what turned `'transparent'` into a bare identifier and broke theme initialisation.
+ *
+ * The variable's own `codeSyntax` field is deliberately not consulted here. It is written by this
+ * plugin's own "Generate Token's Dev Names" command from the same variable name, using different
+ * rules (no `_global-colors` mapping, and only the first numeric segment bracketed), and only
+ * refreshed when someone runs that command by hand. It is documentation derived from the name, not
+ * an independent statement of what the token is called in code.
+ */
+const makeAliasValue = (referencedName: string, tokenName: string): TokenValue => {
+  const expression = makeThemeTokenName(referencedName, true);
+  const root = expression.split(/[.[]/)[0];
+
+  if (EXPRESSION_ROOTS.includes(root)) {
+    reportStrayHyphen(referencedName);
+    return { k: EXPRESSION, v: expression };
+  }
+
+  // A value shaped like a path is a reference to a variable that is not published to code. Writing
+  // it as a string produces a colour of `'_styles.button.primary.default[000]'`, which typechecks
+  // (the token type is just `string`), renders as nothing, and survives every downstream check —
+  // the write side's resolve check only catches bare identifiers. Nothing else will catch this.
+  if (/[.[]/.test(expression)) {
+    report.errors.push(
+      `\`${tokenName}\` aliases \`${referencedName}\`, which is not published to code. Theme tokens have to point at a variable under \`_global-colors\`; publishing this writes the literal string \`'${expression}'\` where a colour belongs.`,
+    );
+    return { k: STRING, v: expression };
+  }
+
+  // A bare word is a CSS keyword like `transparent` — legitimate, but worth naming if unfamiliar.
+  if (!KNOWN_LITERAL_VALUES.includes(expression)) {
+    report.warnings.push(
+      `\`${tokenName}\` aliases \`${referencedName}\`, which will be written as the plain string \`'${expression}'\`. That is correct for a CSS keyword and wrong for anything else.`,
+    );
+  }
+
+  return { k: STRING, v: expression };
+};
+
+const makeThemeColorTokens = async (): Promise<Record<string, ThemeModes>> => {
+  const themeColorTokens: Record<string, ThemeModes> = {};
+  for (const themeName of Object.values(FIGMA_MODE_THEME_MAP)) {
+    themeColorTokens[themeName] = { onLight: {}, onDark: {} };
+  }
 
   // filter colors collection
   const colorsCollection = (await figma.variables.getLocalVariableCollectionsAsync()).find(
@@ -101,10 +194,26 @@ const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
   }
 
   // create modes set in the collection eg: onLight, onDark, etc.
-  const colorModes = colorsCollection.modes.reduce(
+  const colorModes = colorsCollection.modes.reduce<Record<string, string>>(
     (acc, mode) => Object.assign(acc, { [mode.name]: mode.modeId }),
     {},
   );
+
+  // A mode nobody maps is a mode nobody writes. Report it once, up front, rather than dropping
+  // every one of its variables silently the way the previous version did.
+  const unmappedModes = Object.keys(colorModes).filter((modeName) => {
+    const parsed = parseModeName(modeName);
+    return !parsed || !FIGMA_MODE_THEME_MAP[parsed.figmaThemePrefix];
+  });
+  if (unmappedModes.length) {
+    report.errors.push(
+      `The "${THEME_TOKENS_COLLECTION}" collection has ${unmappedModes
+        .map((mode) => `\`${mode}\``)
+        .join(', ')}, which no theme maps to. Modes must be named \`<${Object.keys(
+        FIGMA_MODE_THEME_MAP,
+      ).join('|')}>/<onLight|onDark>\`, or the theme has to be added to the plugin.`,
+    );
+  }
 
   for (const variableId of colorsCollection.variableIds) {
     // get all the variables by their ids in our collection
@@ -118,38 +227,51 @@ const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
     if (tokenName.includes('❌') || tokenName.includes('_') || tokenName.includes('elevation')) {
       continue;
     }
+    reportStrayHyphen(variable.name);
 
     // prepare for storing variables in code in the format of dark and light modes
     for (const [modeName, modeId] of Object.entries(colorModes)) {
-      // mode names are of the form `<figmaThemePrefix><separator><scheme>` where the separator
-      // is either " - " or "/" eg: "bladeNeutral - onLight", "blade/onDark"
-      const [figmaThemePrefix, scheme] = modeName.split(/\s*[-/]\s*/);
-      const themeName = FIGMA_MODE_THEME_MAP[figmaThemePrefix];
-      if (!themeName || (scheme !== 'onLight' && scheme !== 'onDark')) {
-        continue;
-      }
+      const parsedMode = parseModeName(modeName);
+      if (!parsedMode) continue;
 
-      const variableModeValue: VariableValue = variable.valuesByMode[modeId as string];
-      // if the variable references another variable then we take the name of the referenced variable and set that as a value
+      const themeName = FIGMA_MODE_THEME_MAP[parsedMode.figmaThemePrefix];
+      if (!themeName) continue;
+
+      const variableModeValue: VariableValue = variable.valuesByMode[modeId];
+
+      // if the variable references another variable then we take the name of the referenced
+      // variable and set that as a value
       // eg: surface.background.neutral.subtle -> globalColors.gray.200
       if (typeof variableModeValue === 'object' && 'id' in variableModeValue) {
         const referencedVariable = await figma.variables.getVariableByIdAsync(variableModeValue.id);
         if (!referencedVariable) {
+          // dropping this leaves a hole that the write side reads as a deliberate token deletion
+          report.errors.push(
+            `\`${tokenName}\` in \`${modeName}\` aliases a variable that could not be read. Publishing now would delete the token from the theme files.`,
+          );
           continue;
         }
         setValue(
-          themeColorTokens[themeName][scheme],
+          themeColorTokens[themeName][parsedMode.scheme],
           tokenName,
-          makeThemeTokenName(referencedVariable.name, true),
+          makeAliasValue(referencedVariable.name, tokenName),
         );
-      } else if (
-        typeof variableModeValue === 'object' &&
-        (tokenName.includes('transparent') || tokenName.includes('elevation'))
-      ) {
-        const tokenHSLAValue = rgbaToHsla(variableModeValue as RGBA);
-        setValue(themeColorTokens[themeName][scheme], tokenName, `\`${tokenHSLAValue}\``);
+      } else if (typeof variableModeValue === 'object') {
+        // a raw colour rather than an alias — kept, because dropping it deletes the token, but
+        // flagged, because a theme token is supposed to point at a global one
+        if (!tokenName.includes('transparent')) {
+          report.warnings.push(
+            `\`${tokenName}\` in \`${modeName}\` holds a hardcoded colour instead of pointing at a global token.`,
+          );
+        }
+        setValue(themeColorTokens[themeName][parsedMode.scheme], tokenName, {
+          k: TEMPLATE,
+          v: rgbaToHsla(variableModeValue as RGBA),
+        });
       } else {
-        console.error('the theme variable token has hardcoded value', tokenName, variableModeValue);
+        report.errors.push(
+          `\`${tokenName}\` in \`${modeName}\` has a value the plugin cannot read (${typeof variableModeValue}).`,
+        );
       }
     }
   }
@@ -157,8 +279,8 @@ const makeThemeColorTokens = async (): Promise<Record<string, any>> => {
   return themeColorTokens;
 };
 
-const makeGlobalColorTokens = async (): Promise<Record<string, any>> => {
-  const globalColorTokens = {};
+const makeGlobalColorTokens = async (): Promise<TokenTree> => {
+  const globalColorTokens: TokenTree = {};
 
   // filter colors collection
   const globalColorTokensCollection = (
@@ -184,8 +306,7 @@ const makeGlobalColorTokens = async (): Promise<Record<string, any>> => {
       const tokenName = makeGlobalColorTokenName(variable.name);
       const variableColor = variable.valuesByMode[colorModes.default] as RGBA;
       if (typeof variableColor === 'object') {
-        const tokenHSLAValue = rgbaToHsla(variableColor);
-        setValue(globalColorTokens, tokenName, `\`${tokenHSLAValue}\``);
+        setValue(globalColorTokens, tokenName, { k: TEMPLATE, v: rgbaToHsla(variableColor) });
       }
     }
   }
@@ -194,34 +315,60 @@ const makeGlobalColorTokens = async (): Promise<Record<string, any>> => {
 };
 
 export const makeColorTokens = async (): Promise<void> => {
+  report = { errors: [], warnings: [], diagnostics: [] };
+
   const themeColorTokens = await makeThemeColorTokens();
   const globalColorTokens = await makeGlobalColorTokens();
 
-  const hasThemeTokens = Object.values(themeColorTokens).some(
-    (theme) => Object.keys(theme.onLight).length && Object.keys(theme.onDark).length,
-  );
-  const hasGlobalTokens = Object.keys(globalColorTokens).length;
+  // One badly bound variable is walked once per theme per mode, so its message would otherwise be
+  // repeated four times over.
+  report.errors = [...new Set(report.errors)];
+  report.warnings = [...new Set(report.warnings)];
+  report.diagnostics = [...new Set(report.diagnostics)];
 
-  if (hasThemeTokens || hasGlobalTokens) {
-    showNotification({
-      figma,
-      type: 'information',
-      text: '✅ Color tokens created!',
-    });
-    figma.ui.postMessage({
-      type: 'export-color-tokens',
-      data: { themeColorTokens, globalColorTokens },
-    });
-    console.log({ themeColorTokens, globalColorTokens });
-    figma.ui.show();
-  } else {
-    // Surface the failure instead of silently doing nothing so the cause is visible.
-    showNotification({
-      figma,
-      type: 'error',
-      text: `⛔️ No color tokens were generated. Ensure the "${THEME_TOKENS_COLLECTION}" and "${GLOBAL_TOKENS_COLLECTION}" variable collections exist in this file.`,
-    });
+  validateColorTokens({ themeColorTokens, globalColorTokens, report });
+
+  const hasErrors = report.errors.length > 0;
+
+  showNotification({
+    figma,
+    type: hasErrors ? 'error' : 'information',
+    text: hasErrors
+      ? `⛔️ ${report.errors.length} problem(s) found — see the plugin window.`
+      : '✅ Color tokens created!',
+  });
+
+  // Both shapes go out: the flat-string one every version of `uploadTokens.js` can read, and the
+  // tagged one a current script prefers. The workflow runs the script from `master`, so the plugin
+  // cannot assume the other half of the pipeline has caught up with it.
+  const legacyThemeColorTokens: Record<string, LegacyThemeModes> = {};
+  for (const themeName of Object.keys(themeColorTokens)) {
+    legacyThemeColorTokens[themeName] = {
+      onLight: toLegacyTokenTree(themeColorTokens[themeName].onLight),
+      onDark: toLegacyTokenTree(themeColorTokens[themeName].onDark),
+    };
   }
+
+  const data: TokenPayload = {
+    version: 2,
+    themeColorTokens: legacyThemeColorTokens,
+    globalColorTokens: toLegacyTokenTree(globalColorTokens),
+    taggedThemeColorTokens: themeColorTokens,
+    taggedGlobalColorTokens: globalColorTokens,
+    report,
+  };
+
+  figma.ui.postMessage({ type: 'export-color-tokens', data });
+  console.log(data);
+
+  // The default window only fits the token field. A report needs room to be read rather than
+  // scrolled a line at a time, so grow with roughly how much there is to say.
+  const reportLines = report.errors.length + report.warnings.length + report.diagnostics.length;
+  if (reportLines) {
+    figma.ui.resize(460, Math.min(640, 260 + reportLines * 54));
+  }
+
+  figma.ui.show();
 };
 
 export default makeColorTokens;

--- a/packages/plugin-figma-token-publisher/src/plugin/tokenTypes.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/tokenTypes.ts
@@ -1,0 +1,115 @@
+/**
+ * How a token value is written into TypeScript source.
+ *
+ * The write side used to guess: it stripped the quotes off every string value, which turned the
+ * literal `'transparent'` into a bare `transparent` identifier that nothing imported. The plugin
+ * knows which of the two a value is, so it says so rather than leaving it to a regex.
+ */
+export const EXPRESSION = 'e'; // written bare:          globalColors.chromatic.azure[500]
+export const STRING = 's'; // written quoted:        'transparent'
+export const TEMPLATE = 't'; // written in backticks:  `hsla(0, 0%, 0%, ${opacity[8]})`
+
+export type TokenValueKind = typeof EXPRESSION | typeof STRING | typeof TEMPLATE;
+
+/** Short keys keep the gzipped workflow_dispatch payload under GitHub's 65,535 character limit. */
+export type TokenValue = {
+  k: TokenValueKind;
+  v: string;
+};
+
+export type TokenTree = { [key: string]: TokenValue | TokenTree };
+
+export type ThemeModes = {
+  onLight: TokenTree;
+  onDark: TokenTree;
+};
+
+/**
+ * `errors` block the publish. `warnings` and `diagnostics` are carried through to the PR body so a
+ * reviewer sees what the payload was unsure about instead of finding out from CI.
+ */
+export type TokenReport = {
+  errors: string[];
+  warnings: string[];
+  diagnostics: string[];
+};
+
+/**
+ * The payload carries the tokens twice.
+ *
+ * `themeColorTokens` / `globalColorTokens` are the flat-string shape every version of
+ * `uploadTokens.js` has always understood. `taggedThemeColorTokens` / `taggedGlobalColorTokens`
+ * carry the `{ k, v }` values, which a current script prefers.
+ *
+ * This is not belt-and-braces. The plugin dispatches the workflow against `master` (see
+ * `app/api/api.ts`), so the script that runs is whatever is on master at that moment, while the
+ * plugin build is installed by hand. A payload that only the new script can read takes down every
+ * push until the script lands — which is exactly what happened.
+ */
+export type TokenPayload = {
+  version: 2;
+  themeColorTokens: Record<string, LegacyThemeModes>;
+  globalColorTokens: LegacyTokenTree;
+  taggedThemeColorTokens: Record<string, ThemeModes>;
+  taggedGlobalColorTokens: TokenTree;
+  report: TokenReport;
+};
+
+export type LegacyTokenTree = { [key: string]: string | LegacyTokenTree };
+
+export type LegacyThemeModes = {
+  onLight: LegacyTokenTree;
+  onDark: LegacyTokenTree;
+};
+
+export const isTokenValue = (value: unknown): value is TokenValue =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as TokenValue).k === 'string' &&
+  typeof (value as TokenValue).v === 'string';
+
+/**
+ * Projects tagged values down to the flat-string shape older scripts expect.
+ *
+ * Those scripts write the value out verbatim after stripping one layer of JSON quotes
+ * (`.replace(/: "([^"]+)"/g, ': $1')`), so the quoting has to be baked into the string itself:
+ * backticks make a template literal, single quotes make a string, and anything bare is written as
+ * an expression. Wrapping strings this way also fixes the original `transparent` bug on those
+ * scripts, since the quotes now survive their regex instead of being invented by it.
+ */
+export const toLegacyTokenTree = (tree: TokenTree): LegacyTokenTree => {
+  const legacy: LegacyTokenTree = {};
+
+  for (const key of Object.keys(tree)) {
+    const value = tree[key];
+    if (!isTokenValue(value)) {
+      legacy[key] = toLegacyTokenTree(value);
+    } else if (value.k === TEMPLATE) {
+      legacy[key] = `\`${value.v}\``;
+    } else if (value.k === STRING) {
+      legacy[key] = `'${value.v}'`;
+    } else {
+      legacy[key] = value.v;
+    }
+  }
+
+  return legacy;
+};
+
+/** Every leaf path in a token tree, dotted and sorted. */
+export const collectTokenPaths = (
+  tree: TokenTree,
+  prefix = '',
+  collected: string[] = [],
+): string[] => {
+  for (const key of Object.keys(tree)) {
+    const value = tree[key];
+    const tokenPath = prefix ? `${prefix}.${key}` : key;
+    if (isTokenValue(value)) {
+      collected.push(tokenPath);
+    } else {
+      collectTokenPaths(value, tokenPath, collected);
+    }
+  }
+  return collected.sort();
+};

--- a/packages/plugin-figma-token-publisher/src/plugin/validateColorTokens.ts
+++ b/packages/plugin-figma-token-publisher/src/plugin/validateColorTokens.ts
@@ -1,0 +1,257 @@
+/**
+ * Checks the payload against itself before it ever leaves Figma.
+ *
+ * Every rule here is a comment somebody had to leave on a token PR: a theme that only got half its
+ * modes, `onNeutral` carrying the same value at all four emphasis levels in one theme but stepped
+ * values in the other, and `primary.highlighted` collapsing onto `primary.default` so hover had no
+ * visual feedback. None of these are things the write side can judge — they are authoring mistakes
+ * in the Figma variables, and this is the last point where the person who made them is still here.
+ */
+import type { TokenReport, TokenTree, TokenValue, ThemeModes } from './tokenTypes';
+import { collectTokenPaths, isTokenValue } from './tokenTypes';
+
+const SCHEMES: (keyof ThemeModes)[] = ['onLight', 'onDark'];
+
+/** Emphasis groups smaller than this are too small for "every value is identical" to mean much. */
+const MIN_UNIFORM_GROUP_SIZE = 3;
+
+const formatList = (items: string[], limit = 8): string => {
+  const shown = items.slice(0, limit).map((item) => `\`${item}\``);
+  const remaining = items.length - shown.length;
+  return remaining > 0 ? `${shown.join(', ')} and ${remaining} more` : shown.join(', ');
+};
+
+const missingFrom = (expected: string[], actual: string[]): string[] => {
+  const actualSet = new Set(actual);
+  return expected.filter((tokenPath) => !actualSet.has(tokenPath));
+};
+
+/**
+ * Walks every group whose children are all leaves — the emphasis groups (`normal` / `subtle` /
+ * `muted` / `disabled`, `default` / `highlighted` / …).
+ */
+const forEachLeafGroup = (
+  tree: TokenTree,
+  visit: (path: string, leaves: Record<string, TokenValue>) => void,
+  prefix = '',
+): void => {
+  const leaves: Record<string, TokenValue> = {};
+  let hasChildGroup = false;
+
+  for (const key of Object.keys(tree)) {
+    const value = tree[key];
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isTokenValue(value)) {
+      leaves[key] = value;
+    } else {
+      hasChildGroup = true;
+      forEachLeafGroup(value, visit, path);
+    }
+  }
+
+  if (!hasChildGroup && Object.keys(leaves).length && prefix) {
+    visit(prefix, leaves);
+  }
+};
+
+/** A theme with only one mode filled in would silently overwrite the other with stale values. */
+const checkCompleteness = (
+  themeColorTokens: Record<string, ThemeModes>,
+  report: TokenReport,
+): string[] => {
+  const usableThemes: string[] = [];
+
+  for (const themeName of Object.keys(themeColorTokens)) {
+    const modes = themeColorTokens[themeName];
+    const emptyModes = SCHEMES.filter((scheme) => !Object.keys(modes[scheme] ?? {}).length);
+
+    if (emptyModes.length) {
+      report.errors.push(
+        `\`${themeName}\` produced no tokens for ${formatList(
+          emptyModes,
+        )}. Check that the Figma collection has a mode named \`${themeName.replace(/Theme$/, '')}/${
+          emptyModes[0]
+        }\`.`,
+      );
+    } else {
+      usableThemes.push(themeName);
+    }
+  }
+
+  return usableThemes;
+};
+
+/**
+ * Both themes are typed `ColorsWithModes`, so a token present in one and absent from the other is
+ * a compile error waiting to happen — which is exactly how `onNeutral` landed in `bladeTheme` but
+ * not in `blade-core`'s copy on the last push.
+ */
+const checkPathParity = (
+  themeColorTokens: Record<string, ThemeModes>,
+  usableThemes: string[],
+  report: TokenReport,
+): void => {
+  for (const themeName of usableThemes) {
+    const [light, dark] = SCHEMES.map((scheme) =>
+      collectTokenPaths(themeColorTokens[themeName][scheme]),
+    );
+
+    const missingInDark = missingFrom(light, dark);
+    const missingInLight = missingFrom(dark, light);
+    if (missingInDark.length) {
+      report.errors.push(`\`${themeName}\` is missing ${formatList(missingInDark)} in \`onDark\`.`);
+    }
+    if (missingInLight.length) {
+      report.errors.push(
+        `\`${themeName}\` is missing ${formatList(missingInLight)} in \`onLight\`.`,
+      );
+    }
+  }
+
+  const [referenceTheme, ...otherThemes] = usableThemes;
+  if (!referenceTheme) return;
+
+  for (const themeName of otherThemes) {
+    for (const scheme of SCHEMES) {
+      const reference = collectTokenPaths(themeColorTokens[referenceTheme][scheme]);
+      const candidate = collectTokenPaths(themeColorTokens[themeName][scheme]);
+
+      const missing = missingFrom(reference, candidate);
+      const extra = missingFrom(candidate, reference);
+      if (missing.length) {
+        report.errors.push(
+          `\`${themeName}.${scheme}\` is missing ${formatList(
+            missing,
+          )}, which \`${referenceTheme}.${scheme}\` defines. Both themes share one type, so every token has to exist in both.`,
+        );
+      }
+      if (extra.length) {
+        report.errors.push(
+          `\`${themeName}.${scheme}\` defines ${formatList(
+            extra,
+          )}, which \`${referenceTheme}.${scheme}\` does not.`,
+        );
+      }
+    }
+  }
+};
+
+/**
+ * Runs a per-group predicate over every theme and mode and collapses the hits into one line per
+ * distinct set of locations.
+ *
+ * The obvious shape — one warning per theme per mode — repeats the same sentence four times for a
+ * finding that is really "this token looks like this everywhere", which buries the one finding that
+ * only affects a single mode. Grouping by where a path was hit keeps each finding to one line and
+ * makes the odd one out stand out.
+ */
+const groupFindingsByLocation = (
+  themeColorTokens: Record<string, ThemeModes>,
+  usableThemes: string[],
+  isHit: (leaves: Record<string, TokenValue>) => boolean,
+): { paths: string[]; scope: string }[] => {
+  const locationsByPath = new Map<string, string[]>();
+  const allLocations: string[] = [];
+
+  for (const themeName of usableThemes) {
+    for (const scheme of SCHEMES) {
+      const location = `${themeName}.${scheme}`;
+      allLocations.push(location);
+
+      forEachLeafGroup(themeColorTokens[themeName][scheme], (path, leaves) => {
+        if (!isHit(leaves)) return;
+        locationsByPath.set(path, [...(locationsByPath.get(path) ?? []), location]);
+      });
+    }
+  }
+
+  // paths hit in exactly the same places belong on the same line
+  const pathsByScope = new Map<string, string[]>();
+  for (const [path, locations] of locationsByPath) {
+    const key = locations.join(', ');
+    pathsByScope.set(key, [...(pathsByScope.get(key) ?? []), path]);
+  }
+
+  return [...pathsByScope].map(([key, paths]) => ({
+    paths,
+    scope: key.split(', ').length === allLocations.length ? 'every theme and mode' : key,
+  }));
+};
+
+/**
+ * `default` and `highlighted` holding the same value means hover and active states are invisible.
+ * A real design decision occasionally, an unbound variable more often — so it warns rather than
+ * blocks.
+ */
+const checkCollapsedStates = (
+  themeColorTokens: Record<string, ThemeModes>,
+  usableThemes: string[],
+  report: TokenReport,
+): void => {
+  const findings = groupFindingsByLocation(
+    themeColorTokens,
+    usableThemes,
+    (leaves) =>
+      Boolean(leaves.default && leaves.highlighted) && leaves.default.v === leaves.highlighted.v,
+  );
+
+  for (const { paths, scope } of findings) {
+    report.warnings.push(
+      `${formatList(
+        paths,
+      )} share one value for \`default\` and \`highlighted\` in ${scope}. Hover and active will look identical.`,
+    );
+  }
+};
+
+/**
+ * An emphasis group where every level resolves to the same colour. Legitimate now and then, but it
+ * is also what an unbound or half-authored group looks like.
+ */
+const checkUniformEmphasis = (
+  themeColorTokens: Record<string, ThemeModes>,
+  usableThemes: string[],
+  report: TokenReport,
+): void => {
+  const findings = groupFindingsByLocation(themeColorTokens, usableThemes, (leaves) => {
+    const values = Object.keys(leaves).map((key) => leaves[key].v);
+    return values.length >= MIN_UNIFORM_GROUP_SIZE && new Set(values).size === 1;
+  });
+
+  for (const { paths, scope } of findings) {
+    report.warnings.push(
+      `${formatList(
+        paths,
+      )} use one value for every emphasis level in ${scope}. Confirm this is intentional rather than an unbound variable.`,
+    );
+  }
+};
+
+export const validateColorTokens = ({
+  themeColorTokens,
+  globalColorTokens,
+  report,
+}: {
+  themeColorTokens: Record<string, ThemeModes>;
+  globalColorTokens: TokenTree;
+  report: TokenReport;
+}): TokenReport => {
+  if (!Object.keys(themeColorTokens).length) {
+    report.errors.push('No theme tokens were generated.');
+    return report;
+  }
+  if (!Object.keys(globalColorTokens).length) {
+    report.warnings.push(
+      'No global color tokens were generated, so `colors.ts` will be left untouched.',
+    );
+  }
+
+  const usableThemes = checkCompleteness(themeColorTokens, report);
+  checkPathParity(themeColorTokens, usableThemes, report);
+  checkCollapsedStates(themeColorTokens, usableThemes, report);
+  checkUniformEmphasis(themeColorTokens, usableThemes, report);
+
+  return report;
+};
+
+export default validateColorTokens;


### PR DESCRIPTION
Hardens the Figma → code token pipeline. Every change here is a failure that reached review, CI, or a released package on a previous push.

Tooling only — no consumer-facing code changes, so no changeset. `packages/blade/scripts/` is not in the published `files` list.

## What went wrong before, and what stops it now

| Failure | Where it showed up | Fix |
| --- | --- | --- |
| `transparent is not defined` | CI, on #3914 | Values are tagged as expression / string / template by the plugin instead of the write side stripping quotes off everything with a regex. Whatever is written is then read back and checked against the imports of the file it landed in. |
| Deprecated `popup.*` aliases deleted | #3914, again on #3918 | `preservedTokenPaths` in `tokenTargets.json`. Figma has no way to say "deprecated but keep it", so the decision lives in code. Preserved values keep their source text and position, `// @deprecated` markers included. |
| `blade-core` left stale and failing to typecheck | #3914 | Every theme is written into all the files that mirror it. `blade` and `blade-core` keep identical copies and only `blade` was ever written. |
| Removed tokens still referenced by components and the codemod map | #3914 | Token paths are diffed, and a removal that still has consumers anywhere in the repo blocks the push. |
| Changeset bump argued out in review | #3914 | Derived from what actually changed: removals are major, additions minor. |
| `onNeutral` uniform in one theme, stepped in the other | #3914 | Cross-theme path parity and uniform-emphasis checks run in the plugin, before publishing. |
| `primary.highlighted` collapsed onto `default` | #3914 | Collapsed-state check, reported as a warning since it is sometimes intentional. |
| Everything found by CI or a reviewer rather than the push | all of the above | The push verifies itself — prettier, typecheck of both workspaces, snapshot regeneration — and opens the PR as a **draft** with the reasons in the body if anything is unresolved. |

## Also fixed

- An alias pointing at a collection not published to code (e.g. `_styles/…`) used to be written as a string colour. That typechecks, renders as nothing, and no downstream check catches it because the type is just `string`. Now a blocking error.
- A Figma variable named `000` produced `token[000]`, an octal literal, which crashed the whole push with a parse error under strict mode.
- Unmapped Figma modes, unreadable aliases, and hardcoded colours were silently dropped, which the write side then read as a deliberate token deletion. All reported now.
- Hand-written comments inside the declaration were stripped on every regeneration.

## Plugin window

Report sections are collapsible with counts, token paths render as chips rather than raw backticks, the token field and buttons are pinned so a long report cannot push them off-screen, and the window is sized to its content. Findings are grouped by where they occur, so a token that looks the same in every theme and mode is one line instead of four.

## Compatibility

The payload is sent in both shapes. `app/api/api.ts` dispatches the workflow against `master`, so the script that runs is whichever is on `master`, while the plugin build is installed by hand. A payload only the new script can read takes down every push until the script lands — verified by replaying against `master`'s current `uploadTokens.js`, which succeeds and, as a side effect, now writes `'transparent'` correctly.

## Verification

- 32 unit tests over the serializer, covering each failure above
- Replayed a payload rebuilt from the current source: byte-identical round trip on both packages
- Replayed with the deprecated tokens stripped, as Figma sends them: `0 added, 0 removed, 8 preserved`, zero diff
- Every blocking path exercised: unresolvable value, half-empty theme, unmapped theme, plugin-reported error, removal with live consumers
- Replayed against `master`'s script to confirm the payload stays readable by it

## Try it

```bash
cd packages/blade
node ./scripts/uploadTokens.js "$(cat payload.b64)" --dry-run --skip-typecheck --skip-snapshots
```

`--dry-run` writes the files and prints the PR body it would have used, but touches neither git nor GitHub. The plugin logs the payload it posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
