### PR TITLE
chore(changeset): add missing changeset for blade-svelte Modal component

### DIFF
--- a/.changeset/blade-svelte-modal-component.md
+++ b/.changeset/blade-svelte-modal-component.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': patch
+---
+
+feat(blade-svelte): add Modal component
+
+Adds `Modal`, `ModalHeader`, `ModalBody`, and `ModalFooter` to `@razorpay/blade-svelte`. Focus is trapped within the surface while open, moves to the close button (or a caller-supplied `initialFocusRef`) on open, and returns to the previously focused element on close — including when a controlled `isOpen` prop flips to `false` directly. Background content is marked `inert` (falling back to `aria-hidden` where unsupported) while the modal is mounted, and a dev-only warning is logged if `accessibilityLabel` is missing.


### PR DESCRIPTION
## Summary
- #3913 merged the blade-svelte `Modal` component (feat + a11y hardening) without a changeset, so its release never generated version bump / changelog entries.
- Adds the missing changeset, following the same `patch` convention used for prior new blade-svelte component additions (e.g. BottomSheet, IconButton) while the package is pre-1.0.

## Test plan
- [x] No code changes — changeset-only PR