### PR TITLE
feat(tokens): update tokens from figma

### DIFF
--- a/.changeset/figma-token-push-chew-hands.md
+++ b/.changeset/figma-token-push-chew-hands.md
@@ -1,0 +1,8 @@
+---
+'@razorpay/blade': minor
+'@razorpay/blade-core': minor
+---
+
+update design tokens from Figma
+
+Added 32 tokens and removed 0 tokens.

--- a/.changeset/lucky-streets-fold.md
+++ b/.changeset/lucky-streets-fold.md
@@ -1,0 +1,5 @@
+---
+"@razorpay/blade-core": patch
+---
+
+feat(tokens): added a new token for svelte `onNeutral` in `interactive.text` & `interactive.icon` along with minor updates

--- a/packages/blade-core/src/tokens/global/colors.ts
+++ b/packages/blade-core/src/tokens/global/colors.ts
@@ -436,7 +436,7 @@ export const colors: Color = {
     blueGrayLight: {
       0: `hsla(0, 0%, 100%, ${opacity[1300]})`,
       50: `hsla(0, 0%, 97%, ${opacity[1300]})`,
-      100: `hsla(200, 10%, 94%, ${opacity[1300]})`,
+      100: `hsla(0, 0%, 97%, ${opacity[1300]})`,
       200: `hsla(204, 8%, 88%, ${opacity[1300]})`,
       300: `hsla(203, 8%, 80%, ${opacity[1300]})`,
       400: `hsla(205, 8%, 71%, ${opacity[1300]})`,
@@ -455,7 +455,7 @@ export const colors: Color = {
       a48: `hsla(0, 0%, 100%, ${opacity[1200]})`,
       a50: `hsla(0, 0%, 97%, ${opacity[0]})`,
       a75: `hsla(0, 0%, 97%, ${opacity[600]})`,
-      a100: `hsla(200, 10%, 94%, ${opacity[0]})`,
+      a100: `hsla(0, 0%, 97%, ${opacity[0]})`,
       a200: `hsla(204, 8%, 88%, ${opacity[0]})`,
       a400: `hsla(205, 8%, 71%, ${opacity[0]})`,
       a406: `hsla(205, 8%, 71%, ${opacity[50]})`,

--- a/packages/blade-core/src/tokens/theme/bladeNeutralTheme.ts
+++ b/packages/blade-core/src/tokens/theme/bladeNeutralTheme.ts
@@ -257,7 +257,7 @@ const colors: ColorsWithModes = {
         },
         staticBlack: {
           default: globalColors.neutral.black[500],
-          highlighted: globalColors.neutral.black[450],
+          highlighted: globalColors.neutral.black[500],
           disabled: globalColors.neutral.black[200],
           faded: globalColors.neutral.black[50],
           fadedHighlighted: globalColors.neutral.black[100],
@@ -379,6 +379,12 @@ const colors: ColorsWithModes = {
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
         },
+        onNeutral: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[500],
+          muted: globalColors.neutral.white[500],
+          disabled: globalColors.neutral.white[500],
+        },
         staticWhite: {
           normal: globalColors.neutral.white[500],
           subtle: globalColors.neutral.white[400],
@@ -440,6 +446,12 @@ const colors: ColorsWithModes = {
           subtle: globalColors.neutral.white[400],
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
+        },
+        onNeutral: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[500],
+          muted: globalColors.neutral.white[500],
+          disabled: globalColors.neutral.white[500],
         },
         staticWhite: {
           normal: globalColors.neutral.white[500],
@@ -1079,6 +1091,12 @@ const colors: ColorsWithModes = {
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
         },
+        onNeutral: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[500],
+          muted: globalColors.neutral.white[500],
+          disabled: globalColors.neutral.white[500],
+        },
         staticWhite: {
           normal: globalColors.neutral.white[500],
           subtle: globalColors.neutral.white[400],
@@ -1140,6 +1158,12 @@ const colors: ColorsWithModes = {
           subtle: globalColors.neutral.white[400],
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
+        },
+        onNeutral: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[500],
+          muted: globalColors.neutral.white[500],
+          disabled: globalColors.neutral.white[500],
         },
         staticWhite: {
           normal: globalColors.neutral.white[500],

--- a/packages/blade-core/src/tokens/theme/bladeTheme.ts
+++ b/packages/blade-core/src/tokens/theme/bladeTheme.ts
@@ -234,9 +234,9 @@ const colors: ColorsWithModes = {
           fadedHighlighted: globalColors.chromatic.sapphire.a100,
         },
         neutral: {
-          default: globalColors.neutral.blueGrayLight[1000],
-          highlighted: globalColors.neutral.blueGrayLight[1100],
-          disabled: globalColors.neutral.blueGrayLight.a918,
+          default: globalColors.neutral.black[500],
+          highlighted: globalColors.neutral.black[450],
+          disabled: globalColors.neutral.black[50],
           faded: globalColors.neutral.blueGrayLight.a912,
           fadedHighlighted: globalColors.neutral.blueGrayLight.a918,
         },
@@ -298,8 +298,8 @@ const colors: ColorsWithModes = {
           faded: globalColors.chromatic.sapphire.a100,
         },
         neutral: {
-          default: globalColors.neutral.blueGrayLight[1200],
-          highlighted: globalColors.neutral.blueGrayLight[1300],
+          default: globalColors.neutral.black[500],
+          highlighted: globalColors.neutral.black[450],
           disabled: globalColors.neutral.blueGrayLight[300],
           faded: globalColors.neutral.blueGrayLight.a912,
         },
@@ -379,6 +379,12 @@ const colors: ColorsWithModes = {
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
         },
+        onNeutral: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
         staticWhite: {
           normal: globalColors.neutral.white[500],
           subtle: globalColors.neutral.white[400],
@@ -436,6 +442,12 @@ const colors: ColorsWithModes = {
           disabled: globalColors.chromatic.azure.a200,
         },
         onPrimary: {
+          normal: globalColors.neutral.white[500],
+          subtle: globalColors.neutral.white[400],
+          muted: globalColors.neutral.white[300],
+          disabled: globalColors.neutral.white[100],
+        },
+        onNeutral: {
           normal: globalColors.neutral.white[500],
           subtle: globalColors.neutral.white[400],
           muted: globalColors.neutral.white[300],
@@ -928,9 +940,9 @@ const colors: ColorsWithModes = {
           fadedHighlighted: globalColors.chromatic.sapphire.a200,
         },
         neutral: {
-          default: globalColors.neutral.blueGrayDark[50],
-          highlighted: globalColors.neutral.blueGrayDark[200],
-          disabled: globalColors.neutral.blueGrayDark.a518,
+          default: globalColors.neutral.white[500],
+          highlighted: globalColors.neutral.white[450],
+          disabled: globalColors.neutral.white[50],
           faded: globalColors.neutral.blueGrayDark.a512,
           fadedHighlighted: globalColors.neutral.blueGrayDark.a518,
         },
@@ -992,8 +1004,8 @@ const colors: ColorsWithModes = {
           faded: globalColors.chromatic.sapphire.a100,
         },
         neutral: {
-          default: globalColors.neutral.blueGrayDark[100],
-          highlighted: globalColors.neutral.blueGrayDark[0],
+          default: globalColors.neutral.white[500],
+          highlighted: globalColors.neutral.white[450],
           disabled: globalColors.neutral.blueGrayDark[800],
           faded: globalColors.neutral.blueGrayDark.a518,
         },
@@ -1073,6 +1085,12 @@ const colors: ColorsWithModes = {
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
         },
+        onNeutral: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[400],
+          muted: globalColors.neutral.black[300],
+          disabled: globalColors.neutral.black[100],
+        },
         staticWhite: {
           normal: globalColors.neutral.white[500],
           subtle: globalColors.neutral.white[400],
@@ -1134,6 +1152,12 @@ const colors: ColorsWithModes = {
           subtle: globalColors.neutral.white[400],
           muted: globalColors.neutral.white[300],
           disabled: globalColors.neutral.white[100],
+        },
+        onNeutral: {
+          normal: globalColors.neutral.black[500],
+          subtle: globalColors.neutral.black[400],
+          muted: globalColors.neutral.black[300],
+          disabled: globalColors.neutral.black[100],
         },
         staticWhite: {
           normal: globalColors.neutral.white[500],

--- a/packages/blade-core/src/tokens/theme/theme.ts
+++ b/packages/blade-core/src/tokens/theme/theme.ts
@@ -115,11 +115,11 @@ export type Colors = {
     > &
       Record<InteractiveBorderColorsWithFadedHighlighted, InteractiveStatesWithFadedHighlighted>;
     text: Record<
-      InteractiveColorKeys | 'onPrimary',
+      InteractiveColorKeys | 'onPrimary' | 'onNeutral',
       Pick<Emphasis, 'normal' | 'subtle' | 'muted' | 'disabled'>
     >;
     icon: Record<
-      InteractiveColorKeys | 'onPrimary',
+      InteractiveColorKeys | 'onPrimary' | 'onNeutral',
       Pick<Emphasis, 'normal' | 'subtle' | 'muted' | 'disabled'>
     >;
   };


### PR DESCRIPTION
This PR was opened by the Token Upload GitHub action. It updates source token files based on the payload from the Figma plugin.

## ⛔️ Blocking

Opened as a draft because the push could not verify itself. Fix these before marking it ready:

- `@razorpay/blade-core` failed (`yarn typecheck`). See the workflow logs for the output.
- `web snapshots` failed (`cross-env FRAMEWORK=REACT yarn jest -c ./jest.web.config.js --updateSnapshot --forceExit --ci=false`). See the workflow logs for the output.
- `native snapshots` failed (`cross-env FRAMEWORK=REACT_NATIVE yarn jest -c ./jest.native.config.js --updateSnapshot --forceExit --ci=false`). See the workflow logs for the output.

## Token changes

**32** added · **0** removed

<details>
<summary>Added token paths (32)</summary>

- `bladeTheme.onDark.interactive.icon.onNeutral.disabled`
- `bladeTheme.onDark.interactive.icon.onNeutral.muted`
- `bladeTheme.onDark.interactive.icon.onNeutral.normal`
- `bladeTheme.onDark.interactive.icon.onNeutral.subtle`
- `bladeTheme.onDark.interactive.text.onNeutral.disabled`
- `bladeTheme.onDark.interactive.text.onNeutral.muted`
- `bladeTheme.onDark.interactive.text.onNeutral.normal`
- `bladeTheme.onDark.interactive.text.onNeutral.subtle`
- `bladeTheme.onLight.interactive.icon.onNeutral.disabled`
- `bladeTheme.onLight.interactive.icon.onNeutral.muted`
- `bladeTheme.onLight.interactive.icon.onNeutral.normal`
- `bladeTheme.onLight.interactive.icon.onNeutral.subtle`
- `bladeTheme.onLight.interactive.text.onNeutral.disabled`
- `bladeTheme.onLight.interactive.text.onNeutral.muted`
- `bladeTheme.onLight.interactive.text.onNeutral.normal`
- `bladeTheme.onLight.interactive.text.onNeutral.subtle`
- `bladeNeutralTheme.onDark.interactive.icon.onNeutral.disabled`
- `bladeNeutralTheme.onDark.interactive.icon.onNeutral.muted`
- `bladeNeutralTheme.onDark.interactive.icon.onNeutral.normal`
- `bladeNeutralTheme.onDark.interactive.icon.onNeutral.subtle`
- `bladeNeutralTheme.onDark.interactive.text.onNeutral.disabled`
- `bladeNeutralTheme.onDark.interactive.text.onNeutral.muted`
- `bladeNeutralTheme.onDark.interactive.text.onNeutral.normal`
- `bladeNeutralTheme.onDark.interactive.text.onNeutral.subtle`
- `bladeNeutralTheme.onLight.interactive.icon.onNeutral.disabled`
- `bladeNeutralTheme.onLight.interactive.icon.onNeutral.muted`
- `bladeNeutralTheme.onLight.interactive.icon.onNeutral.normal`
- `bladeNeutralTheme.onLight.interactive.icon.onNeutral.subtle`
- `bladeNeutralTheme.onLight.interactive.text.onNeutral.disabled`
- `bladeNeutralTheme.onLight.interactive.text.onNeutral.muted`
- `bladeNeutralTheme.onLight.interactive.text.onNeutral.normal`
- `bladeNeutralTheme.onLight.interactive.text.onNeutral.subtle`

</details>

8 code-owned tokens were kept as-is because Figma does not define them, per `preservedTokenPaths` in `packages/blade/scripts/tokenTargets.json`.

<details>
<summary>Preserved token paths (8)</summary>

- `onDark.popup.background.intense`
- `onDark.popup.background.subtle`
- `onDark.popup.border.intense`
- `onDark.popup.border.subtle`
- `onLight.popup.background.intense`
- `onLight.popup.background.subtle`
- `onLight.popup.border.intense`
- `onLight.popup.border.subtle`

</details>

## Warnings

- The mirrored copies of `bladeTheme` were out of sync before this push — `packages/blade-core/src/tokens/theme/bladeTheme.ts` held a different set of token paths than the file before it. Both have been overwritten with the Figma payload.
- The mirrored copies of `bladeNeutralTheme` were out of sync before this push — `packages/blade-core/src/tokens/theme/bladeNeutralTheme.ts` held a different set of token paths than the file before it. Both have been overwritten with the Figma payload.
- `interactive.background.staticBlack`, `interactive.border.staticBlack` share one value for `default` and `highlighted` in every theme and mode. Hover and active will look identical.
- `interactive.text.onNeutral`, `interactive.icon.onNeutral` use one value for every emphasis level in bladeNeutralTheme.onLight, bladeNeutralTheme.onDark. Confirm this is intentional rather than an unbound variable.
