### PR TITLE
fix(tokens): drop the needs-attention suffix from the token push PR title

### DIFF
--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -500,17 +500,17 @@ const uploadColorTokens = async () => {
   });
   execa.commandSync(`git push origin ${branchName}`, { cwd: REPO_ROOT });
 
-  const title = blockers.length
-    ? 'feat(tokens): update tokens from figma (needs attention)'
-    : 'feat(tokens): update tokens from figma';
-
+  // The title is constant. Draft state carries "this could not verify itself", and the reasons are
+  // written into the body — both of which clear themselves as the PR is fixed and marked ready. A
+  // marker in the title does not: it survives into the squashed commit on master unless somebody
+  // remembers to strip it, which is exactly the kind of cleanup that gets missed.
   execa.sync(
     'gh',
     [
       'pr',
       'create',
       '--title',
-      title,
+      'feat(tokens): update tokens from figma',
       '--head',
       branchName,
       '--repo',


### PR DESCRIPTION
Follow-up to #3919.

A token push that could not verify itself titled its PR `feat(tokens): update tokens from figma (needs attention)`. That marker outlives the problem it describes:

- **draft state** clears when someone marks the PR ready
- the **⛔️ Blocking section** in the body describes what was wrong and stops being relevant once fixed
- the **title** has to be edited by hand

This repo squash-merges with the PR title as the commit message, so a missed cleanup puts `(needs attention)` on master permanently. That nearly happened on #3925 — the blocker was fixed and the PR marked ready with the suffix still in the title.

The title is now constant. Draft state carries the signal, the reasons stay in the body, and both resolve themselves as the PR is fixed.

No behaviour change beyond the title: `--draft` is still driven by `blockers.length`, and the body is unchanged.

## Verification

- 32 serializer tests pass
- Dry-run replay against master: `packages/blade/src/tokens` round-trips byte-identical
- prettier and eslint clean

Tooling only — `packages/blade/scripts/` is not in the published `files` list, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
