### PR TITLE
feat(FloatingActionButton): rename dark color from black to neutral

### DIFF
--- a/.changeset/fab-neutral-color.md
+++ b/.changeset/fab-neutral-color.md
@@ -1,0 +1,12 @@
+---
+"@razorpay/blade": minor
+"@razorpay/blade-mcp": minor
+---
+
+feat(FloatingActionButton): rename the dark color from `black` to `neutral` and align it with the neutral button tokens
+
+`<FloatingActionButton color="black" />` becomes `<FloatingActionButton color="neutral" />`. The dark FAB is now the same treatment as a filled `neutral` button — it reads its surface from `interactive.background.neutral.*` and its label, icon and spinner from `interactive.*.onNeutral.*`, so it inverts with the theme instead of always being black on white. The hover surface is now slightly translucent and the disabled surface is lighter, matching the updated design.
+
+On focus, the filled `neutral` surface now draws its ring from `interactive.border.neutral.faded` instead of the faded primary blue used everywhere else, matching the design.
+
+`color="black"` was never exposed on `Button` and has no consumers, so it is removed rather than deprecated.

--- a/.changeset/spinner-on-neutral-color.md
+++ b/.changeset/spinner-on-neutral-color.md
@@ -1,0 +1,10 @@
+---
+'@razorpay/blade': minor
+'@razorpay/blade-mcp': minor
+---
+
+feat(Spinner): add an `onNeutral` color for spinners on a filled neutral surface
+
+`<Spinner color="onNeutral" />` reads `interactive.icon.onNeutral.normal`, which inverts with the theme. Every other spinner color is either static (`white`) or tracks the page surface (`neutral`, the feedback colors), so none of them stayed visible on a filled `neutral` surface, which is black on light and white on dark.
+
+A loading `Button color="neutral" variant="primary"` and `FloatingActionButton color="neutral"` now use it. Both previously hardcoded a static white spinner, which disappeared against the white surface in dark mode. Fixes #3915 for the `neutral` surface.

--- a/packages/blade-mcp/knowledgebase/components/FloatingActionButton.md
+++ b/packages/blade-mcp/knowledgebase/components/FloatingActionButton.md
@@ -40,7 +40,7 @@ type FloatingActionButtonCommonProps = {
    *
    * @default 'primary'
    */
-  color?: 'primary' | 'white' | 'black';
+  color?: 'primary' | 'white' | 'neutral';
 
   /**
    * Corner of the viewport the button is anchored to.
@@ -139,7 +139,7 @@ type FloatingActionButtonProps =
 - Always pass `accessibilityLabel` when rendering the icon-only form, so screen readers can name the action.
 - Keep the label to one or two words — the button floats over content, so it should stay compact.
 - Raise `offset` when the button would otherwise overlap fixed content at the bottom of the page.
-- Use `color="white"` or `color="black"` when the button sits over a colored or image background that the `primary` blue would not read against.
+- Use `color="white"` or `color="neutral"` when the button sits over a colored or image background that the `primary` blue would not read against.
 
 **Don't**
 

--- a/packages/blade-mcp/knowledgebase/components/Spinner.md
+++ b/packages/blade-mcp/knowledgebase/components/Spinner.md
@@ -18,7 +18,7 @@ type SpinnerProps = {
    *
    * @default 'neutral'
    */
-  color?: 'primary' | 'neutral' | 'white';
+  color?: 'primary' | 'neutral' | 'white' | 'onNeutral';
   /**
    * Sets the label of the spinner.
    */
@@ -63,7 +63,8 @@ type SpinnerMotion = {
 **Do**
 
 - Use `Spinner` for indeterminate loading states where you don't know the completion percentage.
-- Use `color="white"` when placing the spinner on dark backgrounds for proper contrast.
+- Use `color="white"` when placing the spinner on a background that is dark in both color schemes.
+- Use `color="onNeutral"` when placing the spinner on a filled `neutral` surface, such as a loading `Button color="neutral"` or `FloatingActionButton color="neutral"`. It inverts with the theme, so it stays visible in both color schemes.
 - Override `accessibilityLabel` with context-specific text (e.g., "Loading transactions" instead of generic "Loading").
 - Use `size="medium"` for inline loading within buttons or small sections; use `size="large"` or `size="xlarge"` for prominent full-page loading states.
 - Use `label` prop to provide visible loading context alongside the animation.

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -88,12 +88,7 @@ type BaseButtonCommonProps = {
     | 'notice'
     | 'information'
     | 'neutral'
-    | 'transparent'
-    /**
-     * Only supported with `variant="primary"`. Consumed by FloatingActionButton
-     * and intentionally not exposed on `Button`.
-     */
-    | 'black';
+    | 'transparent';
   /**
    * Overrides the size-derived border radius. Used by FloatingActionButton to
    * render a pill. `round` is excluded because a percentage radius distorts on
@@ -142,14 +137,23 @@ type BaseButtonColorTokenModifiers = {
 };
 
 /**
- * `white`, `black` and `transparent` are not feedback colors, so the token
- * factories are still called with `primary` and the value is looked up under its
- * own key instead of under `base`.
+ * `white` and `transparent` are not feedback colors, so the token factories are
+ * still called with `primary` and the value is looked up under its own key
+ * instead of under `base`.
  */
 const isStaticOrTransparentColor = (
   color: BaseButtonProps['color'],
-): color is 'white' | 'black' | 'transparent' =>
-  color === 'white' || color === 'black' || color === 'transparent';
+): color is 'white' | 'transparent' => color === 'white' || color === 'transparent';
+
+/**
+ * The filled `neutral` surface needs inverted content and a heavier inner shadow
+ * than the shared feedback treatment, so its `primary` emphasis is looked up
+ * under a dedicated key. The remaining emphases fall back to `base`.
+ */
+const isFilledNeutral = (
+  color: BaseButtonProps['color'],
+  variant: NonNullable<BaseButtonProps['variant']>,
+): boolean => color === 'neutral' && variant === 'primary';
 
 const getSpinnerColor = ({
   variant,
@@ -158,28 +162,13 @@ const getSpinnerColor = ({
   variant: NonNullable<BaseButtonProps['variant']>;
   color: NonNullable<BaseButtonProps['color']>;
 }): BaseSpinnerProps['color'] => {
-  // `black` only exists as a primary button, so it is looked up separately from
-  // the colors that carry a full variant record.
-  if (color === 'black') {
-    return spinnerColor.black.primary;
-  }
-
   if (color !== 'primary' && color !== 'transparent' && color in spinnerColor) {
-    return spinnerColor[color as Exclude<keyof typeof spinnerColor, 'base' | 'black'>][
+    return spinnerColor[color as Exclude<keyof typeof spinnerColor, 'base'>][
       variant as 'primary' | 'secondary'
     ];
   }
 
   return spinnerColor.base[variant];
-};
-
-const assertBlackIsPrimary = (variant: NonNullable<BaseButtonProps['variant']>): void => {
-  if (variant !== 'primary') {
-    throwBladeError({
-      moduleName: 'BaseButton',
-      message: `Black color can only be used with primary variant but received "${variant}"`,
-    });
-  }
 };
 
 const getRenderElement = (href?: string): 'a' | 'button' | undefined => {
@@ -201,18 +190,13 @@ export const getBackgroundColorToken = ({
 }: BaseButtonColorTokenModifiers) => {
   const _state = state === 'focus' || state === 'hover' ? 'highlighted' : state;
 
-  // For white, black and transparent colors, we use 'primary' as the base color
-  // since the actual token lookup uses the white/black/transparent specific paths
+  // For white and transparent colors, we use 'primary' as the base color
+  // since the actual token lookup uses the white/transparent specific paths
   const gradientColor = isStaticOrTransparentColor(color) || !color ? 'primary' : color;
   const tokens = backgroundGradient(gradientColor);
 
   if (color === 'white') {
     return tokens.white[variant][_state];
-  }
-
-  if (color === 'black') {
-    assertBlackIsPrimary(variant);
-    return tokens.black.primary[_state];
   }
 
   if (color === 'transparent') {
@@ -248,9 +232,8 @@ export const getBoxShadowToken = ({
     return tokens.white[variant][_state];
   }
 
-  if (color === 'black') {
-    assertBlackIsPrimary(variant);
-    return tokens.black.primary[_state];
+  if (isFilledNeutral(color, variant)) {
+    return tokens.neutral.primary[_state];
   }
 
   if (color === 'transparent') {
@@ -280,9 +263,8 @@ export const getTextColorToken = ({
     return tokens.white[variant][_state];
   }
 
-  if (color === 'black') {
-    assertBlackIsPrimary(variant);
-    return tokens.black.primary[_state];
+  if (isFilledNeutral(color, variant)) {
+    return tokens.neutral.primary[_state];
   }
 
   if (color === 'transparent') {
@@ -500,7 +482,14 @@ const getProps = ({
       getBackgroundColorToken({ variant, color, state: 'focus' }),
     ),
     focusBoxShadow: getBoxShadow('focus', color),
-    focusRingColor: getIn(theme.colors, 'surface.border.primary.muted'),
+    // The system focus ring is a faded primary blue, which the design replaces
+    // with a faded neutral ring on the filled neutral surface.
+    focusRingColor: getIn(
+      theme.colors,
+      isFilledNeutral(color, variant)
+        ? 'interactive.border.neutral.faded'
+        : 'surface.border.primary.muted',
+    ),
     borderRadius: makeBorderSize(theme.border.radius[_borderRadius ?? buttonBorderRadius[size]]),
     motionDuration: 'duration.xquick',
     motionEasing: 'easing.standard',

--- a/packages/blade/src/components/Button/BaseButton/__tests__/__snapshots__/BaseButton.native.test.tsx.snap
+++ b/packages/blade/src/components/Button/BaseButton/__tests__/__snapshots__/BaseButton.native.test.tsx.snap
@@ -4053,10 +4053,10 @@ exports[`<BaseButton /> should render disabled neutral color primary button 1`] 
     data-blade-component="button"
     defaultBackgroundColor="hsla(0, 0%, 0%, 0.18)"
     focusBackgroundColor="hsla(0, 0%, 0%, 0.18)"
-    focusRingColor="hsla(218, 89%, 51%, 0.18)"
+    focusRingColor="hsla(206, 10%, 29%, 0.12)"
     focusable={true}
     hoverBackgroundColor="hsla(0, 0%, 0%, 0.18)"
-    hoverIconColor="hsla(206, 10%, 29%, 0.32)"
+    hoverIconColor="hsla(0, 0%, 100%, 0.32)"
     isFullWidth={false}
     isLoading={false}
     isPressed={false}
@@ -4149,7 +4149,7 @@ exports[`<BaseButton /> should render disabled neutral color primary button 1`] 
       >
         <Text
           accessible={true}
-          color="interactive.text.neutral.disabled"
+          color="interactive.text.onNeutral.disabled"
           data-blade-component="base-text"
           fontSize={100}
           fontWeight="medium"
@@ -4158,7 +4158,7 @@ exports[`<BaseButton /> should render disabled neutral color primary button 1`] 
           style={
             [
               {
-                "color": "hsla(206, 10%, 29%, 0.32)",
+                "color": "hsla(0, 0%, 100%, 0.32)",
                 "fontFamily": "Inter",
                 "fontSize": 14,
                 "fontStyle": "normal",
@@ -9077,13 +9077,13 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
     color="neutral"
     data-blade-component="button"
     defaultBackgroundColor="hsla(0, 0%, 0%, 1)"
-    defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 0.88), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+    defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
     focusBackgroundColor="hsla(0, 0%, 0%, 0.88)"
-    focusBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 0.88), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 0.88), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
-    focusRingColor="hsla(218, 89%, 51%, 0.18)"
+    focusBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
+    focusRingColor="hsla(206, 10%, 29%, 0.12)"
     focusable={true}
     hoverBackgroundColor="hsla(0, 0%, 0%, 0.88)"
-    hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 0.88), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 0.88), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.18), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.18)"
+    hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
     hoverIconColor="hsla(0, 0%, 100%, 1)"
     isFullWidth={false}
     isLoading={false}
@@ -9320,7 +9320,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
             ry={8}
             stroke={
               {
-                "payload": 788529151,
+                "payload": 1392508927,
                 "type": 0,
               }
             }
@@ -9344,7 +9344,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
             ry={8}
             stroke={
               {
-                "payload": 788529151,
+                "payload": 1392508927,
                 "type": 0,
               }
             }
@@ -9391,7 +9391,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
             ry={8}
             stroke={
               {
-                "payload": 3758096384,
+                "payload": 4278190080,
                 "type": 0,
               }
             }
@@ -9461,7 +9461,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
       >
         <Text
           accessible={true}
-          color="interactive.text.staticWhite.normal"
+          color="interactive.text.onNeutral.normal"
           data-blade-component="base-text"
           fontSize={100}
           fontWeight="medium"

--- a/packages/blade/src/components/Button/BaseButton/__tests__/__snapshots__/BaseButton.web.test.tsx.snap
+++ b/packages/blade/src/components/Button/BaseButton/__tests__/__snapshots__/BaseButton.web.test.tsx.snap
@@ -2204,7 +2204,7 @@ exports[`<BaseButton /> should render disabled neutral color primary button 1`] 
   background-color: hsla(0,0%,0%,0.18);
   outline: 1px solid hsla(218,89%,51%,0.09);
   background-image: none;
-  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18);
+  box-shadow: 0px 0px 0px 4px hsla(206,10%,29%,0.12);
 }
 
 .c0.c0.c0.c0.c0 * {
@@ -2249,7 +2249,7 @@ exports[`<BaseButton /> should render disabled neutral color primary button 1`] 
 }
 
 .c4.c4.c4.c4.c4 {
-  color: hsla(206,10%,29%,0.32);
+  color: hsla(0,0%,100%,0.32);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.875rem;
   font-weight: 500;
@@ -4840,7 +4840,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
   background-color: hsla(0,0%,0%,1);
   border: none;
   border-radius: 8px;
-  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.88),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
   padding-top: 0px;
   padding-bottom: 0px;
   padding-left: 12px;
@@ -4872,13 +4872,13 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
 
 .c0.c0.c0.c0.c0:hover {
   background-color: hsla(0,0%,0%,0.88);
-  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.88),inset 0 0px 0px 0.5px hsla(0,0%,0%,0.88),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
   background-image: none;
 }
 
 .c0.c0.c0.c0.c0:active {
   background-color: hsla(0,0%,0%,0.88);
-  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.88),inset 0 0px 0px 0.5px hsla(0,0%,0%,0.88),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
   background-image: none;
 }
 
@@ -4886,7 +4886,7 @@ exports[`<BaseButton /> should render neutral color primary button 1`] = `
   background-color: hsla(0,0%,0%,0.88);
   outline: 1px solid hsla(218,89%,51%,0.09);
   background-image: none;
-  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(0,0%,0%,0.88),inset 0 0px 0px 0.5px hsla(0,0%,0%,0.88),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.18),inset 0 -2px 0px 0px hsla(0,0%,100%,0.18);
+  box-shadow: 0px 0px 0px 4px hsla(206,10%,29%,0.12),inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
 }
 
 .c0.c0.c0.c0.c0 * {

--- a/packages/blade/src/components/Button/BaseButton/buttonTokens.ts
+++ b/packages/blade/src/components/Button/BaseButton/buttonTokens.ts
@@ -62,15 +62,6 @@ const backgroundGradient = (color: FeedbackColors | 'primary') => {
         disabled: 'interactive.background.gray.disabled',
       },
     },
-    // Only the `primary` emphasis exists in the design for the black color, which
-    // is currently used by FloatingActionButton and is not exposed on `Button`.
-    black: {
-      primary: {
-        default: 'interactive.background.staticBlack.default',
-        highlighted: 'interactive.background.staticBlack.highlighted',
-        disabled: 'interactive.background.staticBlack.fadedHighlighted',
-      },
-    },
   } as const;
 };
 
@@ -98,7 +89,7 @@ const boxShadow = (
     'primary' | 'secondary' | 'tertiary',
     Record<'default' | 'highlighted' | 'disabled', ButtonBoxShadow>
   >;
-  black: Record<'primary', Record<'default' | 'highlighted' | 'disabled', ButtonBoxShadow>>;
+  neutral: Record<'primary', Record<'default' | 'highlighted' | 'disabled', ButtonBoxShadow>>;
 } => {
   return {
     base: {
@@ -194,7 +185,7 @@ const boxShadow = (
         disabled: [{ y: 0, blur: 0, spread: 1, color: 'interactive.border.staticWhite.disabled' }],
       },
     },
-    black: {
+    neutral: {
       primary: {
         default: [
           { y: -1.5, blur: 0, spread: 0, color: 'interactive.border.staticBlack.highlighted' },
@@ -250,11 +241,11 @@ const textColor = (property: 'icon' | 'text') => {
         disabled: `interactive.${property}.staticWhite.disabled`,
       },
     },
-    black: {
+    neutral: {
       primary: {
-        default: `interactive.${property}.staticWhite.normal`,
-        highlighted: `interactive.${property}.staticWhite.normal`,
-        disabled: `interactive.${property}.staticWhite.disabled`,
+        default: `interactive.${property}.onNeutral.normal`,
+        highlighted: `interactive.${property}.onNeutral.normal`,
+        disabled: `interactive.${property}.onNeutral.disabled`,
       },
     },
     transparent: {
@@ -390,9 +381,6 @@ const spinnerColor = {
     secondary: 'white',
     tertiary: 'white',
   },
-  black: {
-    primary: 'white',
-  },
   positive: {
     primary: 'positive',
     secondary: 'positive',
@@ -410,7 +398,9 @@ const spinnerColor = {
     secondary: 'information',
   },
   neutral: {
-    primary: 'neutral',
+    // The primary emphasis renders content on a filled neutral surface, so the
+    // spinner follows the same inverted treatment as the label.
+    primary: 'white',
     secondary: 'neutral',
   },
 } as const;

--- a/packages/blade/src/components/Button/BaseButton/buttonTokens.ts
+++ b/packages/blade/src/components/Button/BaseButton/buttonTokens.ts
@@ -400,7 +400,7 @@ const spinnerColor = {
   neutral: {
     // The primary emphasis renders content on a filled neutral surface, so the
     // spinner follows the same inverted treatment as the label.
-    primary: 'white',
+    primary: 'onNeutral',
     secondary: 'neutral',
   },
 } as const;

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButton.stories.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButton.stories.tsx
@@ -116,7 +116,7 @@ IconOnly.args = {
 
 export const Colors = (): React.ReactElement => (
   <Box display="flex" flexDirection="column" gap="spacing.5">
-    {(['primary', 'white', 'black'] as const).map((color) => (
+    {(['primary', 'white', 'neutral'] as const).map((color) => (
       <Box key={color} display="flex" flexDirection="column" gap="spacing.3">
         <Text weight="semibold">{color}</Text>
         <Box

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButton.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButton.tsx
@@ -12,7 +12,7 @@ import type { BladeElementRef } from '~utils/types';
  */
 const colorToSpinnerColor = {
   primary: 'white',
-  black: 'white',
+  neutral: 'white',
   white: 'neutral',
 } as const;
 

--- a/packages/blade/src/components/FloatingActionButton/FloatingActionButton.tsx
+++ b/packages/blade/src/components/FloatingActionButton/FloatingActionButton.tsx
@@ -12,7 +12,7 @@ import type { BladeElementRef } from '~utils/types';
  */
 const colorToSpinnerColor = {
   primary: 'white',
-  neutral: 'white',
+  neutral: 'onNeutral',
   white: 'neutral',
 } as const;
 

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.native.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.native.test.tsx
@@ -28,7 +28,7 @@ describe('<FloatingActionButton /> (native)', () => {
     expect(toJSON()).toMatchSnapshot();
   });
 
-  it.each(['primary', 'white', 'black'] as const)('should render %s color', (color) => {
+  it.each(['primary', 'white', 'neutral'] as const)('should render %s color', (color) => {
     const { toJSON } = renderWithTheme(
       <FloatingActionButton icon={PlusIcon} color={color}>
         Create payment

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.native.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.native.test.tsx
@@ -118,4 +118,14 @@ describe('<FloatingActionButton /> (native)', () => {
 
     expect(getByLabelText('Create payment')).toBeTruthy();
   });
+
+  it('should render a loading neutral button with an inverted spinner', () => {
+    const { toJSON } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} color="neutral" isLoading>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(toJSON()).toMatchSnapshot();
+  });
 });

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.web.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.web.test.tsx
@@ -170,6 +170,16 @@ describe('<FloatingActionButton />', () => {
     expect(getByTestId('fab')).toHaveAttribute('data-analytics-name', 'create-payment');
   });
 
+  it('should render a loading neutral button with an inverted spinner', () => {
+    const { container } = renderWithTheme(
+      <FloatingActionButton icon={PlusIcon} color="neutral" isLoading>
+        Create payment
+      </FloatingActionButton>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
   it('should pass general a11y with a label', async () => {
     const { container } = renderWithTheme(
       <FloatingActionButton icon={PlusIcon}>Create payment</FloatingActionButton>,

--- a/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.web.test.tsx
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/FloatingActionButton.web.test.tsx
@@ -24,7 +24,7 @@ describe('<FloatingActionButton />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it.each(['primary', 'white', 'black'] as const)('should render %s color', (color) => {
+  it.each(['primary', 'white', 'neutral'] as const)('should render %s color', (color) => {
     const { container } = renderWithTheme(
       <FloatingActionButton icon={PlusIcon} color={color}>
         Create payment

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.native.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.native.test.tsx.snap
@@ -557,7 +557,7 @@ exports[`<FloatingActionButton /> (native) should render as an icon-only button 
 </View>
 `;
 
-exports[`<FloatingActionButton /> (native) should render black color 1`] = `
+exports[`<FloatingActionButton /> (native) should render neutral color 1`] = `
 <View
   style={
     {
@@ -644,15 +644,15 @@ exports[`<FloatingActionButton /> (native) should render black color 1`] = `
         buttonPaddingRight="16px"
         buttonPaddingTop="0px"
         collapsable={false}
-        color="black"
+        color="neutral"
         data-blade-component="button"
         defaultBackgroundColor="hsla(0, 0%, 0%, 1)"
         defaultBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
-        focusBackgroundColor="hsla(0, 0%, 0%, 1)"
+        focusBackgroundColor="hsla(0, 0%, 0%, 0.88)"
         focusBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
-        focusRingColor="hsla(218, 89%, 51%, 0.18)"
+        focusRingColor="hsla(206, 10%, 29%, 0.12)"
         focusable={true}
-        hoverBackgroundColor="hsla(0, 0%, 0%, 1)"
+        hoverBackgroundColor="hsla(0, 0%, 0%, 0.88)"
         hoverBoxShadow="inset 0 -1.5px 0px 0px hsla(0, 0%, 0%, 1), inset 0 0px 0px 0.5px hsla(0, 0%, 0%, 1), inset 0 1.5px 0px 0px hsla(0, 0%, 100%, 0.32), inset 0 -2px 0px 0px hsla(0, 0%, 100%, 0.32)"
         hoverIconColor="hsla(0, 0%, 100%, 1)"
         isFullWidth={false}
@@ -1104,7 +1104,7 @@ exports[`<FloatingActionButton /> (native) should render black color 1`] = `
             </View>
             <Text
               accessible={true}
-              color="interactive.text.staticWhite.normal"
+              color="interactive.text.onNeutral.normal"
               data-blade-component="base-text"
               fontSize={200}
               fontWeight="medium"

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.native.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.native.test.tsx.snap
@@ -1,5 +1,473 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<FloatingActionButton /> (native) should render a loading neutral button with an inverted spinner 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    bottom="34px"
+    data-blade-component="floating-action-button"
+    display="flex"
+    flexDirection="row"
+    justifyContent="flex-end"
+    left="0px"
+    pointerEvents="box-none"
+    position="absolute"
+    right="0px"
+    style={
+      [
+        {
+          "bottom": 34,
+          "display": "flex",
+          "flexDirection": "row",
+          "justifyContent": "flex-end",
+          "left": 0,
+          "paddingBottom": 16,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "pointerEvents": "box-none",
+          "position": "absolute",
+          "right": 0,
+          "zIndex": 99,
+        },
+      ]
+    }
+    zIndex={99}
+  >
+    <View
+      borderRadius="max"
+      data-blade-component="base-box"
+      elevation="midRaised"
+      style={
+        [
+          {
+            "borderRadius": 9999,
+          },
+          {
+            "elevation": 16,
+            "shadowColor": "hsla(200, 10%, 18%, 1)",
+            "shadowOffset": {
+              "height": 2,
+              "width": 0,
+            },
+            "shadowOpacity": 0.06,
+            "shadowRadius": 4,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": true,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        borderRadius={9999}
+        buttonPaddingBottom="0px"
+        buttonPaddingLeft="16px"
+        buttonPaddingRight="16px"
+        buttonPaddingTop="0px"
+        collapsable={false}
+        color="neutral"
+        data-blade-component="button"
+        defaultBackgroundColor="hsla(0, 0%, 0%, 0.18)"
+        focusBackgroundColor="hsla(0, 0%, 0%, 0.18)"
+        focusRingColor="hsla(206, 10%, 29%, 0.12)"
+        focusable={true}
+        hoverBackgroundColor="hsla(0, 0%, 0%, 0.18)"
+        hoverIconColor="hsla(0, 0%, 100%, 1)"
+        isFullWidth={false}
+        isLoading={true}
+        isPressed={false}
+        minHeight="48px"
+        motionDuration="duration.xquick"
+        motionEasing="easing.standard"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        onTouchEnd={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        size="large"
+        style={
+          [
+            {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "hsla(0, 0%, 0%, 0.18)",
+              "borderColor": "black",
+              "borderRadius": 9999,
+              "borderStyle": "solid",
+              "borderWidth": 0,
+              "cursor": "not-allowed",
+              "display": "flex",
+              "flexDirection": "row",
+              "justifyContent": "center",
+              "minHeight": 48,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 16,
+              "paddingRight": 16,
+              "paddingTop": 0,
+              "textDecorationColor": "black",
+              "textDecorationLine": "none",
+              "textDecorationStyle": "solid",
+              "width": "auto",
+            },
+            {
+              "backgroundColor": "hsla(0, 0%, 0%, 0.18)",
+            },
+          ]
+        }
+        type="button"
+      >
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "scale": 1,
+                },
+              ],
+            }
+          }
+        >
+          <View
+            alignItems="center"
+            bottom="0px"
+            data-blade-component="base-box"
+            display="flex"
+            justifyContent="center"
+            left="0px"
+            position="absolute"
+            right="0px"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "bottom": 0,
+                  "display": "flex",
+                  "justifyContent": "center",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 1,
+                },
+              ]
+            }
+            top="0px"
+            zIndex={1}
+          >
+            <View
+              data-blade-component="spinner"
+              style={
+                [
+                  {},
+                ]
+              }
+            >
+              <View
+                accessibilityLabel="Loading"
+                accessibilityRole="progressbar"
+                accessible={true}
+                alignItems="center"
+                data-blade-component="base-box"
+                display="flex"
+                flexDirection="row"
+                style={
+                  [
+                    {
+                      "alignItems": "center",
+                      "display": "flex",
+                      "flexDirection": "row",
+                    },
+                  ]
+                }
+              >
+                <View
+                  alignSelf="center"
+                  data-blade-component="base-box"
+                  style={
+                    [
+                      {
+                        "alignSelf": "center",
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "transform": [
+                          {
+                            "rotateZ": "0deg",
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <RNSVGSvgView
+                      accessibilityElementsHidden={true}
+                      align="xMidYMid"
+                      bbHeight="20px"
+                      bbWidth="20px"
+                      data-blade-component="icon"
+                      fill="none"
+                      focusable={false}
+                      height="20px"
+                      importantForAccessibility="no-hide-descendants"
+                      meetOrSlice={0}
+                      minX={0}
+                      minY={0}
+                      style={
+                        [
+                          {
+                            "backgroundColor": "transparent",
+                            "borderWidth": 0,
+                          },
+                          [
+                            {},
+                          ],
+                          {
+                            "flex": 0,
+                            "height": 20,
+                            "width": 20,
+                          },
+                        ]
+                      }
+                      vbHeight={24}
+                      vbWidth={24}
+                      width="20px"
+                    >
+                      <RNSVGGroup
+                        fill={null}
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                      >
+                        <RNSVGPath
+                          d="M24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z"
+                          fill={
+                            {
+                              "payload": 4294967295,
+                              "type": 0,
+                            }
+                          }
+                          fillOpacity={0.2}
+                          propList={
+                            [
+                              "fill",
+                              "fillOpacity",
+                            ]
+                          }
+                        />
+                        <RNSVGPath
+                          d="M24 12C24 13.8937 23.5518 15.7606 22.6921 17.4479C21.8324 19.1352 20.5855 20.5951 19.0534 21.7082C17.5214 22.8213 15.7476 23.556 13.8772 23.8523C12.0068 24.1485 10.0928 23.9979 8.29181 23.4127L9.21886 20.5595C10.5696 20.9984 12.0051 21.1114 13.4079 20.8892C14.8107 20.667 16.141 20.116 17.2901 19.2812C18.4391 18.4463 19.3743 17.3514 20.0191 16.0859C20.6639 14.8204 21 13.4203 21 12H24Z"
+                          fill={
+                            {
+                              "payload": 4294967295,
+                              "type": 0,
+                            }
+                          }
+                          propList={
+                            [
+                              "fill",
+                            ]
+                          }
+                        />
+                        <RNSVGPath
+                          d="M-1.33514e-05 12C-1.33514e-05 10.1063 0.448176 8.23944 1.30791 6.55211C2.16764 4.86479 3.41451 3.4049 4.94656 2.2918C6.47862 1.17869 8.25236 0.443983 10.1228 0.147739C11.9932 -0.148504 13.9072 0.00212896 15.7082 0.587322L14.7811 3.44049C13.4304 3.0016 11.9949 2.88862 10.5921 3.11081C9.18927 3.33299 7.85896 3.88402 6.70992 4.71885C5.56088 5.55367 4.62573 6.64859 3.98093 7.91409C3.33613 9.17958 2.99999 10.5797 2.99999 12H-1.33514e-05Z"
+                          fill={
+                            {
+                              "payload": 4294967295,
+                              "type": 0,
+                            }
+                          }
+                          propList={
+                            [
+                              "fill",
+                            ]
+                          }
+                        />
+                      </RNSVGGroup>
+                    </RNSVGSvgView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            alignItems="center"
+            data-blade-component="base-box"
+            display="flex"
+            flexDirection="row"
+            isHidden={true}
+            justifyContent="center"
+            style={
+              [
+                {
+                  "alignItems": "center",
+                  "display": "flex",
+                  "flexBasis": 0,
+                  "flexDirection": "row",
+                  "flexGrow": 1,
+                  "flexShrink": 1,
+                  "justifyContent": "center",
+                  "zIndex": 1,
+                },
+                {
+                  "opacity": 0,
+                },
+              ]
+            }
+            zIndex={1}
+          >
+            <View
+              alignItems="center"
+              data-blade-component="base-box"
+              display="flex"
+              justifyContent="center"
+              style={
+                [
+                  {
+                    "alignItems": "center",
+                    "display": "flex",
+                    "justifyContent": "center",
+                  },
+                ]
+              }
+            >
+              <RNSVGSvgView
+                accessibilityElementsHidden={true}
+                align="xMidYMid"
+                bbHeight="24px"
+                bbWidth="24px"
+                data-blade-component="icon"
+                fill="none"
+                focusable={false}
+                height="24px"
+                importantForAccessibility="no-hide-descendants"
+                meetOrSlice={0}
+                minX={0}
+                minY={0}
+                style={
+                  [
+                    {
+                      "backgroundColor": "transparent",
+                      "borderWidth": 0,
+                    },
+                    [
+                      {},
+                    ],
+                    {
+                      "flex": 0,
+                      "height": 24,
+                      "width": 24,
+                    },
+                  ]
+                }
+                vbHeight={24}
+                vbWidth={24}
+                width="24px"
+              >
+                <RNSVGGroup
+                  fill={null}
+                  propList={
+                    [
+                      "fill",
+                    ]
+                  }
+                >
+                  <RNSVGPath
+                    d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                    fill={
+                      {
+                        "payload": 1392508927,
+                        "type": 0,
+                      }
+                    }
+                    propList={
+                      [
+                        "fill",
+                      ]
+                    }
+                  />
+                </RNSVGGroup>
+              </RNSVGSvgView>
+            </View>
+            <Text
+              accessible={true}
+              color="interactive.text.onNeutral.disabled"
+              data-blade-component="base-text"
+              fontSize={200}
+              fontWeight="medium"
+              lineHeight={200}
+              marginX="spacing.2"
+              style={
+                [
+                  {
+                    "color": "hsla(0, 0%, 100%, 0.32)",
+                    "fontFamily": "Inter",
+                    "fontSize": 16,
+                    "fontStyle": "normal",
+                    "fontWeight": "500",
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 0,
+                    "marginLeft": 4,
+                    "marginRight": 4,
+                    "marginTop": 0,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 0,
+                    "textAlign": "center",
+                    "textDecorationLine": "none",
+                  },
+                ]
+              }
+              textAlign="center"
+            >
+              Create payment
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`<FloatingActionButton /> (native) should render as an icon-only button when children is omitted 1`] = `
 <View
   style={

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.web.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.web.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`<FloatingActionButton /> should render as an icon-only button when chil
 </div>
 `;
 
-exports[`<FloatingActionButton /> should render black color 1`] = `
+exports[`<FloatingActionButton /> should render neutral color 1`] = `
 .c0.c0.c0.c0.c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -268,22 +268,22 @@ exports[`<FloatingActionButton /> should render black color 1`] = `
 }
 
 .c1.c1.c1.c1.c1:hover {
-  background-color: hsla(0,0%,0%,1);
+  background-color: hsla(0,0%,0%,0.88);
   box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
   background-image: none;
 }
 
 .c1.c1.c1.c1.c1:active {
-  background-color: hsla(0,0%,0%,1);
+  background-color: hsla(0,0%,0%,0.88);
   box-shadow: inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
   background-image: none;
 }
 
 .c1.c1.c1.c1.c1:focus-visible {
-  background-color: hsla(0,0%,0%,1);
+  background-color: hsla(0,0%,0%,0.88);
   outline: 1px solid hsla(218,89%,51%,0.09);
   background-image: none;
-  box-shadow: 0px 0px 0px 4px hsla(218,89%,51%,0.18),inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
+  box-shadow: 0px 0px 0px 4px hsla(206,10%,29%,0.12),inset 0 -1.5px 0px 0px hsla(0,0%,0%,1),inset 0 0px 0px 0.5px hsla(0,0%,0%,1),inset 0 1.5px 0px 0px hsla(0,0%,100%,0.32),inset 0 -2px 0px 0px hsla(0,0%,100%,0.32);
 }
 
 .c1.c1.c1.c1.c1 * {

--- a/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.web.test.tsx.snap
+++ b/packages/blade/src/components/FloatingActionButton/__tests__/__snapshots__/FloatingActionButton.web.test.tsx.snap
@@ -1,5 +1,302 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<FloatingActionButton /> should render a loading neutral button with an inverted spinner 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  z-index: 99;
+  right: 16px;
+  bottom: 16px;
+  border-radius: 9999px;
+  box-shadow: 0px 16px 12px 0px hsla(200,10%,18%,0.06);
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: absolute;
+  z-index: 1;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.c4.c4.c4.c4.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6.c6.c6.c6.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.c8.c8.c8.c8.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  min-height: 48px;
+  width: auto;
+  cursor: not-allowed;
+  background-color: hsla(0,0%,0%,0.18);
+  border: none;
+  border-radius: 9999px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  overflow: hidden;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  background-image: none;
+  -webkit-transition-property: background-color,background-image,box-shadow;
+  transition-property: background-color,background-image,box-shadow;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  position: relative;
+}
+
+.c1.c1.c1.c1.c1:hover {
+  background-color: hsla(0,0%,0%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:active {
+  background-color: hsla(0,0%,0%,0.18);
+  background-image: none;
+}
+
+.c1.c1.c1.c1.c1:focus-visible {
+  background-color: hsla(0,0%,0%,0.18);
+  outline: 1px solid hsla(218,89%,51%,0.09);
+  background-image: none;
+  box-shadow: 0px 0px 0px 4px hsla(206,10%,29%,0.12);
+}
+
+.c1.c1.c1.c1.c1 * {
+  -webkit-transition-property: color,fill,opacity;
+  transition-property: color,fill,opacity;
+  -webkit-transition-duration: 160ms;
+  transition-duration: 160ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+}
+
+.c2.c2.c2.c2.c2 {
+  -webkit-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+  -webkit-transition-duration: cubic-bezier(0.3,0,0.2,1);
+  transition-duration: cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition-timing-function: 160px;
+  transition-timing-function: 160px;
+}
+
+.c9.c9.c9.c9.c9 {
+  color: hsla(0,0%,100%,0.32);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 1rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.5rem;
+  -webkit-letter-spacing: 0px;
+  -moz-letter-spacing: 0px;
+  -ms-letter-spacing: 0px;
+  letter-spacing: 0px;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  margin-right: 4px;
+  margin-left: 4px;
+}
+
+.c5.c5.c5.c5.c5 {
+  padding: 1px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-animation: eoUyJr-450290765 960ms cubic-bezier(0.5,0,0.3,1.5) infinite;
+  animation: eoUyJr-450290765 960ms cubic-bezier(0.5,0,0.3,1.5) infinite;
+}
+
+.c7.c7.c7.c7.c7 {
+  opacity: 0;
+}
+
+<div>
+  <div
+    class="c0"
+    data-blade-component="floating-action-button"
+    elevation="midRaised"
+  >
+    <button
+      class="c1"
+      data-blade-component="button"
+      disabled=""
+      role="button"
+      type="button"
+    >
+      <div
+        class=" c2"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c3"
+          data-blade-component="base-box"
+        >
+          <div
+            class=""
+            data-blade-component="spinner"
+          >
+            <div
+              aria-label="Loading"
+              class="c4"
+              data-blade-component="base-box"
+              role="progressbar"
+            >
+              <div
+                class=" c5"
+                data-blade-component="base-box"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="Svgweb__StyledSvg-vcmjs8-0"
+                  data-blade-component="icon"
+                  fill="none"
+                  height="20px"
+                  viewBox="0 0 24 24"
+                  width="20px"
+                >
+                  <path
+                    d="M24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z"
+                    data-blade-component="svg-path"
+                    fill="hsla(0, 0%, 100%, 1)"
+                    fill-opacity="0.2"
+                  />
+                  <path
+                    d="M24 12C24 13.8937 23.5518 15.7606 22.6921 17.4479C21.8324 19.1352 20.5855 20.5951 19.0534 21.7082C17.5214 22.8213 15.7476 23.556 13.8772 23.8523C12.0068 24.1485 10.0928 23.9979 8.29181 23.4127L9.21886 20.5595C10.5696 20.9984 12.0051 21.1114 13.4079 20.8892C14.8107 20.667 16.141 20.116 17.2901 19.2812C18.4391 18.4463 19.3743 17.3514 20.0191 16.0859C20.6639 14.8204 21 13.4203 21 12H24Z"
+                    data-blade-component="svg-path"
+                    fill="hsla(0, 0%, 100%, 1)"
+                  />
+                  <path
+                    d="M-1.33514e-05 12C-1.33514e-05 10.1063 0.448176 8.23944 1.30791 6.55211C2.16764 4.86479 3.41451 3.4049 4.94656 2.2918C6.47862 1.17869 8.25236 0.443983 10.1228 0.147739C11.9932 -0.148504 13.9072 0.00212896 15.7082 0.587322L14.7811 3.44049C13.4304 3.0016 11.9949 2.88862 10.5921 3.11081C9.18927 3.33299 7.85896 3.88402 6.70992 4.71885C5.56088 5.55367 4.62573 6.64859 3.98093 7.91409C3.33613 9.17958 2.99999 10.5797 2.99999 12H-1.33514e-05Z"
+                    data-blade-component="svg-path"
+                    fill="hsla(0, 0%, 100%, 1)"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="c6 c7"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c8"
+            data-blade-component="base-box"
+          >
+            <svg
+              aria-hidden="true"
+              class="Svgweb__StyledSvg-vcmjs8-0"
+              data-blade-component="icon"
+              fill="none"
+              height="24px"
+              viewBox="0 0 24 24"
+              width="24px"
+            >
+              <path
+                d="M13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5V11H5C4.44772 11 4 11.4477 4 12C4 12.5523 4.44772 13 5 13H11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V13H19C19.5523 13 20 12.5523 20 12C20 11.4477 19.5523 11 19 11H13V5Z"
+                data-blade-component="svg-path"
+                fill="hsla(0, 0%, 100%, 0.32)"
+              />
+            </svg>
+          </div>
+          <div
+            class="c9"
+            data-blade-component="base-text"
+          >
+            Create payment
+          </div>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<FloatingActionButton /> should render as an icon-only button when children is omitted 1`] = `
 .c0.c0.c0.c0.c0 {
   display: -webkit-box;

--- a/packages/blade/src/components/FloatingActionButton/_decisions/decisions.md
+++ b/packages/blade/src/components/FloatingActionButton/_decisions/decisions.md
@@ -19,11 +19,10 @@ The Figma spec is, geometrically and tonally, `Button` at `size="large"` with tw
 
 Reimplementing these in a standalone component would have duplicated the press animation, the loading state, the native SVG inset-shadow overlay, the link handling and the analytics wiring — and would have let the FAB drift away from `Button` whenever the shared token map changes. So `FloatingActionButton` renders `BaseButton` with `variant="primary"` and `size="large"` and adds only what the spec actually introduces.
 
-`BaseButton` gained three private props for this (it is an internal component, so this follows the existing `_isNestedDropdown` / `isInsideFullWidthButtonGroup` convention):
+`BaseButton` gained two private props for this (it is an internal component, so this follows the existing `_isNestedDropdown` / `isInsideFullWidthButtonGroup` convention):
 
 - `_borderRadius` — overrides the size-derived radius so the FAB can use `border.radius.max`.
 - `_spinnerColor` — overrides the loading spinner colour, because the FAB's contrast requirements differ from `Button`'s (see below).
-- `color="black"` — a new value in the internal colour union, additive to the shared token maps.
 
 ## Why `elevation` lives on a wrapper, not on the button
 
@@ -79,7 +78,7 @@ type FloatingActionButtonProps = {
   /**
    * @default 'primary'
    */
-  color?: 'primary' | 'white' | 'black';
+  color?: 'primary' | 'white' | 'neutral';
 
   /**
    * Corner of the viewport the button is anchored to.
@@ -132,11 +131,11 @@ type FloatingActionButtonProps = {
 
 **No `variant` prop.** All three colours in the spec are the `primary` emphasis; `secondary`/`tertiary` FABs do not exist. `color` alone therefore covers the full matrix.
 
-**`color` uses `black`, not `staticBlack`.** `Button` already exposes `white` (not `staticWhite`) for the equivalent token family, so `black` keeps the two components readable side by side. The value stays internal to `BaseButton` — it is deliberately *not* added to `Button`'s public colour union, since design has not specified a black `Button`.
+**`color` uses `neutral`, which is a shared `BaseButton` colour rather than a FAB-only one.** The dark FAB is the same treatment as a filled `neutral` button: `interactive.background.neutral.*` for the surface and `interactive.*.onNeutral.*` for the content, both of which invert with the theme. Only the `primary` emphasis is specified, so `neutral` keeps its existing `secondary` behaviour and picks up the dedicated treatment only when `variant="primary"`. `neutral` is deliberately *not* added to `Button`'s public colour union, since design has not specified a neutral `Button`.
 
 **`offset` is a single token rather than per-axis.** It covers the common case, and `StyledPropsBlade` is applied after the placement styles, so a caller needing asymmetric offsets (for example clearing a `BottomNav`) can pass `bottom="spacing.10"` directly without a second offset API.
 
-**Spinner colour is set explicitly per FAB colour.** `BaseButton`'s shared `spinnerColor` map would render a white spinner on the white FAB, which is invisible. The FAB passes `white` for `primary` and `black`, and `neutral` for `white`, matching the spec's loading state. This is scoped to the FAB rather than fixed in the shared map, which would change `Button`'s appearance.
+**Spinner colour is set explicitly per FAB colour.** `BaseButton`'s shared `spinnerColor` map would render a white spinner on the white FAB and a blue one on the primary FAB, both of which are invisible. The FAB passes `white` for `primary` and `neutral`, and `neutral` for `white`, matching the spec's loading state. This is scoped to the FAB rather than fixed in the shared map, which would change `Button`'s appearance.
 
 ## Accessibility
 

--- a/packages/blade/src/components/FloatingActionButton/types.ts
+++ b/packages/blade/src/components/FloatingActionButton/types.ts
@@ -27,7 +27,7 @@ type FloatingActionButtonCommonProps = {
    *
    * @default 'primary'
    */
-  color?: 'primary' | 'white' | 'black';
+  color?: 'primary' | 'white' | 'neutral';
 
   /**
    * Corner of the viewport the button is anchored to.

--- a/packages/blade/src/components/Spinner/BaseSpinner/BaseSpinner.tsx
+++ b/packages/blade/src/components/Spinner/BaseSpinner/BaseSpinner.tsx
@@ -21,7 +21,7 @@ type BaseSpinnerProps = {
    *
    * @default 'default'
    */
-  color?: 'primary' | 'white' | FeedbackColors;
+  color?: 'primary' | 'white' | 'onNeutral' | FeedbackColors;
   /**
    * Sets the label of the spinner.
    *
@@ -50,6 +50,11 @@ type BaseSpinnerProps = {
 const getColor = ({ color, theme }: { color: BaseSpinnerProps['color']; theme: Theme }): string => {
   if (color && color === 'white') {
     return getIn(theme.colors, 'interactive.icon.staticWhite.subtle');
+  }
+  // `onNeutral` renders on a filled neutral surface, which inverts with the
+  // theme, so it tracks the surface instead of resolving to a static color.
+  if (color && color === 'onNeutral') {
+    return getIn(theme.colors, 'interactive.icon.onNeutral.normal');
   }
   if (color && color !== 'neutral') {
     return getIn(theme.colors, `interactive.icon.${color}.subtle`);

--- a/packages/blade/src/components/Spinner/BaseSpinner/__tests__/BaseSpinner.native.test.tsx
+++ b/packages/blade/src/components/Spinner/BaseSpinner/__tests__/BaseSpinner.native.test.tsx
@@ -10,6 +10,7 @@ const colors: BaseSpinnerProps['color'][] = [
   'information',
   'notice',
   'neutral',
+  'onNeutral',
 ];
 
 describe('<BaseSpinner />', () => {

--- a/packages/blade/src/components/Spinner/BaseSpinner/__tests__/BaseSpinner.web.test.tsx
+++ b/packages/blade/src/components/Spinner/BaseSpinner/__tests__/BaseSpinner.web.test.tsx
@@ -2,6 +2,8 @@ import type { BaseSpinnerProps } from '../BaseSpinner';
 import { BaseSpinner } from '../BaseSpinner';
 import renderWithTheme from '~utils/testing/renderWithTheme.web';
 import assertAccessible from '~utils/testing/assertAccessible.web';
+import { BladeProvider } from '~components/BladeProvider';
+import { bladeTheme } from '~tokens/theme';
 
 const colors: BaseSpinnerProps['color'][] = [
   'primary',
@@ -11,6 +13,7 @@ const colors: BaseSpinnerProps['color'][] = [
   'information',
   'notice',
   'neutral',
+  'onNeutral',
 ];
 
 describe('<BaseSpinner />', () => {
@@ -61,6 +64,24 @@ describe('<BaseSpinner />', () => {
       );
       expect(container).toMatchSnapshot();
     });
+  });
+
+  it('should invert the onNeutral color with the theme so it stays visible on a filled neutral surface', () => {
+    const getSpinnerFill = (colorScheme: 'light' | 'dark'): string | null | undefined => {
+      const { container } = renderWithTheme(
+        <BladeProvider themeTokens={bladeTheme} colorScheme={colorScheme}>
+          <BaseSpinner accessibilityLabel="Loading" color="onNeutral" />
+        </BladeProvider>,
+      );
+
+      return container.querySelector('path')?.getAttribute('fill');
+    };
+
+    expect(getSpinnerFill('light')).toBe(
+      bladeTheme.colors.onLight.interactive.icon.onNeutral.normal,
+    );
+    expect(getSpinnerFill('dark')).toBe(bladeTheme.colors.onDark.interactive.icon.onNeutral.normal);
+    expect(getSpinnerFill('light')).not.toBe(getSpinnerFill('dark'));
   });
 
   it('should not have accessibility violations', async () => {

--- a/packages/blade/src/components/Spinner/BaseSpinner/__tests__/__snapshots__/BaseSpinner.native.test.tsx.snap
+++ b/packages/blade/src/components/Spinner/BaseSpinner/__tests__/__snapshots__/BaseSpinner.native.test.tsx.snap
@@ -1444,6 +1444,156 @@ exports[`<BaseSpinner /> should render notice color BaseSpinner 1`] = `
 </View>
 `;
 
+exports[`<BaseSpinner /> should render onNeutral color BaseSpinner 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    data-blade-component="spinner"
+    style={
+      [
+        {},
+      ]
+    }
+  >
+    <View
+      accessibilityLabel="Loading"
+      accessibilityRole="progressbar"
+      accessible={true}
+      alignItems="center"
+      data-blade-component="base-box"
+      display="flex"
+      flexDirection="row"
+      style={
+        [
+          {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+          },
+        ]
+      }
+    >
+      <View
+        alignSelf="center"
+        data-blade-component="base-box"
+        style={
+          [
+            {
+              "alignSelf": "center",
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "transform": [
+                {
+                  "rotateZ": "0deg",
+                },
+              ],
+            }
+          }
+        >
+          <RNSVGSvgView
+            accessibilityElementsHidden={true}
+            align="xMidYMid"
+            bbHeight="16px"
+            bbWidth="16px"
+            data-blade-component="icon"
+            fill="none"
+            focusable={false}
+            height="16px"
+            importantForAccessibility="no-hide-descendants"
+            meetOrSlice={0}
+            minX={0}
+            minY={0}
+            style={
+              [
+                {
+                  "backgroundColor": "transparent",
+                  "borderWidth": 0,
+                },
+                [
+                  {},
+                ],
+                {
+                  "flex": 0,
+                  "height": 16,
+                  "width": 16,
+                },
+              ]
+            }
+            vbHeight={24}
+            vbWidth={24}
+            width="16px"
+          >
+            <RNSVGGroup
+              fill={null}
+              propList={
+                [
+                  "fill",
+                ]
+              }
+            >
+              <RNSVGPath
+                d="M24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z"
+                fill={
+                  {
+                    "payload": 4294967295,
+                    "type": 0,
+                  }
+                }
+                fillOpacity={0.2}
+                propList={
+                  [
+                    "fill",
+                    "fillOpacity",
+                  ]
+                }
+              />
+              <RNSVGPath
+                d="M24 12C24 13.8937 23.5518 15.7606 22.6921 17.4479C21.8324 19.1352 20.5855 20.5951 19.0534 21.7082C17.5214 22.8213 15.7476 23.556 13.8772 23.8523C12.0068 24.1485 10.0928 23.9979 8.29181 23.4127L9.21886 20.5595C10.5696 20.9984 12.0051 21.1114 13.4079 20.8892C14.8107 20.667 16.141 20.116 17.2901 19.2812C18.4391 18.4463 19.3743 17.3514 20.0191 16.0859C20.6639 14.8204 21 13.4203 21 12H24Z"
+                fill={
+                  {
+                    "payload": 4294967295,
+                    "type": 0,
+                  }
+                }
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+              />
+              <RNSVGPath
+                d="M-1.33514e-05 12C-1.33514e-05 10.1063 0.448176 8.23944 1.30791 6.55211C2.16764 4.86479 3.41451 3.4049 4.94656 2.2918C6.47862 1.17869 8.25236 0.443983 10.1228 0.147739C11.9932 -0.148504 13.9072 0.00212896 15.7082 0.587322L14.7811 3.44049C13.4304 3.0016 11.9949 2.88862 10.5921 3.11081C9.18927 3.33299 7.85896 3.88402 6.70992 4.71885C5.56088 5.55367 4.62573 6.64859 3.98093 7.91409C3.33613 9.17958 2.99999 10.5797 2.99999 12H-1.33514e-05Z"
+                fill={
+                  {
+                    "payload": 4294967295,
+                    "type": 0,
+                  }
+                }
+                propList={
+                  [
+                    "fill",
+                  ]
+                }
+              />
+            </RNSVGGroup>
+          </RNSVGSvgView>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`<BaseSpinner /> should render positive color BaseSpinner 1`] = `
 <View
   style={

--- a/packages/blade/src/components/Spinner/BaseSpinner/__tests__/__snapshots__/BaseSpinner.web.test.tsx.snap
+++ b/packages/blade/src/components/Spinner/BaseSpinner/__tests__/__snapshots__/BaseSpinner.web.test.tsx.snap
@@ -743,6 +743,81 @@ exports[`<BaseSpinner /> should render notice color BaseSpinner 1`] = `
 </div>
 `;
 
+exports[`<BaseSpinner /> should render onNeutral color BaseSpinner 1`] = `
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  padding: 1px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-animation: eoUyJr-450290765 960ms cubic-bezier(0.5,0,0.3,1.5) infinite;
+  animation: eoUyJr-450290765 960ms cubic-bezier(0.5,0,0.3,1.5) infinite;
+}
+
+<div>
+  <div
+    class=""
+    data-blade-component="spinner"
+  >
+    <div
+      aria-label="Loading"
+      class="c0"
+      data-blade-component="base-box"
+      role="progressbar"
+    >
+      <div
+        class=" c1"
+        data-blade-component="base-box"
+      >
+        <svg
+          aria-hidden="true"
+          class="Svgweb__StyledSvg-vcmjs8-0"
+          data-blade-component="icon"
+          fill="none"
+          height="16px"
+          viewBox="0 0 24 24"
+          width="16px"
+        >
+          <path
+            d="M24 12C24 18.6274 18.6274 24 12 24C5.37258 24 0 18.6274 0 12C0 5.37258 5.37258 0 12 0C18.6274 0 24 5.37258 24 12ZM3 12C3 16.9706 7.02944 21 12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12Z"
+            data-blade-component="svg-path"
+            fill="hsla(0, 0%, 100%, 1)"
+            fill-opacity="0.2"
+          />
+          <path
+            d="M24 12C24 13.8937 23.5518 15.7606 22.6921 17.4479C21.8324 19.1352 20.5855 20.5951 19.0534 21.7082C17.5214 22.8213 15.7476 23.556 13.8772 23.8523C12.0068 24.1485 10.0928 23.9979 8.29181 23.4127L9.21886 20.5595C10.5696 20.9984 12.0051 21.1114 13.4079 20.8892C14.8107 20.667 16.141 20.116 17.2901 19.2812C18.4391 18.4463 19.3743 17.3514 20.0191 16.0859C20.6639 14.8204 21 13.4203 21 12H24Z"
+            data-blade-component="svg-path"
+            fill="hsla(0, 0%, 100%, 1)"
+          />
+          <path
+            d="M-1.33514e-05 12C-1.33514e-05 10.1063 0.448176 8.23944 1.30791 6.55211C2.16764 4.86479 3.41451 3.4049 4.94656 2.2918C6.47862 1.17869 8.25236 0.443983 10.1228 0.147739C11.9932 -0.148504 13.9072 0.00212896 15.7082 0.587322L14.7811 3.44049C13.4304 3.0016 11.9949 2.88862 10.5921 3.11081C9.18927 3.33299 7.85896 3.88402 6.70992 4.71885C5.56088 5.55367 4.62573 6.64859 3.98093 7.91409C3.33613 9.17958 2.99999 10.5797 2.99999 12H-1.33514e-05Z"
+            data-blade-component="svg-path"
+            fill="hsla(0, 0%, 100%, 1)"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<BaseSpinner /> should render positive color BaseSpinner 1`] = `
 .c0.c0.c0.c0.c0 {
   display: -webkit-box;

--- a/packages/blade/src/components/Spinner/Spinner/Spinner.stories.tsx
+++ b/packages/blade/src/components/Spinner/Spinner/Spinner.stories.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from 'react';
 import type { SpinnerProps } from './Spinner';
 import { Spinner as SpinnerComponent } from './Spinner';
 import BaseBox from '~components/Box/BaseBox';
+import type { TextProps } from '~components/Typography';
 import { Text } from '~components/Typography';
 import { Sandbox } from '~utils/storybook/Sandbox';
 import StoryPageWrapper from '~utils/storybook/StoryPageWrapper';
@@ -88,35 +89,76 @@ const SpinnerSizesTemplate: StoryFn<typeof SpinnerComponent> = ({ ...args }) => 
 export const SpinnerSizes = SpinnerSizesTemplate.bind({});
 SpinnerSizes.storyName = 'Sizes';
 
+const ColorSwatch = ({
+  title,
+  description,
+  backgroundColor,
+  textColor,
+  children,
+}: {
+  title: string;
+  description: string;
+  backgroundColor: string;
+  textColor?: TextProps<{ variant: 'body' }>['color'];
+  children: ReactElement;
+}): ReactElement => {
+  return (
+    <BaseBox
+      marginBottom="spacing.4"
+      paddingTop="spacing.5"
+      paddingBottom="spacing.5"
+      paddingLeft="spacing.5"
+      paddingRight="spacing.5"
+      borderRadius="medium"
+      backgroundColor={backgroundColor}
+    >
+      <Text color={textColor} weight="medium">
+        {title}
+      </Text>
+      <Text color={textColor} size="small">
+        {description}
+      </Text>
+      <BaseBox marginBottom="spacing.4" />
+      {children}
+    </BaseBox>
+  );
+};
+
 const SpinnerColorTemplate: StoryFn<typeof SpinnerComponent> = ({ ...args }) => {
   const { theme } = useTheme();
 
   return (
     <BaseBox>
-      <BaseBox
-        marginBottom="spacing.3"
-        marginTop="spacing.3"
-        paddingTop="spacing.3"
-        paddingBottom="spacing.3"
-        paddingLeft="spacing.3"
+      <ColorSwatch
+        title="neutral"
+        description="The default. Tracks the page surface, so it stays readable in both color schemes."
         backgroundColor={theme.colors.surface.background.gray.subtle}
       >
-        <Text>Primary Color</Text>
-        <BaseBox marginBottom="spacing.2" />
+        <SpinnerComponent {...args} color="neutral" />
+      </ColorSwatch>
+      <ColorSwatch
+        title="primary"
+        description="For a spinner that should carry the brand color."
+        backgroundColor={theme.colors.surface.background.gray.subtle}
+      >
         <SpinnerComponent {...args} color="primary" />
-      </BaseBox>
-      <BaseBox
-        marginBottom="spacing.3"
-        marginTop="spacing.3"
-        paddingTop="spacing.3"
-        paddingBottom="spacing.3"
-        paddingLeft="spacing.3"
-        backgroundColor={theme.colors.surface.background.gray.subtle}
+      </ColorSwatch>
+      <ColorSwatch
+        title="white"
+        description="Static white. Use it on a surface that is dark in both color schemes."
+        backgroundColor={theme.colors.interactive.background.staticBlack.default}
+        textColor="surface.text.staticWhite.normal"
       >
-        <Text contrast="high">White Color</Text>
-        <BaseBox marginBottom="spacing.2" />
         <SpinnerComponent {...args} color="white" />
-      </BaseBox>
+      </ColorSwatch>
+      <ColorSwatch
+        title="onNeutral"
+        description="For a filled neutral surface. It inverts with the theme — switch the toolbar between light and dark to see the surface and the spinner flip together."
+        backgroundColor={theme.colors.interactive.background.neutral.default}
+        textColor="interactive.text.onNeutral.normal"
+      >
+        <SpinnerComponent {...args} color="onNeutral" />
+      </ColorSwatch>
     </BaseBox>
   );
 };

--- a/packages/blade/src/components/Spinner/Spinner/Spinner.tsx
+++ b/packages/blade/src/components/Spinner/Spinner/Spinner.tsx
@@ -9,7 +9,7 @@ type SpinnerProps = BaseSpinnerProps & {
    *
    * @default 'default'
    */
-  color?: 'primary' | 'neutral' | 'white';
+  color?: 'primary' | 'neutral' | 'white' | 'onNeutral';
 };
 
 const _Spinner = (


### PR DESCRIPTION
## Description

Renames the dark `FloatingActionButton` colour from `black` to `neutral` and aligns it with the filled neutral button treatment, so the dark FAB inverts with the theme instead of always being black on white. Matches the `color=neutral` variant in [Figma](https://www.figma.com/design/jubmQL9Z8V7881ayUD95ps/Blade-DSL?node-id=125797-5435).

Also adds a `Spinner` `onNeutral` colour, which closes #3915.

## Storybook preview

Chromatic build for `27e96feea` (all three commits):

- [FloatingActionButton](https://61c19ee8d3d282003ac1d81c-hwpyrxifzb.chromatic.com/?path=/docs/components-floatingactionbutton--docs) — the [Colors](https://61c19ee8d3d282003ac1d81c-hwpyrxifzb.chromatic.com/?path=/story/components-floatingactionbutton--colors) story covers `primary` / `white` / `neutral`, and [States](https://61c19ee8d3d282003ac1d81c-hwpyrxifzb.chromatic.com/?path=/story/components-floatingactionbutton--states) covers loading and disabled
- [Spinner](https://61c19ee8d3d282003ac1d81c-hwpyrxifzb.chromatic.com/?path=/docs/components-spinner--docs) — [Contrasts](https://61c19ee8d3d282003ac1d81c-hwpyrxifzb.chromatic.com/?path=/story/components-spinner--spinner-contrasts) for the colors
- [Button](https://61c19ee8d3d282003ac1d81c-hwpyrxifzb.chromatic.com/?path=/docs/components-button--docs) — worth a look too, since `buttonTokens` is shared (see below)

Use the toolbar theme switcher to check dark mode, which is where the spinner fix matters.

## Changes

**FloatingActionButton / BaseButton**

- `<FloatingActionButton color="black" />` becomes `<FloatingActionButton color="neutral" />`. `color="black"` was never exposed on `Button` and has no consumers, so it is removed rather than deprecated.
- The dark FAB reads its surface from `interactive.background.neutral.*` and its label, icon and spinner from `interactive.*.onNeutral.*`.
- `assertBlackIsPrimary` and the three `color === 'black'` branches in `BaseButton` collapse into a single `isFilledNeutral(color, variant)` check.
- On focus, the filled neutral surface draws its ring from `interactive.border.neutral.faded` rather than the faded primary blue every other colour uses, per the design.

**Spinner** (#3915)

- New `color="onNeutral"`, reading `interactive.icon.onNeutral.normal`, matching the new [Spinner variant in Figma](https://www.figma.com/design/jubmQL9Z8V7881ayUD95ps/Blade-DSL?node-id=126007-141399).
- Every existing spinner colour is either static (`white`) or tracks the page surface (`neutral`, the feedback colours), so none stayed visible on a filled neutral surface — black on light, white on dark. The loading `Button color="neutral" variant="primary"` and `FloatingActionButton color="neutral"` both hardcoded a static white spinner, which disappeared against the white surface in dark mode.

## Additional Information

**Worth a designer's eye before merge.** `buttonTokens` is shared, so this also changes every `<Button color="neutral" variant="primary">`, not just the FAB. Rendered values move to match Figma:

| | before | after |
|---|---|---|
| bottom inner shadow | `hsla(0,0%,0%,0.88)` | `hsla(0,0%,0%,1)` |
| top inner highlight | `hsla(0,0%,100%,0.18)` | `hsla(0,0%,100%,0.32)` |
| disabled label | `hsla(206,10%,29%,0.32)` | `hsla(0,0%,100%,0.32)` |

The disabled label fix is unambiguous — a dark filled button needs a light label. The two shadow values are the part to confirm.

**Verification.** Every neutral state in the Figma component set was compared token by token against what the branch renders — background at all three states, `onNeutral` text and icon, all four inner shadows, the focus ring and the spinner. Full suites run against current master: native 601 suites clean, web 691 suites clean apart from a pre-existing `SankeyChart` font-metric snapshot that fails identically on untouched master. Web and native typechecks both clean.

Adds the first loading-state snapshots the FAB has had, plus a test asserting the `onNeutral` spinner fill equals the theme's own `onNeutral.normal` in each colour scheme and that the two differ.

## Component Checklist

- [ ] Update Component Status Page — not needed, no status change (`in-development`)
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story — the existing story already iterates `['primary', 'white', 'neutral']`
- [ ] Add Interaction Tests (if applicable) — not applicable, no new interaction
- [x] Add changeset — `fab-neutral-color`, `spinner-on-neutral-color`

