### PR TITLE
fix(BaseMotion): resolve Firefox transform commitStyles failure for skipped animations

### DIFF
--- a/packages/blade/src/components/BaseMotion/__tests__/BaseMotion.native.test.tsx
+++ b/packages/blade/src/components/BaseMotion/__tests__/BaseMotion.native.test.tsx
@@ -60,6 +60,46 @@ describe('<BaseMotion /> (native)', () => {
     expect(variants?.exit.transition?.duration).toBe(0.0001);
   });
 
+  it('should add transitionEnd with transform when exit is skipped and variant has transform', () => {
+    const moveVariants: MotionVariantsType = {
+      initial: { opacity: 0, transform: 'translateY(16px)' },
+      animate: {
+        opacity: 1,
+        transform: 'translateY(0px)',
+        transition: { duration: 0.36, ease: [0, 0, 0.2, 1] },
+      },
+      exit: {
+        opacity: 0,
+        transform: 'translateY(16px)',
+        transition: { duration: 0.2, ease: [0.17, 0, 1, 1] },
+      },
+    };
+    const variants = useMotionVariants(moveVariants, 'in');
+
+    expect(variants?.exit.transition?.duration).toBe(0.0001);
+    expect(variants?.exit.transitionEnd).toEqual({ transform: 'translateY(16px)' });
+  });
+
+  it('should add transitionEnd with final transform from keyframe array when entry is skipped', () => {
+    const slideVariants: MotionVariantsType = {
+      initial: { opacity: 0 },
+      animate: {
+        opacity: 1,
+        transform: ['translateY(100vh)', 'translateY(0%)'],
+        transition: { duration: 0.5, ease: [0, 0, 0.2, 1] },
+      },
+      exit: {
+        opacity: 0,
+        transform: 'translateY(100vh)',
+        transition: { duration: 0.3, ease: [0.17, 0, 1, 1] },
+      },
+    };
+    const variants = useMotionVariants(slideVariants, 'out');
+
+    expect(variants?.animate.transition?.duration).toBe(0.0001);
+    expect(variants?.animate.transitionEnd).toEqual({ transform: 'translateY(0%)' });
+  });
+
   it('should zero the entry duration when type is "out"', () => {
     const variants = useMotionVariants(fadeVariants, 'out');
 

--- a/packages/blade/src/components/BaseMotion/__tests__/BaseMotion.web.test.tsx
+++ b/packages/blade/src/components/BaseMotion/__tests__/BaseMotion.web.test.tsx
@@ -77,6 +77,88 @@ describe('<BaseMotionBox />', () => {
     expect(mockMotionProps.variants.exit.transition.duration).toBe(0.0001);
   });
 
+  it('should add transitionEnd with transform when exit is skipped and variant has transform', () => {
+    renderWithTheme(
+      <BaseMotionBox
+        type="in"
+        motionVariants={{
+          initial: { opacity: 0, transform: 'translateY(16px)' },
+          animate: {
+            opacity: 1,
+            transform: 'translateY(0px)',
+            transition: { duration: 0.36, ease: [0, 0, 0.2, 1] },
+          },
+          exit: {
+            opacity: 0,
+            transform: 'translateY(16px)',
+            transition: { duration: 0.2, ease: [0.17, 0, 1, 1] },
+          },
+        }}
+        motionTriggers={['mount']}
+      >
+        <div>hi</div>
+      </BaseMotionBox>,
+    );
+
+    expect(mockMotionProps.variants.exit.transition.duration).toBe(0.0001);
+    expect(mockMotionProps.variants.exit.transitionEnd).toEqual({ transform: 'translateY(16px)' });
+  });
+
+  it('should not override existing transitionEnd.transform when exit is skipped', () => {
+    renderWithTheme(
+      <BaseMotionBox
+        type="in"
+        motionVariants={{
+          initial: { opacity: 0 },
+          animate: {
+            opacity: 1,
+            transform: ['translateY(100vh)', 'translateY(0%)'],
+            transition: { duration: 0.5, ease: [0, 0, 0.2, 1] },
+          },
+          exit: {
+            opacity: 0,
+            transform: 'translateY(100vh)',
+            transitionEnd: { transform: 'translateY(100vh)' },
+            transition: { duration: 0.3, ease: [0.17, 0, 1, 1] },
+          },
+        }}
+        motionTriggers={['mount']}
+      >
+        <div>hi</div>
+      </BaseMotionBox>,
+    );
+
+    expect(mockMotionProps.variants.exit.transition.duration).toBe(0.0001);
+    expect(mockMotionProps.variants.exit.transitionEnd).toEqual({ transform: 'translateY(100vh)' });
+  });
+
+  it('should add transitionEnd with final transform from keyframe array when entry is skipped', () => {
+    renderWithTheme(
+      <BaseMotionBox
+        type="out"
+        motionVariants={{
+          initial: { opacity: 0 },
+          animate: {
+            opacity: 1,
+            transform: ['translateY(100vh)', 'translateY(0%)'],
+            transition: { duration: 0.5, ease: [0, 0, 0.2, 1] },
+          },
+          exit: {
+            opacity: 0,
+            transform: 'translateY(100vh)',
+            transition: { duration: 0.3, ease: [0.17, 0, 1, 1] },
+          },
+        }}
+        motionTriggers={['mount']}
+      >
+        <div>hi</div>
+      </BaseMotionBox>,
+    );
+
+    expect(mockMotionProps.variants.animate.transition.duration).toBe(0.0001);
+    expect(mockMotionProps.variants.animate.transitionEnd).toEqual({ transform: 'translateY(0%)' });
+  });
+
   it('should disable entry animation when type is "out" transition', () => {
     renderWithTheme(
       <BaseMotionBox

--- a/packages/blade/src/components/BaseMotion/baseMotionUtils.ts
+++ b/packages/blade/src/components/BaseMotion/baseMotionUtils.ts
@@ -48,6 +48,21 @@ const makeAnimationVariables = (
   return { initial: 'initial', exit: 'exit', ...interactionVariables };
 };
 
+const getFinalTransformValue = (transform: unknown): string | undefined => {
+  if (typeof transform === 'string') return transform;
+  if (Array.isArray(transform)) {
+    const last = transform[transform.length - 1];
+    return typeof last === 'string' ? last : undefined;
+  }
+  return undefined;
+};
+
+const hasTransitionEndTransform = (variant: unknown): boolean => {
+  return (
+    (variant as { transitionEnd?: { transform?: unknown } })?.transitionEnd?.transform !== undefined
+  );
+};
+
 const useMotionVariants = (
   motionVariants: BaseMotionBoxProps['motionVariants'],
   type: BaseMotionBoxProps['type'],
@@ -59,8 +74,23 @@ const useMotionVariants = (
   const shouldSkipEntryAnimation = type === 'out';
   const shouldSkipExitAnimation = type === 'in';
 
-  // We override durations to stop animations but still continue with the expected position changes
-  const newMotionVariants: BaseMotionBoxProps['motionVariants'] = {
+  // When a direction is skipped (type="in" skips exit, type="out" skips entry), the near-zero
+  // duration (0.0001s) WAAPI animation in Firefox doesn't reliably commit `transform` via
+  // commitStyles(). We add `transitionEnd` with the target `transform` so framer-motion sets it
+  // directly as an inline style after the animation, bypassing the commitStyles() path.
+  const animateTransform = getFinalTransformValue(motionVariants.animate?.transform);
+  const shouldAddAnimateTransitionEnd =
+    shouldSkipEntryAnimation &&
+    animateTransform !== undefined &&
+    !hasTransitionEndTransform(motionVariants.animate);
+
+  const exitTransform = getFinalTransformValue(motionVariants.exit?.transform);
+  const shouldAddExitTransitionEnd =
+    shouldSkipExitAnimation &&
+    exitTransform !== undefined &&
+    !hasTransitionEndTransform(motionVariants.exit);
+
+  const newMotionVariants = {
     initial: {
       ...motionVariants.initial,
     },
@@ -70,6 +100,14 @@ const useMotionVariants = (
         ...motionVariants.animate?.transition,
         duration: shouldSkipEntryAnimation ? 0.0001 : motionVariants.animate?.transition?.duration,
       },
+      ...(shouldAddAnimateTransitionEnd
+        ? {
+            transitionEnd: {
+              ...motionVariants.animate?.transitionEnd,
+              transform: animateTransform,
+            },
+          }
+        : {}),
     },
     exit: {
       ...motionVariants.exit,
@@ -77,8 +115,16 @@ const useMotionVariants = (
         ...motionVariants.exit.transition,
         duration: shouldSkipExitAnimation ? 0.0001 : motionVariants.exit.transition?.duration,
       },
+      ...(shouldAddExitTransitionEnd
+        ? {
+            transitionEnd: {
+              ...motionVariants.exit?.transitionEnd,
+              transform: exitTransform,
+            },
+          }
+        : {}),
     },
-  };
+  } as BaseMotionBoxProps['motionVariants'];
 
   return newMotionVariants;
 };


### PR DESCRIPTION
## Problem

The Blade Interaction Tests workflow failed on Firefox with 2 test failures in Motion.test.stories.tsx:
- OnlyInAnimation — expected 'translateY(0px)' to be 'translateY(16px)'
- OnlyOutAnimation — expected 'translateY(0px)' to be 'translateY(16px)'

Both tests pass on Chromium but fail on Firefox.

CI run: https://github.com/razorpay/blade/actions/runs/32999610592

## Root Cause

When type=in or type=out is used on motion presets (Move, Slide, etc.), useMotionVariants sets a near-zero duration (0.0001s) for the skipped animation direction. On web, framer-motion v11 runs this as a WAAPI animation and relies on Animation.commitStyles() to persist the final transform value to the element's inline style.

Firefox does not reliably commit transform for these near-zero-duration WAAPI animations, so the inline style.transform remains at the resting/visible position (translateY(0px)) instead of the expected hidden position (translateY(16px)).

This only affects components that animate transform as a raw CSS string (Move, Slide). Fade (opacity-only) is unaffected. Slide already worked because its exit variant includes transitionEnd which sets the transform directly after the animation. Move lacked this fallback.

## Fix

In useMotionVariants (baseMotionUtils.ts), when an animation direction is skipped, add transitionEnd with the target transform value to the skipped variant. This tells framer-motion to set the transform directly as an inline style after the animation completes, bypassing the commitStyles() path entirely.

- Handles both string transforms and keyframe arrays — uses the last array element as the final value
- Does not override existing transitionEnd.transform values (e.g. Slide's exit already has this)
- No impact on native (React Native) — the native interpreter reads transform directly, not transitionEnd

## Testing

- All existing BaseMotion unit tests pass (web: 8, native: 40)
- Added 3 new web test cases and 2 new native test cases verifying transitionEnd behavior
- Typecheck passes (yarn tsc:blade)
- Build passes (yarn build)
- Lint passes (eslint + prettier)

Automated changes by autonomous agent.

Requested by: admin <admin>