### PR TITLE
fix(blade-svelte): Button story controls + neutral focus ring

### DIFF
--- a/.changeset/fix-neutral-button-focus-ring-and-stories.md
+++ b/.changeset/fix-neutral-button-focus-ring-and-stories.md
@@ -1,0 +1,8 @@
+---
+'@razorpay/blade-core': patch
+'@razorpay/blade-svelte': patch
+---
+
+fix(Button): use `interactive.border.neutral.faded` for the neutral variant's focus ring instead of the shared blue ring used by primary/positive/negative
+
+fix: correct several Button Storybook stories where Controls didn't drive the rendered output (hardcoded `asChild` demos, dead `variant`/`color` controls on loading-matrix stories)

--- a/packages/blade-core/src/styles/Button/button.module.css
+++ b/packages/blade-core/src/styles/Button/button.module.css
@@ -258,6 +258,28 @@
   }
 }
 
+/*
+ * Neutral's focus ring uses a neutral-tinted color instead of the shared blue
+ * ring every other accent color uses. Overrides only the box-shadow's outer
+ * ring on top of the shared filled/outlined blocks above (same specificity,
+ * later in source order wins) — outline and inset borders stay shared.
+ */
+.color-neutral.primary:focus-visible:not([disabled]) {
+  box-shadow: 0px 0px 0px 4px var(--interactive-border-neutral-faded),
+    inset 0 -1.5px 0 0 var(--btn-accent-border-highlighted),
+    inset 0 0 0 0.5px var(--btn-accent-border-highlighted),
+    inset 0 1.5px 0 0 var(--btn-accent-bevel, var(--interactive-border-static-white-faded)),
+    inset 0 -2px 0 0 var(--btn-accent-bevel, var(--interactive-border-static-white-faded));
+}
+
+.color-neutral.secondary:focus-visible:not([disabled]),
+.color-neutral.tertiary:focus-visible:not([disabled]) {
+  box-shadow: 0px 0px 0px 4px var(--interactive-border-neutral-faded),
+    inset 0 -1px 0.5px 0 var(--interactive-border-static-black-faded-highlighted),
+    inset 0 0 0 1px var(--interactive-border-gray-highlighted),
+    inset 0 -1.5px 0 0 var(--interactive-border-gray-default);
+}
+
 /* ===== Color variant: White ===== */
 .color-white {
   &.primary {

--- a/packages/blade-svelte/src/components/Button/Button.stories.svelte
+++ b/packages/blade-svelte/src/components/Button/Button.stories.svelte
@@ -19,6 +19,7 @@
       isFullWidth: false,
       icon: undefined,
       iconPosition: 'left',
+      accessibilityLabel: undefined,
     },
     argTypes: {
       children: {
@@ -90,6 +91,13 @@
           defaultValue: { summary: 'left' },
         },
       },
+      accessibilityLabel: {
+        control: 'text',
+        description: 'Accessible label for the button. Required for icon-only buttons',
+        table: {
+          defaultValue: { summary: 'undefined' },
+        },
+      },
       loadingType: {
         control: 'select',
         options: ['indefinite', 'definite'],
@@ -139,6 +147,7 @@
     console.log('Loading complete!');
     isDefiniteLoadingDemoActive = false;
   }
+
 </script>
 
 <!-- Playground story - auto-renders Button with args -->
@@ -157,21 +166,27 @@
   args={{ children: 'Loading...', isLoading: true, loadingType: 'indefinite' }}
 />
 
-<Story name="Indefinite Loading Sizes" asChild>
-  <div class="display-flex gap-spacing-4 items-center">
-    <Button size="xsmall" isLoading loadingType="indefinite">Pay Now</Button>
-    <Button size="small" isLoading loadingType="indefinite">Pay Now</Button>
-    <Button size="medium" isLoading loadingType="indefinite">Pay Now</Button>
-    <Button size="large" isLoading loadingType="indefinite">Pay Now</Button>
-  </div>
+<Story name="Indefinite Loading Sizes">
+  {#snippet template(args)}
+    {@const { size, loadingType, isLoading, children, ...rest } = args}
+    <div class="display-flex gap-spacing-4 items-center">
+      <Button size="xsmall" isLoading loadingType="indefinite" {...rest}>Pay Now</Button>
+      <Button size="small" isLoading loadingType="indefinite" {...rest}>Pay Now</Button>
+      <Button size="medium" isLoading loadingType="indefinite" {...rest}>Pay Now</Button>
+      <Button size="large" isLoading loadingType="indefinite" {...rest}>Pay Now</Button>
+    </div>
+  {/snippet}
 </Story>
 
-<Story name="Indefinite Loading Variants" asChild>
-  <div class="display-flex gap-spacing-4 items-center">
-    <Button variant="primary" isLoading loadingType="indefinite">Primary</Button>
-    <Button variant="secondary" isLoading loadingType="indefinite">Secondary</Button>
-    <Button variant="tertiary" isLoading loadingType="indefinite">Tertiary</Button>
-  </div>
+<Story name="Indefinite Loading Variants">
+  {#snippet template(args)}
+    {@const { variant, loadingType, isLoading, children, ...rest } = args}
+    <div class="display-flex gap-spacing-4 items-center">
+      <Button variant="primary" isLoading loadingType="indefinite" {...rest}>Primary</Button>
+      <Button variant="secondary" isLoading loadingType="indefinite" {...rest}>Secondary</Button>
+      <Button variant="tertiary" isLoading loadingType="indefinite" {...rest}>Tertiary</Button>
+    </div>
+  {/snippet}
 </Story>
 
 <!-- Definite loading: left-to-right progress overlay, content stays visible -->
@@ -185,28 +200,37 @@
   }}
 />
 
-<Story name="Definite Loading Variants" asChild>
-  <div class="display-flex gap-spacing-4 items-center">
-    <Button variant="primary" loadingType="definite" loadingTimer={3000}>Primary</Button>
-    <Button variant="primary" color="positive" loadingType="definite" loadingTimer={3000}>
-      Positive
-    </Button>
-    <Button variant="primary" color="negative" loadingType="definite" loadingTimer={3000}>
-      Negative
-    </Button>
-  </div>
+<Story
+  name="Definite Loading Variants"
+  args={{ loadingTimer: 3000 }}
+  argTypes={{
+    variant: { table: { disable: true } },
+    color: { table: { disable: true } },
+  }}
+>
+  {#snippet template(args)}
+    {@const { variant, color, loadingType, children, ...rest } = args}
+    <div class="display-flex gap-spacing-4 items-center">
+      <Button variant="primary" loadingType="definite" {...rest}>Primary</Button>
+      <Button variant="primary" color="positive" loadingType="definite" {...rest}>Positive</Button>
+      <Button variant="primary" color="negative" loadingType="definite" {...rest}>Negative</Button>
+    </div>
+  {/snippet}
 </Story>
 
-<Story name="Definite Loading With Complete Callback" asChild>
-  <Button
-    size="large"
-    loadingType={isDefiniteLoadingDemoActive ? 'definite' : 'indefinite'}
-    loadingTimer={isDefiniteLoadingDemoActive ? 2500 : undefined}
-    onClick={startDefiniteLoadingDemo}
-    onLoadingComplete={handleDefiniteLoadingComplete}
-  >
-    {isDefiniteLoadingDemoActive ? 'Processing' : 'Complete in 2.5s'}
-  </Button>
+<Story name="Definite Loading With Complete Callback" args={{ size: 'large' }}>
+  {#snippet template(args)}
+    {@const { children, ...rest } = args}
+    <Button
+      {...rest}
+      loadingType={isDefiniteLoadingDemoActive ? 'definite' : 'indefinite'}
+      loadingTimer={isDefiniteLoadingDemoActive ? 2500 : undefined}
+      onClick={startDefiniteLoadingDemo}
+      onLoadingComplete={handleDefiniteLoadingComplete}
+    >
+      {isDefiniteLoadingDemoActive ? 'Processing' : 'Complete in 2.5s'}
+    </Button>
+  {/snippet}
 </Story>
 
 <Story name="Disabled" args={{ children: 'Disabled Button', isDisabled: true }} />
@@ -214,17 +238,20 @@
 <Story name="Full Width" args={{ children: 'Full Width Button', isFullWidth: true }} />
 
 <!-- Icon Stories -->
-<Story name="With Icon Left" asChild>
-  <Button icon={SearchIcon} iconPosition="left">Search</Button>
-</Story>
+<Story
+  name="With Icon Left"
+  args={{ children: 'Search', icon: SearchIcon, iconPosition: 'left' }}
+/>
 
-<Story name="With Icon Right" asChild>
-  <Button icon={CloseIcon} iconPosition="right">Close</Button>
-</Story>
+<Story
+  name="With Icon Right"
+  args={{ children: 'Close', icon: CloseIcon, iconPosition: 'right' }}
+/>
 
-<Story name="Icon Only" asChild>
-  <Button icon={SearchIcon} accessibilityLabel="Search" />
-</Story>
+<Story
+  name="Icon Only"
+  args={{ children: undefined, icon: SearchIcon, accessibilityLabel: 'Search' }}
+/>
 
 <Story name="Icon Variants" asChild>
   <div class="display-flex gap-spacing-4 items-center">
@@ -267,11 +294,16 @@
 <!-- Avatar group renders after the text, only on large buttons -->
 <Story name="With Avatar Group" args={{ children: 'Shared with', size: 'large', avatars: sampleAvatars }} />
 
-<Story name="Avatar Group With Icon" asChild>
-  <Button size="large" icon={SearchIcon} iconPosition="left" avatars={sampleAvatars}>
-    Reviewers
-  </Button>
-</Story>
+<Story
+  name="Avatar Group With Icon"
+  args={{
+    children: 'Reviewers',
+    size: 'large',
+    icon: SearchIcon,
+    iconPosition: 'left',
+    avatars: sampleAvatars,
+  }}
+/>
 
 <Story name="Avatar Group Ignored Below Large" asChild>
   <div class="display-flex flex-col gap-spacing-4 items-start">

--- a/packages/blade-svelte/src/components/Button/IconButton/IconButton.stories.svelte
+++ b/packages/blade-svelte/src/components/Button/IconButton/IconButton.stories.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script module>
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import IconButton from './IconButton.svelte';
   import { iconMap } from '../../Icons/iconMap';
@@ -15,6 +15,8 @@
       emphasis: 'intense',
       accessibilityLabel: 'Close',
       icon: CloseIcon,
+      isDisabled: false,
+      isHighlighted: false,
     },
     argTypes: {
       icon: {


### PR DESCRIPTION
## Summary
- Fixed Storybook Controls not driving several Button stories: hardcoded `asChild` demos ("With Icon Left/Right", "Icon Only", "Avatar Group With Icon") converted to args-driven stories; missing `accessibilityLabel` control added.
- Loading-matrix stories (Indefinite Loading Sizes/Variants, Definite Loading Variants) now thread shared controls (size/color/isDisabled/loadingTimer) to every instance while keeping the per-instance axis (size/variant/color) fixed. Dead `variant`/`color` controls disabled via `argTypes` on "Definite Loading Variants" since each button hardcodes its own.
- Modernized `IconButton.stories.svelte`'s `context="module"` to `module`, added missing `isDisabled`/`isHighlighted` defaults.
- Fixed neutral Button variant's focus ring: it was sharing the generic blue ring (`--surface-border-primary-muted`) with primary/positive/negative via a compound selector. Added a higher-specificity override so `color="neutral"` uses `--interactive-border-neutral-faded` instead, without touching the shared outline/inset-border declarations.

## Test plan
- [x] `svelte-autofixer` (desired_svelte_version: 5) on both edited story files: 0 issues
- [x] `yarn svelte-check` (blade-svelte): 0 errors, no new warnings
- [x] `yarn test` (blade-core): 67/67 pass
- [ ] Manual check in Storybook: neutral Button focus ring renders with the new token; loading-matrix stories respond to shared controls