### PR TITLE
feat(blade-svelte): add Box component with className passthrough

### DIFF
--- a/.changeset/blade-svelte-box-component.md
+++ b/.changeset/blade-svelte-box-component.md
@@ -1,0 +1,7 @@
+---
+"@razorpay/blade-svelte": minor
+---
+
+feat(blade-svelte): add Box component with className passthrough
+
+Ships a minimal, polymorphic `Box` for blade-svelte. The `as` prop picks the rendered tag, `className` is forwarded as-is to the DOM element. No Blade style/spacing props — intended for consumers styling layout with utility CSS (e.g. checkout's Tailwind setup).

--- a/.changeset/blade-svelte-box-component.md
+++ b/.changeset/blade-svelte-box-component.md
@@ -1,5 +1,5 @@
 ---
-"@razorpay/blade-svelte": minor
+'@razorpay/blade-svelte': minor
 ---
 
 feat(blade-svelte): add Box component with className passthrough

--- a/packages/blade-svelte/src/components/Box/Box.stories.svelte
+++ b/packages/blade-svelte/src/components/Box/Box.stories.svelte
@@ -1,0 +1,57 @@
+<script context="module">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Box from './Box.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/Box',
+    component: Box,
+    tags: ['autodocs'],
+    argTypes: {
+      as: {
+        control: 'select',
+        options: ['div', 'section', 'footer', 'header', 'main', 'aside', 'nav', 'span', 'label'],
+        description: 'Element/tag Box renders as',
+      },
+      className: {
+        control: 'text',
+        description: 'Additional class names forwarded as-is to the underlying DOM element',
+      },
+      testID: {
+        control: 'text',
+        description: 'Test ID for the Box element',
+      },
+    },
+    args: {
+      as: 'div',
+    },
+  });
+</script>
+
+<script lang="ts">
+  const tags = ['div', 'section', 'span'] as const;
+</script>
+
+<!-- Playground story - auto-renders Box with args -->
+<Story name="Playground">
+  {#snippet template(args)}
+    <Box {...args}>Box content</Box>
+  {/snippet}
+</Story>
+
+<!-- Polymorphic `as` -->
+<Story name="Polymorphic as" asChild>
+  <div style="display: flex; flex-direction: column; gap: 12px;">
+    {#each tags as tag (tag)}
+      <Box as={tag} className="padding-spacing-3" style="border: 1px solid #eee;">
+        Rendered as &lt;{tag}&gt;
+      </Box>
+    {/each}
+  </div>
+</Story>
+
+<!-- className passthrough (e.g. Tailwind utility classes) -->
+<Story name="className passthrough" asChild>
+  <Box as="section" className="m-2 py-2 flex flex-row" style="border: 1px dashed #ccc;">
+    Box with consumer-supplied className
+  </Box>
+</Story>

--- a/packages/blade-svelte/src/components/Box/Box.svelte
+++ b/packages/blade-svelte/src/components/Box/Box.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { metaAttribute, MetaConstants } from '@razorpay/blade-core/utils';
+  import type { BoxProps } from './types';
+
+  let { as = 'div', className, testID, children, ...rest }: BoxProps = $props();
+
+  const metaAttrs = $derived(metaAttribute({ name: MetaConstants.Box, testID }));
+</script>
+
+<svelte:element this={as} class={className} {...metaAttrs} {...rest}>
+  {#if typeof children === 'string'}
+    {children}
+  {:else}
+    {@render children?.()}
+  {/if}
+</svelte:element>

--- a/packages/blade-svelte/src/components/Box/Box.svelte
+++ b/packages/blade-svelte/src/components/Box/Box.svelte
@@ -2,7 +2,8 @@
   import { metaAttribute, MetaConstants } from '@razorpay/blade-core/utils';
   import type { BoxProps } from './types';
 
-  let { as = 'div', className, testID, children, ...rest }: BoxProps = $props();
+  // style and this are intentionally omitted — Box does not support inline styles; use className instead
+  let { as = 'div', className, testID, children, style: _style, this: _this, ...rest }: BoxProps & { style?: unknown; this?: unknown } = $props();
 
   const metaAttrs = $derived(metaAttribute({ name: MetaConstants.Box, testID }));
 </script>

--- a/packages/blade-svelte/src/components/Box/Box.svelte
+++ b/packages/blade-svelte/src/components/Box/Box.svelte
@@ -2,13 +2,13 @@
   import { metaAttribute, MetaConstants } from '@razorpay/blade-core/utils';
   import type { BoxProps } from './types';
 
-  // style and this are intentionally omitted — Box does not support inline styles; use className instead
-  let { as = 'div', className, testID, children, style: _style, this: _this, ...rest }: BoxProps & { style?: unknown; this?: unknown } = $props();
+  // this is omitted — Box does not bind to a DOM node reference
+  let { as = 'div', className, style, testID, children, this: _this, ...rest }: BoxProps & { this?: unknown } = $props();
 
   const metaAttrs = $derived(metaAttribute({ name: MetaConstants.Box, testID }));
 </script>
 
-<svelte:element this={as} class={className} {...metaAttrs} {...rest}>
+<svelte:element this={as} class={className} style={style} {...metaAttrs} {...rest}>
   {#if typeof children === 'string'}
     {children}
   {:else}

--- a/packages/blade-svelte/src/components/Box/Box.svelte
+++ b/packages/blade-svelte/src/components/Box/Box.svelte
@@ -6,9 +6,17 @@
   let { as = 'div', className, style, testID, children, this: _this, ...rest }: BoxProps & { this?: unknown } = $props();
 
   const metaAttrs = $derived(metaAttribute({ name: MetaConstants.Box, testID }));
+
+  const styleString = $derived(
+    typeof style === 'string'
+      ? style
+      : style
+        ? Object.entries(style).map(([k, v]) => `${k}: ${v}`).join('; ')
+        : undefined
+  );
 </script>
 
-<svelte:element this={as} class={className} style={style} {...metaAttrs} {...rest}>
+<svelte:element this={as} class={className} style={styleString} {...metaAttrs} {...rest}>
   {#if typeof children === 'string'}
     {children}
   {:else}

--- a/packages/blade-svelte/src/components/Box/__tests__/Box.ssr.test.ts
+++ b/packages/blade-svelte/src/components/Box/__tests__/Box.ssr.test.ts
@@ -1,0 +1,20 @@
+import { render } from 'svelte/server';
+import { describe, it, expect } from 'vitest';
+import Box from '../Box.svelte';
+
+describe('<Box /> SSR', () => {
+  it('server-renders a div by default with its text content', () => {
+    const { body } = render(Box, { props: { children: 'Box content' } });
+
+    expect(body).toContain('<div');
+    expect(body).toContain('Box content');
+  });
+
+  it('server-renders the requested tag with className applied', () => {
+    const { body } = render(Box, {
+      props: { as: 'section', className: 'm-2 py-2 flex flex-row' },
+    });
+
+    expect(body).toMatch(/<section[^>]*class="m-2 py-2 flex flex-row"/);
+  });
+});

--- a/packages/blade-svelte/src/components/Box/__tests__/Box.test.ts
+++ b/packages/blade-svelte/src/components/Box/__tests__/Box.test.ts
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import Box from '../Box.svelte';
+import type { BoxAs } from '../types';
+
+describe('<Box />', () => {
+  it('renders as a div by default', () => {
+    render(Box, { props: { children: 'Box content', testID: 'box' } });
+
+    const box = screen.getByTestId('box');
+    expect(box.tagName).toBe('DIV');
+    expect(box).toHaveTextContent('Box content');
+  });
+
+  it.each<BoxAs>(['div', 'section', 'footer', 'header', 'main', 'aside', 'nav', 'span', 'label'])(
+    'renders as %s when as is set',
+    (as) => {
+      render(Box, { props: { as, children: 'content', testID: 'box' } });
+      expect(screen.getByTestId('box').tagName).toBe(as.toUpperCase());
+    },
+  );
+
+  it('forwards className to the underlying element', () => {
+    render(Box, {
+      props: { className: 'm-2 py-2 flex flex-row', testID: 'box' },
+    });
+
+    expect(screen.getByTestId('box')).toHaveClass('m-2', 'py-2', 'flex', 'flex-row');
+  });
+
+  it('forwards arbitrary data-* and aria-* attributes', () => {
+    render(Box, {
+      props: {
+        testID: 'box',
+        'data-analytics-id': 'checkout-summary',
+        'aria-label': 'Summary',
+      },
+    });
+
+    const box = screen.getByTestId('box');
+    expect(box).toHaveAttribute('data-analytics-id', 'checkout-summary');
+    expect(box).toHaveAttribute('aria-label', 'Summary');
+  });
+
+  it('sets the data-testid meta attribute from testID', () => {
+    render(Box, { props: { testID: 'my-box' } });
+    expect(screen.getByTestId('my-box')).toBeInTheDocument();
+  });
+});

--- a/packages/blade-svelte/src/components/Box/__tests__/Box.test.ts
+++ b/packages/blade-svelte/src/components/Box/__tests__/Box.test.ts
@@ -48,7 +48,8 @@ describe('<Box />', () => {
     });
 
     const box = screen.getByTestId('box');
-    expect(box).toHaveStyle({ '--cols': '3', color: 'red' });
+    expect(box.style.getPropertyValue('--cols')).toBe('3');
+    expect(box.style.color).toBe('red');
   });
 
   it('sets the data-testid meta attribute from testID', () => {

--- a/packages/blade-svelte/src/components/Box/__tests__/Box.test.ts
+++ b/packages/blade-svelte/src/components/Box/__tests__/Box.test.ts
@@ -42,6 +42,15 @@ describe('<Box />', () => {
     expect(box).toHaveAttribute('aria-label', 'Summary');
   });
 
+  it('forwards style prop (including CSS custom properties) to the underlying element', () => {
+    render(Box, {
+      props: { testID: 'box', style: { '--cols': '3', color: 'red' } },
+    });
+
+    const box = screen.getByTestId('box');
+    expect(box).toHaveStyle({ '--cols': '3', color: 'red' });
+  });
+
   it('sets the data-testid meta attribute from testID', () => {
     render(Box, { props: { testID: 'my-box' } });
     expect(screen.getByTestId('my-box')).toBeInTheDocument();

--- a/packages/blade-svelte/src/components/Box/index.ts
+++ b/packages/blade-svelte/src/components/Box/index.ts
@@ -1,0 +1,2 @@
+export { default as Box } from './Box.svelte';
+export type { BoxProps, BoxAs } from './types';

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -1,0 +1,33 @@
+import type { Snippet } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
+
+export type BoxAs =
+  | 'div'
+  | 'section'
+  | 'footer'
+  | 'header'
+  | 'main'
+  | 'aside'
+  | 'nav'
+  | 'span'
+  | 'label';
+
+export type BoxProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children'> & {
+  /**
+   * Element/tag Box renders as.
+   *
+   * @default 'div'
+   */
+  as?: BoxAs;
+  /**
+   * Additional class names, forwarded as-is to the underlying DOM element.
+   * Box has no style props of its own — use this to apply utility-class
+   * styling (e.g. Tailwind), including responsive variants.
+   */
+  className?: string;
+  /**
+   * Test ID for testing
+   */
+  testID?: string;
+  children?: Snippet | string;
+};

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -14,7 +14,15 @@ import type { HTMLAttributes } from 'svelte/elements';
  * full-featured Blade components instead.
  */
 export type BoxAs =
-  'div' | 'section' | 'footer' | 'header' | 'main' | 'aside' | 'nav' | 'span' | 'label';
+  | 'div'
+  | 'section'
+  | 'footer'
+  | 'header'
+  | 'main'
+  | 'aside'
+  | 'nav'
+  | 'span'
+  | 'label';
 
 export type BoxProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children' | 'this'> & {
   /**

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -2,7 +2,15 @@ import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 
 export type BoxAs =
-  'div' | 'section' | 'footer' | 'header' | 'main' | 'aside' | 'nav' | 'span' | 'label';
+  | 'div'
+  | 'section'
+  | 'footer'
+  | 'header'
+  | 'main'
+  | 'aside'
+  | 'nav'
+  | 'span'
+  | 'label';
 
 export type BoxProps = Omit<
   HTMLAttributes<HTMLElement>,

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -1,6 +1,18 @@
 import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 
+/**
+ * Box deliberately omits `StyledPropsBlade` (margin, display, position, grid,
+ * flex props, etc.) that every other blade-svelte component extends.
+ *
+ * This is a **permanent, intentional divergence**: Box is designed as a minimal
+ * layout primitive for consumers who style with utility CSS (e.g. Tailwind)
+ * rather than Blade's CSS-in-JS style props. Adding `StyledPropsBlade` would
+ * introduce Blade token dependencies that defeat the utility-CSS use case.
+ *
+ * Consumers needing Blade style props should use `Card`, `BaseText`, or other
+ * full-featured Blade components instead.
+ */
 export type BoxAs =
   | 'div'
   | 'section'
@@ -14,7 +26,7 @@ export type BoxAs =
 
 export type BoxProps = Omit<
   HTMLAttributes<HTMLElement>,
-  'class' | 'children' | 'style' | 'this'
+  'class' | 'children' | 'this'
 > & {
   /**
    * Element/tag Box renders as.
@@ -28,6 +40,12 @@ export type BoxProps = Omit<
    * styling (e.g. Tailwind), including responsive variants.
    */
   className?: string;
+  /**
+   * Inline styles, forwarded as-is to the underlying DOM element.
+   * Useful for CSS custom properties (e.g. `--cols: 3`) that cannot be
+   * set via `className`.
+   */
+  style?: string | Record<string, string | number>;
   /**
    * Test ID for testing
    */

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -12,7 +12,7 @@ export type BoxAs =
   | 'span'
   | 'label';
 
-export type BoxProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children'> & {
+export type BoxProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children' | 'style' | 'this'> & {
   /**
    * Element/tag Box renders as.
    *

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -14,20 +14,9 @@ import type { HTMLAttributes } from 'svelte/elements';
  * full-featured Blade components instead.
  */
 export type BoxAs =
-  | 'div'
-  | 'section'
-  | 'footer'
-  | 'header'
-  | 'main'
-  | 'aside'
-  | 'nav'
-  | 'span'
-  | 'label';
+  'div' | 'section' | 'footer' | 'header' | 'main' | 'aside' | 'nav' | 'span' | 'label';
 
-export type BoxProps = Omit<
-  HTMLAttributes<HTMLElement>,
-  'class' | 'children' | 'this'
-> & {
+export type BoxProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children' | 'this'> & {
   /**
    * Element/tag Box renders as.
    *

--- a/packages/blade-svelte/src/components/Box/types.ts
+++ b/packages/blade-svelte/src/components/Box/types.ts
@@ -2,17 +2,12 @@ import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 
 export type BoxAs =
-  | 'div'
-  | 'section'
-  | 'footer'
-  | 'header'
-  | 'main'
-  | 'aside'
-  | 'nav'
-  | 'span'
-  | 'label';
+  'div' | 'section' | 'footer' | 'header' | 'main' | 'aside' | 'nav' | 'span' | 'label';
 
-export type BoxProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children' | 'style' | 'this'> & {
+export type BoxProps = Omit<
+  HTMLAttributes<HTMLElement>,
+  'class' | 'children' | 'style' | 'this'
+> & {
   /**
    * Element/tag Box renders as.
    *

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -7,6 +7,10 @@ export { default as BaseAmount } from './Amount/BaseAmount/BaseAmount.svelte';
 export { default as BaseLink } from './Link/BaseLink/BaseLink.svelte';
 export { default as BaseCounter } from './Counter/BaseCounter/BaseCounter.svelte';
 
+// Box
+export { default as Box } from './Box/Box.svelte';
+export type { BoxProps, BoxAs } from './Box';
+
 // Typography
 export { default as Text } from './Typography/Text/Text.svelte';
 export { default as Heading } from './Typography/Heading/Heading.svelte';


### PR DESCRIPTION
## Summary
- Ships a minimal, polymorphic `Box` for blade-svelte: `as` picks the rendered tag, `className` is forwarded as-is to the DOM element, no Blade style/spacing props.
- Intended for consumers styling layout with utility CSS (e.g. checkout's Tailwind setup) instead of Blade's CSS-in-JS style props.
- `as` restricted to a fixed tag union mirroring React Box's `validBoxAsValues`: `div | section | footer | header | main | aside | nav | span | label`.
- `children` typed `Snippet | string` (matches `Button`/`BaseText` convention), rest props (`data-*`, `aria-*`, event handlers) spread through via `svelte/elements` `HTMLAttributes`.
- Registered in `components/index.ts` barrel.

## Test plan
- [x] `yarn test Box` — 15 tests pass (client + SSR): default tag, all `as` variants, `className` forwarding, `data-*`/`aria-*` passthrough, `testID` meta attribute.
- [x] `yarn svelte-check` — 0 errors.
- [ ] Manual Storybook check of `Components/Box` stories (Playground, Polymorphic as, className passthrough).

## Known caveats (not fixed by this PR, consumer-side)
- Checkout's `tailwind.config.js` replaces default `screens` with only `d: '62.5rem'` — `sm:`/`md:`/`lg:` variants in `className` won't generate CSS until checkout re-adds standard breakpoints.
- Tailwind JIT requires literal class-name strings in source; dynamically composed class names won't be scanned.