### PR TITLE
fix(blade-svelte): BottomSheet snaps to exact snapPoint fraction

### DIFF
--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -31,7 +31,7 @@
   import { setBottomSheetContext } from './bottomSheetContext';
   import type { BottomSheetContextValue } from './bottomSheetContext';
   import type { BottomSheetProps, SnapPoints } from './types';
-  import { computeMaxContent, computeSnapPointBounds } from './utils';
+  import { computeSnapPointBounds } from './utils';
   import BottomSheetBackdrop from './BottomSheetBackdrop.svelte';
   import { portal } from '../../utils/portal';
 
@@ -122,18 +122,12 @@
     }
   });
 
-  function setPositionY(value: number, limit = true): void {
-    if (!limit) {
-      positionY = value;
-      return;
-    }
-    const maxValue = computeMaxContent({
-      contentHeight,
-      footerHeight,
-      headerHeight: headerHeight > 0 ? headerHeight + grabHandleHeight : 0,
-      maxHeight: value,
-    });
-    positionY = maxValue;
+  // Snap to the exact requested fraction. Do NOT clamp to content height —
+  // consumers rely on snapPoints (e.g. 0.85) mapping to that share of the
+  // viewport, even when body content is shorter. This diverges from React
+  // parity (which caps positionY to content via computeMaxContent).
+  function setPositionY(value: number): void {
+    positionY = value;
   }
 
   function returnFocus(): void {
@@ -183,7 +177,7 @@
   }
 
   function handleOnClose(): void {
-    setPositionY(0, false);
+    setPositionY(0);
   }
 
   /* Sync controlled open state to internal animation/position. */
@@ -411,7 +405,7 @@
         isDragging = false;
         cancel();
         const firstSnapPoint = windowHeight * snapPoints[0];
-        setPositionY(firstSnapPoint, true);
+        setPositionY(firstSnapPoint);
         return;
       }
 
@@ -422,7 +416,7 @@
       }
     }
 
-    setPositionY(newY, !down);
+    setPositionY(newY);
   }
   /* eslint-enable @typescript-eslint/no-explicit-any */
 


### PR DESCRIPTION
setPositionY clamped the sheet height to content height via computeMaxContent, so a sheet opened with snapPoints like [0.85, ...] hugged its (often short) body content and settled far below the requested 85% of the viewport. Consumers worked around this by forcing a min-height on body content to inflate the measured content height and defeat the clamp (e.g. checkout's #main-stack-container overlay).

Remove the clamp so positionY maps directly to the requested snap fraction on open, drag-snapback, and settle. The sheet now honors the snapPoint share of the viewport regardless of content height.

Tradeoff: this diverges from React parity (React still caps positionY to content height). Short-content sheets using multi-stop snapPoints may now show empty space below their content. This is the intended global default per product decision.

## Description

<!-- Briefly explain the purpose of your PR -->

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
