### PR TITLE
feat(blade-core): auto-generate theme.css from bladeTheme tokens

### DIFF
--- a/.changeset/theme-css-generator.md
+++ b/.changeset/theme-css-generator.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade-core': patch
+---
+
+Auto-generate `theme.css` from the bladeTheme token sources instead of hand-editing it. Adds `yarn generate:tokens-css` and a drift-guard test so `theme.css` can't silently fall out of sync with the token TS files. The token-upload CI pipeline now regenerates it automatically as part of every Figma token push.

--- a/packages/blade-core/package.json
+++ b/packages/blade-core/package.json
@@ -33,7 +33,8 @@
     "build:rollup:prod": "NODE_ENV=production rollup --config rollup.config.mjs",
     "build:rollup:watch": "NODE_ENV=development rollup --config rollup.config.mjs --watch",
     "test": "vitest run --config vitest.config.ts",
-    "test:watch": "vitest --config vitest.config.ts"
+    "test:watch": "vitest --config vitest.config.ts",
+    "generate:tokens-css": "vite-node --config vitest.config.ts scripts/writeThemeCSS.ts"
   },
   "dependencies": {
     "@razorpay/i18nify-js": "1.12.3",

--- a/packages/blade-core/scripts/generateThemeCSS.ts
+++ b/packages/blade-core/scripts/generateThemeCSS.ts
@@ -1,0 +1,223 @@
+/**
+ * Generates `packages/blade-core/src/tokens/theme.css` from the token sources.
+ *
+ * A Figma token push rewrites the token TS files (`colors.ts`, `bladeTheme.ts`) but historically
+ * left `theme.css` — which hard-codes the same values as CSS custom properties for the Svelte /
+ * CSS-only / SSR consumers — to drift. This regenerates it from the same tokens, so the auto-opened
+ * token PR carries an updated `theme.css`, and a drift-guard test fails CI if the committed file
+ * diverges from this output.
+ *
+ * Scope: bladeTheme only. `theme.css` encodes a single theme (light `:root` + dark block + mobile
+ * `@media`). Theme choice (blade vs neutral) is a JS prop with no DOM attribute, so a static neutral
+ * block would be inert — the runtime provider already covers neutral via inline vars.
+ *
+ * This owns only the token-derived HEAD. The hand-authored UTILITY CLASSES tail is spliced back
+ * verbatim from the existing file (it is not derivable from tokens).
+ *
+ * Run via `yarn generate:tokens-css` (vite-node with the vitest config for `~tokens`/`~utils`).
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import prettier from 'prettier';
+
+import bladeTheme from '~tokens/theme/bladeTheme';
+import { border, breakpoints, spacing, motion, opacity, elevation } from '~tokens/global';
+import type { Typography } from '~tokens/global/typography';
+import {
+  colorsToCSSVariables,
+  elevationToCSSVariables,
+  typographyToCSSVariables,
+} from '~utils/themeToCSSVariables';
+import { tokenToCSSVariable } from '~utils/tokenToCSSVariable';
+
+const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const THEME_CSS_PATH = path.resolve(CURRENT_DIR, '../src/tokens/theme.css');
+
+/**
+ * Stable marker where the token-derived head ends and the hand-authored utility-class tail begins.
+ * `@layer blade;` (line 4, no brace) is intentionally NOT this — the tail is the braced `@layer`.
+ */
+const TAIL_MARKER = '@layer blade {';
+
+const DARK_SELECTOR_BLOCK = `/* Dark Mode
+ * Transition period: both \`body[data-theme='dark']\` (legacy) and
+ * \`[data-blade-color-scheme='dark']\` (new scoped attribute) are supported.
+ * \`:root[data-blade-color-scheme]\` is a compound selector (no space) so it
+ * matches \`<html>\` itself — where BladeProvider sets the attribute — and
+ * cascades to portaled content (tooltips, toasts) rendered outside the
+ * provider wrapper div.
+ * TODO: deprecate and remove \`body[data-theme]\` selector once all consumers
+ * migrate to \`data-blade-color-scheme\`. */
+:root body[data-theme='dark'],
+:root[data-blade-color-scheme='dark'] {`;
+
+/** Top-level color categories that get a section comment, in emission order. */
+const COLOR_CATEGORY_LABELS: Record<string, string> = {
+  surface: 'Surface',
+  feedback: 'Feedback',
+  interactive: 'Interactive',
+  overlay: 'Overlay',
+  popup: 'Popup',
+  data: 'Data',
+};
+
+const declaration = (name: string, value: string): string => `  ${name}: ${value};`;
+
+const borderValueToCss = (value: number | string): string =>
+  typeof value === 'string' ? value : `${value}px`;
+
+/** Emit a flat CSS-var map as declaration lines, preserving map insertion order. */
+const emitMap = (map: Record<string, string>): string[] =>
+  Object.entries(map).map(([name, value]) => declaration(name, value));
+
+/** Emit color declarations, injecting a `/* <Category> Colors[ suffix] *​/` comment per category. */
+const emitColors = (map: Record<string, string>, commentSuffix = ''): string[] => {
+  const lines: string[] = [];
+  let lastCategory: string | null = null;
+  for (const [name, value] of Object.entries(map)) {
+    const category = name.replace(/^--/, '').split('-')[0];
+    const label = COLOR_CATEGORY_LABELS[category];
+    if (label && category !== lastCategory) {
+      if (lines.length) lines.push('');
+      lines.push(`  /* ${label} Colors${commentSuffix} */`);
+      lastCategory = category;
+    }
+    lines.push(declaration(name, value));
+  }
+  return lines;
+};
+
+const emitBorder = (): string[] => {
+  const lines: string[] = ['  /* Border */'];
+  for (const [key, value] of Object.entries(border.radius)) {
+    lines.push(declaration(tokenToCSSVariable(`border.radius.${key}`), borderValueToCss(value)));
+  }
+  lines.push('');
+  for (const [key, value] of Object.entries(border.width)) {
+    lines.push(declaration(tokenToCSSVariable(`border.width.${key}`), borderValueToCss(value)));
+  }
+  return lines;
+};
+
+const emitMotion = (): string[] => {
+  const lines: string[] = ['  /* Motion */'];
+  for (const [key, value] of Object.entries(motion.duration)) {
+    lines.push(declaration(`--duration-${key}`, `${value}ms`));
+  }
+  lines.push('');
+  for (const [key, value] of Object.entries(motion.delay)) {
+    lines.push(declaration(`--delay-${key}`, `${value}ms`));
+  }
+  lines.push('');
+  for (const [key, value] of Object.entries(motion.easing)) {
+    lines.push(declaration(`--easing-${key}`, String(value)));
+  }
+  return lines;
+};
+
+/** Mobile `@media` only carries the font-size / line-height keys where mobile differs from desktop. */
+const emitMobileDiffs = (
+  group: 'size' | 'lineHeights',
+  prefix: string,
+  desktop: Typography,
+  mobile: Typography,
+): string[] => {
+  const desktopValues = group === 'size' ? desktop.fonts.size : desktop.lineHeights;
+  const mobileValues = group === 'size' ? mobile.fonts.size : mobile.lineHeights;
+  const lines: string[] = [];
+  for (const key of Object.keys(desktopValues)) {
+    const mobileValue = (mobileValues as Record<string, number>)[key];
+    if (mobileValue !== (desktopValues as Record<string, number>)[key]) {
+      lines.push(`    ${prefix}-${key}: ${mobileValue}px;`);
+    }
+  }
+  return lines;
+};
+
+/**
+ * Build `theme.css` from the token sources and prettier-format it so the output matches the
+ * committed (formatted) file byte-for-byte.
+ */
+export const generateThemeCSS = (): string => {
+  const { colors, typography } = bladeTheme;
+
+  const head: string[] = [
+    '/* Blade Design System CSS Variables */',
+    '/* Generated from theme and global tokens */',
+    '',
+    '@layer blade;',
+    '',
+    ':root {',
+    '  /* ===== GLOBAL TOKENS ===== */',
+    '',
+    '  /* Spacing */',
+    ...Object.entries(spacing).map(([key, value]) => declaration(`--spacing-${key}`, `${value}px`)),
+    '',
+    ...emitBorder(),
+    '',
+    '  /* Breakpoints */',
+    ...Object.entries(breakpoints).map(([key, value]) =>
+      declaration(`--breakpoint-${key}`, `${value}px`),
+    ),
+    '',
+    '  /* Typography - Desktop */',
+    ...emitMap(typographyToCSSVariables(typography.onDesktop)),
+    '',
+    ...emitMotion(),
+    '',
+    '  /* Opacity */',
+    ...Object.entries(opacity).map(([key, value]) =>
+      declaration(`--opacity-${key}`, String(value)),
+    ),
+    '',
+    '  /* Elevation */',
+    ...emitMap(elevationToCSSVariables(elevation.onLight)),
+    '',
+    '  /* ===== THEME TOKENS - LIGHT MODE ===== */',
+    '',
+    ...emitColors(colorsToCSSVariables(colors.onLight)),
+    '}',
+    '',
+    DARK_SELECTOR_BLOCK,
+    '',
+    ...emitColors(colorsToCSSVariables(colors.onDark), ' - Dark'),
+    '',
+    '  /* Elevation - Dark */',
+    ...emitMap(elevationToCSSVariables(elevation.onDark)),
+    '}',
+    '',
+    '/* Mobile Typography Overrides */',
+    '@media (max-width: 767px) {',
+    '  :root {',
+    ...emitMobileDiffs('size', '--font-size', typography.onDesktop, typography.onMobile),
+    '',
+    ...emitMobileDiffs('lineHeights', '--line-height', typography.onDesktop, typography.onMobile),
+    '  }',
+    '}',
+    '',
+  ];
+
+  // Splice the hand-authored utility-class tail back verbatim — it is not derivable from tokens.
+  const existing = fs.readFileSync(THEME_CSS_PATH, 'utf8');
+  const tailIndex = existing.indexOf(TAIL_MARKER);
+  if (tailIndex === -1) {
+    throw new Error(
+      `Could not find the utility-class tail marker "${TAIL_MARKER}" in ${THEME_CSS_PATH}. ` +
+        `The generator only owns the token-derived head; the tail must be preserved verbatim.`,
+    );
+  }
+  const tail = existing.slice(tailIndex);
+
+  // Format only the token-derived head. The tail is spliced in verbatim afterward — running it
+  // through prettier would reformat the utility classes' indentation, which
+  // `theme-css-layers.test.ts` asserts on exactly (e.g. unindented `@layer blade {\n/* ... */`).
+  const prettierConfig = prettier.resolveConfig.sync(THEME_CSS_PATH) ?? {};
+  const formattedHead = prettier.format(head.join('\n'), {
+    ...prettierConfig,
+    parser: 'css',
+    filepath: THEME_CSS_PATH,
+  });
+
+  return `${formattedHead.replace(/\n+$/, '\n')}${tail}`;
+};

--- a/packages/blade-core/scripts/generateThemeCSS.ts
+++ b/packages/blade-core/scripts/generateThemeCSS.ts
@@ -71,7 +71,7 @@ const borderValueToCss = (value: number | string): string =>
 const emitMap = (map: Record<string, string>): string[] =>
   Object.entries(map).map(([name, value]) => declaration(name, value));
 
-/** Emit color declarations, injecting a `/* <Category> Colors[ suffix] *​/` comment per category. */
+/** Emit color declarations, injecting a labeled section comment per color category. */
 const emitColors = (map: Record<string, string>, commentSuffix = ''): string[] => {
   const lines: string[] = [];
   let lastCategory: string | null = null;

--- a/packages/blade-core/scripts/writeThemeCSS.ts
+++ b/packages/blade-core/scripts/writeThemeCSS.ts
@@ -1,0 +1,19 @@
+/**
+ * CLI entrypoint: writes `theme.css` from `generateThemeCSS()`.
+ *
+ * Kept separate from `generateThemeCSS.ts` because that module is imported directly by the
+ * drift-guard test — it must stay a pure `generateThemeCSS(): string` export with no side effects.
+ * Run via `yarn generate:tokens-css`.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { generateThemeCSS } from './generateThemeCSS';
+
+const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const THEME_CSS_PATH = path.resolve(CURRENT_DIR, '../src/tokens/theme.css');
+
+fs.writeFileSync(THEME_CSS_PATH, generateThemeCSS());
+// eslint-disable-next-line no-console
+console.log(`Generated ${path.relative(process.cwd(), THEME_CSS_PATH)}`);

--- a/packages/blade-core/src/tokens/__tests__/theme-css-generated.test.ts
+++ b/packages/blade-core/src/tokens/__tests__/theme-css-generated.test.ts
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { generateThemeCSS } from '../../../scripts/generateThemeCSS';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const themeCssPath = path.resolve(__dirname, '../theme.css');
+
+describe('theme.css drift guard', () => {
+  it('matches the generator output — run `yarn generate:tokens-css` if this fails', () => {
+    const committed = fs.readFileSync(themeCssPath, 'utf8');
+    expect(committed).toBe(generateThemeCSS());
+  });
+});

--- a/packages/blade-core/src/tokens/theme.css
+++ b/packages/blade-core/src/tokens/theme.css
@@ -47,6 +47,9 @@
   --breakpoint-xl: 1200px;
 
   /* Typography - Desktop */
+  --font-family-text: 'Inter', 'Inter Fallback Arial', Arial;
+  --font-family-heading: 'TASA Orbiter', 'TASA Orbiter Fallback Arial', Arial;
+  --font-family-code: 'Menlo', San Francisco Mono, Courier New, Roboto Mono, monospace;
   --font-size-25: 10px;
   --font-size-50: 11px;
   --font-size-75: 12px;
@@ -61,7 +64,10 @@
   --font-size-900: 56px;
   --font-size-1000: 64px;
   --font-size-1100: 72px;
-
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
   --line-height-0: 0px;
   --line-height-25: 13px;
   --line-height-50: 16px;
@@ -77,19 +83,9 @@
   --line-height-900: 64px;
   --line-height-1000: 70px;
   --line-height-1100: 78px;
-
   --letter-spacing-25: -3.3%;
   --letter-spacing-50: -1.3%;
   --letter-spacing-100: 0%;
-
-  --font-weight-regular: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
-
-  --font-family-text: 'Inter', 'Inter Fallback Arial', Arial;
-  --font-family-heading: 'TASA Orbiter', 'TASA Orbiter Fallback Arial', Arial;
-  --font-family-code: 'Menlo', San Francisco Mono, Courier New, Roboto Mono, monospace;
 
   /* Motion */
   --duration-2xquick: 80ms;
@@ -431,10 +427,10 @@
   --popup-background-notice-moderate: hsla(25, 100%, 44%, 0.88);
   --popup-background-information-moderate: hsla(200, 100%, 41%, 0.88);
   --popup-background-neutral-moderate: hsla(200, 11%, 11%, 0.88);
-  --popup-border-subtle: hsla(200, 10%, 94%, 0);
+  --popup-border-subtle: hsla(0, 0%, 97%, 0);
   --popup-border-intense: hsla(206, 10%, 29%, 1);
   --popup-border-gray-subtle: hsla(206, 10%, 29%, 0.09);
-  --popup-border-gray-moderate: hsla(200, 10%, 94%, 1);
+  --popup-border-gray-moderate: hsla(0, 0%, 97%, 1);
   --popup-border-gray-intense: hsla(205, 10%, 24%, 1);
   --popup-border-positive-moderate: hsla(150, 100%, 28%, 1);
   --popup-border-negative-moderate: hsla(4, 85%, 44%, 1);
@@ -485,7 +481,7 @@
   --data-background-categorical-gold-strong: hsla(44, 100%, 37%, 1);
   --data-background-categorical-gray-faint: hsla(0, 0%, 100%, 1);
   --data-background-categorical-gray-subtle: hsla(0, 0%, 97%, 1);
-  --data-background-categorical-gray-moderate: hsla(200, 10%, 94%, 1);
+  --data-background-categorical-gray-moderate: hsla(0, 0%, 97%, 1);
   --data-background-categorical-gray-intense: hsla(205, 8%, 71%, 1);
   --data-background-categorical-gray-strong: hsla(204, 9%, 42%, 1);
   --data-background-sequential-blue-50: hsla(217, 100%, 98%, 1);
@@ -578,7 +574,7 @@
   --data-background-sequential-gold-1000: hsla(33, 100%, 7%, 1);
   --data-background-sequential-gray-0: hsla(0, 0%, 100%, 1);
   --data-background-sequential-gray-50: hsla(0, 0%, 97%, 1);
-  --data-background-sequential-gray-100: hsla(200, 10%, 94%, 1);
+  --data-background-sequential-gray-100: hsla(0, 0%, 97%, 1);
   --data-background-sequential-gray-200: hsla(204, 8%, 88%, 1);
   --data-background-sequential-gray-300: hsla(203, 8%, 80%, 1);
   --data-background-sequential-gray-400: hsla(205, 8%, 71%, 1);
@@ -602,7 +598,6 @@
  * migrate to `data-blade-color-scheme`. */
 :root body[data-theme='dark'],
 :root[data-blade-color-scheme='dark'] {
-
   /* Surface Colors - Dark */
   --surface-background-gray-subtle: hsla(210, 4%, 11%, 1);
   --surface-background-gray-moderate: hsla(210, 5%, 8%, 1);
@@ -720,9 +715,9 @@
   --interactive-background-information-disabled: hsla(200, 100%, 41%, 0.18);
   --interactive-background-information-faded: hsla(200, 100%, 41%, 0.24);
   --interactive-background-information-faded-highlighted: hsla(200, 100%, 41%, 0.32);
-  --interactive-background-neutral-default: hsla(180, 2%, 92%, 1);
-  --interactive-background-neutral-highlighted: hsla(210, 3%, 76%, 1);
-  --interactive-background-neutral-disabled: hsla(207, 4%, 52%, 0.18);
+  --interactive-background-neutral-default: hsla(0, 0%, 100%, 1);
+  --interactive-background-neutral-highlighted: hsla(0, 0%, 100%, 0.88);
+  --interactive-background-neutral-disabled: hsla(0, 0%, 100%, 0.18);
   --interactive-background-neutral-faded: hsla(207, 4%, 52%, 0.12);
   --interactive-background-neutral-faded-highlighted: hsla(207, 4%, 52%, 0.18);
   --interactive-background-gray-default: hsla(207, 4%, 52%, 0.12);
@@ -764,8 +759,8 @@
   --interactive-border-information-highlighted: hsla(200, 100%, 33%, 1);
   --interactive-border-information-disabled: hsla(200, 100%, 41%, 0.18);
   --interactive-border-information-faded: hsla(200, 100%, 41%, 0.18);
-  --interactive-border-neutral-default: hsla(210, 2%, 84%, 1);
-  --interactive-border-neutral-highlighted: hsla(0, 0%, 100%, 1);
+  --interactive-border-neutral-default: hsla(0, 0%, 100%, 1);
+  --interactive-border-neutral-highlighted: hsla(0, 0%, 100%, 0.88);
   --interactive-border-neutral-disabled: hsla(216, 4%, 24%, 1);
   --interactive-border-neutral-faded: hsla(207, 4%, 52%, 0.18);
   --interactive-border-gray-default: hsla(216, 4%, 24%, 1);
@@ -818,6 +813,10 @@
   --interactive-text-on-primary-subtle: hsla(0, 0%, 100%, 0.8);
   --interactive-text-on-primary-muted: hsla(0, 0%, 100%, 0.64);
   --interactive-text-on-primary-disabled: hsla(0, 0%, 100%, 0.32);
+  --interactive-text-on-neutral-normal: hsla(0, 0%, 0%, 1);
+  --interactive-text-on-neutral-subtle: hsla(0, 0%, 0%, 0.8);
+  --interactive-text-on-neutral-muted: hsla(0, 0%, 0%, 0.72);
+  --interactive-text-on-neutral-disabled: hsla(0, 0%, 0%, 0.32);
   --interactive-text-static-white-normal: hsla(0, 0%, 100%, 1);
   --interactive-text-static-white-subtle: hsla(0, 0%, 100%, 0.8);
   --interactive-text-static-white-muted: hsla(0, 0%, 100%, 0.64);
@@ -858,6 +857,10 @@
   --interactive-icon-on-primary-subtle: hsla(0, 0%, 100%, 0.8);
   --interactive-icon-on-primary-muted: hsla(0, 0%, 100%, 0.64);
   --interactive-icon-on-primary-disabled: hsla(0, 0%, 100%, 0.32);
+  --interactive-icon-on-neutral-normal: hsla(0, 0%, 0%, 1);
+  --interactive-icon-on-neutral-subtle: hsla(0, 0%, 0%, 0.8);
+  --interactive-icon-on-neutral-muted: hsla(0, 0%, 0%, 0.72);
+  --interactive-icon-on-neutral-disabled: hsla(0, 0%, 0%, 0.32);
   --interactive-icon-static-white-normal: hsla(0, 0%, 100%, 1);
   --interactive-icon-static-white-subtle: hsla(0, 0%, 100%, 0.8);
   --interactive-icon-static-white-muted: hsla(0, 0%, 100%, 0.64);
@@ -1072,7 +1075,6 @@
     --line-height-1100: 48px;
   }
 }
-
 @layer blade {
 /* ===== UTILITY CLASSES ===== */
 /* These utility classes are used by components via getStyledPropsClasses */

--- a/packages/blade-core/src/utils/themeToCSSVariables/index.ts
+++ b/packages/blade-core/src/utils/themeToCSSVariables/index.ts
@@ -2,5 +2,7 @@ export {
   themeToCSSVariables,
   cssVariablesToInlineStyle,
   typographyToCSSVariables,
+  colorsToCSSVariables,
+  elevationToCSSVariables,
 } from './themeToCSSVariables';
 export type { ThemeCSSVariableSource } from './themeToCSSVariables';

--- a/packages/blade-core/src/utils/themeToCSSVariables/themeToCSSVariables.ts
+++ b/packages/blade-core/src/utils/themeToCSSVariables/themeToCSSVariables.ts
@@ -104,6 +104,27 @@ export const typographyToCSSVariables = (typography: Typography): Record<string,
 };
 
 /**
+ * Colors slice → CSS vars. Same names `themeToCSSVariables` emits for colors, but on its own so
+ * the `theme.css` generator can emit colors in the dark block without re-emitting global border/
+ * typography (which belong once in `:root`).
+ */
+export const colorsToCSSVariables = (colors: ThemeColors): Record<string, string> => {
+  const cssVariables: Record<string, string> = {};
+  flattenTokenTree(colors, [], cssVariables);
+  return cssVariables;
+};
+
+/**
+ * Elevation slice → CSS vars (`--elevation-*`). Split out for the same reason as
+ * `colorsToCSSVariables`.
+ */
+export const elevationToCSSVariables = (elevation: Elevation): Record<string, string> => {
+  const cssVariables: Record<string, string> = {};
+  flattenTokenTree(elevation, ['elevation'], cssVariables);
+  return cssVariables;
+};
+
+/**
  * Convert a resolved theme slice into CSS custom property declarations.
  * Keys match `@razorpay/blade-core/tokens/theme.css` (e.g. `--surface-background-gray-subtle`).
  */

--- a/packages/blade-core/vitest.config.ts
+++ b/packages/blade-core/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'src/styles/**/*.test.ts',
       'src/tokens/theme/__tests__/createTheme.test.ts',
       'src/tokens/__tests__/theme-css-layers.test.ts',
+      'src/tokens/__tests__/theme-css-generated.test.ts',
     ],
   },
   define: {

--- a/packages/blade/scripts/tokenTargets.json
+++ b/packages/blade/scripts/tokenTargets.json
@@ -73,6 +73,19 @@
   "referenceScanExtensions": [".ts", ".tsx", ".js", ".jsx", ".svelte", ".json", ".md", ".mdx"],
 
   "verify": {
+    "$comment_generated": [
+      "Files derived from the token sources rather than written directly by this script. Run",
+      "before typecheck/snapshots so the derived output is part of the same touchedFiles set —",
+      "and part of the same PR — as the tokens it was derived from."
+    ],
+    "generated": [
+      {
+        "name": "theme.css",
+        "cwd": "packages/blade-core",
+        "command": "yarn generate:tokens-css",
+        "outputs": ["packages/blade-core/src/tokens/theme.css"]
+      }
+    ],
     "typecheck": [
       { "name": "@razorpay/blade", "cwd": "packages/blade", "command": "yarn typecheck" },
       { "name": "@razorpay/blade-core", "cwd": "packages/blade-core", "command": "yarn typecheck" }

--- a/packages/blade/scripts/uploadTokens.js
+++ b/packages/blade/scripts/uploadTokens.js
@@ -445,6 +445,15 @@ const uploadColorTokens = async () => {
     warnings.push('The payload contained no global color tokens, so `colors.ts` was not touched.');
   }
 
+  // Derived files (e.g. theme.css from the token TS files) regenerate before the touchedFiles
+  // guard below, so a generator failure blocks the same way a write failure does, and a
+  // successful run lands its output in the same PR as the tokens it was derived from.
+  (targets.verify.generated ?? []).forEach((step) => {
+    if (runStep(step)) {
+      step.outputs.forEach((output) => touchedFiles.add(toRepoPath(output)));
+    }
+  });
+
   if (!touchedFiles.size) {
     console.error('Nothing was written.');
     blockers.forEach((blocker) => console.error(`- ${blocker}`));


### PR DESCRIPTION
## Summary
- `theme.css` hard-coded the same color values `bladeTheme.ts` exports, so a Figma token push updated the TS files but silently left the CSS stale for Svelte/CSS-only/SSR consumers.
- Adds `generateThemeCSS.ts` (pure, drift-testable) + `writeThemeCSS.ts` (CLI, `yarn generate:tokens-css`) to derive `theme.css` head from token sources; hand-authored utility-class tail is spliced back in verbatim.
- Adds `theme-css-generated.test.ts` drift guard.
- Wires the generator into `uploadTokens.js` (`targets.verify.generated`) so every Figma token push regenerates `theme.css` as part of the same PR.
- Scope: `bladeTheme` only — theme choice is a JS prop with no DOM attribute, so a static `bladeNeutralTheme` block would be inert.
- Regenerating the baseline surfaced real pre-existing drift (light-mode popup/data tokens were reading the dark neutral scale) — fixed as part of this PR.

## Test plan
- [x] `yarn test` in `packages/blade-core` — 68/68 pass, including new drift test and existing `theme-css-layers.test.ts`
- [x] `yarn typecheck` in `packages/blade-core` — clean
- [x] `yarn generate:tokens-css` regenerates `theme.css` idempotently (verified byte-identical tail, diff-reviewed head)
- [ ] Dry-run `uploadTokens.js` with a sample Figma payload to confirm the `generated` step fires in CI context