### PR TITLE
fix(blade-svelte): PhoneNumberInput country selector popup on desktop

### DIFF
--- a/packages/blade-svelte/src/components/Input/PhoneNumberInput/CountrySelector.svelte
+++ b/packages/blade-svelte/src/components/Input/PhoneNumberInput/CountrySelector.svelte
@@ -39,6 +39,7 @@
 </script>
 
 <script lang="ts">
+  import { computePosition, autoUpdate, shift, flip, offset } from '@floating-ui/dom';
   import { getDialCodeByCountryCode } from '@razorpay/i18nify-js/phoneNumber';
   import { getFlagOfCountry } from '@razorpay/i18nify-js/geo';
   import {
@@ -49,7 +50,13 @@
   } from '../../ActionList';
   import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '../../BottomSheet';
   import { ChevronUpDownIcon } from '../../Icons';
+  import { portal } from '../../../utils/portal';
   import type { CountrySelectorProps } from './types';
+
+  const DESKTOP_BREAKPOINT_QUERY = '(min-width: 768px)';
+  const OVERLAY_GAP = 8; // React `OVERLAY_OFFSET` — size[8] = 8px
+  const OVERLAY_PADDING = 12; // React `OVERLAY_PADDING` — size[12]; rough padding for flip/shift
+  const POPOVER_Z_INDEX = 1002; // React `componentZIndices.dropdownOverlay`
 
   let {
     isDisabled = false,
@@ -62,27 +69,135 @@
   }: CountrySelectorProps = $props();
 
   let isOpen = $state(false);
+  let isDesktop = $state(false);
+  let isPopoverMounted = $state(false);
+  let triggerEl = $state<HTMLButtonElement | null>(null);
+  let floatingEl = $state<HTMLDivElement | null>(null);
+  let floatingX = $state(0);
+  let floatingY = $state(0);
 
   const countryNameFormatter = new Intl.DisplayNames(['en'], { type: 'region' });
 
   const flagSrc = $derived(getFlagOfCountry(selectedCountry)['4X3']);
   const triggerLabel = $derived(`${countryNameFormatter.of(selectedCountry)} - Select Country`);
 
-  const handleSelect = ({ value }: { value: string }): void => {
-    onItemClick({ name: value });
+  /* Desktop/mobile switch — mirrors React's `useIsMobile` (breakpoints base/xs/s =
+     width < 768px ⇒ mobile), listening for runtime reseize. Falls back to mobile
+     (BottomSheet) when matchMedia is unavailable (SSR/non-browser). */
+  $effect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      isDesktop = false;
+      return;
+    }
+    const mediaQuery = window.matchMedia(DESKTOP_BREAKPOINT_QUERY);
+    const update = (): void => {
+      isDesktop = mediaQuery.matches;
+    };
+    update();
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', update);
+      return () => mediaQuery.removeEventListener('change', update);
+    }
+    return;
+  });
+
+  const closePopover = (): void => {
     isOpen = false;
   };
+
+  const handleSelect = ({ value }: { value: string }): void => {
+    onItemClick({ name: value });
+    closePopover();
+  };
+
+  const handleTriggerClick = (): void => {
+    isOpen = !isOpen;
+  };
+
+  /* Floating positioning for the desktop popover — anchored to the trigger,
+     kept in sync on scroll/resize via autoUpdate. Effect re-runs once the
+     floating node is bound (isPopoverMounted flips to true on the first pass). */
+  $effect(() => {
+    if (!isDesktop || !isOpen) {
+      isPopoverMounted = false;
+      return;
+    }
+    isPopoverMounted = true;
+    const reference = triggerEl;
+    const floating = floatingEl;
+    if (!reference || !floating) return;
+
+    const update = (): void => {
+      computePosition(reference, floating, {
+        strategy: 'fixed',
+        placement: 'bottom-start',
+        middleware: [
+          offset(OVERLAY_GAP),
+          flip({ padding: OVERLAY_GAP + OVERLAY_PADDING }),
+          shift({ padding: OVERLAY_GAP }),
+        ],
+      }).then(({ x, y }) => {
+        floatingX = x;
+        floatingY = y;
+      });
+    };
+
+    return autoUpdate(reference, floating, update);
+  });
+
+  /* Outside click + Escape close the desktop popover. */
+  const handleGlobalPointerDown = (event: PointerEvent | MouseEvent): void => {
+    const target = event.target as Node | null;
+    if (!target) return;
+    if (triggerEl?.contains(target) || floatingEl?.contains(target)) return;
+    closePopover();
+  };
+
+  const handleGlobalKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      closePopover();
+    }
+  };
+
+  $effect(() => {
+    if (!isDesktop || !isOpen) return;
+    document.addEventListener('pointerdown', handleGlobalPointerDown, true);
+    document.addEventListener('keydown', handleGlobalKeyDown, true);
+    return () => {
+      document.removeEventListener('pointerdown', handleGlobalPointerDown, true);
+      document.removeEventListener('keydown', handleGlobalKeyDown, true);
+    };
+  });
+
+  const popoverStyle = $derived(
+    [
+      'position: fixed',
+      'left: 0',
+      'top: 0',
+      `transform: translate3d(${Math.round(floatingX)}px, ${Math.round(floatingY)}px, 0)`,
+      `z-index: ${POPOVER_Z_INDEX}`,
+      'min-width: 240px',
+      'max-width: 400px',
+      // React `StyledDropdownOverlay`: popup bg, radius.medium, backdrop blur,
+      // popup box shadow (border + midRaised elevation + top inner shadow).
+      'background-color: var(--popup-background-gray-moderate)',
+      'border-radius: var(--border-radius-medium)',
+      'backdrop-filter: blur(8px)',
+      'box-shadow: inset 0 0 0 1px var(--popup-border-gray-subtle), var(--elevation-mid-raised), inset 0 0 0 0 var(--popup-border-gray-moderate)',
+    ].join(';'),
+  );
 </script>
 
 <button
+  bind:this={triggerEl}
   type="button"
   class="country-selector-trigger"
   style={`height: ${chipHeight[size]}px; border-radius: ${chipRadius[size]}px; padding: 0 ${chipPadX[size]}px;`}
   disabled={isDisabled || undefined}
   aria-label={triggerLabel}
-  aria-haspopup="dialog"
+  aria-haspopup={isDesktop ? 'listbox' : 'dialog'}
   aria-expanded={isOpen}
-  onclick={() => (isOpen = true)}
+  onclick={handleTriggerClick}
 >
   <img
     loading="lazy"
@@ -96,23 +211,47 @@
   </span>
 </button>
 
-<BottomSheet {isOpen} onDismiss={() => (isOpen = false)} {portalTarget}>
-  <BottomSheetHeader title="Select A Country" />
-  <BottomSheetBody hasActionList>
-    <ActionList selectionType="single" selectedValue={selectedCountry} onAction={handleSelect}>
-      {#each countryData as country (country.code)}
-        <ActionListItem title={country.name} value={country.code}>
-          {#snippet leading()}
-            <ActionListItemAsset src={flags[country.code]?.['4X3'] ?? ''} alt={country.name} />
-          {/snippet}
-          {#snippet trailing()}
-            <ActionListItemText>{getDialCodeByCountryCode(country.code)}</ActionListItemText>
-          {/snippet}
-        </ActionListItem>
-      {/each}
-    </ActionList>
-  </BottomSheetBody>
-</BottomSheet>
+{#if isDesktop}
+  {#if isPopoverMounted}
+    <div
+      bind:this={floatingEl}
+      class="country-selector-popover"
+      style={popoverStyle}
+      use:portal
+    >
+      <ActionList selectionType="single" selectedValue={selectedCountry} onAction={handleSelect}>
+        {#each countryData as country (country.code)}
+          <ActionListItem title={country.name} value={country.code}>
+            {#snippet leading()}
+              <ActionListItemAsset src={flags[country.code]?.['4X3'] ?? ''} alt={country.name} />
+            {/snippet}
+            {#snippet trailing()}
+              <ActionListItemText>{getDialCodeByCountryCode(country.code)}</ActionListItemText>
+            {/snippet}
+          </ActionListItem>
+        {/each}
+      </ActionList>
+    </div>
+  {/if}
+{:else}
+  <BottomSheet {isOpen} onDismiss={closePopover} {portalTarget}>
+    <BottomSheetHeader title="Select A Country" />
+    <BottomSheetBody hasActionList>
+      <ActionList selectionType="single" selectedValue={selectedCountry} onAction={handleSelect}>
+        {#each countryData as country (country.code)}
+          <ActionListItem title={country.name} value={country.code}>
+            {#snippet leading()}
+              <ActionListItemAsset src={flags[country.code]?.['4X3'] ?? ''} alt={country.name} />
+            {/snippet}
+            {#snippet trailing()}
+              <ActionListItemText>{getDialCodeByCountryCode(country.code)}</ActionListItemText>
+            {/snippet}
+          </ActionListItem>
+        {/each}
+      </ActionList>
+    </BottomSheetBody>
+  </BottomSheet>
+{/if}
 
 <style>
   /* Mirrors React's InputDropdownButton chip: transparent at rest, gray-faded on

--- a/packages/blade-svelte/src/components/Input/PhoneNumberInput/index.ts
+++ b/packages/blade-svelte/src/components/Input/PhoneNumberInput/index.ts
@@ -5,11 +5,12 @@
  * powered by `@razorpay/i18nify-js`.
  *
  * ### Deviations from React
- * - **Country list is a `BottomSheet` on BOTH mobile and desktop.** React opens
- *   an anchored `DropdownOverlay` on desktop and a `BottomSheet` on mobile
- *   (via `useIsMobile`). Since Dropdown is not yet migrated, the Svelte
- *   `CountrySelector` always opens the migrated `BottomSheet` + `ActionList` —
- *   there is no anchored popover and no `useIsMobile` branch.
+ * - **Country list uses a desktop popover, BottomSheet on mobile (like React).**
+ *   On desktop (≥ 768px) the selector opens an anchored, floating `ActionList`
+ *   popover positioned with `@floating-ui/dom` and portaled to `body`; on mobile
+ *   (and SSR/non-browser where `matchMedia` is unavailable) it falls back to the
+ *   migrated `BottomSheet`. There is no eager Dropdown migration — the desktop
+ *   popover reuses the standalone `ActionList` render branch.
  * - **`ref` → `focus()` / `getInput()`:** bind the component instance and call
  *   `instance.focus()` or `instance.getInput()`.
  *

--- a/packages/blade-svelte/src/components/Input/PhoneNumberInput/types.ts
+++ b/packages/blade-svelte/src/components/Input/PhoneNumberInput/types.ts
@@ -101,7 +101,8 @@ export interface PhoneNumberInputProps extends StyledPropsBlade, DataAnalyticsAt
   /** Optional stable HTML id for the underlying input. Auto-generated when omitted. */
   id?: string;
   /**
-   * Portals the country-selector bottom sheet into this element. Pass the same
+   * Portals the country-selector bottom sheet into this element (mobile only;
+   * the desktop popover always portals to `document.body`). Pass the same
    * target used by a parent `BottomSheet` when the input lives inside one.
    */
   portalTarget?: HTMLElement | null;
@@ -129,6 +130,6 @@ export type CountrySelectorProps = {
   isDisabled?: boolean;
   /** Size of the trigger (drives flag size). */
   size: BaseInputSize;
-  /** Portals the country list bottom sheet into this element. */
+  /** Portals the country list bottom sheet into this element (desktop popover ignores it). */
   portalTarget?: HTMLElement | null;
 };


### PR DESCRIPTION
Automated changes by autonomous agent.

Requested by: 1995navinkumar <navin.kumar@razorpay.com>

## What
On desktop (>= 768px) the `PhoneNumberInput` country selector in `@razorpay/blade-svelte` now opens an anchored, floating `ActionList` popover (positioned with `@floating-ui/dom`, portaled to `document.body`) instead of a BottomSheet — matching React/BLADE's `useIsMobile` behaviour. Mobile (and SSR/non-browser where `matchMedia` is unavailable) keeps the BottomSheet.

## Why
Fixes the reported issue that the country code list opened in a BottomSheet on desktop screens.

## Files changed
- `packages/blade-svelte/.../PhoneNumberInput/CountrySelector.svelte` — added desktop/mobile branch + floating popover, outside-click/Escape close
- `.../PhoneNumberInput/index.ts`, `types.ts` — updated docs