### PR TITLE
fix(browserstack): resolve 4 mobile test failures in blade-svelte

### DIFF
--- a/packages/blade-svelte/tests/browserstack/avatar.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/avatar.spec.ts
@@ -9,5 +9,5 @@ test('Interactive Avatar renders as a link when href is set', async ({ page }) =
   );
   const link = page.getByRole('link');
   await expect(link).toBeVisible();
-  await expect(link).toHaveAttribute('href', 'https://razorpay.com');
+  await expect(link).toHaveAttribute('href', /https:\/\/razorpay\.com\/?$/);
 });

--- a/packages/blade-svelte/tests/browserstack/breadcrumb.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/breadcrumb.spec.ts
@@ -6,7 +6,7 @@ registerBrowserStackStatusReporter(test);
 test('Breadcrumb renders links with correct hrefs and marks current page', async ({ page }) => {
   await page.goto('iframe.html?id=components-breadcrumb--basic');
   const dashboardLink = page.getByRole('link', { name: 'Dashboard' });
-  await expect(dashboardLink).toHaveAttribute('href', '/dashboard');
+  await expect(dashboardLink).toHaveAttribute('href', /\/dashboard$/);
 
   const currentPage = page.getByText('Settlements');
   await expect(currentPage).toBeVisible();

--- a/packages/blade-svelte/tests/browserstack/cardInteractive.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/cardInteractive.spec.ts
@@ -8,7 +8,7 @@ test('Selectable Card selects a card on click', async ({ page }) => {
   const radios = page.getByRole('radio');
   const secondCard = radios.nth(1);
 
-  await expect(radios.first()).toBeVisible();
+  await expect(radios.first()).toBeAttached();
   // The native radio is visually hidden (clip-rect) inside the Card `as="label"`
   // element. `.check()` tries to interact with the hidden input directly and
   // throws an internal error on BrowserStack's mobile SDK, so click the visible

--- a/packages/blade-svelte/tests/browserstack/otpInput.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/otpInput.spec.ts
@@ -10,7 +10,6 @@ test('OTPInput accepts digits and moves focus across fields', async ({ page }) =
   const fieldCount = await fields.count();
   expect(fieldCount).toBeGreaterThan(1);
 
-  await fields.nth(0).click();
-  await page.keyboard.type('1');
+  await fields.nth(0).fill('1');
   await expect(fields.nth(1)).toBeFocused();
 });


### PR DESCRIPTION
Automated changes by autonomous agent.

## Summary

Fixes 4 BrowserStack mobile test failures (iPhone 15 Pro) detected in workflow run 33505160794.

## Root Cause Analysis

All 4 failures are real test assertion issues, not infra/downtime problems:

1. **avatar.spec.ts** — toHaveAttribute('href', 'https://razorpay.com') fails because mobile Safari normalizes the URL to 'https://razorpay.com/' (adds trailing slash). Fixed with regex.

2. **breadcrumb.spec.ts** — toHaveAttribute('href', '/dashboard') fails because the Storybook iframe resolves relative hrefs to absolute URLs. Fixed with regex.

3. **cardInteractive.spec.ts** — toBeVisible() on the radio input fails because the radio is intentionally visually hidden with clip: rect(0,0,0,0). Changed to toBeAttached().

4. **otpInput.spec.ts** — toBeFocused() on the second field fails because page.keyboard.type() on the BrowserStack mobile SDK doesn't reliably trigger the oninput handler. Switched to fill() which explicitly dispatches input events.

Requested by: admin <admin>