### PR TITLE
chore(changeset): add missing changeset for blade-svelte PhoneNumberInput country search

### DIFF
--- a/.changeset/blade-svelte-phone-input-country-search.md
+++ b/.changeset/blade-svelte-phone-input-country-search.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': patch
+---
+
+feat(blade-svelte): add country search to PhoneNumberInput selector
+
+Adds a `SearchInput` inside `CountrySelector`'s `BottomSheetHeader` for `PhoneNumberInput`. Filters the country list by name or dial code (case-insensitive substring match) and shows a "No countries found" empty state when the filter matches nothing.


### PR DESCRIPTION
## Summary
- #3955 merged country search in blade-svelte `PhoneNumberInput`'s `CountrySelector` without a changeset, so its release never generated version bump / changelog entries.
- Adds the missing changeset with `patch` bump for `@razorpay/blade-svelte`, following the same convention used for prior blade-svelte feature additions (e.g. Modal in #3921).

## Test plan
- [x] No code changes — changeset-only PR

Made with [Cursor](https://cursor.com)