### PR TITLE
fix(blade-svelte): budget grab handle and empty header in BottomSheet height

### DIFF
--- a/.changeset/bottomsheet-height-scroll-fix.md
+++ b/.changeset/bottomsheet-height-scroll-fix.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': patch
+---
+
+fix(blade-svelte): budget grab handle and empty header in BottomSheet height
+
+Measure empty `BottomSheetHeader` height instead of skipping it, and always budget grab-handle height in snap/scroll math. Zero both only when the header floats (zero body padding). Fixes spurious body scroll (~28px) on short sheets with an empty header and drag handle.

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -106,6 +106,10 @@
   const isOnTopOfStack = $derived(stackArr[0] === id);
   const bottomSheetZIndex = $derived(zIndex - Math.max(0, currentStackIndex));
 
+  /* Empty header + zero body padding floats the header and grab handle out of
+   * flow, so neither consumes height in the surface's flex column. */
+  const isHeaderFloating = $derived(!hasBodyPadding && isHeaderEmpty);
+
   const totalHeight = $derived(grabHandleHeight + headerHeight + footerHeight + contentHeight);
 
   let initialSnapPointFraction = $state(snapPoints[1]);
@@ -130,7 +134,9 @@
     const maxValue = computeMaxContent({
       contentHeight,
       footerHeight,
-      headerHeight: headerHeight > 0 ? headerHeight + grabHandleHeight : 0,
+      /* Grab handle and header sit above the body in the same flex column, so
+       * both must be budgeted or the body scrolls by exactly their height. */
+      headerHeight: headerHeight + grabHandleHeight,
       maxHeight: value,
     });
     positionY = maxValue;
@@ -290,6 +296,10 @@
   $effect(() => {
     if (!grabHandleEl) return;
     void isOpen;
+    if (isHeaderFloating) {
+      grabHandleHeight = 0;
+      return;
+    }
     const cs = getComputedStyle(grabHandleEl);
     const marginBottom = parseFloat(cs.marginBottom) || 0;
     grabHandleHeight = grabHandleEl.getBoundingClientRect().height + marginBottom;
@@ -499,7 +509,7 @@
     },
     close,
     get isHeaderFloating() {
-      return !hasBodyPadding && isHeaderEmpty;
+      return isHeaderFloating;
     },
     get isDismissible() {
       return isDismissible;
@@ -536,7 +546,7 @@
   const surfaceExtraClasses = $derived((styledProps.classes || []).filter(Boolean).join(' '));
 
   const grabHandleClasses = $derived(
-    [bottomSheetGrabHandleClass, !hasBodyPadding && isHeaderEmpty ? bottomSheetGrabHandleFloatingClass : '']
+    [bottomSheetGrabHandleClass, isHeaderFloating ? bottomSheetGrabHandleFloatingClass : '']
       .filter(Boolean)
       .join(' '),
   );

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheetHeader.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheetHeader.svelte
@@ -57,15 +57,14 @@
   });
 
   /* Measure the header height after mount/open so the parent can size its
-   * total content. Mirrors React's `useIsomorphicLayoutEffect` measurement.
-   * Run for any non-empty header (covers leading/trailing/showBackButton/children
-   * cases too — not just title/subtitle) so snap-point math always accounts for
-   * the rendered header. */
+   * total content. An empty header still occupies a band above the body, so it
+   * is measured too — skipping it leaves the body scrollable by that height.
+   * When the header floats its content is out of flow and this measures 0. */
   $effect(() => {
     if (!headerEl) return;
-    if (isHeaderEmpty) return;
-    // Re-run on isOpen toggle by reading it.
+    // Re-run on isOpen / float toggles by reading them.
     void ctx?.isOpen;
+    void ctx?.isHeaderFloating;
     ctx?.setHeaderHeight(headerEl.getBoundingClientRect().height);
   });
 


### PR DESCRIPTION
## Summary
- Measure empty `BottomSheetHeader` height instead of skipping it, so snap/height math accounts for the header band above the body
- Always budget grab-handle height in `computeMaxContent`; zero it only when header floats (zero body padding)
- Fixes spurious body scroll (~28px) on short sheets with empty header + drag handle

## Root cause
Sheet `positionY` was clamped to body content height, but flex layout still reserved space for the grab handle (~20px) and empty header band (~8px). Those were excluded when `headerHeight === 0`, so the body scroll container was shorter than its padded content.

## Test plan
- [x] Headless repro: overflow dropped from 28px → 0 with fix
- [x] `yarn test` in `packages/blade-svelte` (59 tests)
- [x] `yarn svelte-check` (0 errors)
- [ ] Storybook: open **Zero Padding** or add short-content + empty-header story; confirm `body.scrollHeight - body.clientHeight === 0`
- [ ] Mobile viewport in Storybook to verify grab-handle case


Made with [Cursor](https://cursor.com)