### PR TITLE
feat(blade-svelte): add backdropPortalTarget to BottomSheet

### DIFF
--- a/.changeset/bottomsheet-backdrop-portal.md
+++ b/.changeset/bottomsheet-backdrop-portal.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': minor
+---
+
+feat(blade-svelte): add `backdropPortalTarget` to BottomSheet
+
+Adds an optional `backdropPortalTarget` prop so the dim overlay can mount into a wider ancestor while the sheet surface stays in a nested container. When the targets differ, backdrop and surface render in separate portals with stacking tuned so the surface still paints above the dim layer.

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -963,40 +963,51 @@
 <!-- Story 14: With Split Portal Targets — backdrop covers a wider frame, surface stays nested. -->
 <Story name="With Split Portal Targets">
   {#snippet template()}
-    <div>
-      <Text marginBottom="spacing.4">
-        Pass backdropPortalTarget when the dim overlay must cover a wider ancestor (e.g. checkout
-        sidebar + main pane) while the sheet surface stays portaled into a nested container. The
-        surface host needs its own stacking context (e.g. z-index: 1) so it paints above the
-        backdrop.
+    <div style="max-width: 640px;">
+      <Text marginBottom="spacing.5">
+        Pass <b>backdropPortalTarget</b> when the dim overlay must cover a wider ancestor (e.g. a
+        checkout sidebar + main pane) while the sheet surface stays portaled into a nested
+        container. The surface host needs its own stacking context (z-index: 1) so it paints above
+        the backdrop.
       </Text>
 
       <div
         bind:this={backdropPortalTargetEl}
         style="
           position: relative;
-          width: 480px;
-          height: 360px;
+          width: 100%;
+          height: 420px;
           overflow: hidden;
-          border-radius: var(--radius-medium);
-          border: 2px solid var(--surface-border-gray-subtle);
+          border-radius: var(--border-radius-large);
+          border: 1px solid var(--surface-border-gray-muted);
           background: var(--surface-background-gray-subtle);
+          box-shadow: var(--elevation-low);
         "
       >
         <div style="display: flex; height: 100%;">
           <aside
             style="
-              width: 140px;
-              padding: var(--spacing-4);
-              border-right: 1px solid var(--surface-border-gray-subtle);
-              background: var(--surface-background-gray-intense);
+              width: 176px;
+              flex-shrink: 0;
+              padding: var(--spacing-6) var(--spacing-5);
+              border-right: 1px solid var(--surface-border-gray-muted);
+              background: var(--surface-background-gray-moderate);
+              display: flex;
+              flex-direction: column;
+              gap: var(--spacing-4);
             "
           >
-            <Text size="small" weight="semibold" marginBottom="spacing.3">Sidebar</Text>
-            <Text size="small" color="surface.text.gray.muted">
-              This pane is outside the sheet portal but inside the backdrop target — it dims when the
-              sheet opens.
-            </Text>
+            <Text size="xsmall" weight="semibold" color="surface.text.gray.muted">CHECKOUT</Text>
+            <div style="display: flex; flex-direction: column; gap: var(--spacing-3);">
+              <Text size="small" color="surface.text.gray.subtle">Contact</Text>
+              <Text size="small" color="surface.text.gray.subtle">Delivery address</Text>
+              <Text size="small" weight="semibold">Payment</Text>
+            </div>
+            <div style="margin-top: auto;">
+              <Text size="xsmall" color="surface.text.gray.muted">
+                Dims with the surface when the sheet opens.
+              </Text>
+            </div>
           </aside>
 
           <div
@@ -1005,17 +1016,21 @@
               position: relative;
               z-index: 1;
               flex: 1;
-              padding: var(--spacing.5);
+              padding: var(--spacing-7) var(--spacing-6);
               display: flex;
               flex-direction: column;
-              gap: var(--spacing.4);
+              gap: var(--spacing-5);
             "
           >
-            <Heading size="small">Main checkout pane</Heading>
-            <Text color="surface.text.gray.muted" size="small">
-              The sheet surface mounts here; the backdrop mounts on the outer frame.
-            </Text>
-            <Button onClick={() => (isSplitPortalOpen = true)}>Open bottom sheet</Button>
+            <div style="display: flex; flex-direction: column; gap: var(--spacing-2);">
+              <Heading size="medium">Pay ₹2,499</Heading>
+              <Text color="surface.text.gray.muted" size="small">
+                Choose a payment method to continue.
+              </Text>
+            </div>
+            <Button isFullWidth onClick={() => (isSplitPortalOpen = true)}>
+              Select bank for Netbanking
+            </Button>
 
             <BottomSheet
               isOpen={isSplitPortalOpen}
@@ -1024,10 +1039,7 @@
               backdropPortalTarget={backdropPortalTargetEl}
             >
               {#snippet children()}
-                <BottomSheetHeader
-                  title="Select bank"
-                  subtitle="Backdrop covers sidebar + main pane; surface stays in the main pane"
-                />
+                <BottomSheetHeader title="Select bank" subtitle="Netbanking" />
                 <BottomSheetBody hasActionList>
                   {#snippet children()}
                     <ActionList>
@@ -1036,6 +1048,7 @@
                         <ActionListItem title="ICICI Bank" value="icici" />
                         <ActionListItem title="State Bank of India" value="sbi" />
                         <ActionListItem title="Axis Bank" value="axis" />
+                        <ActionListItem title="Kotak Mahindra Bank" value="kotak" />
                       {/snippet}
                     </ActionList>
                   {/snippet}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -93,6 +93,9 @@
   let isNonDismissibleOpen = $state(false);
   let isPortalTargetOpen = $state(false);
   let portalTargetEl = $state<HTMLDivElement | null>(null);
+  let isSplitPortalOpen = $state(false);
+  let backdropPortalTargetEl = $state<HTMLDivElement | null>(null);
+  let surfacePortalTargetEl = $state<HTMLDivElement | null>(null);
 
   let searchInput: { focus: () => void; getInput: () => HTMLInputElement | null } | undefined =
     $state();
@@ -957,7 +960,96 @@
   {/snippet}
 </Story>
 
-<!-- Story 14: Non-Dismissible BottomSheet — locked open, must use footer buttons.
+<!-- Story 14: With Split Portal Targets — backdrop covers a wider frame, surface stays nested. -->
+<Story name="With Split Portal Targets">
+  {#snippet template()}
+    <div>
+      <Text marginBottom="spacing.4">
+        Pass backdropPortalTarget when the dim overlay must cover a wider ancestor (e.g. checkout
+        sidebar + main pane) while the sheet surface stays portaled into a nested container. The
+        surface host needs its own stacking context (e.g. z-index: 1) so it paints above the
+        backdrop.
+      </Text>
+
+      <div
+        bind:this={backdropPortalTargetEl}
+        style="
+          position: relative;
+          width: 480px;
+          height: 360px;
+          overflow: hidden;
+          border-radius: var(--radius-medium);
+          border: 2px solid var(--surface-border-gray-subtle);
+          background: var(--surface-background-gray-subtle);
+        "
+      >
+        <div style="display: flex; height: 100%;">
+          <aside
+            style="
+              width: 140px;
+              padding: var(--spacing-4);
+              border-right: 1px solid var(--surface-border-gray-subtle);
+              background: var(--surface-background-gray-intense);
+            "
+          >
+            <Text size="small" weight="semibold" marginBottom="spacing.3">Sidebar</Text>
+            <Text size="small" color="surface.text.gray.muted">
+              This pane is outside the sheet portal but inside the backdrop target — it dims when the
+              sheet opens.
+            </Text>
+          </aside>
+
+          <div
+            bind:this={surfacePortalTargetEl}
+            style="
+              position: relative;
+              z-index: 1;
+              flex: 1;
+              padding: var(--spacing.5);
+              display: flex;
+              flex-direction: column;
+              gap: var(--spacing.4);
+            "
+          >
+            <Heading size="small">Main checkout pane</Heading>
+            <Text color="surface.text.gray.muted" size="small">
+              The sheet surface mounts here; the backdrop mounts on the outer frame.
+            </Text>
+            <Button onClick={() => (isSplitPortalOpen = true)}>Open bottom sheet</Button>
+
+            <BottomSheet
+              isOpen={isSplitPortalOpen}
+              onDismiss={() => (isSplitPortalOpen = false)}
+              portalTarget={surfacePortalTargetEl}
+              backdropPortalTarget={backdropPortalTargetEl}
+            >
+              {#snippet children()}
+                <BottomSheetHeader
+                  title="Select bank"
+                  subtitle="Backdrop covers sidebar + main pane; surface stays in the main pane"
+                />
+                <BottomSheetBody hasActionList>
+                  {#snippet children()}
+                    <ActionList>
+                      {#snippet children()}
+                        <ActionListItem title="HDFC Bank" value="hdfc" />
+                        <ActionListItem title="ICICI Bank" value="icici" />
+                        <ActionListItem title="State Bank of India" value="sbi" />
+                        <ActionListItem title="Axis Bank" value="axis" />
+                      {/snippet}
+                    </ActionList>
+                  {/snippet}
+                </BottomSheetBody>
+              {/snippet}
+            </BottomSheet>
+          </div>
+        </div>
+      </div>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story 15: Non-Dismissible BottomSheet — locked open, must use footer buttons.
      The exported storyName in React is verbatim "Non-Dismissible BottomSheet" — DO NOT change. -->
 <Story name="Non-Dismissible BottomSheet">
   {#snippet template()}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -50,6 +50,7 @@
     isDismissible = true,
     zIndex = BOTTOM_SHEET_Z_INDEX,
     portalTarget,
+    backdropPortalTarget = portalTarget,
     showDragHandle = true,
     testID,
     ...rest
@@ -105,6 +106,17 @@
   const currentStackIndex = $derived(stackArr.indexOf(id));
   const isOnTopOfStack = $derived(stackArr[0] === id);
   const bottomSheetZIndex = $derived(zIndex - Math.max(0, currentStackIndex));
+
+  const useSplitPortals = $derived(
+    backdropPortalTarget != null &&
+      portalTarget != null &&
+      backdropPortalTarget !== portalTarget,
+  );
+
+  /* When the backdrop sits in a wider ancestor than the surface, keep it
+   * under an intermediate stacking context (e.g. checkout `#main-container`
+   * at z-index 1) so the sheet still paints above the dim layer. */
+  const backdropZIndex = $derived(useSplitPortals ? 0 : bottomSheetZIndex);
 
   const totalHeight = $derived(grabHandleHeight + headerHeight + footerHeight + contentHeight);
 
@@ -553,7 +565,19 @@
 </script>
 
 {#if isMounted}
-  {#if portalTarget}
+  {#if useSplitPortals}
+    <div use:portal={backdropPortalTarget} class={bottomSheetPortalRootClass}>
+      <BottomSheetBackdrop
+        isOpen={isVisible}
+        zIndex={backdropZIndex}
+        {isDismissible}
+        onClose={close}
+      />
+    </div>
+    <div use:portal={portalTarget} class={bottomSheetPortalRootClass}>
+      {@render surface()}
+    </div>
+  {:else if portalTarget}
     <div use:portal={portalTarget} class={bottomSheetPortalRootClass}>
       {@render overlay()}
     </div>
@@ -567,10 +591,14 @@
 {#snippet overlay()}
   <BottomSheetBackdrop
     isOpen={isVisible}
-    zIndex={bottomSheetZIndex}
+    zIndex={backdropZIndex}
     {isDismissible}
     onClose={close}
   />
+  {@render surface()}
+{/snippet}
+
+{#snippet surface()}
   <div
     class="{bottomSheetSurfaceClass} {surfaceExtraClasses}"
     style={surfaceStyle}

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import BottomSheetFocusTestHarness from './BottomSheetFocusTestHarness.svelte';
 import BottomSheetBindableTestHarness from './BottomSheetBindableTestHarness.svelte';
+import BottomSheetSplitPortalTestHarness from './BottomSheetSplitPortalTestHarness.svelte';
 
 /* Spy on the prototype so the focus call is captured regardless of when the
  * target element mounts (the sheet portals + defers focus across two rAFs). */
@@ -18,6 +19,14 @@ function focusOptionsFor(spy: ReturnType<typeof vi.spyOn>, el: Element): FocusOp
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  globalThis.ResizeObserver = (vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  })) as unknown) as typeof ResizeObserver;
 });
 
 describe('<BottomSheet /> focus management', () => {
@@ -68,5 +77,21 @@ describe('<BottomSheet /> focus management', () => {
     /* Escape dismisses the dismissible sheet — the bound `isOpen` must flip back. */
     await fireEvent.keyDown(window, { key: 'Escape' });
     await waitFor(() => expect(screen.getByTestId('bound-is-open')).toHaveTextContent('false'));
+  });
+
+  it('mounts backdrop and surface into separate portal targets', async () => {
+    render(BottomSheetSplitPortalTestHarness, { props: { isOpen: true } });
+
+    const backdropHost = screen.getByTestId('backdrop-host');
+    const surfaceHost = screen.getByTestId('surface-host');
+
+    await waitFor(() => expect(screen.getByTestId('sheet-content')).toBeInTheDocument());
+
+    const backdrop = backdropHost.querySelector('[data-testid="bottomsheet-backdrop"]');
+    const surface = surfaceHost.querySelector('[data-testid="bottomsheet-surface"]');
+
+    expect(backdrop).toBeTruthy();
+    expect(surface).toBeTruthy();
+    expect(surfaceHost.contains(backdrop as Node)).toBe(false);
   });
 });

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheetSplitPortalTestHarness.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheetSplitPortalTestHarness.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import BottomSheet from '../BottomSheet.svelte';
+  import BottomSheetBody from '../BottomSheetBody.svelte';
+
+  let {
+    isOpen = false,
+  }: {
+    isOpen?: boolean;
+  } = $props();
+
+  let backdropHost = $state<HTMLDivElement | null>(null);
+  let surfaceHost = $state<HTMLDivElement | null>(null);
+  let portalTarget = $state<HTMLElement | null>(null);
+  let backdropPortalTarget = $state<HTMLElement | null>(null);
+
+  onMount(() => {
+    portalTarget = surfaceHost;
+    backdropPortalTarget = backdropHost;
+  });
+</script>
+
+<div
+  bind:this={backdropHost}
+  data-testid="backdrop-host"
+  style="position: relative; width: 400px; height: 400px;"
+>
+  <div
+    bind:this={surfaceHost}
+    data-testid="surface-host"
+    style="position: relative; z-index: 1; width: 200px; height: 200px; margin-left: auto;"
+  >
+    {#if portalTarget && backdropPortalTarget}
+      <BottomSheet {isOpen} {portalTarget} {backdropPortalTarget}>
+        <BottomSheetBody>
+          <div data-testid="sheet-content">Sheet content</div>
+        </BottomSheetBody>
+      </BottomSheet>
+    {/if}
+  </div>
+</div>

--- a/packages/blade-svelte/src/components/BottomSheet/types.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/types.ts
@@ -72,6 +72,16 @@ export interface BottomSheetProps extends StyledPropsBlade {
   portalTarget?: HTMLElement | null;
 
   /**
+   * Mounts the backdrop into this element. Defaults to `portalTarget`. Set a
+   * wider ancestor when the sheet surface should stay in a nested container
+   * but the dim overlay must cover a larger region (e.g. a checkout card
+   * sidebar + main pane). The surface `portalTarget` must be a descendant of
+   * this element, and an intermediate ancestor should establish a higher
+   * stacking context for the surface (e.g. `z-index: 1`).
+   */
+  backdropPortalTarget?: HTMLElement | null;
+
+  /**
    * Toggles the drag handle (the pill affordance rendered at the top of the
    * sheet) and drag-to-move/dismiss gestures. Set to `false` for desktop flows
    * where dragging is not expected — this hides the handle and disables all

--- a/packages/blade-svelte/src/utils/portal.ts
+++ b/packages/blade-svelte/src/utils/portal.ts
@@ -13,7 +13,7 @@
 export type PortalTarget = HTMLElement | string;
 
 export type PortalActionReturn = {
-  update?: (target: PortalTarget) => void;
+  update?: (target: PortalTarget | null | undefined) => void;
   destroy: () => void;
 };
 
@@ -30,14 +30,14 @@ const resolveTarget = (target: PortalTarget): HTMLElement => {
 
 export function portal(
   node: HTMLElement,
-  target: PortalTarget = document.body,
+  target: PortalTarget | null | undefined = document.body,
 ): PortalActionReturn {
-  let resolved = resolveTarget(target);
+  let resolved = resolveTarget(target ?? document.body);
   resolved.appendChild(node);
 
   return {
-    update(next: PortalTarget) {
-      resolved = resolveTarget(next);
+    update(next: PortalTarget | null | undefined) {
+      resolved = resolveTarget(next ?? document.body);
       resolved.appendChild(node);
     },
     destroy() {


### PR DESCRIPTION
## Summary

- Adds optional `backdropPortalTarget` prop to `BottomSheet` so the dim overlay can mount into a wider ancestor while the sheet surface stays in a nested container
- When targets differ, backdrop and surface render in separate portals with z-index handling so the surface still paints above the dim layer
- Includes unit test coverage via `BottomSheetSplitPortalTestHarness`

## Motivation

Checkout overlay stacks need the backdrop to cover a larger region (e.g. card sidebar + main pane) while the sheet surface remains portaled into a nested container with its own stacking context.

## Test plan

- [x] `yarn test BottomSheet` in `packages/blade-svelte`
- [ ] Verify in checkout overlay stack with split portal targets (backdrop on card root, surface in main container)


Made with [Cursor](https://cursor.com)