### PR TITLE
fix(Input): update PAN regex validation and trim whitespace

### DIFF
--- a/packages/blade/src/components/Input/TextInput/index.ts
+++ b/packages/blade/src/components/Input/TextInput/index.ts
@@ -1,2 +1,3 @@
 export { TextInput } from './TextInput';
 export type { TextInputProps } from './TextInput';
+export { PAN_REGEX, validatePAN, isValidPAN } from '../validators';

--- a/packages/blade/src/components/Input/__tests__/validators.test.ts
+++ b/packages/blade/src/components/Input/__tests__/validators.test.ts
@@ -1,0 +1,57 @@
+import { PAN_REGEX, validatePAN, isValidPAN } from '../validators';
+
+describe('PAN Validator', () => {
+  describe('PAN_REGEX', () => {
+    it('should match valid 10-character PAN patterns', () => {
+      expect(PAN_REGEX.test('ABCDE1234F')).toBe(true);
+      expect(PAN_REGEX.test('AAAPA1234A')).toBe(true);
+      expect(PAN_REGEX.test('ZZZZZ9999Z')).toBe(true);
+    });
+
+    it('should not match invalid PAN formats', () => {
+      expect(PAN_REGEX.test('ABCDE12345')).toBe(false);
+      expect(PAN_REGEX.test('12345ABCDE')).toBe(false);
+      expect(PAN_REGEX.test('ABCD1234F')).toBe(false);
+      expect(PAN_REGEX.test('ABCDEF1234F')).toBe(false);
+      expect(PAN_REGEX.test('ABCDE1234FG')).toBe(false);
+      expect(PAN_REGEX.test('abcde1234f')).toBe(false);
+    });
+  });
+
+  describe('validatePAN and isValidPAN', () => {
+    it('should validate valid uppercase 10-character PAN', () => {
+      expect(validatePAN('ABCDE1234F')).toBe(true);
+      expect(isValidPAN('ABCDE1234F')).toBe(true);
+    });
+
+    it('should validate lowercase or mixed case PAN by uppercasing', () => {
+      expect(validatePAN('abcde1234f')).toBe(true);
+      expect(validatePAN('AbCdE1234f')).toBe(true);
+      expect(isValidPAN('abcde1234f')).toBe(true);
+    });
+
+    it('should trim surrounding whitespace and validate', () => {
+      expect(validatePAN('  ABCDE1234F  ')).toBe(true);
+      expect(validatePAN('\tABCDE1234F\n')).toBe(true);
+      expect(isValidPAN('  abcde1234f  ')).toBe(true);
+    });
+
+    it('should return false for invalid formats', () => {
+      expect(validatePAN('ABCDE12345')).toBe(false);
+      expect(validatePAN('12345ABCDE')).toBe(false);
+      expect(validatePAN('ABCDE123')).toBe(false);
+      expect(validatePAN('ABCDE12345F')).toBe(false);
+      expect(validatePAN('ABC1234F')).toBe(false);
+      expect(validatePAN('ABCDE 1234 F')).toBe(false);
+    });
+
+    it('should return false for empty, null, undefined, or non-string inputs', () => {
+      expect(validatePAN('')).toBe(false);
+      expect(validatePAN('   ')).toBe(false);
+      expect(validatePAN(null)).toBe(false);
+      expect(validatePAN(undefined)).toBe(false);
+      // @ts-expect-error testing non-string input
+      expect(validatePAN(12345)).toBe(false);
+    });
+  });
+});

--- a/packages/blade/src/components/Input/validators.ts
+++ b/packages/blade/src/components/Input/validators.ts
@@ -1,0 +1,24 @@
+/**
+ * Standard Indian Permanent Account Number (PAN) regular expression pattern.
+ * Format: 5 uppercase letters, 4 digits, 1 uppercase letter (e.g., ABCDE1234F).
+ */
+const PAN_REGEX = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/;
+
+/**
+ * Validates a PAN number by trimming whitespace and matching against the 10-character PAN pattern (`^[A-Z]{5}[0-9]{4}[A-Z]{1}$`).
+ *
+ * @param pan - The PAN string to validate.
+ * @returns `true` if the input is a valid 10-character PAN number, `false` otherwise.
+ */
+const validatePAN = (pan?: string | null): boolean => {
+  if (!pan || typeof pan !== 'string') {
+    return false;
+  }
+
+  const trimmed = pan.trim().toUpperCase();
+  return PAN_REGEX.test(trimmed);
+};
+
+const isValidPAN = validatePAN;
+
+export { PAN_REGEX, validatePAN, isValidPAN };

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -45,6 +45,7 @@ export * from './Input/TextInput';
 export * from './Input/SearchInput';
 export * from './Input/PhoneNumberInput';
 export * from './Input/ColorInput';
+export * from './Input/validators';
 export * from './InputGroup';
 export * from './Link';
 export * from './List';

--- a/packages/blade/src/utils/index.ts
+++ b/packages/blade/src/utils/index.ts
@@ -20,3 +20,4 @@ export * from './toTitleCase';
 export * from './usePrevious';
 
 export { default as useTheme, ThemeContext } from '~components/BladeProvider/useTheme';
+export { PAN_REGEX, validatePAN, isValidPAN } from '~components/Input/validators';


### PR DESCRIPTION
## Description
Fixes #3905

This PR introduces PAN number validation support and helpers in Blade input components:
- Updates and standardizes the PAN regex pattern (`^[A-Z]{5}[0-9]{4}[A-Z]{1}$`).
- Adds `validatePAN` / `isValidPAN` helper that trims surrounding whitespace and validates 10-character PANs.
- Adds comprehensive unit tests for PAN validation across web and native test runners.