### PR TITLE
feat(blade-svelte): BottomSheet auto mode and maxHeight cap

### DIFF
--- a/.changeset/bottomsheet-auto-mode-max-height.md
+++ b/.changeset/bottomsheet-auto-mode-max-height.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': minor
+---
+
+feat(blade-svelte): add BottomSheet auto mode and maxHeight cap
+
+When `snapPoints` is omitted, BottomSheet now opens at its natural content height (capped by `maxHeight`, default `0.97` of the viewport or portal container). Content height is tracked via `ResizeObserver` and the sheet re-clamps as content grows or shrinks. Drag-to-dismiss remains; drag-to-resize is disabled in auto mode. Passing `snapPoints` keeps the existing multi-detent behaviour unchanged. Also fixes portal-target sheets occasionally exceeding `maxHeight` when height math used `window.innerHeight` before the container height was synced.

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.stories.svelte
@@ -52,6 +52,8 @@
   import Badge from '../Badge/Badge.svelte';
   import Counter from '../Counter/Counter.svelte';
   import Link from '../Link/Link.svelte';
+  import Amount from '../Amount/Amount.svelte';
+  import Divider from '../Divider/Divider.svelte';
   import ActionList from '../ActionList/ActionList.svelte';
   import ActionListItem from '../ActionList/ActionListItem.svelte';
   import ActionListSection from '../ActionList/ActionListSection.svelte';
@@ -60,6 +62,7 @@
   import Checkbox from '../Checkbox/Checkbox.svelte';
   import RadioGroup from '../Radio/RadioGroup.svelte';
   import Radio from '../Radio/Radio.svelte';
+  import TrustBadge from '../TrustBadge/TrustBadge.svelte';
 
   /* Playground story state — separate from product-demo stories. */
   let isPlaygroundOpen = $state(false);
@@ -92,6 +95,9 @@
   let productSimError = $state<string | undefined>();
   let isNonDismissibleOpen = $state(false);
   let isPortalTargetOpen = $state(false);
+  let isAutoModeOpen = $state(false);
+  let autoModeItemCount = $state(3);
+  let autoModePortalEl = $state<HTMLDivElement | null>(null);
   let portalTargetEl = $state<HTMLDivElement | null>(null);
 
   let searchInput: { focus: () => void; getInput: () => HTMLInputElement | null } | undefined =
@@ -948,6 +954,135 @@
             <BottomSheetFooter>
               {#snippet children()}
                 <Button isFullWidth onClick={() => (isPortalTargetOpen = false)}>Continue</Button>
+              {/snippet}
+            </BottomSheetFooter>
+          {/snippet}
+        </BottomSheet>
+      </div>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- Story: Content Height Adapts — checkout-like sidebar + main; sheet renders in main, height tracks content. -->
+<Story name="Content Height Adapts">
+  {#snippet template()}
+    <div
+      style="
+        display: flex;
+        width: 1024px;
+        height: 616px;
+        border-radius: var(--border-radius-large);
+        overflow: hidden;
+        box-shadow: 0 8px 32px hsla(217, 56%, 17%, 0.18);
+        font-family: var(--font-family-text);
+      "
+    >
+      <!-- ===== SIDEBAR ===== -->
+      <div
+        style="
+          width: 340px;
+          flex-shrink: 0;
+          background: var(--surface-background-primary-intense);
+          padding: var(--spacing-6);
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-5);
+        "
+      >
+        <div style="display: flex; align-items: center; gap: var(--spacing-3);">
+          <div
+            style="width: 40px; height: 40px; border-radius: var(--border-radius-medium); background: var(--surface-background-gray-intense); display: flex; align-items: center; justify-content: center;"
+          >
+            <Text weight="semibold">R</Text>
+          </div>
+          <div>
+            <Text weight="semibold" color="surface.text.staticWhite.normal">Razorpay</Text>
+            <TrustBadge label="Trusted Business" />
+          </div>
+        </div>
+
+        <div
+          style="background: hsla(0, 0%, 100%, 0.08); border-radius: var(--border-radius-medium); padding: var(--spacing-5); display: flex; flex-direction: column; gap: var(--spacing-2);"
+        >
+          <Text size="small" color="surface.text.staticWhite.muted">Price Summary</Text>
+          <Amount value={2138.51} currency="AED" type="heading" size="large" color="surface.text.staticWhite.normal" />
+          <Text size="xsmall" color="surface.text.staticWhite.muted">
+            Order amount updated as Tabby charges in AED
+          </Text>
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: var(--spacing-3);">
+          <div style="background: hsla(0, 0%, 100%, 0.08); border-radius: var(--border-radius-medium); padding: var(--spacing-4);">
+            <Text size="small" color="surface.text.staticWhite.normal">Using as +91 93478 41747</Text>
+          </div>
+          <div style="background: hsla(0, 0%, 100%, 0.08); border-radius: var(--border-radius-medium); padding: var(--spacing-4);">
+            <Text size="small" color="surface.text.staticWhite.normal">Offers on IndusInd, SBI …</Text>
+          </div>
+        </div>
+
+        <div style="margin-top: auto;">
+          <Text size="xsmall" color="surface.text.staticWhite.muted">Money Back Promise by Razorpay</Text>
+        </div>
+      </div>
+
+      <!-- ===== MAIN — sheet portals into here ===== -->
+      <div
+        bind:this={autoModePortalEl}
+        style="
+          position: relative;
+          flex: 1;
+          background: var(--surface-background-gray-intense);
+          display: flex;
+          flex-direction: column;
+        "
+      >
+        <div style="flex: 1; padding: var(--spacing-8) var(--spacing-7); display: flex; flex-direction: column; gap: var(--spacing-5); align-items: center; overflow: auto;">
+          <Heading size="medium">Choose a payment method</Heading>
+          <Text color="surface.text.gray.subtle" textAlign="center">
+            Split your purchase into interest-free instalments
+          </Text>
+          <div style="width: 100%; max-width: 360px; margin-top: var(--spacing-5);">
+            <Button isFullWidth onClick={() => (isAutoModeOpen = true)}>
+              Select instalment plan
+            </Button>
+          </div>
+        </div>
+
+        <BottomSheet
+          isOpen={isAutoModeOpen}
+          onDismiss={() => (isAutoModeOpen = false)}
+          portalTarget={autoModePortalEl}
+        >
+          {#snippet children()}
+            <BottomSheetHeader title="Instalment plans" subtitle="Sheet height follows content" />
+            <BottomSheetBody>
+              {#snippet children()}
+                <div style="display: flex; gap: var(--spacing-3); margin-bottom: var(--spacing-4);">
+                  <Button size="small" onClick={() => (autoModeItemCount += 1)}>Add plan</Button>
+                  <Button
+                    size="small"
+                    variant="secondary"
+                    onClick={() => (autoModeItemCount = Math.max(0, autoModeItemCount - 1))}
+                  >
+                    Remove plan
+                  </Button>
+                </div>
+                {#each Array.from({ length: autoModeItemCount }), index}
+                  <div style="padding: var(--spacing-4) 0;">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                      <Text weight="semibold">{index + 1} × monthly</Text>
+                      <Amount value={2138.51 / (index + 1)} currency="AED" type="body" size="medium" />
+                    </div>
+                    {#if index < autoModeItemCount - 1}
+                      <div style="margin-top: var(--spacing-4);"><Divider /></div>
+                    {/if}
+                  </div>
+                {/each}
+              {/snippet}
+            </BottomSheetBody>
+            <BottomSheetFooter>
+              {#snippet children()}
+                <Button isFullWidth onClick={() => (isAutoModeOpen = false)}>Continue</Button>
               {/snippet}
             </BottomSheetFooter>
           {/snippet}

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -15,7 +15,6 @@
   } from '@razorpay/blade-core/utils';
   import {
     BOTTOM_SHEET_Z_INDEX,
-    BOTTOM_SHEET_DEFAULT_SNAP_POINTS,
     bottomSheetSurfaceClass,
     bottomSheetInnerWrapperClass,
     bottomSheetGrabHandleClass,
@@ -46,7 +45,8 @@
     onDismiss,
     children,
     initialFocusRef = null,
-    snapPoints = [...BOTTOM_SHEET_DEFAULT_SNAP_POINTS] as SnapPoints,
+    snapPoints,
+    maxHeight = 0.97,
     isDismissible = true,
     zIndex = BOTTOM_SHEET_Z_INDEX,
     portalTarget,
@@ -110,20 +110,27 @@
    * flow, so neither consumes height in the surface's flex column. */
   const isHeaderFloating = $derived(!hasBodyPadding && isHeaderEmpty);
 
+  const isAutoMode = $derived(snapPoints === undefined);
+  /* In auto mode a single implicit snap point at maxHeight acts as the ceiling. */
+  const effectiveSnapPoints = $derived(
+    isAutoMode
+      ? ([maxHeight, maxHeight, maxHeight] as SnapPoints)
+      : (snapPoints as SnapPoints),
+  );
+
   const totalHeight = $derived(grabHandleHeight + headerHeight + footerHeight + contentHeight);
 
-  let initialSnapPointFraction = $state(snapPoints[1]);
-
-  /* Adjust the initial snap point so a small total content sits on the
-   * lowest snap point, otherwise stays on the middle one. Mirrors React. */
-  $effect(() => {
-    const middleSnapPoint = snapPoints[1] * windowHeight;
-    const lowerSnapPoint = snapPoints[0] * windowHeight;
+  /* In auto mode the sheet always opens at content height — never at a fixed
+   * fraction. In snap-point mode keep the existing React logic. */
+  const initialSnapPointFraction = $derived.by(() => {
+    if (isAutoMode) return Math.min(totalHeight / windowHeight, maxHeight);
+    const pts = snapPoints as SnapPoints;
+    const middleSnapPoint = pts[1] * windowHeight;
+    const lowerSnapPoint = pts[0] * windowHeight;
     if (totalHeight > lowerSnapPoint && totalHeight < middleSnapPoint) {
-      initialSnapPointFraction = snapPoints[0];
-    } else {
-      initialSnapPointFraction = snapPoints[1];
+      return pts[0];
     }
+    return pts[1];
   });
 
   function setPositionY(value: number, limit = true): void {
@@ -179,6 +186,14 @@
   }
 
   function handleOnOpen(): void {
+    /* Sync the viewport height to the portal container synchronously before
+     * positioning. `windowHeight` initializes to `window.innerHeight` and is
+     * only corrected to the portal height by a later effect — positioning
+     * before that correction would cap against the full window, letting the
+     * sheet grow far taller than a bounded portal container. */
+    windowHeight =
+      portalTarget?.clientHeight ??
+      (typeof window !== 'undefined' ? window.innerHeight : windowHeight);
     setPositionY(windowHeight * initialSnapPointFraction);
     if (typeof document !== 'undefined') {
       originalFocusEl = originalFocusEl ?? (document.activeElement as HTMLElement | null);
@@ -231,6 +246,24 @@
         unmountTimeoutId = null;
       }
     };
+  });
+
+  /* Re-clamp the sheet height when measured content changes while open.
+   * React gets this from `setPositionY`/`handleOnOpen` identity churn feeding
+   * its open-sync effect; here it needs to be explicit. Skipped mid-drag so
+   * the gesture stays authoritative over the position. */
+  $effect(() => {
+    const total = totalHeight;
+    if (!isOpen || isDragging || total === 0) return;
+    /* Guard against a stale `windowHeight` (still the full window instead of a
+     * bounded portal): re-sync first, then let the derived cap recompute on the
+     * next run. Assign-if-changed avoids an effect loop. */
+    const viewportHeight = portalTarget?.clientHeight ?? windowHeight;
+    if (viewportHeight !== windowHeight) {
+      windowHeight = viewportHeight;
+      return;
+    }
+    setPositionY(windowHeight * initialSnapPointFraction);
   });
 
   /* Stack registration. */
@@ -362,21 +395,29 @@
     isDragging = Boolean(dragging);
 
     const rawY = lastOffsetY - movementY;
-    const lowerSnapPoint = windowHeight * snapPoints[0];
-    const upperSnapPoint = windowHeight * snapPoints[snapPoints.length - 1];
+    const pts = effectiveSnapPoints;
+    const lowerSnapPoint = windowHeight * pts[0];
+    const upperSnapPoint = windowHeight * pts[pts.length - 1];
+
+    /* In auto mode the sheet has a single resting height — upward drag is a
+     * no-op (rubber-bands back to rest). Downward drag is the dismiss gesture. */
+    const autoUpperCap = isAutoMode ? windowHeight * initialSnapPointFraction : upperSnapPoint;
 
     /* Velocity-driven momentum — same formula as React. */
     const predictedDistance = movementY * (velocityY / 2);
     const predictedY = Math.max(
       lowerSnapPoint,
-      Math.min(upperSnapPoint, rawY - predictedDistance * 2),
+      Math.min(autoUpperCap, rawY - predictedDistance * 2),
     );
 
     let newY = rawY;
 
     if (down) {
       const dampening = 0.55;
-      if (totalHeight < upperSnapPoint) {
+      if (isAutoMode) {
+        /* Rubber-band both ends — downward toward dismiss, upward toward rest. */
+        newY = rubberbandIfOutOfBounds(rawY, 0, autoUpperCap, dampening);
+      } else if (totalHeight < upperSnapPoint) {
         newY = rubberbandIfOutOfBounds(rawY, 0, totalHeight, dampening);
       } else {
         newY = rubberbandIfOutOfBounds(rawY, 0, upperSnapPoint, dampening);
@@ -385,51 +426,73 @@
       newY = predictedY;
     }
 
-    const isPosAtUpperSnapPoint = newY >= upperSnapPoint;
+    const isPosAtUpperSnapPoint = newY >= autoUpperCap;
 
     if (isContentDragging) {
       if (isPosAtUpperSnapPoint) {
-        newY = upperSnapPoint;
+        newY = autoUpperCap;
       }
 
       /* Pin to upper snap point while content isn't scrolled to top — keeps
        * the scroll feel natural when crossing the boundary between sheet
        * drag and content scroll. */
       const isContentScrolledAtTop = scrollEl != null && scrollEl.scrollTop <= 0;
-      if (lastOffsetY === upperSnapPoint && !isContentScrolledAtTop) {
-        newY = upperSnapPoint;
+      if (lastOffsetY === autoUpperCap && !isContentScrolledAtTop) {
+        newY = autoUpperCap;
       }
-      preventScrolling = newY < upperSnapPoint;
+      preventScrolling = newY < autoUpperCap;
     }
 
     if (last) {
-      const [nearest, lower] = computeSnapPointBounds(
-        newY,
-        snapPoints.map((point) => windowHeight * point) as SnapPoints,
-      );
-
       const lowerPointBuffer = 60;
-      const lowerestSnap = Math.min(lower, totalHeight) - lowerPointBuffer;
-      const shouldClose = rawY < lowerestSnap;
 
-      if (shouldClose) {
-        if (isDismissible) {
+      if (isAutoMode) {
+        /* Auto mode: only dismiss or snap back — no middle detents. */
+        const dismissThreshold = autoUpperCap - lowerPointBuffer;
+        const shouldClose = rawY < dismissThreshold;
+        if (shouldClose) {
+          if (isDismissible) {
+            isDragging = false;
+            cancel();
+            close();
+            return;
+          }
           isDragging = false;
           cancel();
-          close();
+          setPositionY(autoUpperCap, false);
           return;
         }
-        isDragging = false;
-        cancel();
-        const firstSnapPoint = windowHeight * snapPoints[0];
-        setPositionY(firstSnapPoint, true);
-        return;
-      }
+        if (!active && !tap) {
+          newY = autoUpperCap;
+        }
+      } else {
+        const [nearest, lower] = computeSnapPointBounds(
+          newY,
+          pts.map((point) => windowHeight * point) as SnapPoints,
+        );
 
-      /* `filterTaps: true` makes taps fire with `last: true, tap: true` —
-       * skip the snap-to-nearest branch so a tap doesn't trigger a flicker. */
-      if (!active && !tap) {
-        newY = nearest;
+        const lowerestSnap = Math.min(lower, totalHeight) - lowerPointBuffer;
+        const shouldClose = rawY < lowerestSnap;
+
+        if (shouldClose) {
+          if (isDismissible) {
+            isDragging = false;
+            cancel();
+            close();
+            return;
+          }
+          isDragging = false;
+          cancel();
+          const firstSnapPoint = windowHeight * pts[0];
+          setPositionY(firstSnapPoint, true);
+          return;
+        }
+
+        /* `filterTaps: true` makes taps fire with `last: true, tap: true` —
+         * skip the snap-to-nearest branch so a tap doesn't trigger a flicker. */
+        if (!active && !tap) {
+          newY = nearest;
+        }
       }
     }
 

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { DragGesture, rubberbandIfOutOfBounds } from '@use-gesture/vanilla';
   import {
     disableBodyScroll,
@@ -263,11 +263,14 @@
 
   /* Re-clamp the sheet height when measured content changes while open.
    * React gets this from `setPositionY`/`handleOnOpen` identity churn feeding
-   * its open-sync effect; here it needs to be explicit. Skipped mid-drag so
-   * the gesture stays authoritative over the position. */
+   * its open-sync effect; here it needs to be explicit. Auto mode only — in
+   * snap-point mode the resting detent belongs to the gesture, not to content
+   * size. `isDragging` is read untracked so drag-end flipping it false cannot
+   * re-trigger this effect and overwrite the position the gesture committed. */
   $effect(() => {
     const total = totalHeight;
-    if (!isOpen || isDragging || total === 0) return;
+    if (!isAutoMode || !isOpen || total === 0) return;
+    if (untrack(() => isDragging)) return;
     /* Guard against a stale `windowHeight` (still the full window instead of a
      * bounded portal): re-sync first, then let the derived cap recompute on the
      * next run. Assign-if-changed avoids an effect loop. */

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -33,6 +33,7 @@
   import { computeMaxContent, computeSnapPointBounds } from './utils';
   import BottomSheetBackdrop from './BottomSheetBackdrop.svelte';
   import { portal } from '../../utils/portal';
+  import { observeResize } from '../../utils/observeResize';
 
   /* Anchor structural classes against the Rollup tree-shaker — CSS modules
    * export ESM objects whose unused individual exports otherwise get
@@ -317,11 +318,9 @@
     const target = portalTarget;
     if (target) {
       windowHeight = target.clientHeight;
-      const observer = new ResizeObserver(() => {
+      return observeResize(target, () => {
         windowHeight = target.clientHeight;
       });
-      observer.observe(target);
-      return () => observer.disconnect();
     }
     return undefined;
   });

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheetBody.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheetBody.svelte
@@ -33,14 +33,22 @@
     return () => ctx?.setScrollElement(null);
   });
 
-  /* Measure content height every time the body re-renders. The parent uses
-   * this to compute snap-point bounds. Mirrors React's `useIsomorphicLayoutEffect`
-   * with `[contentRef, isOpen, children]` deps — Svelte's `$effect` re-runs
-   * automatically when reactive deps change. */
+  /* Measure content height and keep it in sync as the content grows/shrinks.
+   * React re-measures via a `children` dep — a new element object on every
+   * parent render. Svelte snippets render in the caller's reactive scope, so
+   * this effect would never see consumer state changes. Observe layout
+   * directly instead: `ResizeObserver` fires regardless of what caused the
+   * resize. The parent uses this to compute snap-point bounds. */
   $effect(() => {
-    if (!contentEl) return;
+    if (!contentEl) return undefined;
+    const node = contentEl;
     void ctx?.isOpen;
-    ctx?.setContentHeight(contentEl.getBoundingClientRect().height);
+    ctx?.setContentHeight(node.getBoundingClientRect().height);
+    const observer = new ResizeObserver(() => {
+      ctx?.setContentHeight(node.getBoundingClientRect().height);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
   });
 
   /* Inform the parent whether the body has zero padding. React tracks this

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheetBody.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheetBody.svelte
@@ -9,6 +9,7 @@
     getBottomSheetBodyContentClasses,
   } from '@razorpay/blade-core/styles';
   import { getBottomSheetContext } from './bottomSheetContext';
+  import { observeResize } from '../../utils/observeResize';
   import type { BottomSheetBodyProps } from './types';
 
   let {
@@ -44,11 +45,9 @@
     const node = contentEl;
     void ctx?.isOpen;
     ctx?.setContentHeight(node.getBoundingClientRect().height);
-    const observer = new ResizeObserver(() => {
+    return observeResize(node, () => {
       ctx?.setContentHeight(node.getBoundingClientRect().height);
     });
-    observer.observe(node);
-    return () => observer.disconnect();
   });
 
   /* Inform the parent whether the body has zero padding. React tracks this

--- a/packages/blade-svelte/src/components/BottomSheet/types.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/types.ts
@@ -16,12 +16,28 @@ export interface BottomSheetProps extends StyledPropsBlade {
   children: Snippet;
 
   /**
-   * SnapPoints in which the bottom sheet will rest on. Each value is a
-   * fraction of the viewport height; e.g. `0.5` means 50% of the screen.
+   * Multi-detent snap points. Each value is a fraction of the viewport height;
+   * e.g. `0.5` means 50% of the screen.
    *
-   * @default [0.35, 0.5, 0.85]
+   * When omitted the sheet enters **auto mode**: it opens at its natural content
+   * height (capped by `maxHeight`), resizes as content changes, and collapses
+   * entirely on dismiss. Drag-to-dismiss is available; drag-to-resize is not.
+   *
+   * @default undefined (auto mode)
    */
   snapPoints?: SnapPoints;
+
+  /**
+   * Maximum height the sheet may reach in auto mode, expressed as a fraction
+   * of the viewport (or portal container) height. Content taller than this cap
+   * scrolls inside the body instead of growing the sheet further.
+   *
+   * Has no effect when `snapPoints` is provided — in that case the upper snap
+   * point is the effective ceiling.
+   *
+   * @default 0.97
+   */
+  maxHeight?: number;
 
   /**
    * Called when the bottom sheet is closed via swipe down or backdrop tap.

--- a/packages/blade-svelte/src/utils/index.ts
+++ b/packages/blade-svelte/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './portal';
 export * from './useInteraction';
 export * from './resolveComponentStyleOverride';
 export * from './subscribeToViewportWidth';
+export * from './observeResize';

--- a/packages/blade-svelte/src/utils/observeResize.test.ts
+++ b/packages/blade-svelte/src/utils/observeResize.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { observeResize } from './observeResize';
+
+const OriginalResizeObserver = globalThis.ResizeObserver;
+
+afterEach(() => {
+  globalThis.ResizeObserver = OriginalResizeObserver;
+  vi.restoreAllMocks();
+});
+
+describe('observeResize', () => {
+  it('observes a single node and returns a cleanup that disconnects', () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    globalThis.ResizeObserver = (vi.fn(() => ({
+      observe,
+      disconnect,
+      unobserve: vi.fn(),
+    })) as unknown) as typeof ResizeObserver;
+
+    const node = document.createElement('div');
+    const callback = vi.fn();
+
+    const cleanup = observeResize(node, callback);
+
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(observe).toHaveBeenCalledWith(node);
+    expect(typeof cleanup).toBe('function');
+
+    cleanup?.();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('observes every node when given an array', () => {
+    const observe = vi.fn();
+    globalThis.ResizeObserver = (vi.fn(() => ({
+      observe,
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+    })) as unknown) as typeof ResizeObserver;
+
+    const nodeA = document.createElement('div');
+    const nodeB = document.createElement('div');
+
+    observeResize([nodeA, nodeB], vi.fn());
+
+    expect(observe).toHaveBeenCalledTimes(2);
+    expect(observe).toHaveBeenNthCalledWith(1, nodeA);
+    expect(observe).toHaveBeenNthCalledWith(2, nodeB);
+  });
+
+  it('degrades gracefully to undefined when ResizeObserver is unavailable', () => {
+    // @ts-expect-error deliberately removing the global for the unsupported path
+    delete globalThis.ResizeObserver;
+
+    const node = document.createElement('div');
+
+    expect(observeResize(node, vi.fn())).toBeUndefined();
+  });
+});

--- a/packages/blade-svelte/src/utils/observeResize.ts
+++ b/packages/blade-svelte/src/utils/observeResize.ts
@@ -1,0 +1,15 @@
+/**
+ * Wraps ResizeObserver with a guard so callers degrade gracefully instead of
+ * throwing in environments where ResizeObserver is unavailable (SSR, old
+ * WebViews). Returns a cleanup function, or undefined if unsupported.
+ */
+export function observeResize(
+  nodes: Element | Element[],
+  callback: ResizeObserverCallback,
+): (() => void) | undefined {
+  if (typeof ResizeObserver === 'undefined') return undefined;
+  const observer = new ResizeObserver(callback);
+  const targets = Array.isArray(nodes) ? nodes : [nodes];
+  targets.forEach((n) => observer.observe(n));
+  return () => observer.disconnect();
+}


### PR DESCRIPTION
## Summary
- Adds **auto mode** when `snapPoints` is omitted: BottomSheet opens at natural content height, capped by `maxHeight` (default `0.97` of viewport/portal container), and resizes as body content changes.
- Adds `maxHeight` prop for auto mode; existing multi-detent behaviour is unchanged when `snapPoints` is passed.
- Fixes dynamic content measurement via `ResizeObserver` in `BottomSheetBody` and explicit reflow re-clamping in the parent.
- Fixes portal-target sheets occasionally exceeding `maxHeight` by syncing container height before positioning.
- Adds **Content Height Adapts** Storybook story (checkout sidebar + main container with `portalTarget`).

## Test plan
- [ ] Open `Components/BottomSheet → Content Height Adapts` in blade-svelte Storybook
- [ ] Verify sheet opens at content height inside the main panel (not full window)
- [ ] Click **Add plan** / **Remove plan** — sheet grows/shrinks with content
- [ ] Add many plans — sheet stops at ~97% of main container; body scrolls beyond that
- [ ] Drag down — dismiss works; drag up — rubber-bands back (no resize detents)
- [ ] Open a story with explicit `snapPoints` (e.g. Snap Points) — multi-detent behaviour unchanged
- [ ] `yarn svelte-check` passes


Made with [Cursor](https://cursor.com)