### PR TITLE
fix(blade-svelte): keep formatted TextInput in sync with controlled value

### DIFF
--- a/.changeset/blade-svelte-textinput-formatted-controlled.md
+++ b/.changeset/blade-svelte-textinput-formatted-controlled.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': patch
+---
+
+fix(blade-svelte): keep formatted TextInput in sync with controlled value
+
+Controlled `format` mode on TextInput now reconciles the display against the parent `value` after every change, so consumer sanitisation (digit-only card fields) and programmatic prefill/reset actually show up on screen. The formatter no longer leaks a trailing delimiter when the value ends on a group boundary, and the caret stays after the typed character when a delimiter is inserted.

--- a/packages/blade-svelte/src/components/Input/TextInput/TextInput.stories.svelte
+++ b/packages/blade-svelte/src/components/Input/TextInput/TextInput.stories.svelte
@@ -66,6 +66,44 @@
   let controlledValue = $state('');
   let inputInstance: { focus: () => void; getInput: () => HTMLInputElement | null } | undefined =
     $state();
+
+  // State for the Formatted + Controlled bug-repro story.
+  let cardValue = $state('');
+  let cardLog = $state<string[]>([]);
+  const onlyDigits = (v: string): string => v.replace(/\D/g, '');
+  const cardPrefill = (raw: string): void => {
+    cardValue = raw;
+    cardLog = [`Prefilled → "${raw}"`, ...cardLog.slice(0, 4)];
+  };
+  const cardShorten = (): void => {
+    cardValue = cardValue.slice(0, 12);
+    cardLog = [`Shortened to 12 digits`, ...cardLog.slice(0, 4)];
+  };
+  const cardClear = (): void => {
+    cardValue = '';
+    cardLog = [`Cleared`, ...cardLog.slice(0, 4)];
+  };
+
+  // Controlled card form modeled on checkout's AddNewCard.svelte. Controlled
+  // (value + onChange, not defaultValue) is required because the parent must
+  // reset/prefill fields externally — NFC autofill writes number+expiry, and a
+  // DCC provider switch (GPay/Apple Pay) clears every field. Uncontrolled
+  // inputs would not reflect those external mutations.
+  let checkoutNumber = $state('');
+  let checkoutExpiry = $state('');
+  let checkoutCvv = $state('');
+  const digits = (v: string): string => v.replace(/\D/g, '');
+  // Simulates registerNfcScanner autofill: sets number + expiry programmatically.
+  const nfcAutofill = (): void => {
+    checkoutNumber = '4111111111111111';
+    checkoutExpiry = '1229';
+  };
+  // Simulates the international DCC provider switch: clears the whole form.
+  const dccSwitch = (): void => {
+    checkoutNumber = '';
+    checkoutExpiry = '';
+    checkoutCvv = '';
+  };
 </script>
 
 <!-- 1 -->
@@ -207,6 +245,76 @@
     name="fullName"
     onChange={(e) => (controlledValue = e.value ?? '')}
   />
+</Story>
+
+<!-- 11a: manual test for controlled-value sync in format mode -->
+<Story name="Text Input Formatted Controlled" asChild>
+  <div style="display: flex; flex-direction: column; gap: var(--spacing-5); max-width: 400px;">
+    <TextInput
+      label="Card Number"
+      format="#### #### #### #### ###"
+      value={cardValue}
+      onChange={({ rawValue }) => {
+        const clean = onlyDigits(rawValue ?? '');
+        cardValue = clean;
+        cardLog = [`onChange rawValue="${rawValue}" → stored="${clean}"`, ...cardLog.slice(0, 4)];
+      }}
+    />
+    <div style="display: flex; gap: var(--spacing-3); flex-wrap: wrap;">
+      <Button size="small" onClick={() => cardPrefill('4111111111111111')}>Prefill Visa (16d)</Button>
+      <Button size="small" onClick={() => cardPrefill('378282246310005')}>Prefill Amex (15d)</Button>
+      <Button size="small" onClick={cardShorten}>Shorten (IIN sim)</Button>
+      <Button size="small" onClick={cardClear}>Clear</Button>
+    </div>
+    <div style="font-family: monospace; font-size: 12px;">
+      <div>stored: "{cardValue}"</div>
+      {#each cardLog as entry}
+        <div style="color: #888;">{entry}</div>
+      {/each}
+    </div>
+    <div style="font-size: 12px; color: #888;">
+      Type letters mixed with digits (e.g. 4111abcd2222) — letters must vanish from the field.
+    </div>
+  </div>
+</Story>
+
+<!-- 11b: controlled card form modeled on checkout AddNewCard.svelte -->
+<Story name="Text Input Checkout Card (Controlled)" asChild>
+  <div style="display: flex; flex-direction: column; gap: var(--spacing-5); max-width: 400px;">
+    <TextInput
+      label="Card Number"
+      placeholder="Enter card number"
+      type="telephone"
+      format="#### #### #### #### ###"
+      value={checkoutNumber}
+      onChange={({ rawValue }) => (checkoutNumber = digits(rawValue ?? ''))}
+    />
+    <div style="display: flex; gap: var(--spacing-4);">
+      <TextInput
+        label="Expiry"
+        placeholder="MM/YY"
+        type="telephone"
+        format="##/##"
+        value={checkoutExpiry}
+        onChange={({ rawValue }) => (checkoutExpiry = digits(rawValue ?? ''))}
+      />
+      <TextInput
+        label="CVV"
+        placeholder="CVV"
+        type="telephone"
+        maxCharacters={3}
+        value={checkoutCvv}
+        onChange={({ value }) => (checkoutCvv = digits(value ?? ''))}
+      />
+    </div>
+    <div style="display: flex; gap: var(--spacing-3); flex-wrap: wrap;">
+      <Button size="small" onClick={nfcAutofill}>NFC Autofill</Button>
+      <Button size="small" variant="secondary" onClick={dccSwitch}>Switch to GPay (DCC)</Button>
+    </div>
+    <div style="font-family: monospace; font-size: 12px; color: #888;">
+      number: "{checkoutNumber}" · expiry: "{checkoutExpiry}" · cvv: "{checkoutCvv}"
+    </div>
+  </div>
 </Story>
 
 <!-- 12 -->

--- a/packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte
+++ b/packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte
@@ -74,13 +74,34 @@
     untrack(() => (formatter ? formatter.formatValue(value ?? defaultValue ?? '') : '')),
   );
 
-  // Re-format the current raw value whenever the pattern changes at runtime.
+  // In controlled `format` mode the parent's `value` is the source of truth, so
+  // reconcile the display against it after EVERY change — not just when the
+  // `value` reference changes. Tracking `formattedValue` (the optimistic value
+  // `handleChange` writes) is what makes consumer sanitisation stick: when the
+  // parent strips a just-typed character (e.g. a letter in a digit-only card
+  // field), the sanitised value is byte-identical to the previous one, so a
+  // `value`-only effect never re-runs and the rejected character lingers on
+  // screen. Re-deriving here snaps the field back to exactly what the consumer
+  // stored (letter stripping, IIN truncation, programmatic prefill/reset).
   $effect(() => {
     const currentFormatter = formatter;
+    const userValue = value;
+    const currentDisplay = formattedValue;
     untrack(() => {
-      if (currentFormatter) {
-        const raw = stripPatternCharacters(formattedValue);
-        formattedValue = currentFormatter.formatValue(raw);
+      if (!currentFormatter) return;
+      // Uncontrolled (`value` never supplied): keep the optimistic display so
+      // typing works without a parent feeding the value back.
+      if (userValue === undefined) return;
+
+      // Controlled: empty string resets to the formatted shell; otherwise
+      // reformat from the raw characters the consumer stored.
+      const expected =
+        userValue === ''
+          ? currentFormatter.formatValue('')
+          : currentFormatter.formatValue(stripPatternCharacters(userValue));
+
+      if (expected !== currentDisplay) {
+        formattedValue = expected;
       }
     });
   });

--- a/packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte
+++ b/packages/blade-svelte/src/components/Input/TextInput/TextInput.svelte
@@ -89,9 +89,20 @@
     const currentDisplay = formattedValue;
     untrack(() => {
       if (!currentFormatter) return;
-      // Uncontrolled (`value` never supplied): keep the optimistic display so
-      // typing works without a parent feeding the value back.
-      if (userValue === undefined) return;
+      // Uncontrolled (`value` never supplied): the display is the source of
+      // truth, so we keep the optimistic value typed by the user. But the
+      // pattern can still change at runtime (e.g. card-network detection
+      // swapping the grouping mask), so re-format the current raw chars against
+      // the new pattern. The guard keeps this idempotent per keystroke, so the
+      // caret is only touched when the pattern actually changed.
+      if (userValue === undefined) {
+        const raw = stripPatternCharacters(currentDisplay);
+        const expected = currentFormatter.formatValue(raw);
+        if (expected !== currentDisplay) {
+          formattedValue = expected;
+        }
+        return;
+      }
 
       // Controlled: empty string resets to the formatted shell; otherwise
       // reformat from the raw characters the consumer stored.

--- a/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInput.test.ts
+++ b/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInput.test.ts
@@ -101,7 +101,7 @@ describe('<TextInput /> isReadOnly & spellCheck', () => {
       const user = userEvent.setup();
       render(TextInputFormattedControlled);
 
-      const input = screen.getByLabelText('Card') as HTMLInputElement;
+      const input = screen.getByLabelText('Card');
 
       await user.type(input, '1234');
       await tick();
@@ -159,7 +159,7 @@ describe('<TextInput /> isReadOnly & spellCheck', () => {
     const user = userEvent.setup();
     render(TextInputFormattedControlled);
 
-    const inputEl = screen.getByLabelText('Card') as HTMLInputElement;
+    const inputEl = screen.getByLabelText('Card');
 
     await user.type(inputEl, '4111a2222');
     await tick();
@@ -177,7 +177,7 @@ describe('<TextInput /> isReadOnly & spellCheck', () => {
     const user = userEvent.setup();
     render(TextInputFormattedControlled);
 
-    const inputEl = screen.getByLabelText('Card') as HTMLInputElement;
+    const inputEl = screen.getByLabelText('Card');
 
     await user.type(inputEl, '12345');
     await tick();

--- a/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInput.test.ts
+++ b/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInput.test.ts
@@ -146,6 +146,62 @@ describe('<TextInput /> isReadOnly & spellCheck', () => {
     });
   });
 
+  describe('formatted + uncontrolled value', () => {
+    it('formats the value into groups as the user types', async () => {
+      const user = userEvent.setup();
+      render(TextInput, {
+        props: { label: 'Card', format: '#### #### #### ####' },
+      });
+
+      const input = screen.getByLabelText('Card');
+      await user.type(input, '4111222');
+      await tick();
+
+      expect(input).toHaveValue('4111 222');
+    });
+
+    it('does not show a trailing delimiter when the value fills all groups exactly', async () => {
+      const user = userEvent.setup();
+      render(TextInput, {
+        props: { label: 'Card', format: '#### #### #### ####' },
+      });
+
+      const input = screen.getByLabelText('Card');
+      await user.type(input, '4111111111111111');
+      await tick();
+
+      expect(input).toHaveValue('4111 1111 1111 1111');
+    });
+
+    it('does not show a trailing delimiter when value ends on a group boundary with extra slots remaining', async () => {
+      const user = userEvent.setup();
+      render(TextInput, {
+        props: { label: 'Card', format: '#### #### #### #### ###' },
+      });
+
+      const input = screen.getByLabelText('Card');
+      await user.type(input, '4111111111111111');
+      await tick();
+
+      expect(input).toHaveValue('4111 1111 1111 1111');
+    });
+
+    it('keeps the caret after the typed char when formatting inserts a delimiter at a group boundary', async () => {
+      const user = userEvent.setup();
+      render(TextInput, {
+        props: { label: 'Card', format: '#### #### #### ####' },
+      });
+
+      const inputEl = screen.getByLabelText('Card');
+      await user.type(inputEl, '12345');
+      await tick();
+      await Promise.resolve();
+
+      expect(inputEl.value).toBe('1234 5');
+      expect(inputEl.selectionStart).toBe(inputEl.value.length);
+    });
+  });
+
   it('inputEl.value matches the state stored by onChange after typing a letter', async () => {
     // Reproduction recipe from the bug report:
     //   1. Render TextInput with `format` and `value` bound to $state.

--- a/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInput.test.ts
+++ b/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInput.test.ts
@@ -4,6 +4,8 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import TextInput from '../TextInput.svelte';
 import TextInputControlled from './TextInputControlled.svelte';
+import TextInputFormattedControlled from './TextInputFormattedControlled.svelte';
+import { format } from '../useFormattedInput';
 
 async function findInput(): Promise<HTMLElement> {
   return screen.findByRole('textbox');
@@ -75,5 +77,131 @@ describe('<TextInput /> isReadOnly & spellCheck', () => {
     // A `value` supplied *after* mount is still respected: the input switches
     // to controlled and renders the value instead of staying uncontrolled.
     expect(input).toHaveValue('1234');
+  });
+
+  describe('formatted + controlled value stays in sync', () => {
+    it('reflects consumer sanitisation (letters stripped) on screen', async () => {
+      const user = userEvent.setup();
+      render(TextInputFormattedControlled);
+
+      const input = screen.getByLabelText('Card');
+      // Parent strips non-digits in onChange and feeds the cleaned value back.
+      await user.type(input, '4111abcd2222');
+      await tick();
+
+      // Screen must match the sanitised store value, not the typed letters.
+      // No trailing delimiter: value ends exactly on a group boundary.
+      expect(input).toHaveValue('4111 2222');
+    });
+
+    it('rejects letters immediately even when the sanitised value is unchanged', async () => {
+      // Letters typed after a digit boundary sanitise to the SAME stored value
+      // (digits only), so the `value` prop reference never changes. The display
+      // must still snap back to digits instead of leaking "1234 abc".
+      const user = userEvent.setup();
+      render(TextInputFormattedControlled);
+
+      const input = screen.getByLabelText('Card') as HTMLInputElement;
+
+      await user.type(input, '1234');
+      await tick();
+      expect(input).toHaveValue('1234');
+
+      // Type letters only — no digit changes the sanitised store value.
+      await user.type(input, 'abc');
+      await tick();
+      await Promise.resolve();
+      expect(input).toHaveValue('1234');
+
+      // A following digit continues formatting cleanly.
+      await user.type(input, '1');
+      await tick();
+      await Promise.resolve();
+      expect(input).toHaveValue('1234 1');
+    });
+
+    it('reflects programmatic prefill after mount', async () => {
+      const user = userEvent.setup();
+      render(TextInputFormattedControlled);
+
+      await user.click(screen.getByText('prefill'));
+      await tick();
+
+      const input = screen.getByLabelText('Card');
+      expect(input).toHaveValue('3782 8224 6310 005');
+    });
+
+    it('clears the field on programmatic reset', async () => {
+      const user = userEvent.setup();
+      render(TextInputFormattedControlled);
+
+      const input = screen.getByLabelText('Card');
+      await user.type(input, '4111');
+      await tick();
+      expect(input).toHaveValue('4111');
+
+      await user.click(screen.getByText('reset'));
+      await tick();
+      expect(input).toHaveValue('');
+    });
+  });
+
+  it('inputEl.value matches the state stored by onChange after typing a letter', async () => {
+    // Reproduction recipe from the bug report:
+    //   1. Render TextInput with `format` and `value` bound to $state.
+    //   2. In onChange, write a sanitised (digits-only) version back to state.
+    //   3. Type a letter mixed with digits.
+    //   4. Assert inputEl.value === what onChange stored — the two must agree.
+    //
+    // Uses TextInputFormattedControlled which owns the $state so the `value`
+    // prop actually updates on each onChange call (plain JS var doesn't trigger
+    // re-renders).
+    const user = userEvent.setup();
+    render(TextInputFormattedControlled);
+
+    const inputEl = screen.getByLabelText('Card') as HTMLInputElement;
+
+    await user.type(inputEl, '4111a2222');
+    await tick();
+
+    // DOM and state must agree — before the fix, DOM kept letters while state had digits.
+    expect(inputEl.value).not.toContain('a');
+    // Digits only: "41112222" formatted → "4111 2222" (no trailing delimiter).
+    expect(inputEl.value).toBe('4111 2222');
+  });
+
+  it('keeps the caret after the typed char when formatting inserts a delimiter at a group boundary', async () => {
+    // Regression: typing the 5th digit turns "1234" into "1234 5". The inserted
+    // space shifted the typed char forward, but the caret used the pre-format
+    // selectionStart (5) and landed *before* the "5" instead of after it.
+    const user = userEvent.setup();
+    render(TextInputFormattedControlled);
+
+    const inputEl = screen.getByLabelText('Card') as HTMLInputElement;
+
+    await user.type(inputEl, '12345');
+    await tick();
+    await Promise.resolve(); // flush the microtask that applies the caret
+
+    expect(inputEl.value).toBe('1234 5');
+    // Caret must sit at the end (after "5"), i.e. index 6 — not 5.
+    expect(inputEl.selectionStart).toBe(inputEl.value.length);
+  });
+});
+
+describe('format() — no trailing delimiter on group boundary', () => {
+  const cardMask = '#### #### #### #### ###'; // 19-slot, e.g. Maestro/UnionPay
+
+  it('does not append a trailing delimiter when value ends on a group boundary', () => {
+    // 16 digits fill 4 groups exactly; the 5th group's slots stay empty.
+    expect(format('6759640123456785', cardMask)).toBe('6759 6401 2345 6785');
+  });
+
+  it('keeps formatting once the next group is partially filled', () => {
+    expect(format('67596401234567851', cardMask)).toBe('6759 6401 2345 6785 1');
+  });
+
+  it('still fills exact-length masks with no trailing delimiter', () => {
+    expect(format('4111111111111111', '#### #### #### ####')).toBe('4111 1111 1111 1111');
   });
 });

--- a/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInputFormattedControlled.svelte
+++ b/packages/blade-svelte/src/components/Input/TextInput/__tests__/TextInputFormattedControlled.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import TextInput from '../TextInput.svelte';
+
+  // Reproduces a controlled card-number parent that sanitises input in its
+  // change handler (strips non-digits) and feeds the cleaned value back via
+  // `value`. Before the fix, `format` mode ignored `value` after mount, so the
+  // stripped letters stayed on screen even though the store held digits only.
+  const onlyDigits = (v: string): string => v.replace(/\D/g, '');
+
+  let value: string | undefined = $state(undefined);
+</script>
+
+<button type="button" onclick={() => (value = '378282246310005')}>prefill</button>
+<button type="button" onclick={() => (value = '')}>reset</button>
+
+<TextInput
+  label="Card"
+  accessibilityLabel="Card"
+  format="#### #### #### ####"
+  {value}
+  onChange={({ rawValue }) => {
+    value = onlyDigits(rawValue ?? '');
+  }}
+/>

--- a/packages/blade-svelte/src/components/Input/TextInput/useFormattedInput.ts
+++ b/packages/blade-svelte/src/components/Input/TextInput/useFormattedInput.ts
@@ -19,6 +19,10 @@ export const format = (value: string, pattern: string): string => {
         break;
       }
     } else {
+      // Stop before appending a delimiter when the value ended exactly on a
+      // group boundary; otherwise a trailing delimiter leaks into the value
+      // (e.g. 16 digits into "#### #### #### #### ###" → "6785 ").
+      if (valueIndex >= value.length) break;
       result += patternChar;
     }
   }
@@ -117,29 +121,26 @@ export const createFormattedInput = ({
     info.endOfSection = false;
 
     if (!didDelete) {
-      const nextChar = formattedValue[cursorPosition];
-      const nextIsDelimiter = nextChar ? !isUserCharacter(nextChar) : false;
+      // Place the caret after the same number of user characters that preceded
+      // it in the freshly typed value. `selectionStart` counts positions in the
+      // pre-format string, so it ignores delimiters the formatter inserts before
+      // the caret at a group boundary (e.g. "1234" + "5" → "1234 5": the space
+      // pushes "5" to index 5, so a raw caret of 5 would sit *before* it). Anchor
+      // on user characters instead so the caret stays glued to the typed char.
+      const userCharsBeforeCursor = stripPatternCharacters(
+        newInputValue.substring(0, cursorPosition),
+      ).length;
 
-      const remainingText = formattedValue.substring(cursorPosition);
-      const nextUserCharIndex = remainingText.search(/[\dA-z]/);
-      const hasMoreUserChars = nextUserCharIndex !== -1;
-
-      info.endOfSection = nextIsDelimiter && !hasMoreUserChars;
-
-      if (nextIsDelimiter && hasMoreUserChars) {
-        const prevChar = formattedValue[cursorPosition - 1] ?? '';
-        const prevIsDelimiter = !isUserCharacter(prevChar);
-
-        if (prevIsDelimiter) {
-          info.cursorPosition = cursorPosition + nextUserCharIndex + 1;
-        } else {
-          const delimiterExistedBefore =
-            currentValue[cursorPosition] === formattedValue[cursorPosition];
-          if (delimiterExistedBefore) {
-            info.cursorPosition = cursorPosition + 1;
-          }
+      let seenUserChars = 0;
+      let nextCursor = formattedValue.length;
+      for (let i = 0; i < formattedValue.length; i++) {
+        if (seenUserChars === userCharsBeforeCursor) {
+          nextCursor = i;
+          break;
         }
+        if (isUserCharacter(formattedValue[i])) seenUserChars++;
       }
+      info.cursorPosition = nextCursor;
     }
 
     onChange?.({ name, value: formattedValue, rawValue });


### PR DESCRIPTION
## Summary
- Controlled `format` mode on Svelte `TextInput` now reconciles the display against the parent `value` after every change, so consumer sanitisation (digit-only card fields) and programmatic prefill/reset actually show up on screen.
- Formatter no longer leaks a trailing delimiter when the value ends on a group boundary, and the caret stays after the typed character when a delimiter is inserted.
- Adds unit tests plus Storybook stories that reproduce the checkout-style controlled card form (NFC autofill / DCC clear).

## Test plan
- [ ] Type letters mixed with digits in a formatted + controlled card field — letters vanish from the input, stored value stays digits-only
- [ ] Type letters after a digit-group boundary (e.g. `1234` then `abc`) — display stays `1234`, no leaked letters
- [ ] Programmatic prefill and clear (Visa/Amex buttons, reset) update the visible field
- [ ] Type the 5th digit of a card number — caret lands after the digit, not before the inserted space
- [ ] 16-digit value against `#### #### #### #### ###` has no trailing space
- [ ] Storybook: `Text Input Formatted Controlled` and `Text Input Checkout Card (Controlled)` (NFC Autofill / Switch to GPay)


Made with [Cursor](https://cursor.com)