### PR TITLE
fix(blade): keep formatted TextInput in sync with controlled value

### DIFF
--- a/.changeset/textinput-formatted-controlled-fix.md
+++ b/.changeset/textinput-formatted-controlled-fix.md
@@ -1,0 +1,5 @@
+---
+'@razorpay/blade': patch
+---
+
+fix(TextInput): keep formatted TextInput in sync with controlled value — remove trailing delimiter on group boundary and anchor caret on user-character count

--- a/packages/blade/src/components/Input/TextInput/TextInputFormat.stories.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInputFormat.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react-vite';
 import React from 'react';
 import { TextInput as TextInputComponent } from './TextInput';
 import { Box } from '~components/Box';
+import { Button } from '~components/Button';
 import { Text } from '~components/Typography';
 import {
   detectPaymentCardBrand,
@@ -99,6 +100,87 @@ export const CardNumberFormat: StoryFn<typeof TextInputComponent> = () => {
   );
 };
 CardNumberFormat.storyName = 'Format Controlled';
+
+/**
+ * Controlled card form modeled on checkout's AddNewCard.svelte. Controlled
+ * (value + onChange, not defaultValue) is required because the parent must
+ * reset/prefill fields externally — NFC autofill writes number + expiry, and an
+ * international DCC provider switch (GPay/Apple Pay) clears every field.
+ * Uncontrolled inputs would not reflect those external mutations.
+ */
+export const CheckoutCardControlled: StoryFn<typeof TextInputComponent> = () => {
+  const [cardNumber, setCardNumber] = React.useState('');
+  const [expiry, setExpiry] = React.useState('');
+  const [cvv, setCvv] = React.useState('');
+  const [cardBrand, setCardBrand] = React.useState<PaymentCardBrand>('unknown');
+
+  const digits = (v: string): string => v.replace(/\D/g, '');
+
+  // Simulates registerNfcScanner autofill: sets number + expiry programmatically.
+  const nfcAutofill = (): void => {
+    setCardNumber('4111111111111111');
+    setExpiry('1229');
+    setCardBrand(detectPaymentCardBrand('4111111111111111'));
+  };
+
+  // Simulates the international DCC provider switch: clears the whole form.
+  const dccSwitch = (): void => {
+    setCardNumber('');
+    setExpiry('');
+    setCvv('');
+    setCardBrand('unknown');
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.4" maxWidth="400px">
+      <TextInputComponent
+        label="Card Number"
+        placeholder="Enter card number"
+        type="number"
+        value={cardNumber}
+        format={getPaymentCardNumberFormat(cardBrand)}
+        trailing={getPaymentCardBrandIcon(cardBrand)}
+        onChange={({ rawValue }) => {
+          const raw = digits(rawValue ?? '');
+          setCardNumber(raw);
+          setCardBrand(detectPaymentCardBrand(raw));
+        }}
+      />
+      <Box display="flex" gap="spacing.4">
+        <TextInputComponent
+          label="Expiry"
+          placeholder="MM/YY"
+          type="number"
+          format="##/##"
+          value={expiry}
+          onChange={({ rawValue }) => setExpiry(digits(rawValue ?? ''))}
+        />
+        <TextInputComponent
+          label="CVV"
+          placeholder="CVV"
+          type="number"
+          maxCharacters={3}
+          value={cvv}
+          onChange={({ value }) => setCvv(digits(value ?? ''))}
+        />
+      </Box>
+      <Box display="flex" gap="spacing.3" flexWrap="wrap">
+        <Button size="small" onClick={nfcAutofill}>
+          NFC Autofill
+        </Button>
+        <Button size="small" variant="secondary" onClick={dccSwitch}>
+          Switch to GPay (DCC)
+        </Button>
+      </Box>
+      <Box backgroundColor="surface.background.gray.moderate" padding="spacing.4" borderRadius="medium">
+        <Text>
+          number: "{cardNumber}" · expiry: "{expiry}" · cvv: "{cvv}"
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+CheckoutCardControlled.storyName = 'Checkout Card (Controlled)';
 
 export const DateFormat: StoryFn<typeof TextInputComponent> = () => {
   const [date, setDate] = React.useState('');

--- a/packages/blade/src/components/Input/TextInput/TextInputFormat.stories.tsx
+++ b/packages/blade/src/components/Input/TextInput/TextInputFormat.stories.tsx
@@ -172,7 +172,11 @@ export const CheckoutCardControlled: StoryFn<typeof TextInputComponent> = () => 
           Switch to GPay (DCC)
         </Button>
       </Box>
-      <Box backgroundColor="surface.background.gray.moderate" padding="spacing.4" borderRadius="medium">
+      <Box
+        backgroundColor="surface.background.gray.moderate"
+        padding="spacing.4"
+        borderRadius="medium"
+      >
         <Text>
           number: "{cardNumber}" · expiry: "{expiry}" · cvv: "{cvv}"
         </Text>

--- a/packages/blade/src/components/Input/TextInput/__tests__/TextInput.web.test.tsx
+++ b/packages/blade/src/components/Input/TextInput/__tests__/TextInput.web.test.tsx
@@ -599,3 +599,87 @@ describe('<TextInput />', () => {
     expect(getByLabelText('Enter name')).toHaveAttribute('data-analytics-name', 'Enter name');
   });
 });
+
+// ─── Formatted TextInput — controlled value sync ───────────────────────────────
+// Reproduces the checkout AddNewCard scenario: parent strips non-digits in
+// onChange and feeds the cleaned value back via `value`.
+const ControlledCardInput = (): ReactElement => {
+  const onlyDigits = (v: string): string => v.replace(/\D/g, '');
+  const [value, setValue] = useState<string>('');
+  return (
+    <>
+      <Button onClick={() => setValue('378282246310005')}>prefill</Button>
+      <Button onClick={() => setValue('')}>reset</Button>
+      <TextInput
+        label="Card"
+        format="#### #### #### ####"
+        value={value}
+        onChange={({ rawValue }) => setValue(onlyDigits(rawValue ?? ''))}
+      />
+    </>
+  );
+};
+
+describe('<TextInput /> formatted + controlled value', () => {
+  it('reflects consumer sanitisation (letters stripped) on screen', async () => {
+    const { getByLabelText } = renderWithTheme(<ControlledCardInput />);
+    const input = getByLabelText('Card');
+    await userEvent.type(input, '4111abcd2222');
+    // Letters must be stripped; digits formatted, no trailing delimiter.
+    expect(input).toHaveValue('4111 2222');
+  });
+
+  it('rejects letters even when the sanitised value is unchanged', async () => {
+    // Typing letters after "1234" leaves the same stored value, so the `value`
+    // prop reference is identical. The display must still snap back to digits.
+    const { getByLabelText } = renderWithTheme(<ControlledCardInput />);
+    const input = getByLabelText('Card') as HTMLInputElement;
+
+    await userEvent.type(input, '1234');
+    expect(input).toHaveValue('1234');
+
+    await userEvent.type(input, 'abc');
+    expect(input).toHaveValue('1234');
+
+    await userEvent.type(input, '1');
+    expect(input).toHaveValue('1234 1');
+  });
+
+  it('reflects programmatic prefill after mount', async () => {
+    const { getByLabelText, getByRole } = renderWithTheme(<ControlledCardInput />);
+    await userEvent.click(getByRole('button', { name: 'prefill' }));
+    expect(getByLabelText('Card')).toHaveValue('3782 8224 6310 005');
+  });
+
+  it('clears the field on programmatic reset', async () => {
+    const { getByLabelText, getByRole } = renderWithTheme(<ControlledCardInput />);
+    const input = getByLabelText('Card');
+    await userEvent.type(input, '4111');
+    expect(input).toHaveValue('4111');
+    await userEvent.click(getByRole('button', { name: 'reset' }));
+    expect(input).toHaveValue('');
+  });
+
+  it('does not leak a trailing delimiter when value ends on a group boundary', async () => {
+    const { getByLabelText } = renderWithTheme(<ControlledCardInput />);
+    const input = getByLabelText('Card');
+    // 16 digits fills all four groups of "#### #### #### ####" exactly.
+    await userEvent.type(input, '4111111111111111');
+    expect(input).toHaveValue('4111 1111 1111 1111');
+    // No trailing space after the 16th digit.
+    expect((input as HTMLInputElement).value.endsWith(' ')).toBe(false);
+  });
+
+  it('places caret after typed digit when formatter inserts a delimiter at a group boundary', async () => {
+    // Typing the 5th digit turns "1234" into "1234 5". The inserted space
+    // shifts the digit right; caret must land after "5" (index 6), not before it (5).
+    const { getByLabelText } = renderWithTheme(<ControlledCardInput />);
+    const input = getByLabelText('Card') as HTMLInputElement;
+
+    await userEvent.type(input, '12345');
+    await waitFor(() => {
+      expect(input.value).toBe('1234 5');
+      expect(input.selectionStart).toBe(6); // after "5"
+    });
+  });
+});

--- a/packages/blade/src/components/Input/TextInput/__tests__/TextInput.web.test.tsx
+++ b/packages/blade/src/components/Input/TextInput/__tests__/TextInput.web.test.tsx
@@ -683,3 +683,63 @@ describe('<TextInput /> formatted + controlled value', () => {
     });
   });
 });
+
+// ─── Formatted TextInput — bracket delimiter handling ─────────────────────────
+// When the format pattern contains structural bracket pairs like "(###) ###-####",
+// the closing bracket must always be emitted even when the value ends exactly
+// on a group boundary inside the brackets.  Non-bracket delimiters (spaces,
+// dashes, slashes) should still be suppressed to avoid trailing junk.
+const BracketFormatInput = ({
+  pattern,
+  value,
+}: {
+  pattern: string;
+  value: string;
+}): ReactElement => {
+  const onlyDigits = (v: string): string => v.replace(/\D/g, '');
+  const [internalValue, setInternalValue] = useState<string>(value);
+  return (
+    <TextInput
+      label="Phone"
+      format={pattern}
+      value={internalValue}
+      onChange={({ rawValue }) => setInternalValue(onlyDigits(rawValue ?? ''))}
+    />
+  );
+};
+
+describe('<TextInput /> formatted — bracket delimiters', () => {
+  it('preserves closing bracket when value fills the bracketed group exactly', () => {
+    const { getByLabelText } = renderWithTheme(
+      <BracketFormatInput pattern="(###) ###-####" value="123" />,
+    );
+    // "(123)" not "(123" — the ")" must survive even though value is exhausted.
+    expect(getByLabelText('Phone')).toHaveValue('(123)');
+  });
+
+  it('does not emit trailing non-bracket delimiters after the closing bracket', () => {
+    const { getByLabelText } = renderWithTheme(
+      <BracketFormatInput pattern="(###) ###-####" value="123" />,
+    );
+    const input = getByLabelText('Phone') as HTMLInputElement;
+    // No trailing space or dash after "(123)".
+    expect(input.value).toBe('(123)');
+  });
+
+  it('preserves closing bracket for (####)-####-#### custom pattern', () => {
+    const { getByLabelText } = renderWithTheme(
+      <BracketFormatInput pattern="(####)-####-####" value="1234" />,
+    );
+    // "(1234)" not "(1234" — the ")" must survive.
+    expect(getByLabelText('Phone')).toHaveValue('(1234)');
+  });
+
+  it('still strips trailing space for non-bracket patterns (card number)', () => {
+    const { getByLabelText } = renderWithTheme(
+      <BracketFormatInput pattern="#### #### #### ####" value="4111111111111111" />,
+    );
+    const input = getByLabelText('Phone') as HTMLInputElement;
+    expect(input.value).toBe('4111 1111 1111 1111');
+    expect(input.value.endsWith(' ')).toBe(false);
+  });
+});

--- a/packages/blade/src/components/Input/TextInput/useFormattedInput.ts
+++ b/packages/blade/src/components/Input/TextInput/useFormattedInput.ts
@@ -84,28 +84,30 @@ export const useFormattedInput = ({
 
   const maxLength = useMemo(() => pattern?.length, [pattern]);
 
-  // Reset internal state when parent clears value (form resets, external state changes)
-  // Preserves format delimiters for visual guidance. Example: "(###)" → "(   )" when cleared
+  // In controlled mode the parent's `value` is the source of truth, so reconcile
+  // the display against it after EVERY change — not just when `value` changes.
+  // Depending on `internalValue` is what makes consumer sanitisation stick: when
+  // the parent strips a just-typed character (e.g. a letter in a digit-only card
+  // field), the sanitised value is byte-identical to the previous one, so a
+  // `value`-only effect never re-runs and the rejected character lingers on
+  // screen. Re-deriving here snaps the field back to exactly what the consumer
+  // stored (letter stripping, IIN truncation, programmatic prefill/reset —
+  // including DatePicker writing the value from the calendar).
   useEffect(() => {
-    if ((userValue === '' || userValue === undefined) && defaultValue === '') {
-      const emptyFormatted = format('', pattern ?? '');
-      setInternalValue(emptyFormatted);
-    }
-    // DATEPICKER FIX: Sync internal state when external value changes
-    // This addresses the issue where DatePicker programmatically updates the value prop
-    // (e.g., when user selects date from calendar), but the formatted input's internal
-    // state doesn't update, causing the input to not reflect the new value.
-    // Without this, only user typing and empty resets were handled.
-    if (userValue !== undefined && userValue !== '' && pattern) {
-      const rawValue = stripPatternCharacters(userValue);
-      const newFormatted = format(rawValue, pattern);
+    if (!pattern) return;
+    // Uncontrolled (`value` never supplied): keep the optimistic display so
+    // typing works without a parent feeding the value back.
+    if (userValue === undefined) return;
 
-      // Only update if the formatted value actually changed to avoid unnecessary re-renders
-      if (newFormatted !== internalValue) {
-        setInternalValue(newFormatted);
-      }
+    // Controlled: empty string resets to the formatted shell; otherwise reformat
+    // from the raw characters the consumer stored.
+    const expected =
+      userValue === '' ? format('', pattern) : format(stripPatternCharacters(userValue), pattern);
+
+    if (expected !== internalValue) {
+      setInternalValue(expected);
     }
-  }, [userValue, pattern]);
+  }, [userValue, pattern, internalValue]);
 
   // Apply calculated cursor position after value updates
   useEffect(() => {

--- a/packages/blade/src/components/Input/TextInput/useFormattedInput.ts
+++ b/packages/blade/src/components/Input/TextInput/useFormattedInput.ts
@@ -10,6 +10,7 @@ const format = (value: string, pattern: string): string => {
 
   let result = '';
   let valueIndex = 0;
+  const openBrackets: string[] = [];
 
   for (let i = 0; i < pattern.length; i++) {
     const patternChar = pattern[i]; // "#" or "/"
@@ -22,10 +23,25 @@ const format = (value: string, pattern: string): string => {
         break; // No more input chars, stop
       }
     } else {
+      // Track opening brackets so their matching closings are always emitted.
+      if ('([{'.includes(patternChar)) openBrackets.push(patternChar);
+
       // Stop before appending a delimiter when the value ended exactly on a
       // group boundary; otherwise a trailing delimiter leaks into the output
       // (e.g. 16 digits into "#### #### #### #### ###" → "6785 ").
-      if (valueIndex >= value.length) break;
+      // Closing brackets that match an already-emitted opening bracket are
+      // always emitted so structural delimiters like "(###)" stay intact
+      // (e.g. format('123', '(###) ###-####') → "(123)" not "(123").
+      if (valueIndex >= value.length) {
+        if (')]}'.includes(patternChar) && openBrackets.length > 0) {
+          openBrackets.pop();
+          result += patternChar;
+          continue;
+        }
+        break;
+      }
+
+      if (')]}'.includes(patternChar) && openBrackets.length > 0) openBrackets.pop();
       result += patternChar; // add "/" delimiter
     }
   }

--- a/packages/blade/src/components/Input/TextInput/useFormattedInput.ts
+++ b/packages/blade/src/components/Input/TextInput/useFormattedInput.ts
@@ -22,6 +22,10 @@ const format = (value: string, pattern: string): string => {
         break; // No more input chars, stop
       }
     } else {
+      // Stop before appending a delimiter when the value ended exactly on a
+      // group boundary; otherwise a trailing delimiter leaks into the output
+      // (e.g. 16 digits into "#### #### #### #### ###" → "6785 ").
+      if (valueIndex >= value.length) break;
       result += patternChar; // add "/" delimiter
     }
   }
@@ -156,35 +160,27 @@ export const useFormattedInput = ({
       const formattedValue = format(rawValue, pattern); // format("134", "##/##") → "13/4"
       infoRef.current.endOfSection = false;
 
-      // Handle cursor positioning when typing (not deleting)
+      // Handle cursor positioning when typing (not deleting).
+      // Anchor on user characters rather than raw position: selectionStart counts
+      // positions in the pre-format string, so it ignores delimiters the formatter
+      // inserts before the caret at a group boundary (e.g. "1234" + "5" → "1234 5":
+      // the space pushes "5" to index 5, so a raw caret of 5 would sit *before* it).
       if (!didDelete) {
-        // User types "2" in "1|" → becomes "12|/" → should jump to "12/|"
-        const nextChar = formattedValue[cursorPosition]; // "12/"[2] → "/" (delimiter)
-        const nextIsDelimiter = nextChar ? !isUserCharacter(nextChar) : false; // "/" → true
+        const userCharsBeforeCursor = stripPatternCharacters(
+          newInputValue.substring(0, cursorPosition),
+        ).length;
 
-        const remainingText = formattedValue.substring(cursorPosition); // "12/".substring(2) → "/"
-        const nextUserCharIndex = remainingText.search(/[\dA-z]/); // "/".search() → -1 (no user chars)
-        const hasMoreUserChars = nextUserCharIndex !== -1; // -1 !== -1 → false
-
-        infoRef.current.endOfSection = nextIsDelimiter && !hasMoreUserChars; // true && false → false
-
-        // Move cursor past auto-inserted delimiters for smooth typing
-        if (nextIsDelimiter && hasMoreUserChars) {
-          const prevChar = formattedValue[cursorPosition - 1] ?? '';
-          const prevIsDelimiter = !isUserCharacter(prevChar);
-
-          if (prevIsDelimiter) {
-            infoRef.current.cursorPosition = cursorPosition + nextUserCharIndex + 1;
-          } else {
-            // If we're at a delimiter after typing (not deleting), and there are more chars,
-            // we probably need to move past it unless it's a brand new delimiter
-            const delimiterExistedBefore =
-              currentValue[cursorPosition] === formattedValue[cursorPosition];
-            if (delimiterExistedBefore) {
-              infoRef.current.cursorPosition = cursorPosition + 1;
-            }
+        let seenUserChars = 0;
+        let nextCursor = formattedValue.length;
+        for (let i = 0; i < formattedValue.length; i++) {
+          if (seenUserChars === userCharsBeforeCursor) {
+            nextCursor = i;
+            break;
           }
+          if (isUserCharacter(formattedValue[i])) seenUserChars++;
         }
+        infoRef.current.cursorPosition = nextCursor;
+        infoRef.current.endOfSection = false;
       }
 
       onChange?.({ name, value: formattedValue, rawValue });


### PR DESCRIPTION
## Summary

Port of the Svelte fix ([#3973](https://github.com/razorpay/blade/pull/3973)) to React.

### Bugs fixed

**Trailing delimiter** — `format()` appended a delimiter even when the value ended exactly on a group boundary. Example: 16 digits into \`#### #### #### #### ###\` produced \`"4111 1111 1111 1111 "\` (trailing space). Fix: break before appending a delimiter when no more input chars remain.

**Caret positioning** — After typing a digit that lands on a group boundary (e.g. 5th digit of a card number), the formatter inserts a space, shifting the digit right. The old logic used raw \`selectionStart\` which now sat *before* the typed digit. Fix: anchor the caret by counting user characters (non-delimiters) so it stays glued to the typed char regardless of how many delimiters were inserted.

### Changes

| File | Change |
|---|---|
| \`useFormattedInput.ts\` | Trailing delimiter guard + user-character-anchored caret |
| \`TextInput.web.test.tsx\` | 5 new tests covering letter-stripping, prefill, reset, no trailing delimiter, caret position |
| \`TextInputFormat.stories.tsx\` | \`CheckoutCardControlled\` story — NFC autofill + DCC provider switch simulation |

## Test plan
- [ ] Type letters mixed with digits in a card field — letters vanish, stored value stays digits-only
- [ ] Type letters after "1234" (no digit change) — display stays "1234", no leaked chars
- [ ] Programmatic prefill (NFC Autofill button) and clear (Switch to GPay) update the visible field
- [ ] Type the 5th digit — caret lands after it, not before the inserted space
- [ ] 16-digit value shows no trailing space

Made with [Cursor](https://cursor.com)