### PR TITLE
feat(blade-svelte): Dropdown component (partial)

### DIFF
--- a/.changeset/blade-svelte-dropdown-component.md
+++ b/.changeset/blade-svelte-dropdown-component.md
@@ -1,0 +1,6 @@
+---
+'@razorpay/blade-core': patch
+'@razorpay/blade-svelte': patch
+---
+
+feat(blade-svelte): add Dropdown component (partial — controller, overlay, header/footer, InputDropdownButton) with ActionList option-registration

--- a/packages/blade-core/src/styles/ActionList/actionList.module.css
+++ b/packages/blade-core/src/styles/ActionList/actionList.module.css
@@ -70,6 +70,16 @@
   &[aria-disabled='true'] {
     cursor: not-allowed;
   }
+
+  /* Keyboard "active-focus" highlight — mirrors React ActionListItem
+   * `className="active-focus"` set when `activeIndex === _index`. Only applies
+   * when the item is registered in a Dropdown (data attr set by ActionListItem);
+   * standalone/BottomSheet lists never set it, so their appearance is unchanged. */
+  &[data-active-focus='true']:not([disabled]):not([aria-disabled='true']):not(
+      [aria-selected='true']
+    ) {
+    background-color: var(--interactive-background-gray-default);
+  }
 }
 
 /* Negative intent row — negative faded hover (mirrors React `color==='negative'`). */

--- a/packages/blade-core/src/styles/Dropdown/dropdown.module.css
+++ b/packages/blade-core/src/styles/Dropdown/dropdown.module.css
@@ -1,0 +1,193 @@
+/* ----------------------------------------------------------------------------
+ * Dropdown Styles
+ *
+ * Visual parity with React `StyledDropdownOverlay.tsx` + `InputDropdownButton`
+ * (`StyledSearchTrailingDropdown`).
+ * ------------------------------------------------------------------------- */
+
+/* ===== Floating wrapper =====
+ * Portaled node positioned by floating-ui (`strategy: 'fixed'`). Positioning
+ * (transform, width, z-index, display) is set inline from JS because it is
+ * fully dynamic — the same approach `Tooltip.svelte` uses.
+ */
+.floating {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+}
+
+/* ===== Overlay surface (StyledDropdownOverlay) ===== */
+.overlaySurface {
+  width: 100%;
+  box-sizing: border-box;
+  background-color: var(--popup-background-gray-moderate);
+  border-radius: var(--border-radius-medium);
+  /* backdropBlur.medium = 8 (no --backdrop-blur-* token in the Svelte theme). */
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  /* Mirrors React getPopupBoxShadowString: inset 1px border + elevation + top. */
+  box-shadow: inset 0 0 0 1px var(--popup-border-gray-subtle),
+    var(--elevation-mid-raised), inset 0 0 0 0 var(--popup-border-gray-moderate);
+  /* Open/close transition — mirrors React `useTransitionStyles`
+   * (fade + translateY(-8px)); driven by `data-state`. */
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity var(--duration-quick) ease, transform var(--duration-quick) ease;
+}
+
+.overlaySurface[data-state='open'] {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.overlaySurface[data-state='closed'] {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+/* In a BottomSheet the sheet surface provides elevation, so drop the shadow. */
+.overlaySurfaceInBottomSheet {
+  box-shadow: none;
+}
+
+/* Menu triggers get a flexible min/max width; input triggers take the reference
+ * width applied inline by the floating-ui `size` middleware. */
+.overlayMenuWidth {
+  /* React size['240']/size['400']; no --size-* scale in the Svelte theme. */
+  min-width: 240px;
+  max-width: 400px;
+}
+
+/* ===== InputDropdownButton (StyledSearchTrailingDropdown) ===== */
+.idButton {
+  display: flex;
+  box-sizing: border-box;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+}
+
+.idButton[disabled] {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.idButton:hover {
+  background-color: var(--interactive-background-gray-faded);
+}
+
+.idButton:focus {
+  background-color: var(--interactive-background-gray-faded);
+}
+
+.idButton:focus-visible {
+  outline: var(--border-width-thick, 2px) solid var(--surface-border-primary-muted);
+  outline-offset: 0;
+}
+
+/* Inner content box (mirrors React inner Box padding). */
+.idButtonContent {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+/* size variants — height derived from baseInputHeight − 2×wrapper padding;
+ * border-radius from inputDropdownButtonBorderRadius; inner padding from
+ * inputDropdownButtonPadding. */
+.idButtonSmall {
+  height: 28px;
+  border-radius: 6px;
+}
+
+.idButtonSmall .idButtonContent {
+  padding: var(--spacing-1);
+}
+
+.idButtonMedium {
+  height: 28px;
+  border-radius: 6px;
+}
+
+.idButtonMedium .idButtonContent {
+  padding: var(--spacing-2);
+}
+
+.idButtonLarge {
+  height: 40px;
+  border-radius: 8px;
+}
+
+.idButtonLarge .idButtonContent {
+  padding: var(--spacing-2);
+}
+
+/* ===== Dropdown container ===== */
+.triggerWrapper {
+  position: relative;
+  height: 100%;
+  text-align: left;
+}
+
+/* ===== DropdownFooter wrapper ===== */
+.footer {
+  display: block;
+}
+
+/* ===== BaseHeader / BaseFooter (shim layout) =====
+ * Minimal web-only port of `BaseHeaderFooter` used by DropdownHeader/Footer.
+ * Spacing mirrors React `BaseHeader`/`BaseFooter` (padding/margin spacing.5).
+ */
+.headerInner {
+  padding: var(--spacing-5) var(--spacing-6);
+}
+
+.headerRow {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  user-select: none;
+}
+
+.headerTitleBlock {
+  flex: auto;
+  margin-right: auto;
+  padding-right: var(--spacing-5);
+  display: flex;
+  flex-direction: column;
+}
+
+.headerLeading {
+  display: flex;
+  align-items: center;
+  margin-right: var(--spacing-3);
+}
+
+.headerTitleRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.headerTrailing {
+  margin-left: var(--spacing-5);
+  display: flex;
+  align-items: center;
+}
+
+.headerChildren {
+  width: 100%;
+}
+
+.footerInner {
+  padding: var(--spacing-5) var(--spacing-6);
+}
+

--- a/packages/blade-core/src/styles/Dropdown/dropdown.ts
+++ b/packages/blade-core/src/styles/Dropdown/dropdown.ts
@@ -1,0 +1,118 @@
+import { cva } from 'class-variance-authority';
+// @ts-expect-error - CSS modules may not have type definitions in build
+import styles from './dropdown.module.css';
+
+export type DropdownOverlayVariants = {
+  isInBottomSheet?: boolean;
+  isMenu?: boolean;
+};
+
+export type InputDropdownButtonSize = 'small' | 'medium' | 'large';
+
+export type InputDropdownButtonVariants = {
+  size?: InputDropdownButtonSize;
+};
+
+/**
+ * Overlay surface classes. `isMenu` drives the flexible min/max width (input
+ * triggers instead take the reference width applied inline by floating-ui's
+ * `size` middleware); `isInBottomSheet` removes the box-shadow.
+ */
+export const dropdownOverlayStyles = cva(styles.overlaySurface, {
+  variants: {
+    isInBottomSheet: {
+      true: styles.overlaySurfaceInBottomSheet,
+      false: null,
+    },
+    isMenu: {
+      true: styles.overlayMenuWidth,
+      false: null,
+    },
+  },
+  defaultVariants: {
+    isInBottomSheet: false,
+    isMenu: false,
+  },
+});
+
+export function getDropdownOverlayClasses(props: DropdownOverlayVariants): string {
+  return dropdownOverlayStyles(props);
+}
+
+/**
+ * InputDropdownButton classes. `size` maps height / border-radius / inner
+ * padding (mirrors `baseInputHeight`, `inputDropdownButtonBorderRadius`,
+ * `inputDropdownButtonPadding`).
+ */
+export const inputDropdownButtonStyles = cva(styles.idButton, {
+  variants: {
+    size: {
+      small: styles.idButtonSmall,
+      medium: styles.idButtonMedium,
+      large: styles.idButtonLarge,
+    },
+  },
+  defaultVariants: {
+    size: 'medium',
+  },
+});
+
+export function getInputDropdownButtonClasses(props: InputDropdownButtonVariants): string {
+  return inputDropdownButtonStyles(props);
+}
+
+export const dropdownFloatingClass = styles.floating;
+export const dropdownTriggerWrapperClass = styles.triggerWrapper;
+export const dropdownFooterClass = styles.footer;
+export const inputDropdownButtonContentClass = styles.idButtonContent;
+
+export const baseHeaderInnerClass = styles.headerInner;
+export const baseHeaderRowClass = styles.headerRow;
+export const baseHeaderTitleBlockClass = styles.headerTitleBlock;
+export const baseHeaderLeadingClass = styles.headerLeading;
+export const baseHeaderTitleRowClass = styles.headerTitleRow;
+export const baseHeaderTrailingClass = styles.headerTrailing;
+export const baseHeaderChildrenClass = styles.headerChildren;
+export const baseFooterInnerClass = styles.footerInner;
+
+/**
+ * Structural/template classes. Call from Svelte components so class references
+ * used only in compound selectors aren't tree-shaken.
+ */
+export function getDropdownTemplateClasses(): {
+  floating: string;
+  triggerWrapper: string;
+  overlaySurface: string;
+  overlaySurfaceInBottomSheet: string;
+  overlayMenuWidth: string;
+  idButton: string;
+  idButtonContent: string;
+  footer: string;
+  headerInner: string;
+  headerRow: string;
+  headerTitleBlock: string;
+  headerLeading: string;
+  headerTitleRow: string;
+  headerTrailing: string;
+  headerChildren: string;
+  footerInner: string;
+} {
+  return {
+    floating: styles.floating,
+    triggerWrapper: styles.triggerWrapper,
+    overlaySurface: styles.overlaySurface,
+    overlaySurfaceInBottomSheet: styles.overlaySurfaceInBottomSheet,
+    overlayMenuWidth: styles.overlayMenuWidth,
+    idButton: styles.idButton,
+    idButtonContent: styles.idButtonContent,
+    footer: styles.footer,
+    headerInner: styles.headerInner,
+    headerRow: styles.headerRow,
+    headerTitleBlock: styles.headerTitleBlock,
+    headerLeading: styles.headerLeading,
+    headerTitleRow: styles.headerTitleRow,
+    headerTrailing: styles.headerTrailing,
+    headerChildren: styles.headerChildren,
+    footerInner: styles.footerInner,
+  };
+}

--- a/packages/blade-core/src/styles/Dropdown/index.ts
+++ b/packages/blade-core/src/styles/Dropdown/index.ts
@@ -1,0 +1,24 @@
+export {
+  dropdownOverlayStyles,
+  getDropdownOverlayClasses,
+  inputDropdownButtonStyles,
+  getInputDropdownButtonClasses,
+  getDropdownTemplateClasses,
+  dropdownFloatingClass,
+  dropdownTriggerWrapperClass,
+  dropdownFooterClass,
+  inputDropdownButtonContentClass,
+  baseHeaderInnerClass,
+  baseHeaderRowClass,
+  baseHeaderTitleBlockClass,
+  baseHeaderLeadingClass,
+  baseHeaderTitleRowClass,
+  baseHeaderTrailingClass,
+  baseHeaderChildrenClass,
+  baseFooterInnerClass,
+} from './dropdown';
+export type {
+  DropdownOverlayVariants,
+  InputDropdownButtonVariants,
+  InputDropdownButtonSize,
+} from './dropdown';

--- a/packages/blade-core/src/styles/index.ts
+++ b/packages/blade-core/src/styles/index.ts
@@ -553,3 +553,27 @@ export {
   getInputGroupTemplateClasses,
 } from './InputGroup';
 export type { InputGroupLabelPosition, InputGroupFieldVariants } from './InputGroup';
+export {
+  dropdownOverlayStyles,
+  getDropdownOverlayClasses,
+  inputDropdownButtonStyles,
+  getInputDropdownButtonClasses,
+  getDropdownTemplateClasses,
+  dropdownFloatingClass,
+  dropdownTriggerWrapperClass,
+  dropdownFooterClass,
+  inputDropdownButtonContentClass,
+  baseHeaderInnerClass,
+  baseHeaderRowClass,
+  baseHeaderTitleBlockClass,
+  baseHeaderLeadingClass,
+  baseHeaderTitleRowClass,
+  baseHeaderTrailingClass,
+  baseHeaderChildrenClass,
+  baseFooterInnerClass,
+} from './Dropdown';
+export type {
+  DropdownOverlayVariants,
+  InputDropdownButtonVariants,
+  InputDropdownButtonSize,
+} from './Dropdown';

--- a/packages/blade-svelte/src/components/ActionList/ActionList.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionList.svelte
@@ -8,6 +8,7 @@
   } from '@razorpay/blade-core/utils';
   import { getActionListWrapperClasses, getActionListTemplateClasses } from '@razorpay/blade-core/styles';
   import { getBottomSheetContext } from '../BottomSheet/bottomSheetContext';
+  import { getDropdownContext } from '../Dropdown/dropdownContext';
   import { setActionListContext } from './actionListContext';
   import { getActionListContainerRole } from './getA11yRoles';
   import type { ActionListContextValue, ActionListProps } from './types';
@@ -28,6 +29,19 @@
   // (not a public prop) — mirrors React's `useBottomSheetContext()`.
   const bs = getBottomSheetContext();
   const isInBottomSheet = $derived(bs?.isInBottomSheet ?? false);
+
+  // Optional Dropdown bridge — undefined for standalone / BottomSheet usage, so
+  // that path stays unchanged. When present, the container adopts the Dropdown
+  // a11y role + id and exposes its scroll element for keyboard scroll-visibility.
+  const dropdown = getDropdownContext();
+  const isInsideDropdown = Boolean(dropdown);
+
+  let scrollWrapperEl = $state<HTMLDivElement | null>(null);
+  $effect(() => {
+    if (!dropdown) return;
+    dropdown.setActionListContainerEl(scrollWrapperEl);
+    return () => dropdown.setActionListContainerEl(null);
+  });
 
   // Reactive context for child items (getters keep `selectedValue` live).
   const contextValue: ActionListContextValue = {
@@ -59,11 +73,24 @@
 
   const isMultiSelectable = $derived(selectionType === 'multiple');
 
+  const containerRole = $derived(
+    isInsideDropdown
+      ? getActionListContainerRole(
+          dropdown?.hasFooterAction ?? false,
+          dropdown?.dropdownTriggerer,
+          true,
+        )
+      : getActionListContainerRole(),
+  );
+  const containerId = $derived(
+    isInsideDropdown && dropdown ? `${dropdown.dropdownBaseId}-actionlist` : undefined,
+  );
+
   const metaAttrs = $derived(metaAttribute({ name: MetaConstants.ActionList, testID }));
   const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
   const a11yAttrs = $derived(
     makeAccessible({
-      role: getActionListContainerRole(),
+      role: containerRole,
       multiSelectable: isMultiSelectable,
     }),
   );
@@ -85,8 +112,15 @@
   <!-- Standalone: plain outer shell (a11y/meta/analytics/styled props) + inner scroll
        wrapper — mirrors React's BaseBox + ActionListBox. Border/shadow come from the
        Dropdown overlay when embedded, not ActionList itself. -->
-  <div class={styledClassString || undefined} style={styledStyleString} {...a11yAttrs} {...metaAttrs} {...analyticsAttrs}>
-    <div class={wrapperClasses}>
+  <div
+    id={containerId}
+    class={styledClassString || undefined}
+    style={styledStyleString}
+    {...a11yAttrs}
+    {...metaAttrs}
+    {...analyticsAttrs}
+  >
+    <div class={wrapperClasses} bind:this={scrollWrapperEl}>
       {@render children()}
     </div>
   </div>

--- a/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
+++ b/packages/blade-svelte/src/components/ActionList/ActionListItem.svelte
@@ -6,7 +6,9 @@
     makeAnalyticsAttribute,
   } from '@razorpay/blade-core/utils';
   import { getActionListItemClasses, getActionListTemplateClasses } from '@razorpay/blade-core/styles';
+  import { useId } from '@razorpay/blade-core/utils';
   import Text from '../Typography/Text/Text.svelte';
+  import { getDropdownContext } from '../Dropdown/dropdownContext';
   import { getActionListContext, setActionListItemContext } from './actionListContext';
   import { getActionListItemRole } from './getA11yRoles';
   import type { ActionListItemContextValue, ActionListItemProps } from './types';
@@ -33,6 +35,22 @@
 
   const ctx = getActionListContext();
 
+  // Optional Dropdown bridge — undefined for standalone / BottomSheet usage
+  // (no-op), so that path is unchanged. When present, the item registers into
+  // the Dropdown option registry and adopts index-based selection / keyboard nav.
+  const dd = getDropdownContext();
+  const itemId = useId('action-list-item');
+
+  $effect(() => {
+    if (!dd) return;
+    dd.registerOption({ id: itemId, title, value, href });
+    return () => dd.unregisterOption(itemId);
+  });
+
+  const dropdownIndex = $derived(dd ? dd.getOptionIndex(itemId) : -1);
+  const isActiveFocus = $derived(dd ? dd.activeIndex === dropdownIndex : false);
+  const dropdownItemId = $derived(dd ? `${dd.dropdownBaseId}-${dropdownIndex}` : undefined);
+
   const isMultiSelect = $derived(ctx?.selectionType === 'multiple');
 
   // Lazy-load the Checkbox: it's only rendered as the selection indicator for
@@ -51,10 +69,12 @@
   // In multiple mode `selectedValue` is an array → membership check; in single
   // mode it's a scalar → equality (mirrors React's array vs scalar handling).
   const isItemSelected = $derived(
-    isSelected ??
-      (Array.isArray(ctx?.selectedValue)
-        ? ctx.selectedValue.includes(value)
-        : ctx?.selectedValue === value),
+    dd
+      ? dd.selectedIndices.includes(dropdownIndex)
+      : isSelected ??
+          (Array.isArray(ctx?.selectedValue)
+            ? ctx.selectedValue.includes(value)
+            : ctx?.selectedValue === value),
   );
 
   // Provide row-local disabled/intent to ActionListItemText (React `useBaseMenuItem`).
@@ -68,7 +88,11 @@
   };
   setActionListItemContext(() => itemContext);
 
-  const role = $derived(getActionListItemRole(href));
+  const role = $derived(
+    dd
+      ? getActionListItemRole(dd.dropdownTriggerer, href, dd.selectionType, true)
+      : getActionListItemRole(undefined, href),
+  );
 
   // Title/description colors mirror React BaseMenuItem `menuItemTitleColor` / `menuItemDescriptionColor`.
   const titleColor = $derived(
@@ -89,6 +113,9 @@
       event.preventDefault();
       event.stopPropagation();
       return;
+    }
+    if (dd) {
+      dd.onOptionClick(event, dropdownIndex);
     }
     onClick?.({ value, isSelected: isItemSelected, event });
     ctx?.onAction?.({ value });
@@ -155,10 +182,12 @@
 
 {#if href}
   <a
+    id={dropdownItemId}
     class={rowClasses}
     {href}
     {target}
     data-value={value}
+    data-active-focus={isActiveFocus ? 'true' : undefined}
     onclick={handleClick}
     {...a11yAttrs}
     {...metaAttrs}
@@ -168,9 +197,11 @@
   </a>
 {:else}
   <button
+    id={dropdownItemId}
     class={rowClasses}
     type="button"
     data-value={value}
+    data-active-focus={isActiveFocus ? 'true' : undefined}
     onclick={handleClick}
     {...a11yAttrs}
     {...metaAttrs}

--- a/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
+++ b/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
@@ -1,18 +1,66 @@
 /**
- * Accessibility roles for the ActionList family. React's `getA11yRoles.ts`
- * switches between `menu`/`listbox`/`dialog` based on the Dropdown trigger; that
- * coupling is stripped here. This scope is single-select, BottomSheet-mode only,
- * so it emits list/option roles exclusively.
+ * Accessibility roles for the ActionList family (web-only).
+ *
+ * Standalone / BottomSheet usage emits list/option roles. When rendered inside a
+ * `Dropdown`, callers pass `isInsideDropdown = true` so the container/item roles
+ * widen to React parity (`menu`/`dialog`/`listbox` + `menuitem`/
+ * `menuitemcheckbox`/`option`/`link`). No-arg callers keep the original
+ * `listbox`/`option` defaults so existing standalone usage is unchanged.
  */
+import type { DropdownTriggerer } from '../Dropdown/dropdownComponentIds';
+import type { DropdownSelectionType } from '../Dropdown/types';
 
-/** Container role — always `listbox` (no Dropdown/footer/menu branches). */
-export function getActionListContainerRole(): 'listbox' {
+/**
+ * Whether the container should behave as a `menu`. Menu triggers (Button /
+ * IconButton / Link / undefined) are menus; select-style triggers
+ * (`InputDropdownButton`) are listboxes.
+ */
+const isRoleMenu = (dropdownTriggerer: DropdownTriggerer): boolean => {
+  return dropdownTriggerer !== 'InputDropdownButton';
+};
+
+/**
+ * Container role. Standalone → `listbox`. Inside a Dropdown: `dialog` when the
+ * overlay has footer actions, `menu` for menu triggers, else `listbox`.
+ */
+export function getActionListContainerRole(
+  hasFooterAction: boolean = false,
+  dropdownTriggerer: DropdownTriggerer = undefined,
+  isInsideDropdown: boolean = false,
+): 'dialog' | 'listbox' | 'menu' {
+  if (!isInsideDropdown) {
+    return 'listbox';
+  }
+  if (hasFooterAction) {
+    return 'dialog';
+  }
+  if (isRoleMenu(dropdownTriggerer)) {
+    return 'menu';
+  }
   return 'listbox';
 }
 
-/** Row role — `link` when the item navigates (`href`), else `option`. */
-export function getActionListItemRole(href?: string): 'link' | 'option' {
-  return href ? 'link' : 'option';
+/**
+ * Row role. `link` when navigating (`href`). Standalone → `option`. Inside a
+ * Dropdown menu: `menuitemcheckbox` (multiple) / `menuitem` (single); select
+ * triggers → `option`.
+ */
+export function getActionListItemRole(
+  dropdownTriggerer: DropdownTriggerer = undefined,
+  href?: string,
+  selectionType?: DropdownSelectionType,
+  isInsideDropdown: boolean = false,
+): 'menuitem' | 'menuitemcheckbox' | 'option' | 'link' {
+  if (href) {
+    return 'link';
+  }
+  if (!isInsideDropdown) {
+    return 'option';
+  }
+  if (isRoleMenu(dropdownTriggerer)) {
+    return selectionType === 'multiple' ? 'menuitemcheckbox' : 'menuitem';
+  }
+  return 'option';
 }
 
 /** Section wrapper role — `group` (announces the section title as its label). */
@@ -21,11 +69,8 @@ export function getActionListSectionRole(): 'group' {
 }
 
 /**
- * Section items wrapper role — `listbox` on web. Mirrors React's deliberate
- * inner listbox (ActionListItem.tsx `role: isReactNative() ? undefined : 'listbox'`)
- * so screen readers announce the per-group item count. Yields
- * `listbox > group > listbox > option`; the intervening `group` keeps the outer
- * listbox's owned children valid.
+ * Section items wrapper role — `listbox` on web (mirrors React's inner listbox
+ * so screen readers announce the per-group item count).
  */
 export function getActionListSectionItemsRole(): 'listbox' {
   return 'listbox';

--- a/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
+++ b/packages/blade-svelte/src/components/ActionList/getA11yRoles.ts
@@ -24,9 +24,9 @@ const isRoleMenu = (dropdownTriggerer: DropdownTriggerer): boolean => {
  * overlay has footer actions, `menu` for menu triggers, else `listbox`.
  */
 export function getActionListContainerRole(
-  hasFooterAction: boolean = false,
+  hasFooterAction = false,
   dropdownTriggerer: DropdownTriggerer = undefined,
-  isInsideDropdown: boolean = false,
+  isInsideDropdown = false,
 ): 'dialog' | 'listbox' | 'menu' {
   if (!isInsideDropdown) {
     return 'listbox';
@@ -49,7 +49,7 @@ export function getActionListItemRole(
   dropdownTriggerer: DropdownTriggerer = undefined,
   href?: string,
   selectionType?: DropdownSelectionType,
-  isInsideDropdown: boolean = false,
+  isInsideDropdown = false,
 ): 'menuitem' | 'menuitemcheckbox' | 'option' | 'link' {
   if (href) {
     return 'link';

--- a/packages/blade-svelte/src/components/BaseHeaderFooter/BaseFooter.svelte
+++ b/packages/blade-svelte/src/components/BaseHeaderFooter/BaseFooter.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { metaAttribute, makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import { baseFooterInnerClass, getDropdownTemplateClasses } from '@razorpay/blade-core/styles';
+  import Divider from '../Divider/Divider.svelte';
+  import type { BaseFooterProps } from './types';
+
+  // Prevent tree-shaking of template classes used in compound selectors.
+  void getDropdownTemplateClasses();
+
+  let {
+    children,
+    showDivider = true,
+    metaComponentName,
+    testID,
+    ...rest
+  }: BaseFooterProps = $props();
+
+  const metaAttrs = $derived(metaAttribute({ name: metaComponentName, testID }));
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+{#if showDivider}
+  <Divider />
+{/if}
+<div class={baseFooterInnerClass} {...metaAttrs} {...analyticsAttrs}>
+  {@render children?.()}
+</div>

--- a/packages/blade-svelte/src/components/BaseHeaderFooter/BaseHeader.svelte
+++ b/packages/blade-svelte/src/components/BaseHeaderFooter/BaseHeader.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { metaAttribute, makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import {
+    getDropdownTemplateClasses,
+    baseHeaderInnerClass,
+    baseHeaderRowClass,
+    baseHeaderTitleBlockClass,
+    baseHeaderLeadingClass,
+    baseHeaderTitleRowClass,
+    baseHeaderTrailingClass,
+  } from '@razorpay/blade-core/styles';
+  import Text from '../Typography/Text/Text.svelte';
+  import Divider from '../Divider/Divider.svelte';
+  import IconButton from '../Button/IconButton/IconButton.svelte';
+  import { ChevronLeftIcon, CloseIcon } from '../Icons';
+  import type { BaseHeaderProps } from './types';
+
+  // Prevent tree-shaking of template classes used in compound selectors.
+  void getDropdownTemplateClasses();
+
+  let {
+    title,
+    subtitle,
+    leading,
+    trailing,
+    titleSuffix,
+    showDivider = true,
+    showBackButton = false,
+    showCloseButton = true,
+    onBackButtonClick,
+    onCloseButtonClick,
+    isDisabled = false,
+    metaComponentName,
+    testID,
+    children,
+    ...rest
+  }: BaseHeaderProps = $props();
+
+  const titleColor = $derived(
+    isDisabled ? 'surface.text.gray.disabled' : 'surface.text.gray.normal',
+  );
+  const subtitleColor = $derived(
+    isDisabled ? 'surface.text.gray.disabled' : 'surface.text.gray.muted',
+  );
+
+  const hasOnlyChildren = $derived(
+    Boolean(children) && !(title || subtitle || titleSuffix || leading),
+  );
+
+  const metaAttrs = $derived(metaAttribute({ name: metaComponentName, testID }));
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<div {...metaAttrs} {...analyticsAttrs}>
+  <div class={baseHeaderInnerClass}>
+    <div class={baseHeaderRowClass}>
+      {#if showBackButton}
+        <div class={baseHeaderLeadingClass}>
+          <IconButton
+            icon={ChevronLeftIcon}
+            size="large"
+            accessibilityLabel="Back"
+            onClick={() => onBackButtonClick?.()}
+          />
+        </div>
+      {/if}
+
+      {#if !hasOnlyChildren}
+        <div class={baseHeaderTitleBlockClass}>
+          <div class={baseHeaderTitleRowClass}>
+            {#if leading}
+              <span class={baseHeaderLeadingClass}>{@render leading()}</span>
+            {/if}
+            {#if title}
+              <Text as="span" size="large" weight="semibold" color={titleColor} wordBreak="break-word">
+                {title}
+              </Text>
+            {/if}
+            {#if titleSuffix}
+              {@render titleSuffix()}
+            {/if}
+          </div>
+          {#if subtitle}
+            <Text variant="body" size="small" weight="regular" color={subtitleColor}>
+              {subtitle}
+            </Text>
+          {/if}
+        </div>
+      {/if}
+
+      {#if trailing}
+        <div class={baseHeaderTrailingClass}>{@render trailing()}</div>
+      {/if}
+
+      {#if showCloseButton}
+        <div class={baseHeaderTrailingClass}>
+          <IconButton
+            icon={CloseIcon}
+            size="large"
+            accessibilityLabel="Close"
+            onClick={() => onCloseButtonClick?.()}
+          />
+        </div>
+      {/if}
+    </div>
+
+    {#if children}
+      {@render children()}
+    {/if}
+  </div>
+  {#if showDivider}
+    <Divider />
+  {/if}
+</div>

--- a/packages/blade-svelte/src/components/BaseHeaderFooter/types.ts
+++ b/packages/blade-svelte/src/components/BaseHeaderFooter/types.ts
@@ -1,0 +1,67 @@
+import type { Snippet } from 'svelte';
+import type { DataAnalyticsAttribute } from '@razorpay/blade-core/utils';
+
+/**
+ * Web-only Svelte port of React `BaseHeaderProps`. Only the slice consumed by
+ * `DropdownHeader` is modeled; RN branches, prop-restriction, and background
+ * image are dropped.
+ */
+export type BaseHeaderProps = {
+  /** Header title text. */
+  title?: string;
+  /** Secondary text below the title. */
+  subtitle?: string;
+  /** Leading slot (left of the title). */
+  leading?: Snippet;
+  /** Trailing slot (right side, before the close button). */
+  trailing?: Snippet;
+  /** Slot rendered adjacent to the title text. */
+  titleSuffix?: Snippet;
+  /**
+   * Show the divider under the header.
+   * @default true
+   */
+  showDivider?: boolean;
+  /**
+   * Show the back button.
+   * @default false
+   */
+  showBackButton?: boolean;
+  /**
+   * Show the close button.
+   * @default true
+   */
+  showCloseButton?: boolean;
+  /** Called when the back button is clicked. */
+  onBackButtonClick?: () => void;
+  /** Called when the close button is clicked. */
+  onCloseButtonClick?: () => void;
+  /**
+   * Disabled visual state.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /** Meta component name used for `data-blade-component`. */
+  metaComponentName?: string;
+  /** Test ID for the header element. */
+  testID?: string;
+  /** Inner children (e.g. AutoComplete in header). */
+  children?: Snippet;
+} & DataAnalyticsAttribute;
+
+/**
+ * Web-only Svelte port of React `BaseFooterProps`.
+ */
+export type BaseFooterProps = {
+  /** Footer content. */
+  children?: Snippet;
+  /**
+   * Show the divider above the footer.
+   * @default true
+   */
+  showDivider?: boolean;
+  /** Meta component name used for `data-blade-component`. */
+  metaComponentName?: string;
+  /** Test ID for the footer element. */
+  testID?: string;
+} & DataAnalyticsAttribute;

--- a/packages/blade-svelte/src/components/ButtonGroup/buttonGroupContext.ts
+++ b/packages/blade-svelte/src/components/ButtonGroup/buttonGroupContext.ts
@@ -1,0 +1,26 @@
+import { getContext, setContext } from 'svelte';
+
+/**
+ * Minimal ButtonGroup context (getter pattern). Mirrors React's
+ * `ButtonGroupContext` — buttons read it to inherit group `size`/`variant`/etc.
+ * Only the reset use-case (see `OverlayContextReset`) is needed in this scope,
+ * so the shape is kept open and the default is empty.
+ */
+export type ButtonGroupContextValue = {
+  isInsideButtonGroup?: boolean;
+  size?: 'xsmall' | 'small' | 'medium' | 'large';
+  variant?: 'primary' | 'secondary' | 'tertiary';
+  color?: 'primary' | 'white' | 'positive' | 'negative';
+  isDisabled?: boolean;
+};
+
+const BUTTON_GROUP_CONTEXT_KEY = Symbol('button-group-context');
+
+export function setButtonGroupContext(getter: () => ButtonGroupContextValue): void {
+  setContext(BUTTON_GROUP_CONTEXT_KEY, getter);
+}
+
+export function getButtonGroupContext(): ButtonGroupContextValue {
+  const getter = getContext<(() => ButtonGroupContextValue) | undefined>(BUTTON_GROUP_CONTEXT_KEY);
+  return getter?.() ?? {};
+}

--- a/packages/blade-svelte/src/components/Dropdown/Dropdown.stories.svelte
+++ b/packages/blade-svelte/src/components/Dropdown/Dropdown.stories.svelte
@@ -1,0 +1,210 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Dropdown from './Dropdown.svelte';
+  import type { DropdownProps } from './types';
+
+  /* Partial-scope deviation from strict story parity (migration-plan Decision 3):
+   * React stories depend on out-of-scope SelectInput/AutoComplete/DropdownButton/
+   * FilterChip triggers, so in-scope surfaces are demonstrated with migrated
+   * Button / Link / IconButton triggers + InputDropdownButton instead. Menu
+   * triggers have no DropdownButton wrapper in scope, so the trigger toggles the
+   * controllable `isOpen` locally. */
+  const { Story } = defineMeta({
+    title: 'Components/Dropdown/With Button and Link',
+    component: Dropdown,
+    tags: ['autodocs'],
+    args: {
+      selectionType: 'single',
+    },
+    argTypes: {
+      children: { table: { disable: true } },
+      onOpenChange: { table: { disable: true } },
+      selectionType: { control: 'select', options: ['single', 'multiple'] },
+      isOpen: { control: 'boolean' },
+    } as Record<string, unknown>,
+  } as Parameters<typeof defineMeta>[0] & { argTypes: Record<string, unknown> });
+</script>
+
+<script lang="ts">
+  import DropdownOverlay from './DropdownOverlay.svelte';
+  import DropdownHeader from './DropdownHeader.svelte';
+  import DropdownFooter from './DropdownFooter.svelte';
+  import InputDropdownButton from './InputDropdownButton.svelte';
+  import ActionList from '../ActionList/ActionList.svelte';
+  import ActionListItem from '../ActionList/ActionListItem.svelte';
+  import Button from '../Button/Button.svelte';
+  import Checkbox from '../Checkbox/Checkbox.svelte';
+
+  let defaultOpen = $state(false);
+  let controlledOpen = $state(false);
+  let headerFooterOpen = $state(false);
+  let multiOpen = $state(false);
+  let inputOpen = $state(false);
+  const cornerOpen = $state([false, false, false, false]);
+  const corners: Array<{ top?: string; bottom?: string; left?: string; right?: string }> = [
+    { top: '0', left: '0' },
+    { top: '0', right: '0' },
+    { bottom: '0', left: '0' },
+    { bottom: '0', right: '0' },
+  ];
+</script>
+
+<!-- 1. Default — single-select menu with a Button trigger, arrow-key nav. -->
+<Story name="Default">
+  {#snippet template(args: DropdownProps)}
+    <Dropdown {...args} isOpen={defaultOpen} onOpenChange={(o) => (defaultOpen = o)}>
+      {#snippet children()}
+        <Button onClick={() => (defaultOpen = !defaultOpen)}>Select Action</Button>
+        <DropdownOverlay>
+          {#snippet children()}
+            <ActionList>
+              {#snippet children()}
+                <ActionListItem title="Profile" value="profile" />
+                <ActionListItem title="Settings" value="settings" />
+                <ActionListItem title="Billing" value="billing" />
+                <ActionListItem title="Logout" value="logout" intent="negative" />
+              {/snippet}
+            </ActionList>
+          {/snippet}
+        </DropdownOverlay>
+      {/snippet}
+    </Dropdown>
+  {/snippet}
+</Story>
+
+<!-- 2. With Controlled Menu — external open control via bound state. -->
+<Story name="With Controlled Menu">
+  {#snippet template()}
+    <div>
+      <Button marginBottom="spacing.3" onClick={() => (controlledOpen = !controlledOpen)}>
+        Toggle menu ({controlledOpen ? 'open' : 'closed'})
+      </Button>
+      <Dropdown isOpen={controlledOpen} onOpenChange={(o) => (controlledOpen = o)}>
+        {#snippet children()}
+          <Button onClick={() => (controlledOpen = !controlledOpen)}>Menu</Button>
+          <DropdownOverlay>
+            {#snippet children()}
+              <ActionList>
+                {#snippet children()}
+                  <ActionListItem title="Overview" value="overview" />
+                  <ActionListItem title="Transactions" value="transactions" />
+                  <ActionListItem title="Reports" value="reports" />
+                {/snippet}
+              </ActionList>
+            {/snippet}
+          </DropdownOverlay>
+        {/snippet}
+      </Dropdown>
+    </div>
+  {/snippet}
+</Story>
+
+<!-- 3. With Header And Footer — hasFooterAction switches the container role to
+     `dialog`; footer Button closes via the controllable `isOpen`. -->
+<Story name="With Header And Footer">
+  {#snippet template()}
+    <Dropdown isOpen={headerFooterOpen} onOpenChange={(o) => (headerFooterOpen = o)}>
+      {#snippet children()}
+        <Button onClick={() => (headerFooterOpen = !headerFooterOpen)}>Filters</Button>
+        <DropdownOverlay>
+          {#snippet children()}
+            <DropdownHeader title="Filter by" subtitle="Choose one or more" />
+            <ActionList selectionType="multiple">
+              {#snippet children()}
+                <ActionListItem title="Success" value="success" />
+                <ActionListItem title="Pending" value="pending" />
+                <ActionListItem title="Failed" value="failed" />
+              {/snippet}
+            </ActionList>
+            <DropdownFooter>
+              {#snippet children()}
+                <Checkbox>Save this filter</Checkbox>
+                <Button marginTop="spacing.3" isFullWidth onClick={() => (headerFooterOpen = false)}>
+                  Apply
+                </Button>
+              {/snippet}
+            </DropdownFooter>
+          {/snippet}
+        </DropdownOverlay>
+      {/snippet}
+    </Dropdown>
+  {/snippet}
+</Story>
+
+<!-- 4. With Auto Positioning — triggers pinned to the viewport corners exercise
+     flip/offset placement. -->
+<Story name="With Auto Positioning">
+  {#snippet template()}
+    <div style="position:relative;height:80vh;width:100%">
+      {#each corners as pos, i (i)}
+        <div
+          style="position:absolute;top:{pos.top ?? 'auto'};bottom:{pos.bottom ?? 'auto'};left:{pos.left ?? 'auto'};right:{pos.right ?? 'auto'}"
+        >
+          <Dropdown isOpen={cornerOpen[i]} onOpenChange={(o) => (cornerOpen[i] = o)}>
+            {#snippet children()}
+              <Button onClick={() => (cornerOpen[i] = !cornerOpen[i])}>Menu {i + 1}</Button>
+              <DropdownOverlay>
+                {#snippet children()}
+                  <ActionList>
+                    {#snippet children()}
+                      <ActionListItem title="Edit" value="edit" />
+                      <ActionListItem title="Duplicate" value="duplicate" />
+                      <ActionListItem title="Delete" value="delete" intent="negative" />
+                    {/snippet}
+                  </ActionList>
+                {/snippet}
+              </DropdownOverlay>
+            {/snippet}
+          </Dropdown>
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
+
+<!-- 5. Multi Select — selection stays open; selected rows keep their highlight. -->
+<Story name="Multi Select">
+  {#snippet template()}
+    <Dropdown selectionType="multiple" isOpen={multiOpen} onOpenChange={(o) => (multiOpen = o)}>
+      {#snippet children()}
+        <Button onClick={() => (multiOpen = !multiOpen)}>Select products</Button>
+        <DropdownOverlay>
+          {#snippet children()}
+            <ActionList selectionType="multiple">
+              {#snippet children()}
+                <ActionListItem title="Payments" value="payments" />
+                <ActionListItem title="Payouts" value="payouts" />
+                <ActionListItem title="Payment Links" value="payment_links" />
+                <ActionListItem title="Smart Collect" value="smart_collect" />
+              {/snippet}
+            </ActionList>
+          {/snippet}
+        </DropdownOverlay>
+      {/snippet}
+    </Dropdown>
+  {/snippet}
+</Story>
+
+<!-- 6. With Input Dropdown Button — displayValue is derived from the selected
+     registered option; typeahead works when the overlay is open. -->
+<Story name="With Input Dropdown Button">
+  {#snippet template()}
+    <Dropdown isOpen={inputOpen} onOpenChange={(o) => (inputOpen = o)}>
+      {#snippet children()}
+        <InputDropdownButton defaultValue="INR" />
+        <DropdownOverlay>
+          {#snippet children()}
+            <ActionList>
+              {#snippet children()}
+                <ActionListItem title="INR" value="INR" />
+                <ActionListItem title="USD" value="USD" />
+                <ActionListItem title="EUR" value="EUR" />
+                <ActionListItem title="GBP" value="GBP" />
+              {/snippet}
+            </ActionList>
+          {/snippet}
+        </DropdownOverlay>
+      {/snippet}
+    </Dropdown>
+  {/snippet}
+</Story>

--- a/packages/blade-svelte/src/components/Dropdown/Dropdown.svelte
+++ b/packages/blade-svelte/src/components/Dropdown/Dropdown.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import {
+    metaAttribute,
+    MetaConstants,
+    makeAnalyticsAttribute,
+    getStyledPropsClasses,
+    useId,
+  } from '@razorpay/blade-core/utils';
+  import {
+    dropdownTriggerWrapperClass,
+    getDropdownTemplateClasses,
+  } from '@razorpay/blade-core/styles';
+  import { setDropdownContext } from './dropdownContext';
+  import { createDropdownController } from './useDropdown';
+  import { makeInputValue, makeInputDisplayValue } from './dropdownUtils';
+
+  // Prevent tree-shaking of template classes used in compound selectors.
+  void getDropdownTemplateClasses();
+  import type { DropdownContextValue, DropdownOption, DropdownProps } from './types';
+  import type { DropdownTriggerer } from './dropdownComponentIds';
+
+  let {
+    children,
+    isOpen,
+    onOpenChange,
+    selectionType = 'single',
+    _width,
+    testID,
+    ...rest
+  }: DropdownProps = $props();
+
+  // Controllable open state — internal `$state` mirrors the `isOpen` prop when
+  // uncontrolled; `onOpenChange` fires on every change (mirrors React
+  // `useControllableState`).
+  let internalOpen = $state(false);
+  const isControlled = $derived(isOpen !== undefined);
+  const openState = $derived(isControlled ? (isOpen as boolean) : internalOpen);
+
+  function setIsOpen(next: boolean): void {
+    if (next === openState) return;
+    if (!isControlled) {
+      internalOpen = next;
+    }
+    onOpenChange?.(next);
+  }
+
+  function close(): void {
+    setIsOpen(false);
+  }
+
+  // Option registry — populated by ActionListItem on mount (append = visual
+  // order). Reorder-safe: items read their index via `getOptionIndex(id)`.
+  let options = $state<DropdownOption[]>([]);
+  let selectedIndices = $state<number[]>([]);
+  let activeIndex = $state(-1);
+  let filteredValues = $state<string[]>([]);
+  let hasFooterAction = $state(false);
+  let hasAutoCompleteInHeader = $state(false);
+  let isKeydownPressed = $state(false);
+  let dropdownTriggerer = $state<DropdownTriggerer>(undefined);
+
+  let triggererEl = $state<HTMLElement | null>(null);
+  let triggererWrapperEl = $state<HTMLElement | null>(null);
+  let actionListContainerEl = $state<HTMLElement | null>(null);
+
+  const dropdownBaseId = useId('dropdown');
+
+  // `registerOption`/`unregisterOption` both read AND write `options`. They are
+  // called from `ActionListItem`'s registration `$effect`, so the reads must be
+  // untracked — otherwise the calling effect subscribes to `options`, and each
+  // (un)registration re-triggers every item's effect → reactive update loop
+  // (`effect_update_depth_exceeded`).
+  function registerOption(option: DropdownOption): void {
+    untrack(() => {
+      const existing = options.findIndex((o) => o.id === option.id);
+      if (existing >= 0) {
+        options[existing] = option;
+      } else {
+        options = [...options, option];
+      }
+    });
+  }
+
+  function unregisterOption(id: string): void {
+    untrack(() => {
+      options = options.filter((o) => o.id !== id);
+      selectedIndices = selectedIndices.filter((i) => i < options.length);
+    });
+  }
+
+  function getOptionIndex(id: string): number {
+    return options.findIndex((o) => o.id === id);
+  }
+
+  const value = $derived(makeInputValue(selectedIndices, options));
+  const displayValue = $derived(makeInputDisplayValue(selectedIndices, options));
+
+  const controller = createDropdownController({
+    getIsOpen: () => openState,
+    setIsOpen,
+    close,
+    getSelectionType: () => selectionType,
+    getOptions: () => options,
+    getSelectedIndices: () => selectedIndices,
+    setSelectedIndices: (indices) => {
+      selectedIndices = indices;
+    },
+    getActiveIndex: () => activeIndex,
+    setActiveIndex: (index) => {
+      activeIndex = index;
+    },
+    getFilteredValues: () => filteredValues,
+    getDropdownTriggerer: () => dropdownTriggerer,
+    getActionListContainerEl: () => actionListContainerEl,
+    getTriggererEl: () => triggererEl,
+    getHasFooterAction: () => hasFooterAction,
+    getIsKeydownPressed: () => isKeydownPressed,
+    setIsKeydownPressed: (v) => {
+      isKeydownPressed = v;
+    },
+  });
+
+  const contextValue: DropdownContextValue = {
+    get isOpen() {
+      return openState;
+    },
+    setIsOpen,
+    close,
+    get selectionType() {
+      return selectionType;
+    },
+    get selectedIndices() {
+      return selectedIndices;
+    },
+    setSelectedValues: (values) => {
+      const indices = values
+        .map((v) => options.findIndex((o) => o.value === v))
+        .filter((i) => i >= 0);
+      selectedIndices = indices;
+      if (indices.length > 0) {
+        activeIndex = indices[indices.length - 1];
+      }
+    },
+    get activeIndex() {
+      return activeIndex;
+    },
+    get filteredValues() {
+      return filteredValues;
+    },
+    get options() {
+      return options;
+    },
+    get hasFooterAction() {
+      return hasFooterAction;
+    },
+    setHasFooterAction: (v) => {
+      hasFooterAction = v;
+    },
+    get hasAutoCompleteInHeader() {
+      return hasAutoCompleteInHeader;
+    },
+    setHasAutoCompleteInHeader: (v) => {
+      hasAutoCompleteInHeader = v;
+    },
+    dropdownBaseId,
+    get dropdownTriggerer() {
+      return dropdownTriggerer;
+    },
+    setDropdownTriggerer: (t) => {
+      dropdownTriggerer = t;
+    },
+    get value() {
+      return value;
+    },
+    get displayValue() {
+      return displayValue;
+    },
+    registerOption,
+    unregisterOption,
+    getOptionIndex,
+    onOptionClick: controller.onOptionClick,
+    onTriggerClick: controller.onTriggerClick,
+    onTriggerKeydown: controller.onTriggerKeydown,
+    get triggererEl() {
+      return triggererEl;
+    },
+    setTriggererEl: (el) => {
+      triggererEl = el;
+    },
+    get triggererWrapperEl() {
+      return triggererWrapperEl;
+    },
+    get actionListContainerEl() {
+      return actionListContainerEl;
+    },
+    setActionListContainerEl: (el) => {
+      actionListContainerEl = el;
+    },
+  };
+  setDropdownContext(() => contextValue);
+
+  // Dismiss on outside pointerdown / Escape while open (mirrors React
+  // `useDismiss`). Both the trigger wrapper and the portaled overlay are tagged
+  // with `data-dropdown-id` so a click on either counts as "inside".
+  $effect(() => {
+    if (!openState) return;
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      const target = event.target as HTMLElement | null;
+      if (target?.closest(`[data-dropdown-id="${dropdownBaseId}"]`)) {
+        return;
+      }
+      close();
+    };
+    const handleKeydown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        close();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+    document.addEventListener('keydown', handleKeydown, true);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+      document.removeEventListener('keydown', handleKeydown, true);
+    };
+  });
+
+  const styledProps = $derived(getStyledPropsClasses(rest));
+  const styledClassString = $derived((styledProps.classes || []).filter(Boolean).join(' ') || undefined);
+  const containerStyle = $derived(
+    [
+      _width ? `width:${_width}` : undefined,
+      ...Object.entries(styledProps.inlineStyles || {}).map(([k, v]) => `${k}:${v}`),
+    ]
+      .filter(Boolean)
+      .join(';') || undefined,
+  );
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.Dropdown, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<div
+  class={styledClassString}
+  style={containerStyle}
+  data-dropdown-id={dropdownBaseId}
+  {...metaAttrs}
+  {...analyticsAttrs}
+>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    bind:this={triggererWrapperEl}
+    class={dropdownTriggerWrapperClass}
+    onkeydown={(event) => contextValue.onTriggerKeydown({ event })}
+  >
+    {@render children()}
+  </div>
+</div>

--- a/packages/blade-svelte/src/components/Dropdown/DropdownFooter.svelte
+++ b/packages/blade-svelte/src/components/Dropdown/DropdownFooter.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { MetaConstants, makeAccessible, makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import { dropdownFooterClass } from '@razorpay/blade-core/styles';
+  import BaseFooter from '../BaseHeaderFooter/BaseFooter.svelte';
+  import { getDropdownContext } from './dropdownContext';
+  import type { DropdownFooterProps } from './types';
+
+  let { children, testID, ...rest }: DropdownFooterProps = $props();
+
+  const dropdown = getDropdownContext();
+
+  // Announce that the overlay has footer actions (switches the ActionList
+  // container role to `dialog` — mirrors React `setHasFooterAction(true)`).
+  $effect(() => {
+    dropdown?.setHasFooterAction(true);
+  });
+
+  const isOpen = $derived(dropdown?.isOpen ?? false);
+
+  const a11yAttrs = makeAccessible({ role: 'group' });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<div class={dropdownFooterClass} {...a11yAttrs} {...analyticsAttrs}>
+  <BaseFooter metaComponentName={MetaConstants.DropdownFooter} {testID}>
+    <!-- Interactive footer children are removed from the DOM while closed so they
+         aren't tabbable (mirrors React `isOpen ? children : null`). -->
+    {#if isOpen}
+      {@render children?.()}
+    {/if}
+  </BaseFooter>
+</div>

--- a/packages/blade-svelte/src/components/Dropdown/DropdownHeader.svelte
+++ b/packages/blade-svelte/src/components/Dropdown/DropdownHeader.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { MetaConstants, makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import BaseHeader from '../BaseHeaderFooter/BaseHeader.svelte';
+  import { getDropdownContext } from './dropdownContext';
+  import type { DropdownHeaderProps } from './types';
+
+  let {
+    title,
+    subtitle,
+    leading,
+    trailing,
+    titleSuffix,
+    children,
+    testID,
+    ...rest
+  }: DropdownHeaderProps = $props();
+
+  const dropdown = getDropdownContext();
+
+  // Keep focus off the (static) header on mousedown, except when an AutoComplete
+  // lives in the header (mirrors React DropdownHeader `onMouseDown`).
+  function handleMouseDown(event: MouseEvent): void {
+    if (!dropdown?.hasAutoCompleteInHeader) {
+      event.preventDefault();
+    }
+  }
+
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div onmousedown={handleMouseDown}>
+  <BaseHeader
+    {title}
+    {subtitle}
+    {leading}
+    {trailing}
+    {titleSuffix}
+    {children}
+    metaComponentName={MetaConstants.DropdownHeader}
+    {testID}
+    showBackButton={false}
+    showCloseButton={false}
+    {...analyticsAttrs}
+  />
+</div>

--- a/packages/blade-svelte/src/components/Dropdown/DropdownOverlay.svelte
+++ b/packages/blade-svelte/src/components/Dropdown/DropdownOverlay.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import { computePosition, autoUpdate, offset, flip, size as sizeMiddleware } from '@floating-ui/dom';
+  import { metaAttribute, MetaConstants, makeAnalyticsAttribute } from '@razorpay/blade-core/utils';
+  import {
+    getDropdownOverlayClasses,
+    getDropdownTemplateClasses,
+    dropdownFloatingClass,
+  } from '@razorpay/blade-core/styles';
+  import { portal } from '../../utils/portal';
+  import OverlayContextReset from '../OverlayContextReset/OverlayContextReset.svelte';
+  import { getBottomSheetContext } from '../BottomSheet/bottomSheetContext';
+  import { getDropdownContext } from './dropdownContext';
+  import type { DropdownOverlayProps } from './types';
+
+  // Prevent tree-shaking of template classes used in compound selectors.
+  void getDropdownTemplateClasses();
+
+  // React parity: `OVERLAY_OFFSET` / `OVERLAY_TRANSITION_OFFSET` = size['8'] = 8;
+  // `OVERLAY_PADDING` = size['12'] used as flip padding.
+  const OVERLAY_OFFSET = 8;
+  const OVERLAY_PADDING = 12;
+
+  let {
+    children,
+    testID,
+    zIndex = 1001,
+    width,
+    minWidth,
+    maxWidth,
+    referenceEl,
+    defaultPlacement = 'bottom-start',
+    _isNestedDropdown = false,
+    ...rest
+  }: DropdownOverlayProps = $props();
+
+  const dropdown = getDropdownContext();
+  const bottomSheet = getBottomSheetContext();
+  const isInBottomSheet = $derived(bottomSheet?.isInBottomSheet ?? false);
+
+  const isOpen = $derived(dropdown?.isOpen ?? false);
+
+  const reference = $derived(referenceEl ?? dropdown?.triggererWrapperEl ?? dropdown?.triggererEl ?? null);
+
+  const isMenu = $derived(
+    (dropdown?.dropdownTriggerer !== 'InputDropdownButton' && !referenceEl) || _isNestedDropdown,
+  );
+
+  let floatingEl = $state<HTMLDivElement | null>(null);
+  let floatingX = $state(0);
+  let floatingY = $state(0);
+  let referenceWidth = $state<number | null>(null);
+
+  // Visibility: the portal node is always mounted (so ActionList options stay
+  // registered even while closed); `isActive` toggles display + drives the
+  // enter/exit transition via `data-state`.
+  let isActive = $state(false);
+  let dataState = $state<'open' | 'closed'>('closed');
+  let unmountTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  const UNMOUNT_FALLBACK_MS = 240;
+
+  $effect(() => {
+    if (unmountTimeoutId !== null) {
+      clearTimeout(unmountTimeoutId);
+      unmountTimeoutId = null;
+    }
+    if (!isOpen) {
+      dataState = 'closed';
+      if (isActive) {
+        unmountTimeoutId = setTimeout(() => {
+          unmountTimeoutId = null;
+          if (!isOpen) isActive = false;
+        }, UNMOUNT_FALLBACK_MS);
+      }
+      return () => {
+        if (unmountTimeoutId !== null) {
+          clearTimeout(unmountTimeoutId);
+          unmountTimeoutId = null;
+        }
+      };
+    }
+    isActive = true;
+    const id = requestAnimationFrame(() => {
+      dataState = 'open';
+    });
+    return () => cancelAnimationFrame(id);
+  });
+
+  function handleSurfaceTransitionEnd(): void {
+    if (!isOpen && dataState === 'closed') {
+      if (unmountTimeoutId !== null) {
+        clearTimeout(unmountTimeoutId);
+        unmountTimeoutId = null;
+      }
+      isActive = false;
+    }
+  }
+
+  // Focus the trigger on open (Safari doesn't focus non-input triggers on click).
+  $effect(() => {
+    if (isOpen) {
+      dropdown?.triggererEl?.focus();
+    }
+  });
+
+  // Floating UI positioning — active only while the overlay is visible.
+  $effect(() => {
+    const ref = reference;
+    const float = floatingEl;
+    const placement = defaultPlacement;
+    if (!ref || !float || !isActive) return () => {};
+
+    const update = (): void => {
+      computePosition(ref, float, {
+        placement,
+        strategy: 'fixed',
+        middleware: [
+          offset({ mainAxis: OVERLAY_OFFSET }),
+          flip({ padding: OVERLAY_OFFSET + OVERLAY_PADDING }),
+          sizeMiddleware({
+            apply({ rects }) {
+              referenceWidth = rects.reference.width;
+            },
+          }),
+        ],
+      }).then(({ x, y }) => {
+        floatingX = x;
+        floatingY = y;
+      });
+    };
+
+    return autoUpdate(ref, float, update);
+  });
+
+  const surfaceClasses = $derived(getDropdownOverlayClasses({ isInBottomSheet, isMenu }));
+
+  const floatingStyle = $derived(
+    [
+      `z-index:${zIndex}`,
+      `transform:translate3d(${Math.round(floatingX)}px,${Math.round(floatingY)}px,0)`,
+      `display:${isActive ? 'flex' : 'none'}`,
+      // menu width comes from CSS min/max; input triggers take the reference width.
+      width ? `width:${width}` : !isMenu && referenceWidth ? `width:${referenceWidth}px` : undefined,
+      minWidth ? `min-width:${minWidth}` : undefined,
+      maxWidth ? `max-width:${maxWidth}` : undefined,
+    ]
+      .filter(Boolean)
+      .join(';'),
+  );
+
+  const metaAttrs = metaAttribute({ name: MetaConstants.DropdownOverlay, testID });
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+</script>
+
+<div
+  bind:this={floatingEl}
+  class={dropdownFloatingClass}
+  style={floatingStyle}
+  data-dropdown-id={dropdown?.dropdownBaseId}
+  use:portal={document.body}
+>
+  <OverlayContextReset>
+    <div
+      class={surfaceClasses}
+      data-state={dataState}
+      ontransitionend={handleSurfaceTransitionEnd}
+      {...metaAttrs}
+      {...analyticsAttrs}
+    >
+      {@render children()}
+    </div>
+  </OverlayContextReset>
+</div>

--- a/packages/blade-svelte/src/components/Dropdown/InputDropdownButton.svelte
+++ b/packages/blade-svelte/src/components/Dropdown/InputDropdownButton.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import {
+    metaAttribute,
+    makeAccessible,
+    makeAnalyticsAttribute,
+    useId,
+  } from '@razorpay/blade-core/utils';
+  import {
+    getInputDropdownButtonClasses,
+    inputDropdownButtonContentClass,
+    getDropdownTemplateClasses,
+  } from '@razorpay/blade-core/styles';
+  import Text from '../Typography/Text/Text.svelte';
+  import { ChevronUpDownIcon } from '../Icons';
+  import { getActionListContainerRole } from '../ActionList/getA11yRoles';
+  import { getDropdownContext } from './dropdownContext';
+  import type { InputDropdownButtonProps } from './types';
+
+  // Prevent tree-shaking of template classes used in compound selectors.
+  void getDropdownTemplateClasses();
+
+  let {
+    onClick,
+    onBlur,
+    onKeyDown,
+    accessibilityLabel,
+    _isInsideSearchInput = false,
+    isDisabled = false,
+    onChange,
+    name,
+    testID,
+    value,
+    defaultValue,
+    icon,
+    leading,
+    showDisplayValue = true,
+    size = 'medium',
+    ...rest
+  }: InputDropdownButtonProps = $props();
+
+  const idBase = useId('input-drop-down-button');
+  const dropdown = getDropdownContext();
+
+  // Register as the (select-style) trigger so a11y roles resolve correctly.
+  $effect(() => {
+    dropdown?.setDropdownTriggerer('InputDropdownButton');
+  });
+
+  const isOpen = $derived(dropdown?.isOpen ?? false);
+  const activeIndex = $derived(dropdown?.activeIndex ?? -1);
+  const hasFooterAction = $derived(dropdown?.hasFooterAction ?? false);
+  const dropdownBaseId = $derived(dropdown?.dropdownBaseId ?? idBase);
+  const displayValue = $derived(dropdown?.displayValue ?? '');
+
+  // Seed selection from `value` (controlled) / `defaultValue` (uncontrolled) once
+  // the matching option has registered. Minimal port of
+  // `useControlledDropdownInput`.
+  let hasSeededDefault = $state(false);
+  $effect(() => {
+    const opts = dropdown?.options ?? [];
+    if (value !== undefined) {
+      if (opts.some((o) => o.value === value)) {
+        dropdown?.setSelectedValues([value]);
+      }
+    } else if (!hasSeededDefault && defaultValue !== undefined) {
+      if (opts.some((o) => o.value === defaultValue)) {
+        dropdown?.setSelectedValues([defaultValue]);
+        hasSeededDefault = true;
+      }
+    }
+  });
+
+  // Fire onChange when the selected value changes (skips the initial value).
+  let previousValue = $state<string | undefined>(undefined);
+  $effect(() => {
+    const current = dropdown?.value ?? '';
+    if (previousValue !== undefined && current !== previousValue) {
+      onChange?.({ name: name ?? idBase, value: current });
+    }
+    previousValue = current;
+  });
+
+  const iconColor = $derived(
+    isDisabled ? 'surface.icon.gray.disabled' : 'surface.icon.gray.muted',
+  );
+  const displayColor = $derived(
+    isDisabled ? 'surface.text.gray.disabled' : 'surface.text.gray.subtle',
+  );
+
+  const buttonClasses = $derived(getInputDropdownButtonClasses({ size }));
+
+  const a11yAttrs = $derived(
+    makeAccessible({
+      label: accessibilityLabel ?? `change ${displayValue} filter`,
+      hasPopup: getActionListContainerRole(hasFooterAction, 'InputDropdownButton', true),
+      expanded: isOpen,
+      controls: `${dropdownBaseId}-actionlist`,
+      activeDescendant: activeIndex >= 0 ? `${dropdownBaseId}-${activeIndex}` : undefined,
+    }),
+  );
+
+  const metaAttrs = $derived(metaAttribute({ name: 'InputDropdownButton', testID }));
+  const analyticsAttrs = $derived(makeAnalyticsAttribute(rest));
+
+  function handleClick(event: MouseEvent): void {
+    if (isDisabled) return;
+    dropdown?.onTriggerClick();
+    onClick?.(event);
+    event.stopPropagation();
+  }
+
+  function handleBlur(event: FocusEvent): void {
+    if (isDisabled) return;
+    onBlur?.(event);
+    event.stopPropagation();
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (isDisabled) return;
+    dropdown?.onTriggerKeydown({ event });
+    onKeyDown?.(event);
+    event.stopPropagation();
+  }
+
+  function setTriggerRef(node: HTMLButtonElement): { destroy: () => void } {
+    dropdown?.setTriggererEl(node);
+    return { destroy: () => dropdown?.setTriggererEl(null) };
+  }
+</script>
+
+{#if displayValue}
+  <button
+    type="button"
+    class={buttonClasses}
+    disabled={isDisabled || undefined}
+    onclick={handleClick}
+    onblur={handleBlur}
+    onkeydown={handleKeydown}
+    use:setTriggerRef
+    {...a11yAttrs}
+    {...metaAttrs}
+    {...analyticsAttrs}
+  >
+    <span class={inputDropdownButtonContentClass}>
+      {#if _isInsideSearchInput}
+        <Text
+          variant="body"
+          size="medium"
+          weight="regular"
+          color={isDisabled ? 'surface.text.gray.disabled' : 'surface.text.gray.muted'}
+        >
+          in
+        </Text>
+      {/if}
+      {#if leading}
+        {@render leading()}
+      {/if}
+      {#if icon}
+        {@const IconComp = icon}
+        <IconComp size="medium" color={iconColor} />
+      {/if}
+      {#if showDisplayValue}
+        <Text variant="body" size="medium" weight="regular" color={displayColor}>
+          {displayValue}
+        </Text>
+      {/if}
+      <ChevronUpDownIcon color={iconColor} />
+    </span>
+  </button>
+{/if}

--- a/packages/blade-svelte/src/components/Dropdown/dropdownComponentIds.ts
+++ b/packages/blade-svelte/src/components/Dropdown/dropdownComponentIds.ts
@@ -1,0 +1,21 @@
+/**
+ * Component id constants for the Dropdown family. Only the in-scope surfaces are
+ * listed; out-of-scope triggers (SelectInput / AutoComplete / DropdownButton /
+ * FilterChip* etc.) are intentionally omitted from this partial migration.
+ */
+export const dropdownComponentIds = {
+  Dropdown: 'Dropdown',
+  DropdownOverlay: 'DropdownOverlay',
+  DropdownHeader: 'DropdownHeader',
+  DropdownFooter: 'DropdownFooter',
+  triggers: {
+    InputDropdownButton: 'InputDropdownButton',
+  },
+} as const;
+
+/**
+ * Which element triggered the Dropdown. In this partial scope only
+ * `InputDropdownButton` self-registers; menu triggers (Button/Link/IconButton)
+ * leave this `undefined`, which the a11y-role helpers treat as a `menu`.
+ */
+export type DropdownTriggerer = 'InputDropdownButton' | undefined;

--- a/packages/blade-svelte/src/components/Dropdown/dropdownContext.ts
+++ b/packages/blade-svelte/src/components/Dropdown/dropdownContext.ts
@@ -1,0 +1,23 @@
+import { getContext, setContext } from 'svelte';
+import type { DropdownContextValue } from './types';
+
+const DROPDOWN_CONTEXT_KEY = Symbol('dropdown-context');
+
+/**
+ * Reactive Dropdown context (getter pattern, mirrors `tooltipContext` /
+ * `bottomSheetContext`). `setContext(KEY, () => value)` keeps getter fields on
+ * the context object live across the boundary.
+ */
+export function setDropdownContext(getter: () => DropdownContextValue): void {
+  setContext(DROPDOWN_CONTEXT_KEY, getter);
+}
+
+/**
+ * Read the Dropdown context. Returns `undefined` when there is no `Dropdown`
+ * ancestor — consumers (notably `ActionList`/`ActionListItem`) must treat this
+ * as a no-op so standalone + BottomSheet usage stays unchanged.
+ */
+export function getDropdownContext(): DropdownContextValue | undefined {
+  const getter = getContext<(() => DropdownContextValue) | undefined>(DROPDOWN_CONTEXT_KEY);
+  return getter?.();
+}

--- a/packages/blade-svelte/src/components/Dropdown/dropdownUtils.ts
+++ b/packages/blade-svelte/src/components/Dropdown/dropdownUtils.ts
@@ -64,7 +64,7 @@ export function filterOptions(
 export function getActionFromKey(
   e: MouseEvent | KeyboardEvent,
   isOpen: boolean,
-  dropdownTriggerer: DropdownTriggerer,
+  _dropdownTriggerer: DropdownTriggerer,
 ): SelectActionsType | undefined {
   if (!e) {
     return undefined;

--- a/packages/blade-svelte/src/components/Dropdown/dropdownUtils.ts
+++ b/packages/blade-svelte/src/components/Dropdown/dropdownUtils.ts
@@ -1,0 +1,305 @@
+/*
+ * This content is licensed according to the W3C Software License at
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ * Derived from
+ * https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html.
+ *
+ * Web-only Svelte port of React `dropdownUtils.ts`. React event types are
+ * replaced with DOM events; React Native branches and the TreeView-specific
+ * display override are stripped.
+ */
+import type { DropdownOption } from './types';
+import type { DropdownTriggerer } from './dropdownComponentIds';
+
+export type SelectActionsType =
+  | 'Close'
+  | 'CloseSelect'
+  | 'Expand'
+  | 'Collapse'
+  | 'First'
+  | 'Last'
+  | 'Next'
+  | 'Open'
+  | 'PageDown'
+  | 'PageUp'
+  | 'Previous'
+  | 'Select'
+  | 'Type';
+
+const SelectActions: Record<SelectActionsType, SelectActionsType> = {
+  Close: 'Close',
+  CloseSelect: 'CloseSelect',
+  Expand: 'Expand',
+  Collapse: 'Collapse',
+  First: 'First',
+  Last: 'Last',
+  Next: 'Next',
+  Open: 'Open',
+  PageDown: 'PageDown',
+  PageUp: 'PageUp',
+  Previous: 'Previous',
+  Select: 'Select',
+  Type: 'Type',
+};
+
+/**
+ * Filter an array of options against an input string. Returns options that begin
+ * with the filter string (case-insensitive), excluding any in `exclude`.
+ */
+export function filterOptions(
+  options: string[] = [],
+  filter: string,
+  exclude: string[] = [],
+): string[] {
+  return options.filter((option) => {
+    const matches = String(option).toLowerCase().startsWith(filter.toLowerCase());
+    return matches && !exclude.includes(option);
+  });
+}
+
+/**
+ * Map a keypress to a combobox action.
+ */
+export function getActionFromKey(
+  e: MouseEvent | KeyboardEvent,
+  isOpen: boolean,
+  dropdownTriggerer: DropdownTriggerer,
+): SelectActionsType | undefined {
+  if (!e) {
+    return undefined;
+  }
+
+  const { altKey, ctrlKey, metaKey } = e;
+  let key = '';
+  if ('key' in e) {
+    key = e.key;
+  }
+  const openKeys = ['ArrowDown', 'ArrowUp', 'Enter', ' '];
+  if (!key) return undefined;
+  if (!isOpen && key && openKeys.includes(key)) {
+    return SelectActions.Open;
+  }
+
+  if (key === 'Home') {
+    return SelectActions.First;
+  }
+  if (key === 'End') {
+    return SelectActions.Last;
+  }
+
+  if (
+    key === 'Backspace' ||
+    key === 'Clear' ||
+    (key.length === 1 && key !== ' ' && !altKey && !ctrlKey && !metaKey)
+  ) {
+    return SelectActions.Type;
+  }
+
+  if (isOpen) {
+    if (key === 'ArrowUp' && altKey) {
+      return SelectActions.CloseSelect;
+    } else if (key === 'ArrowDown' && !altKey) {
+      return SelectActions.Next;
+    } else if (key === 'ArrowUp') {
+      return SelectActions.Previous;
+    } else if (key === 'ArrowRight' && !altKey) {
+      return SelectActions.Expand;
+    } else if (key === 'ArrowLeft' && !altKey) {
+      return SelectActions.Collapse;
+    } else if (key === 'PageUp') {
+      return SelectActions.PageUp;
+    } else if (key === 'PageDown') {
+      return SelectActions.PageDown;
+    } else if (key === 'Escape') {
+      return SelectActions.Close;
+    } else if (key === 'Enter' || key === ' ') {
+      return SelectActions.CloseSelect;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Return the index of an option based on a search string. Cycles through
+ * first-letter matches when the same letter is repeated (e.g. "aaa").
+ */
+export function getIndexByLetter(options: string[], filter: string, startIndex = 0): number {
+  const orderedOptions = [...options.slice(startIndex), ...options.slice(0, startIndex)];
+  const firstMatch = filterOptions(orderedOptions, filter)[0];
+  const allSameLetter = (array: string[]): boolean => array.every((letter) => letter === array[0]);
+
+  if (firstMatch) {
+    return options.indexOf(firstMatch);
+  } else if (allSameLetter(filter.split(''))) {
+    const matches = filterOptions(orderedOptions, filter[0]);
+    return options.indexOf(matches[0]);
+  }
+  return -1;
+}
+
+/**
+ * Clamp the option index within bounds for the given action.
+ */
+export function getUpdatedIndex({
+  currentIndex,
+  maxIndex,
+  actionType,
+}: {
+  currentIndex: number;
+  maxIndex: number;
+  actionType: SelectActionsType;
+}): number {
+  const pageSize = 10;
+
+  switch (actionType) {
+    case SelectActions.First:
+      return 0;
+    case SelectActions.Last:
+      return maxIndex;
+    case SelectActions.Previous:
+      return Math.max(0, currentIndex - 1);
+    case SelectActions.Next:
+      return Math.min(maxIndex, currentIndex + 1);
+    case SelectActions.PageUp:
+      return Math.max(0, currentIndex - pageSize);
+    case SelectActions.PageDown:
+      return Math.min(maxIndex, currentIndex + pageSize);
+    default:
+      return currentIndex;
+  }
+}
+
+/** Whether the element is fully within the viewport. */
+export function isElementVisibleOnScreen(element: HTMLElement): boolean {
+  const bounding = element.getBoundingClientRect();
+  return (
+    bounding.top >= 0 &&
+    bounding.left >= 0 &&
+    bounding.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    bounding.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}
+
+/** Whether `element` is vertically visible inside `container`. */
+function isElementVisible(container: HTMLElement, element: HTMLElement): boolean {
+  const containerRect = container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  return elementRect.top >= containerRect.top && elementRect.bottom <= containerRect.bottom;
+}
+
+/** Whether the element has a vertical scrollbar. */
+export function isScrollable(element: HTMLElement): boolean {
+  return Boolean(element) && element.clientHeight < element.scrollHeight;
+}
+
+type ActionsType = {
+  setIsOpen: (isOpen: boolean) => void;
+  close: () => void;
+  selectCurrentOption: (event?: KeyboardEvent) => void;
+  onOptionChange: (action: SelectActionsType) => void;
+  onComboType: (letter: string, action: SelectActionsType) => void;
+  onTreeExpandCollapse?: (action: SelectActionsType) => void;
+};
+
+/**
+ * Perform the keydown action. Returns `true` when the action was handled.
+ */
+export const performAction = (
+  action: SelectActionsType,
+  payload: { event: KeyboardEvent },
+  actions: ActionsType,
+): boolean => {
+  const { event } = payload;
+
+  switch (action) {
+    case SelectActions.First:
+    case SelectActions.Last:
+      actions.setIsOpen(true);
+      event.preventDefault();
+      actions.onOptionChange(action);
+      return true;
+    case SelectActions.Next:
+    case SelectActions.Previous:
+    case SelectActions.PageUp:
+    case SelectActions.PageDown:
+      event.preventDefault();
+      actions.onOptionChange(action);
+      return true;
+    case SelectActions.CloseSelect:
+      event.preventDefault();
+      actions.selectCurrentOption(event);
+      return true;
+    case SelectActions.Expand:
+    case SelectActions.Collapse:
+      if (actions.onTreeExpandCollapse) {
+        event.preventDefault();
+        actions.onTreeExpandCollapse(action);
+        return true;
+      }
+      return false;
+    case SelectActions.Close:
+      event.preventDefault();
+      actions.close();
+      return true;
+    case SelectActions.Type:
+      actions.onComboType(event.key, action);
+      return true;
+    case SelectActions.Open:
+      event.preventDefault();
+      actions.setIsOpen(true);
+      return true;
+    default:
+      break;
+  }
+
+  return false;
+};
+
+/**
+ * Scroll the active option into view within its scroll container.
+ */
+export const ensureScrollVisiblity = (
+  newActiveIndex: number,
+  containerElement: HTMLElement | null,
+  options: string[],
+): void => {
+  if (!containerElement) return;
+  if (!isScrollable(containerElement)) return;
+
+  const optionEl = containerElement.querySelectorAll<HTMLElement>(
+    '[role="option"], [role="menuitem"], [role="menuitemcheckbox"]',
+  );
+  if (newActiveIndex >= 0 && optionEl[newActiveIndex]?.dataset.value === options[newActiveIndex]) {
+    const activeElement = optionEl[newActiveIndex];
+    if (!isElementVisible(containerElement, activeElement)) {
+      activeElement.scrollIntoView({ inline: 'nearest' });
+    }
+    if (!isElementVisibleOnScreen(optionEl[newActiveIndex])) {
+      activeElement.scrollIntoView({ behavior: 'smooth' });
+    }
+  }
+};
+
+/** Value set in the underlying form input. */
+export const makeInputValue = (selectedIndices: number[], options: DropdownOption[]): string => {
+  if (options.length === 0) {
+    return '';
+  }
+  return selectedIndices.map((selectedIndex) => options[selectedIndex]?.value).join(', ');
+};
+
+/** Value displayed inside the trigger after selection. */
+export const makeInputDisplayValue = (
+  selectedIndices: number[],
+  options: DropdownOption[],
+): string => {
+  if (options.length === 0 || selectedIndices.length === 0) {
+    return '';
+  }
+  if (selectedIndices.length === 1) {
+    return options[selectedIndices[0]]?.title ?? '';
+  }
+  return `${selectedIndices.length} items selected`;
+};

--- a/packages/blade-svelte/src/components/Dropdown/index.ts
+++ b/packages/blade-svelte/src/components/Dropdown/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Dropdown — a generic controller that opens a floating `DropdownOverlay`
+ * (portaled, positioned with `@floating-ui/dom`) containing an `ActionList`,
+ * with optional `DropdownHeader` / `DropdownFooter`. Works with menu triggers
+ * (Button / Link / IconButton) or the select-style `InputDropdownButton`.
+ *
+ * This is a partial (Tiers 1–3), web-only migration. Out of scope: SelectInput,
+ * AutoComplete, FilterChip* triggers, DropdownButton/Link/IconButton wrappers,
+ * TreeView / ListView overlay content, and the TopNav theme override.
+ *
+ * When an `ActionList` is rendered inside a `Dropdown`, its items self-register
+ * into the Dropdown's option registry to power index-based keyboard navigation,
+ * selection highlight, typeahead, and the trigger `displayValue`. Standalone /
+ * BottomSheet `ActionList` usage is unaffected (registration is a no-op without
+ * a Dropdown ancestor).
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import {
+ *     Dropdown,
+ *     DropdownOverlay,
+ *     ActionList,
+ *     ActionListItem,
+ *     Button,
+ *   } from '@razorpay/blade-svelte/components';
+ * </script>
+ *
+ * <Dropdown selectionType="single">
+ *   {#snippet children()}
+ *     <Button>Open menu</Button>
+ *     <DropdownOverlay>
+ *       {#snippet children()}
+ *         <ActionList>
+ *           {#snippet children()}
+ *             <ActionListItem title="Profile" value="profile" />
+ *             <ActionListItem title="Settings" value="settings" />
+ *           {/snippet}
+ *         </ActionList>
+ *       {/snippet}
+ *     </DropdownOverlay>
+ *   {/snippet}
+ * </Dropdown>
+ * ```
+ */
+export { default as Dropdown } from './Dropdown.svelte';
+export { default as DropdownOverlay } from './DropdownOverlay.svelte';
+export { default as DropdownHeader } from './DropdownHeader.svelte';
+export { default as DropdownFooter } from './DropdownFooter.svelte';
+export { default as InputDropdownButton } from './InputDropdownButton.svelte';
+export type {
+  DropdownProps,
+  DropdownOverlayProps,
+  DropdownHeaderProps,
+  DropdownFooterProps,
+  InputDropdownButtonProps,
+  DropdownSelectionType,
+  DropdownContextValue,
+  DropdownOption,
+} from './types';

--- a/packages/blade-svelte/src/components/Dropdown/types.ts
+++ b/packages/blade-svelte/src/components/Dropdown/types.ts
@@ -1,0 +1,214 @@
+import type { Snippet } from 'svelte';
+import type { Placement } from '@floating-ui/dom';
+import type { StyledPropsBlade, DataAnalyticsAttribute } from '@razorpay/blade-core/utils';
+import type { IconComponent } from '../Icons';
+import type { DropdownTriggerer } from './dropdownComponentIds';
+
+/** Selection mode of the Dropdown. */
+export type DropdownSelectionType = 'single' | 'multiple';
+
+/** Keydown handler shape (web-only port of React `FormInputHandleOnKeyDownEvent`). */
+export type DropdownKeydownEvent = { event: KeyboardEvent };
+
+export interface DropdownProps extends StyledPropsBlade, DataAnalyticsAttribute {
+  /**
+   * Trigger + `DropdownOverlay` children.
+   */
+  children: Snippet;
+  /**
+   * Control the open/close state (controlled mode). Leave undefined for
+   * uncontrolled behavior.
+   */
+  isOpen?: boolean;
+  /**
+   * Called whenever the open state changes.
+   */
+  onOpenChange?: (isOpen: boolean) => void;
+  /**
+   * Selection mode.
+   * @default 'single'
+   */
+  selectionType?: DropdownSelectionType;
+  /**
+   * @private
+   * Width applied to the outer relative container. Use `width` on
+   * `DropdownOverlay` to change the menu width.
+   */
+  _width?: string;
+  /**
+   * Test ID for the container element.
+   */
+  testID?: string;
+}
+
+export interface DropdownOverlayProps extends DataAnalyticsAttribute {
+  /**
+   * Overlay content — `DropdownHeader?`, `ActionList`, `DropdownFooter?`.
+   */
+  children: Snippet;
+  /**
+   * z-index of the overlay.
+   * @default 1001
+   */
+  zIndex?: number;
+  /**
+   * Override the overlay width.
+   */
+  width?: string;
+  /**
+   * Override the overlay min-width.
+   */
+  minWidth?: string;
+  /**
+   * Override the overlay max-width.
+   */
+  maxWidth?: string;
+  /**
+   * Element to position the overlay relative to. When omitted, the Dropdown's
+   * own trigger wrapper is used. Svelte uses an element binding instead of
+   * React's ref object.
+   */
+  referenceEl?: HTMLElement | null;
+  /**
+   * Placement of the overlay.
+   * @default 'bottom-start'
+   */
+  defaultPlacement?: Placement;
+  /**
+   * @private
+   * @default false
+   */
+  _isNestedDropdown?: boolean;
+  /**
+   * Test ID for the overlay element.
+   */
+  testID?: string;
+}
+
+export interface DropdownHeaderProps extends DataAnalyticsAttribute {
+  /** Header title text. */
+  title?: string;
+  /** Secondary text below the title. */
+  subtitle?: string;
+  /** Leading slot (left of the title). */
+  leading?: Snippet;
+  /** Trailing slot (right side). */
+  trailing?: Snippet;
+  /** Slot rendered adjacent to the title text. */
+  titleSuffix?: Snippet;
+  /** Inner children (e.g. AutoComplete in header). */
+  children?: Snippet;
+  /** Test ID for the header element. */
+  testID?: string;
+}
+
+export interface DropdownFooterProps extends DataAnalyticsAttribute {
+  /** Footer content. */
+  children?: Snippet;
+  /** Test ID for the footer element. */
+  testID?: string;
+}
+
+type BaseInputDropdownButtonProps = {
+  /** Controls open state of the dropdown. */
+  isOpen?: boolean;
+  /** Called when the button loses focus. */
+  onBlur?: (event: FocusEvent) => void;
+  /** Called on keydown. */
+  onKeyDown?: (event: KeyboardEvent) => void;
+  /** Called on click. */
+  onClick?: (event: MouseEvent) => void;
+  /** Accessibility label. @default `change ${displayValue} filter` */
+  accessibilityLabel?: string;
+  /** @private */
+  _isInsideSearchInput?: boolean;
+  /** Disabled state. */
+  isDisabled?: boolean;
+  /** Called when the selected value changes. */
+  onChange?: (props: { name: string; value: string }) => void;
+  /** Name used in the change payload. */
+  name?: string;
+  /** Test ID for the button element. */
+  testID?: string;
+  /** Leading icon component. */
+  icon?: IconComponent;
+  /** Custom leading slot (e.g. a flag). */
+  leading?: Snippet;
+  /**
+   * Show the selected value text in the trigger.
+   * @default true
+   */
+  showDisplayValue?: boolean;
+  /**
+   * Size of the button.
+   * @default 'medium'
+   */
+  size?: 'small' | 'medium' | 'large';
+} & DataAnalyticsAttribute;
+
+type ControlledInputDropdownButtonProps = BaseInputDropdownButtonProps & {
+  /** Controlled selected value. */
+  value: string;
+  defaultValue?: never;
+};
+
+type UncontrolledInputDropdownButtonProps = BaseInputDropdownButtonProps & {
+  value?: never;
+  /** Initial selected value (uncontrolled). */
+  defaultValue: string;
+};
+
+export type InputDropdownButtonProps =
+  | ControlledInputDropdownButtonProps
+  | UncontrolledInputDropdownButtonProps;
+
+/** A registered ActionList option (mirrors React `OptionsType[number]`). */
+export type DropdownOption = {
+  /** Stable id of the registering item (used for reordering-safe indexing). */
+  id: string;
+  title: string;
+  value: string;
+  href?: string;
+  onClickTrigger?: (isSelected: boolean) => void;
+};
+
+/**
+ * Reactive context provided by `Dropdown` and consumed by `DropdownOverlay`,
+ * `DropdownHeader/Footer`, `InputDropdownButton`, and (optionally) `ActionList`.
+ * Getter fields stay live across the context boundary.
+ */
+export type DropdownContextValue = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  close: () => void;
+  selectionType: DropdownSelectionType;
+  selectedIndices: number[];
+  /** Seed/replace selection by option value (used by controllable triggers). */
+  setSelectedValues: (values: string[]) => void;
+  activeIndex: number;
+  filteredValues: string[];
+  options: DropdownOption[];
+  hasFooterAction: boolean;
+  setHasFooterAction: (value: boolean) => void;
+  hasAutoCompleteInHeader: boolean;
+  setHasAutoCompleteInHeader: (value: boolean) => void;
+  dropdownBaseId: string;
+  dropdownTriggerer: DropdownTriggerer;
+  setDropdownTriggerer: (triggerer: DropdownTriggerer) => void;
+  value: string;
+  displayValue: string;
+  /** Register an option; returns nothing — the item reads its index reactively. */
+  registerOption: (option: DropdownOption) => void;
+  unregisterOption: (id: string) => void;
+  /** Index of an option by its stable id (reorder-safe). */
+  getOptionIndex: (id: string) => number;
+  onOptionClick: (event: MouseEvent | KeyboardEvent, index: number) => void;
+  onTriggerClick: () => void;
+  onTriggerKeydown: (payload: DropdownKeydownEvent) => void;
+  /** Element bindings (Svelte uses element refs instead of React ref objects). */
+  triggererEl: HTMLElement | null;
+  setTriggererEl: (el: HTMLElement | null) => void;
+  triggererWrapperEl: HTMLElement | null;
+  actionListContainerEl: HTMLElement | null;
+  setActionListContainerEl: (el: HTMLElement | null) => void;
+};

--- a/packages/blade-svelte/src/components/Dropdown/useDropdown.ts
+++ b/packages/blade-svelte/src/components/Dropdown/useDropdown.ts
@@ -1,0 +1,193 @@
+/**
+ * Framework-agnostic Dropdown controller. Mirrors the interaction slice of
+ * React's `useDropdown` hook (select / keyboard-nav / typeahead) but is a plain
+ * factory: `Dropdown.svelte` wires its `$state` in via accessor callbacks so the
+ * logic stays outside the component and reusable.
+ *
+ * TreeView / AutoComplete / controlled-SelectInput branches are out of scope.
+ */
+import {
+  ensureScrollVisiblity,
+  getActionFromKey,
+  getIndexByLetter,
+  getUpdatedIndex,
+  performAction,
+} from './dropdownUtils';
+import type { SelectActionsType } from './dropdownUtils';
+import type { DropdownOption } from './types';
+import type { DropdownTriggerer } from './dropdownComponentIds';
+
+export type DropdownControllerState = {
+  getIsOpen: () => boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  close: () => void;
+  getSelectionType: () => 'single' | 'multiple';
+  getOptions: () => DropdownOption[];
+  getSelectedIndices: () => number[];
+  setSelectedIndices: (indices: number[]) => void;
+  getActiveIndex: () => number;
+  setActiveIndex: (index: number) => void;
+  getFilteredValues: () => string[];
+  getDropdownTriggerer: () => DropdownTriggerer;
+  getActionListContainerEl: () => HTMLElement | null;
+  getTriggererEl: () => HTMLElement | null;
+  getHasFooterAction: () => boolean;
+  getIsKeydownPressed: () => boolean;
+  setIsKeydownPressed: (value: boolean) => void;
+};
+
+export type DropdownController = {
+  onTriggerClick: () => void;
+  onTriggerKeydown: (payload: { event: KeyboardEvent }) => void;
+  onOptionClick: (event: MouseEvent | KeyboardEvent, index: number) => void;
+};
+
+let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+let searchString = '';
+
+export function createDropdownController(state: DropdownControllerState): DropdownController {
+  /**
+   * Marks the given index selected. Single-select closes the menu; multi-select
+   * toggles and keeps it open. Returns the item's resulting selected state.
+   */
+  const selectOption = (index: number, closeOnSelection = true): boolean => {
+    const options = state.getOptions();
+    let isSelected = false;
+
+    if (index < 0 || index > options.length - 1) {
+      return isSelected;
+    }
+
+    const selectionType = state.getSelectionType();
+    const selectedIndices = state.getSelectedIndices();
+
+    if (selectionType === 'multiple') {
+      if (selectedIndices.includes(index)) {
+        state.setSelectedIndices(selectedIndices.filter((i) => i !== index));
+        isSelected = false;
+      } else {
+        state.setSelectedIndices([...selectedIndices, index]);
+        isSelected = true;
+      }
+    } else {
+      state.setSelectedIndices([index]);
+      isSelected = true;
+    }
+
+    if (state.getActiveIndex() !== index) {
+      state.setActiveIndex(index);
+    }
+
+    if (closeOnSelection && selectionType !== 'multiple') {
+      state.close();
+    }
+
+    return isSelected;
+  };
+
+  const onOptionChange = (actionType: SelectActionsType, index?: number): void => {
+    const options = state.getOptions();
+    const newIndex = index ?? state.getActiveIndex();
+    const filteredValues = state.getFilteredValues();
+    let updatedIndex: number;
+
+    if (filteredValues.length > 0) {
+      const filteredIndexes = filteredValues
+        .map((filteredValue) => options.findIndex((option) => option.value === filteredValue))
+        .sort((a, b) => a - b);
+      updatedIndex =
+        filteredIndexes[
+          getUpdatedIndex({
+            currentIndex: filteredIndexes.indexOf(newIndex),
+            maxIndex: filteredIndexes.length - 1,
+            actionType,
+          })
+        ];
+    } else {
+      updatedIndex = getUpdatedIndex({
+        currentIndex: newIndex,
+        maxIndex: options.length - 1,
+        actionType,
+      });
+    }
+
+    state.setActiveIndex(updatedIndex);
+    const optionValues = options.map((option) => option.value);
+    ensureScrollVisiblity(updatedIndex, state.getActionListContainerEl(), optionValues);
+  };
+
+  const onComboType = (letter: string, actionType: SelectActionsType): void => {
+    state.setIsOpen(true);
+
+    if (searchTimeout) {
+      clearTimeout(searchTimeout);
+    }
+    searchTimeout = setTimeout(() => {
+      searchString = '';
+    }, 500);
+    searchString += letter;
+
+    const options = state.getOptions();
+    const optionTitles = options.map((option) => option.title);
+    const searchIndex = getIndexByLetter(optionTitles, searchString, state.getActiveIndex() + 1);
+
+    if (searchIndex >= 0) {
+      onOptionChange(actionType, searchIndex);
+    } else {
+      clearTimeout(searchTimeout);
+      searchString = '';
+    }
+  };
+
+  const onTriggerClick = (): void => {
+    if (state.getIsOpen()) {
+      state.close();
+    } else {
+      state.setIsOpen(true);
+    }
+  };
+
+  const onTriggerKeydown = (payload: { event: KeyboardEvent }): void => {
+    const { event } = payload;
+    if (
+      !state.getIsKeydownPressed() &&
+      ![' ', 'Enter', 'Escape', 'Meta'].includes(event.key)
+    ) {
+      state.setIsKeydownPressed(true);
+    }
+
+    const actionType = getActionFromKey(event, state.getIsOpen(), state.getDropdownTriggerer());
+
+    if (actionType) {
+      performAction(actionType, { event }, {
+        setIsOpen: state.setIsOpen,
+        close: state.close,
+        onOptionChange,
+        onComboType,
+        selectCurrentOption: () => {
+          const activeIndex = state.getActiveIndex();
+          if (activeIndex < 0) {
+            return;
+          }
+          const isSelected = selectOption(activeIndex);
+          if (state.getHasFooterAction()) {
+            state.getTriggererEl()?.focus();
+          }
+          state.getOptions()[activeIndex]?.onClickTrigger?.(isSelected);
+        },
+      });
+    }
+  };
+
+  const onOptionClick = (event: MouseEvent | KeyboardEvent, index: number): void => {
+    state.setIsKeydownPressed(false);
+    const actionType = getActionFromKey(event, state.getIsOpen(), state.getDropdownTriggerer());
+    if (typeof actionType === 'string') {
+      onOptionChange(actionType, index);
+    }
+    selectOption(index);
+    state.getTriggererEl()?.focus();
+  };
+
+  return { onTriggerClick, onTriggerKeydown, onOptionClick };
+}

--- a/packages/blade-svelte/src/components/Dropdown/useDropdown.ts
+++ b/packages/blade-svelte/src/components/Dropdown/useDropdown.ts
@@ -149,33 +149,34 @@ export function createDropdownController(state: DropdownControllerState): Dropdo
 
   const onTriggerKeydown = (payload: { event: KeyboardEvent }): void => {
     const { event } = payload;
-    if (
-      !state.getIsKeydownPressed() &&
-      ![' ', 'Enter', 'Escape', 'Meta'].includes(event.key)
-    ) {
+    if (!state.getIsKeydownPressed() && ![' ', 'Enter', 'Escape', 'Meta'].includes(event.key)) {
       state.setIsKeydownPressed(true);
     }
 
     const actionType = getActionFromKey(event, state.getIsOpen(), state.getDropdownTriggerer());
 
     if (actionType) {
-      performAction(actionType, { event }, {
-        setIsOpen: state.setIsOpen,
-        close: state.close,
-        onOptionChange,
-        onComboType,
-        selectCurrentOption: () => {
-          const activeIndex = state.getActiveIndex();
-          if (activeIndex < 0) {
-            return;
-          }
-          const isSelected = selectOption(activeIndex);
-          if (state.getHasFooterAction()) {
-            state.getTriggererEl()?.focus();
-          }
-          state.getOptions()[activeIndex]?.onClickTrigger?.(isSelected);
+      performAction(
+        actionType,
+        { event },
+        {
+          setIsOpen: state.setIsOpen,
+          close: state.close,
+          onOptionChange,
+          onComboType,
+          selectCurrentOption: () => {
+            const activeIndex = state.getActiveIndex();
+            if (activeIndex < 0) {
+              return;
+            }
+            const isSelected = selectOption(activeIndex);
+            if (state.getHasFooterAction()) {
+              state.getTriggererEl()?.focus();
+            }
+            state.getOptions()[activeIndex]?.onClickTrigger?.(isSelected);
+          },
         },
-      });
+      );
     }
   };
 

--- a/packages/blade-svelte/src/components/OverlayContextReset/OverlayContextReset.svelte
+++ b/packages/blade-svelte/src/components/OverlayContextReset/OverlayContextReset.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { setButtonGroupContext } from '../ButtonGroup/buttonGroupContext';
+
+  /**
+   * Resets contexts that shouldn't leak into portaled overlay content. Mirrors
+   * React's `OverlayContextReset` — buttons inside an overlay triggered from a
+   * ButtonGroup must not inherit the group's size/variant. Renders its children
+   * with an empty ButtonGroup context.
+   */
+  let { children }: { children: Snippet } = $props();
+
+  setButtonGroupContext(() => ({}));
+</script>
+
+{@render children()}

--- a/packages/blade-svelte/src/components/index.ts
+++ b/packages/blade-svelte/src/components/index.ts
@@ -315,6 +315,25 @@ export type { InputGroupProps, InputRowProps } from './InputGroup';
 // BladeProvider
 export * from './BladeProvider';
 
+// Dropdown
+export {
+  Dropdown,
+  DropdownOverlay,
+  DropdownHeader,
+  DropdownFooter,
+  InputDropdownButton,
+} from './Dropdown';
+export type {
+  DropdownProps,
+  DropdownOverlayProps,
+  DropdownHeaderProps,
+  DropdownFooterProps,
+  InputDropdownButtonProps,
+  DropdownSelectionType,
+  DropdownContextValue,
+  DropdownOption,
+} from './Dropdown';
+
 // Tabs
 export { default as Tabs } from './Tabs/Tabs.svelte';
 export { default as TabList } from './Tabs/TabList.svelte';


### PR DESCRIPTION
## Description

Migrates the React Dropdown to Svelte 5 — **partial scope (Tiers 1–3)**. Ships the controller, overlay, header/footer, and InputDropdownButton trigger, plus extends the existing Svelte ActionList with Dropdown option-registration (index-based keyboard nav, displayValue, typeahead).

## Scope

**In-scope (this PR):**
- `Dropdown` controller (context + bottomsheet glue + controllable `isOpen`)
- `DropdownOverlay` (`@floating-ui/dom` computePosition/autoUpdate + `use:portal`, modeled on Tooltip)
- `DropdownHeader` / `DropdownFooter` (+ `BaseHeaderFooter` shim)
- `InputDropdownButton` trigger
- `useDropdown` / `dropdownUtils` / `dropdownContext` / `types` / `dropdownComponentIds`
- Extended `ActionList` (context, ActionList, ActionListItem, getA11yRoles) — registration is **optional/no-op** outside a Dropdown, so standalone + BottomSheet usage is unchanged
- Prereq shims: `OverlayContextReset`, `ButtonGroup` context, BaseMenu offset constants

**Out of scope (deferred):** SelectInput, AutoComplete, FilterChipSelectInput, FilterChipGroup, DropdownButton, DropdownLink, DropdownIconButton, TreeView, ListView, TopNavOverlayThemeOverride.

## Changes

- Adds `packages/blade-svelte/src/components/Dropdown/`
- Adds `packages/blade-svelte/src/components/{BaseHeaderFooter,ButtonGroup,OverlayContextReset}/`
- Extends `packages/blade-svelte/src/components/ActionList/`
- Adds `packages/blade-core/src/styles/Dropdown/`
- Re-exports from `packages/blade-svelte/src/components/index.ts` + `packages/blade-core/src/styles/index.ts`

## Verification

- `svelte-check`: 0 errors
- blade-svelte + blade-core builds pass
- Visual/computed-style parity vs React verified; overlay positioning, multi-select, displayValue, header/footer `dialog` role checked
- No-regression confirmed: standalone ActionList + ActionList-in-BottomSheet unchanged

## Component Checklist

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [x] Add changeset

Made with [Cursor](https://cursor.com)