### PR TITLE
fix: bottomsheet scroll lock issue

### DIFF
--- a/.changeset/bottomsheet-ios-scroll-jump.md
+++ b/.changeset/bottomsheet-ios-scroll-jump.md
@@ -1,0 +1,7 @@
+---
+'@razorpay/blade-svelte': patch
+---
+
+fix(blade-svelte): stop BottomSheet and Modal from scrolling the page to the top on iOS
+
+`body-scroll-lock-upgrade` locks iOS by moving the page into `body { position: fixed; top: -scrollY }` and restoring it with `window.scrollTo()` on unlock, which loses the reading position; Android and desktop take its `overflow: hidden` branch and were unaffected. Both overlays now use a ref-counted lock that applies the same `overflow: hidden` bookkeeping on every platform and blocks background scrolling on iOS by intercepting `touchmove`, so nothing mutates page geometry. BottomSheet additionally acquires its lock at most once per open instead of on every content re-measurement.

--- a/packages/blade-svelte/package.json
+++ b/packages/blade-svelte/package.json
@@ -67,7 +67,6 @@
     "@razorpay/blade-core": ">=0.16.0",
     "@razorpay/i18nify-js": "1.12.3",
     "@use-gesture/vanilla": "10.2.24",
-    "body-scroll-lock-upgrade": "1.1.0",
     "class-variance-authority": "^0.7.0"
   },
   "devDependencies": {

--- a/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/BottomSheet.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { DragGesture, rubberbandIfOutOfBounds } from '@use-gesture/vanilla';
-  import {
-    disableBodyScroll,
-    enableBodyScroll,
-    clearAllBodyScrollLocks,
-  } from 'body-scroll-lock-upgrade';
   import {
     metaAttribute,
     MetaConstants,
@@ -34,6 +29,7 @@
   import BottomSheetBackdrop from './BottomSheetBackdrop.svelte';
   import { portal } from '../../utils/portal';
   import { observeResize } from '../../utils/observeResize';
+  import { lockBodyScroll, unlockBodyScroll } from '../../utils/bodyScrollLock';
 
   /* Anchor structural classes against the Rollup tree-shaker — CSS modules
    * export ESM objects whose unused individual exports otherwise get
@@ -291,29 +287,52 @@
     return undefined;
   });
 
-  /* Body scroll lock — defer to `body-scroll-lock-upgrade` so we get
-   * `reserveScrollBarGap: true` (no layout shift on Windows / non-overlay
-   * scrollbars) and proper iOS Safari momentum handling. Mirrors React's
-   * `useScrollLock({ targetRef: scrollRef, reserveScrollBarGap: true })`. */
+  /* Body scroll lock. Mirrors React's
+   * `useScrollLock({ targetRef: scrollRef, reserveScrollBarGap: true })`, but
+   * on our own lock (see utils/bodyScrollLock) rather than
+   * `body-scroll-lock-upgrade`, whose iOS branch loses the page's scroll
+   * position.
+   *
+   * Acquire at most once per open: `contentHeight` changes on every
+   * ResizeObserver tick, and a lock that is released and re-acquired on each
+   * of those ticks lets the page settle back into a scrollable state in
+   * between. */
+  let lockedScrollEl: HTMLElement | null = null;
+
+  function releaseScrollLock(): void {
+    if (!lockedScrollEl) return;
+    unlockBodyScroll(lockedScrollEl);
+    lockedScrollEl = null;
+  }
+
+  function acquireScrollLock(target: HTMLElement): void {
+    if (lockedScrollEl === target) return;
+    releaseScrollLock();
+    lockedScrollEl = target;
+    lockBodyScroll(target, {
+      reserveScrollBarGap: true,
+      /* Same escape hatch the drag handler honours, so nested scrollers keep
+       * working under the lock's touchmove interception. */
+      allowTouchMove: (el) => Boolean(el.closest('[data-allow-scroll]')),
+    });
+  }
+
   $effect(() => {
-    if (!scrollEl) return undefined;
     const target = scrollEl;
     const isReady = contentHeight > 0;
-    const shouldLock = isReady && stackArr.length > 0;
+    const shouldLock = target !== null && isReady && stackArr.length > 0;
     if (shouldLock) {
-      disableBodyScroll(target, { reserveScrollBarGap: true });
-      return () => enableBodyScroll(target);
+      acquireScrollLock(target);
+    } else {
+      releaseScrollLock();
     }
-    return undefined;
   });
 
-  /* Belt-and-braces: clear all body locks when the last sheet unmounts
-   * (matches React's `clearAllBodyScrollLocks()` cleanup). */
-  $effect(() => {
-    if (stackArr.length === 0 && typeof document !== 'undefined') {
-      clearAllBodyScrollLocks();
-    }
-  });
+  /* Release on teardown. Stacked sheets each hold a lock keyed by their own
+   * scroll element and the page is restored once the last one is released, so
+   * there is no blanket clear here — it would also drop the lock held by an
+   * enclosing Modal. */
+  onDestroy(releaseScrollLock);
 
   /* Track viewport height for snap-point math — use portal target height when
    * portaling into a bounded container (e.g. checkout phone frame). */

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheet.test.ts
@@ -1,8 +1,16 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { lockBodyScroll, unlockBodyScroll } from '../../../utils/bodyScrollLock';
 import BottomSheetFocusTestHarness from './BottomSheetFocusTestHarness.svelte';
 import BottomSheetBindableTestHarness from './BottomSheetBindableTestHarness.svelte';
 import BottomSheetSplitPortalTestHarness from './BottomSheetSplitPortalTestHarness.svelte';
+import BottomSheetScrollLockTestHarness from './BottomSheetScrollLockTestHarness.svelte';
+
+vi.mock('../../../utils/bodyScrollLock', () => ({
+  lockBodyScroll: vi.fn(),
+  unlockBodyScroll: vi.fn(),
+  clearBodyScrollLocks: vi.fn(),
+}));
 
 /* Spy on the prototype so the focus call is captured regardless of when the
  * target element mounts (the sheet portals + defers focus across two rAFs). */
@@ -17,16 +25,26 @@ function focusOptionsFor(spy: ReturnType<typeof vi.spyOn>, el: Element): FocusOp
   return spy.mock.calls[idx][0] as FocusOptions | undefined;
 }
 
+/* Callbacks handed to ResizeObserver by the components under test, so a test
+ * can replay a re-measurement without a real layout engine. */
+let resizeCallbacks: ResizeObserverCallback[] = [];
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 beforeEach(() => {
-  globalThis.ResizeObserver = (vi.fn().mockImplementation(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  })) as unknown) as typeof ResizeObserver;
+  vi.mocked(lockBodyScroll).mockClear();
+  vi.mocked(unlockBodyScroll).mockClear();
+  resizeCallbacks = [];
+  globalThis.ResizeObserver = (vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+    resizeCallbacks.push(callback);
+    return {
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    };
+  }) as unknown) as typeof ResizeObserver;
 });
 
 describe('<BottomSheet /> focus management', () => {
@@ -93,5 +111,44 @@ describe('<BottomSheet /> focus management', () => {
     expect(backdrop).toBeTruthy();
     expect(surface).toBeTruthy();
     expect(surfaceHost.contains(backdrop as Node)).toBe(false);
+  });
+});
+
+describe('<BottomSheet /> body scroll lock', () => {
+  /* jsdom reports every box as 0×0, so the sheet would never reach the
+   * `contentHeight > 0` readiness gate that arms the lock. */
+  function mockMeasuredHeight(height: number): ReturnType<typeof vi.spyOn> {
+    return vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ height } as DOMRect);
+  }
+
+  it('locks the body once per open, even as the content is re-measured', async () => {
+    const rectSpy = mockMeasuredHeight(200);
+    render(BottomSheetScrollLockTestHarness, { props: { isOpen: true } });
+
+    await waitFor(() => expect(lockBodyScroll).toHaveBeenCalledTimes(1));
+
+    /* Replay a ResizeObserver tick with a different content height. Releasing
+     * and re-acquiring the lock on each of those ticks lets the page become
+     * scrollable again in between, which is what makes iOS lose the reading
+     * position as the sheet opens. */
+    rectSpy.mockReturnValue({ height: 260 } as DOMRect);
+    resizeCallbacks.forEach((callback) => callback([], {} as ResizeObserver));
+    await waitFor(() => expect(screen.getByTestId('sheet-body-content')).toBeInTheDocument());
+
+    expect(unlockBodyScroll).not.toHaveBeenCalled();
+    expect(lockBodyScroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the lock on dismiss', async () => {
+    mockMeasuredHeight(200);
+    render(BottomSheetScrollLockTestHarness, { props: { isOpen: true } });
+
+    await waitFor(() => expect(lockBodyScroll).toHaveBeenCalledTimes(1));
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => expect(unlockBodyScroll).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheetScrollLockTestHarness.svelte
+++ b/packages/blade-svelte/src/components/BottomSheet/__tests__/BottomSheetScrollLockTestHarness.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import BottomSheet from '../BottomSheet.svelte';
+  import BottomSheetBody from '../BottomSheetBody.svelte';
+
+  let {
+    isOpen = false,
+    onDismiss,
+  }: {
+    isOpen?: boolean;
+    onDismiss?: () => void;
+  } = $props();
+</script>
+
+<BottomSheet {isOpen} {onDismiss}>
+  {#snippet children()}
+    <BottomSheetBody>
+      {#snippet children()}
+        <p data-testid="sheet-body-content">body content</p>
+      {/snippet}
+    </BottomSheetBody>
+  {/snippet}
+</BottomSheet>

--- a/packages/blade-svelte/src/components/Modal/Modal.svelte
+++ b/packages/blade-svelte/src/components/Modal/Modal.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
   import {
-    disableBodyScroll,
-    enableBodyScroll,
-    clearAllBodyScrollLocks,
-  } from 'body-scroll-lock-upgrade';
-  import {
     metaAttribute,
     MetaConstants,
     makeAccessible,
@@ -19,6 +14,7 @@
     modalWrapperClass,
   } from '@razorpay/blade-core/styles';
   import { portal } from '../../utils/portal';
+  import { lockBodyScroll, unlockBodyScroll } from '../../utils/bodyScrollLock';
   import ModalBackdrop from './ModalBackdrop.svelte';
   import { setModalContext } from './modalContext';
   import type { ModalContextValue } from './modalContext';
@@ -120,22 +116,14 @@
     };
   });
 
-  /* Body scroll lock while mounted. `body-scroll-lock-upgrade` gives us
-   * `reserveScrollBarGap: true` (no layout shift) — descendants of the target
-   * (the ModalBody) still scroll. */
+  /* Body scroll lock while mounted. `reserveScrollBarGap` avoids the layout
+   * shift on non-overlay scrollbars; descendants of the target (the ModalBody)
+   * still scroll. */
   $effect(() => {
     if (!surfaceEl) return undefined;
     const target = surfaceEl;
-    disableBodyScroll(target, { reserveScrollBarGap: true });
-    return () => enableBodyScroll(target);
-  });
-
-  $effect(() => {
-    return () => {
-      if (typeof document !== 'undefined') {
-        clearAllBodyScrollLocks();
-      }
-    };
+    lockBodyScroll(target, { reserveScrollBarGap: true });
+    return () => unlockBodyScroll(target);
   });
 
   let portalWrapperEl = $state<HTMLElement | null>(null);

--- a/packages/blade-svelte/src/utils/bodyScrollLock.test.ts
+++ b/packages/blade-svelte/src/utils/bodyScrollLock.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { clearBodyScrollLocks, lockBodyScroll, unlockBodyScroll } from './bodyScrollLock';
+
+/* jsdom has no TouchEvent, and the handlers only read `touches`. */
+function dispatchTouch(type: 'touchstart' | 'touchmove', target: EventTarget, clientY = 0): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'touches', { value: [{ clientY }] });
+  target.dispatchEvent(event);
+  return event;
+}
+
+/* jsdom reports every box as 0×0, which reads as "scrolled to both edges". */
+function makeScrollable(element: HTMLElement): void {
+  element.style.overflowY = 'auto';
+  Object.defineProperty(element, 'scrollTop', { value: 50, writable: true });
+  Object.defineProperty(element, 'scrollHeight', { value: 500 });
+  Object.defineProperty(element, 'clientHeight', { value: 100 });
+}
+
+function pretendIos(): void {
+  Object.defineProperty(window.navigator, 'platform', {
+    value: 'iPhone',
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  clearBodyScrollLocks();
+  document.body.style.overflow = '';
+  document.body.style.paddingRight = '';
+  document.body.innerHTML = '';
+  Object.defineProperty(window.navigator, 'platform', {
+    value: 'MacIntel',
+    configurable: true,
+  });
+});
+
+describe('bodyScrollLock', () => {
+  it('hides body overflow while locked and restores the previous value', () => {
+    document.body.style.overflow = 'auto';
+    const scroller = document.createElement('div');
+
+    lockBodyScroll(scroller);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unlockBodyScroll(scroller);
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('keeps the lock until every holder of the same target releases it', () => {
+    const scroller = document.createElement('div');
+
+    lockBodyScroll(scroller);
+    lockBodyScroll(scroller);
+    unlockBodyScroll(scroller);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unlockBodyScroll(scroller);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('keeps the lock while another target still holds one', () => {
+    const sheetScroller = document.createElement('div');
+    const modalSurface = document.createElement('div');
+
+    lockBodyScroll(sheetScroller);
+    lockBodyScroll(modalSurface);
+    unlockBodyScroll(sheetScroller);
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unlockBodyScroll(modalSurface);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('reserves the scrollbar gap when asked', () => {
+    const scroller = document.createElement('div');
+
+    lockBodyScroll(scroller, { reserveScrollBarGap: true });
+    expect(document.body.style.paddingRight).not.toBe('');
+
+    unlockBodyScroll(scroller);
+    expect(document.body.style.paddingRight).toBe('');
+  });
+
+  it('blocks touchmove outside the locked scroller on iOS', () => {
+    pretendIos();
+    const scroller = document.createElement('div');
+    document.body.append(scroller);
+
+    lockBodyScroll(scroller);
+
+    expect(dispatchTouch('touchmove', document.body).defaultPrevented).toBe(true);
+  });
+
+  it('lets the locked scroller scroll, but blocks overscroll at its edges', () => {
+    pretendIos();
+    const scroller = document.createElement('div');
+    makeScrollable(scroller);
+    document.body.append(scroller);
+
+    lockBodyScroll(scroller);
+
+    dispatchTouch('touchstart', scroller, 100);
+    expect(dispatchTouch('touchmove', scroller, 60).defaultPrevented).toBe(false);
+
+    (scroller as { scrollTop: number }).scrollTop = 0;
+    /* Dragging down at the top would otherwise chain to the page behind. */
+    expect(dispatchTouch('touchmove', scroller, 140).defaultPrevented).toBe(true);
+  });
+
+  it('scrolls a scrollable descendant of the locked target on iOS', () => {
+    pretendIos();
+    /* Modal locks its whole surface, but the scrolling element is the body
+     * nested inside it. */
+    const surface = document.createElement('div');
+    const body = document.createElement('div');
+    makeScrollable(body);
+    surface.append(body);
+    document.body.append(surface);
+
+    lockBodyScroll(surface);
+
+    dispatchTouch('touchstart', body, 100);
+    expect(dispatchTouch('touchmove', body, 60).defaultPrevented).toBe(false);
+    /* The surface itself has nothing to scroll. */
+    expect(dispatchTouch('touchmove', surface, 60).defaultPrevented).toBe(true);
+  });
+
+  it('honours the allowTouchMove escape hatch on iOS', () => {
+    pretendIos();
+    const scroller = document.createElement('div');
+    const nestedScroller = document.createElement('div');
+    nestedScroller.setAttribute('data-allow-scroll', '');
+    document.body.append(scroller, nestedScroller);
+
+    lockBodyScroll(scroller, {
+      allowTouchMove: (element) => Boolean(element.closest('[data-allow-scroll]')),
+    });
+
+    expect(dispatchTouch('touchmove', nestedScroller).defaultPrevented).toBe(false);
+  });
+});

--- a/packages/blade-svelte/src/utils/bodyScrollLock.ts
+++ b/packages/blade-svelte/src/utils/bodyScrollLock.ts
@@ -1,0 +1,202 @@
+/**
+ * Ref-counted body scroll lock for overlays (Modal, BottomSheet).
+ *
+ * Replaces `body-scroll-lock-upgrade`. That library locks iOS by moving the
+ * page into `body { position: fixed; top: -scrollY }` and restoring it with
+ * `window.scrollTo()` on unlock. Both halves of that trick lose the reading
+ * position: the offset is only correct when the window is the scroller, and
+ * the `html { height: 100% }` it sets alongside collapses `height: 100%`
+ * layout chains, clamping an inner scroll container to 0. Either way iOS jumps
+ * to the top of the page as the overlay opens, while Android and desktop —
+ * which take the library's `overflow: hidden` branch — behave correctly.
+ *
+ * Here iOS gets the same `overflow: hidden` bookkeeping as every other
+ * platform, and background scrolling is blocked by intercepting `touchmove`
+ * at the document instead. Nothing mutates page geometry, so scroll position
+ * survives the lock.
+ */
+
+export type BodyScrollLockOptions = {
+  /**
+   * Pad the body by the width of the removed scrollbar so the page doesn't
+   * shift horizontally on platforms with non-overlay scrollbars.
+   */
+  reserveScrollBarGap?: boolean;
+  /** Opt an element out of touch interception (e.g. a nested scroller). */
+  allowTouchMove?: (element: Element) => boolean;
+};
+
+type Lock = {
+  target: HTMLElement;
+  options: BodyScrollLockOptions;
+};
+
+const isIosDevice = (): boolean => {
+  if (typeof window === 'undefined' || !window.navigator) return false;
+  const { platform, maxTouchPoints, userAgent } = window.navigator;
+  return (
+    /iP(ad|hone|od)/.test(platform ?? '') ||
+    /iP(ad|hone|od)/.test(userAgent ?? '') ||
+    /* iPadOS reports itself as a Mac with a touchscreen. */
+    (platform === 'MacIntel' && maxTouchPoints > 1)
+  );
+};
+
+let locks: Lock[] = [];
+/* Nested consumers can lock the same target more than once (a BottomSheet
+ * effect re-running, a Modal inside a Modal); only the last unlock releases. */
+const lockCounts = new Map<HTMLElement, number>();
+let previousBodyOverflow: string | undefined;
+let previousBodyPaddingRight: string | undefined;
+let touchListenersAdded = false;
+let initialClientY = -1;
+
+const isTouchMoveAllowed = (element: Element | null): boolean => {
+  if (!element) return false;
+  return locks.some((lock) => lock.options.allowTouchMove?.(element));
+};
+
+const findLockedTarget = (element: Element | null): HTMLElement | null => {
+  if (!element) return null;
+  return locks.find((lock) => lock.target.contains(element))?.target ?? null;
+};
+
+/**
+ * Nearest scrollable element between the touch target and the locked target
+ * (inclusive). Consumers lock whichever node they own — BottomSheet locks its
+ * body scroller, Modal locks the whole surface — so the element that actually
+ * scrolls can sit anywhere in between.
+ */
+const findScroller = (element: Element | null, lockedTarget: HTMLElement): HTMLElement => {
+  let node: Element | null = element;
+  while (node) {
+    if (node instanceof HTMLElement && node.scrollHeight > node.clientHeight) {
+      const { overflowY } = window.getComputedStyle(node);
+      if (overflowY === 'auto' || overflowY === 'scroll') return node;
+    }
+    if (node === lockedTarget) break;
+    node = node.parentElement;
+  }
+  return lockedTarget;
+};
+
+const handleTouchStart = (event: TouchEvent): void => {
+  if (event.touches.length !== 1) return;
+  initialClientY = event.touches[0].clientY;
+};
+
+const handleTouchMove = (event: TouchEvent): void => {
+  /* Leave pinch-zoom alone. */
+  if (event.touches.length > 1) return;
+
+  const target = event.target as Element | null;
+  if (isTouchMoveAllowed(target)) return;
+
+  const lockedTarget = findLockedTarget(target);
+  if (!lockedTarget) {
+    if (event.cancelable) event.preventDefault();
+    return;
+  }
+
+  /* Inside a locked overlay: allow the scroll, but block it at the edges so
+   * the gesture doesn't chain to the page behind. A non-scrollable overlay
+   * falls back to the locked target, whose edges always match — every move is
+   * blocked, which is what we want when there is nothing to scroll. */
+  const scroller = findScroller(target, lockedTarget);
+  const deltaY = event.touches[0].clientY - initialClientY;
+  const isAtTop = scroller.scrollTop <= 0;
+  const isAtBottom = scroller.scrollHeight - scroller.scrollTop <= scroller.clientHeight;
+  if (((isAtTop && deltaY > 0) || (isAtBottom && deltaY < 0)) && event.cancelable) {
+    event.preventDefault();
+  }
+};
+
+const addTouchListeners = (): void => {
+  if (touchListenersAdded || !isIosDevice()) return;
+  document.addEventListener('touchstart', handleTouchStart, { passive: true });
+  document.addEventListener('touchmove', handleTouchMove, { passive: false });
+  touchListenersAdded = true;
+};
+
+const removeTouchListeners = (): void => {
+  if (!touchListenersAdded) return;
+  document.removeEventListener('touchstart', handleTouchStart);
+  document.removeEventListener('touchmove', handleTouchMove);
+  touchListenersAdded = false;
+  initialClientY = -1;
+};
+
+const applyBodyStyles = (options: BodyScrollLockOptions): void => {
+  const body = document.body;
+
+  if (previousBodyPaddingRight === undefined && options.reserveScrollBarGap) {
+    const scrollBarGap = window.innerWidth - document.documentElement.getBoundingClientRect().width;
+    if (scrollBarGap > 0) {
+      const computedPaddingRight =
+        parseInt(window.getComputedStyle(body).getPropertyValue('padding-right'), 10) || 0;
+      previousBodyPaddingRight = body.style.paddingRight;
+      body.style.paddingRight = `${computedPaddingRight + scrollBarGap}px`;
+    }
+  }
+
+  if (previousBodyOverflow === undefined) {
+    previousBodyOverflow = body.style.overflow;
+    body.style.overflow = 'hidden';
+  }
+};
+
+const restoreBodyStyles = (): void => {
+  if (previousBodyPaddingRight !== undefined) {
+    document.body.style.paddingRight = previousBodyPaddingRight;
+    previousBodyPaddingRight = undefined;
+  }
+  if (previousBodyOverflow !== undefined) {
+    document.body.style.overflow = previousBodyOverflow;
+    previousBodyOverflow = undefined;
+  }
+};
+
+/**
+ * Lock page scrolling. `target` stays scrollable — pass the overlay's scroll
+ * container.
+ */
+export function lockBodyScroll(
+  target: HTMLElement | null,
+  options: BodyScrollLockOptions = {},
+): void {
+  if (typeof document === 'undefined' || !target) return;
+
+  lockCounts.set(target, (lockCounts.get(target) ?? 0) + 1);
+  if (locks.some((lock) => lock.target === target)) return;
+
+  locks = [...locks, { target, options }];
+  applyBodyStyles(options);
+  addTouchListeners();
+}
+
+/** Release one lock held on `target`. */
+export function unlockBodyScroll(target: HTMLElement | null): void {
+  if (typeof document === 'undefined' || !target) return;
+
+  const nextCount = (lockCounts.get(target) ?? 0) - 1;
+  if (nextCount > 0) {
+    lockCounts.set(target, nextCount);
+    return;
+  }
+
+  lockCounts.delete(target);
+  locks = locks.filter((lock) => lock.target !== target);
+  if (locks.length > 0) return;
+
+  removeTouchListeners();
+  restoreBodyStyles();
+}
+
+/** Release every lock — guards against leaks when overlays unmount abruptly. */
+export function clearBodyScrollLocks(): void {
+  if (typeof document === 'undefined') return;
+  locks = [];
+  lockCounts.clear();
+  removeTouchListeners();
+  restoreBodyStyles();
+}

--- a/packages/blade-svelte/src/utils/bodyScrollLock.ts
+++ b/packages/blade-svelte/src/utils/bodyScrollLock.ts
@@ -105,7 +105,8 @@ const handleTouchMove = (event: TouchEvent): void => {
   const deltaY = event.touches[0].clientY - initialClientY;
   const isAtTop = scroller.scrollTop <= 0;
   const isAtBottom = scroller.scrollHeight - scroller.scrollTop <= scroller.clientHeight;
-  if (((isAtTop && deltaY > 0) || (isAtBottom && deltaY < 0)) && event.cancelable) {
+  const cannotScroll = isAtTop && isAtBottom;
+  if ((cannotScroll || (isAtTop && deltaY > 0) || (isAtBottom && deltaY < 0)) && event.cancelable) {
     event.preventDefault();
   }
   initialClientY = event.touches[0].clientY;

--- a/packages/blade-svelte/src/utils/bodyScrollLock.ts
+++ b/packages/blade-svelte/src/utils/bodyScrollLock.ts
@@ -46,8 +46,7 @@ let locks: Lock[] = [];
 /* Nested consumers can lock the same target more than once (a BottomSheet
  * effect re-running, a Modal inside a Modal); only the last unlock releases. */
 const lockCounts = new Map<HTMLElement, number>();
-let previousBodyOverflow: string | undefined;
-let previousBodyPaddingRight: string | undefined;
+let previousBodyOverflow: string | undefined, previousBodyPaddingRight: string | undefined;
 let touchListenersAdded = false;
 let initialClientY = -1;
 

--- a/packages/blade-svelte/src/utils/bodyScrollLock.ts
+++ b/packages/blade-svelte/src/utils/bodyScrollLock.ts
@@ -108,6 +108,7 @@ const handleTouchMove = (event: TouchEvent): void => {
   if (((isAtTop && deltaY > 0) || (isAtBottom && deltaY < 0)) && event.cancelable) {
     event.preventDefault();
   }
+  initialClientY = event.touches[0].clientY;
 };
 
 const addTouchListeners = (): void => {

--- a/packages/blade-svelte/tests/browserstack/bottomSheet.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/bottomSheet.spec.ts
@@ -11,3 +11,28 @@ test('BottomSheet opens on trigger click', async ({ page }) => {
   const sheet = page.getByRole('dialog');
   await expect(sheet).toBeVisible();
 });
+
+test('BottomSheet locks body scroll while open and restores on dismiss', async ({ page }) => {
+  await page.goto('iframe.html?id=components-bottomsheet--default');
+
+  // The Default story renders enough Lorem Ipsum to make the page scrollable.
+  await page.evaluate(() => window.scrollTo(0, 300));
+  const scrollYBeforeOpen = await page.evaluate(() => window.scrollY);
+
+  // Open the BottomSheet.
+  await page.getByRole('button', { name: 'open' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  // The scroll lock runs in an effect after the sheet content is measured,
+  // so wait for the inline overflow style rather than checking synchronously.
+  await page.waitForFunction(() => document.body.style.overflow === 'hidden');
+
+  // The page's scroll position is preserved — the old body-scroll-lock-upgrade
+  // library moved the page to position:fixed on iOS, jumping it to the top.
+  expect(await page.evaluate(() => window.scrollY)).toBe(scrollYBeforeOpen);
+
+  // Dismiss and verify the lock is released.
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('dialog')).not.toBeVisible();
+  await page.waitForFunction(() => document.body.style.overflow !== 'hidden');
+});


### PR DESCRIPTION
## Description

<!-- Briefly explain the purpose of your PR -->
`body-scroll-lock-upgrade` locks iOS by moving the page into `body { position: fixed; top: -scrollY }` and restoring it with `window.scrollTo()` on unlock, which loses the reading position; Android and desktop take its `overflow: hidden` branch and were unaffected. Both overlays now use a ref-counted lock that applies the same `overflow: hidden` bookkeeping on every platform and blocks background scrolling on iOS by intercepting `touchmove`, so nothing mutates page geometry. BottomSheet additionally acquires its lock at most once per open instead of on every content re-measurement.

## Changes

<!-- List the specific changes made, consider adding screenshots if relevant -->

## Additional Information

<!-- Include any relevant details, links to issues, or additional messages -->

## Component Checklist

<!-- Ensure that the following tasks are completed before submitting your PR. Tick the applicable boxes -->

- [ ] Update Component Status Page
- [ ] Perform Manual Testing in Other Browsers
- [ ] Add KitchenSink Story
- [ ] Add Interaction Tests (if applicable)
- [ ] Add changeset
