### PR TITLE
fix(BottomSheet): merge browserstack tests to avoid multiple browser contexts

### DIFF
--- a/packages/blade-svelte/tests/browserstack/bottomSheet.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/bottomSheet.spec.ts
@@ -3,16 +3,7 @@ import { registerBrowserStackStatusReporter } from './reportStatus';
 
 registerBrowserStackStatusReporter(test);
 
-test('BottomSheet opens on trigger click', async ({ page }) => {
-  await page.goto('iframe.html?id=components-bottomsheet--default');
-  const openButton = page.getByRole('button', { name: 'open' });
-  await openButton.click();
-
-  const sheet = page.getByRole('dialog');
-  await expect(sheet).toBeVisible();
-});
-
-test('BottomSheet locks body scroll while open and restores on dismiss', async ({ page }) => {
+test('BottomSheet opens on trigger click, locks body scroll while open, and restores on dismiss', async ({ page }) => {
   await page.goto('iframe.html?id=components-bottomsheet--default');
 
   // The Default story renders enough Lorem Ipsum to make the page scrollable.
@@ -20,8 +11,11 @@ test('BottomSheet locks body scroll while open and restores on dismiss', async (
   const scrollYBeforeOpen = await page.evaluate(() => window.scrollY);
 
   // Open the BottomSheet.
-  await page.getByRole('button', { name: 'open' }).click();
-  await expect(page.getByRole('dialog')).toBeVisible();
+  const openButton = page.getByRole('button', { name: 'open' });
+  await openButton.click();
+
+  const sheet = page.getByRole('dialog');
+  await expect(sheet).toBeVisible();
 
   // The scroll lock runs in an effect after the sheet content is measured,
   // so wait for the inline overflow style rather than checking synchronously.

--- a/packages/blade-svelte/tests/browserstack/bottomSheet.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/bottomSheet.spec.ts
@@ -3,7 +3,9 @@ import { registerBrowserStackStatusReporter } from './reportStatus';
 
 registerBrowserStackStatusReporter(test);
 
-test('BottomSheet opens on trigger click, locks body scroll while open, and restores on dismiss', async ({ page }) => {
+test('BottomSheet opens on trigger click, locks body scroll while open, and restores on dismiss', async ({
+  page,
+}) => {
   await page.goto('iframe.html?id=components-bottomsheet--default');
 
   // The Default story renders enough Lorem Ipsum to make the page scrollable.


### PR DESCRIPTION
## Problem

The BrowserStack mobile test for `bottomSheet.spec.ts` fails with:

```
Error: browser.newContext: Failed to execute newContext. browserstack_error: Only one browser context is allowed
```

**Workflow run:** https://github.com/razorpay/blade/actions/runs/34473828536
**Failing job:** BrowserStack Tests / Run BrowserStack Tests (Mobile)
**Test:** `bottomSheet.spec.ts:15:1` — BottomSheet locks body scroll while open and restores on dismiss

## Root Cause

BrowserStack only allows **one browser context per session**. Playwright creates a new browser context for each `test()` block. `bottomSheet.spec.ts` was the **only spec file** with 2 tests — all other spec files have exactly 1 test. The second test triggered `browser.newContext()`, which BrowserStack rejected.

## Fix

Merged the two tests into a single test that covers all the original assertions:
1. BottomSheet opens on trigger click (dialog is visible)
2. Body scroll is locked while open (`overflow: hidden`)
3. Scroll position is preserved
4. Scroll lock is released on dismiss (Escape key)

This matches the pattern of all other BrowserStack spec files (1 test per file = 1 browser context per session).

Automated changes by autonomous agent.

Requested by: admin <admin>
