### PR TITLE
fix(Accordion): add toBeVisible wait to resolve Safari browserstack test timing failure

### DIFF
--- a/packages/blade-svelte/tests/browserstack/accordion.spec.ts
+++ b/packages/blade-svelte/tests/browserstack/accordion.spec.ts
@@ -7,6 +7,7 @@ test('Accordion expands and collapses an item on click', async ({ page }) => {
   await page.goto('iframe.html?id=components-accordion--basic-example');
   const firstHeader = page.getByRole('button').first();
 
+  await expect(firstHeader).toBeVisible();
   await expect(firstHeader).toHaveAttribute('aria-expanded', 'false');
   await firstHeader.click();
   await expect(firstHeader).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
## Problem

The BrowserStack desktop Safari test for `accordion.spec.ts` fails with:

```
Error: expect(locator).toHaveAttribute(expected) failed
Locator: getByRole('button').first()
Expected: "false"
Timeout: 5000ms
Error: Error: element(s) not found
```

**Workflow run:** https://github.com/razorpay/blade/actions/runs/34479923019
**Failing job:** BrowserStack Tests / Run BrowserStack Tests (Desktop)
**Test:** `accordion.spec.ts:6:1` — Accordion expands and collapses an item on click

## Root Cause

The accordion test navigates to the Storybook iframe page and immediately checks `toHaveAttribute('aria-expanded', 'false')` without first waiting for the element to be visible. In Safari (via BrowserStack), the accordion component — which nests multiple components (Collapsible, Divider, BaseText, etc.) — takes longer to render than the 5s `toHaveAttribute` timeout, so the button element is never found.

All other browserstack spec files that check attributes (`button.spec.ts`, `tabs.spec.ts`, `checkbox.spec.ts`) include an `await expect(element).toBeVisible()` guard before attribute assertions. The accordion test was the only one missing this pattern.

## Fix

Added `await expect(firstHeader).toBeVisible()` before the `toHaveAttribute` check, matching the established pattern in all other browserstack test files.

Automated changes by autonomous agent.

Requested by: admin <admin>