### PR TITLE
docs: fix installation step count

### DIFF
--- a/packages/blade/docs/guides/Installation.mdx
+++ b/packages/blade/docs/guides/Installation.mdx
@@ -72,7 +72,7 @@ Before you install the package, make sure that you have performed the following 
 
 <br />
 
-<Text marginY="spacing.4">Follow these 3 steps to get started!</Text>
+<Text marginY="spacing.4">Follow these 4 steps to get started!</Text>
 
 <Tabs marginTop="spacing.8" variant="bordered" orientation="horizontal">
   <Box position="sticky" top="0px" zIndex={1} backgroundColor="surface.background.gray.intense">


### PR DESCRIPTION
## Summary

This PR fixes an incorrect step count in the Blade installation guide.

The installation section currently contains **four setup steps**, but the introductory text incorrectly states:

> Follow these 3 steps to get started!

This PR updates the text to accurately reflect the four steps:

> Follow these 4 steps to get started!

## Problem

The installation documentation displayed a mismatch between the number mentioned in the introductory heading and the actual number of installation steps provided below it.

This could cause confusion for developers following the installation guide, especially when they expect the documented step count to match the instructions.

## Changes

* Updated `packages/blade/docs/guides/Installation.mdx`
* Changed the installation step count from **3** to **4**
* No functional or source-code changes were made.

## Validation

* Reviewed the staged Git diff to confirm that only the intended documentation line was modified.
* Ran `git diff --cached --check` successfully with no whitespace errors.
* Created a focused commit containing only this documentation correction.

## Related Issue

Closes #3077
