### PR TITLE
feat(getFocusRingStyles): add a neutral variant of the focus ring

### DIFF
--- a/packages/blade/.changeset/focus-ring-neutral-variant.md
+++ b/packages/blade/.changeset/focus-ring-neutral-variant.md
@@ -1,0 +1,9 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(getFocusRingStyles): add a neutral variant of the focus ring
+
+Figma models the focus ring as a component set with a primary and a neutral variant, but the helper only ever drew the primary one, so `BaseButton` had hand-rolled the neutral ring for its filled neutral surface. The variant now lives in `getFocusRingStyles` and `FocusRingWrapper`, and `BaseButton` uses it.
+
+No visual change: the default is still `primary`, and only the colour varies by variant, so focus geometry and motion stay identical across the system.

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -23,6 +23,7 @@ import type { BaseButtonStyleProps, IconColor } from './types';
 import AnimatedButtonContent from './AnimatedButtonContent';
 import type { DotNotationToken } from '~utils/lodashButBetter/get';
 import getIn from '~utils/lodashButBetter/get';
+import { focusRingColorTokens } from '~utils/getFocusRingStyles/focusRingTokens';
 import type { BaseLinkProps } from '~components/Link/BaseLink';
 import type { Theme } from '~components/BladeProvider';
 import type { IconComponent, IconSize } from '~components/Icons';
@@ -486,9 +487,7 @@ const getProps = ({
     // with a faded neutral ring on the filled neutral surface.
     focusRingColor: getIn(
       theme.colors,
-      isFilledNeutral(color, variant)
-        ? 'interactive.border.neutral.faded'
-        : 'surface.border.primary.muted',
+      focusRingColorTokens[isFilledNeutral(color, variant) ? 'neutral' : 'primary'],
     ),
     borderRadius: makeBorderSize(theme.border.radius[_borderRadius ?? buttonBorderRadius[size]]),
     motionDuration: 'duration.xquick',

--- a/packages/blade/src/utils/getFocusRingStyles/focusRingTokens.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/focusRingTokens.ts
@@ -1,0 +1,17 @@
+/**
+ * Figma models the focus ring as a component set with a primary and a neutral variant. The
+ * primary ring is the default; the neutral one is used by neutral components, where a blue
+ * ring reads as an accent the component does not otherwise have.
+ *
+ * Shared by web and native so the two platforms cannot drift apart.
+ *
+ * Kept `as const` so the values stay literal token paths that `getIn` can check, rather than
+ * widening to `string`. Indexing this by `FocusRingVariant` still forces every variant to have
+ * an entry here.
+ */
+const focusRingColorTokens = {
+  primary: 'surface.border.primary.muted',
+  neutral: 'interactive.border.neutral.faded',
+} as const;
+
+export { focusRingColorTokens };

--- a/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.native.tsx
+++ b/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.native.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import type { CSSProperties } from 'styled-components';
 import type { GetFocusRingArgs, FocusRingWrapperProps } from './types';
+import { focusRingColorTokens } from './focusRingTokens';
 import { useTheme } from '~components/BladeProvider';
 import getIn from '~utils/lodashButBetter/get';
 import { castNativeType, makeMotionTime } from '~utils';
@@ -18,10 +19,11 @@ const FocusRingWrapper = ({
   isFocused,
   borderRadius,
   disabled,
+  variant = 'primary',
   children,
 }: FocusRingWrapperProps): React.ReactElement => {
   const { theme } = useTheme();
-  const focusRingColor = getIn(theme.colors, 'surface.border.primary.muted');
+  const focusRingColor = getIn(theme.colors, focusRingColorTokens[variant]);
 
   const motionConfig = {
     duration: castNativeType(makeMotionTime(getIn(theme.motion.duration, 'xgentle') as number)),

--- a/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.test.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.test.ts
@@ -19,4 +19,25 @@ describe('getFocusRingStyles', () => {
       transitionTimingFunction: 'cubic-bezier(0.3, 0, 0.2, 1)',
     });
   });
+
+  it('should draw the neutral ring when asked for the neutral variant', () => {
+    const theme = {
+      ...bladeTheme,
+      colors: bladeTheme.colors.onLight,
+      elevation: bladeTheme.elevation.onLight,
+      typography: bladeTheme.typography.onDesktop,
+    };
+
+    // Everything but the colour should match the primary ring, so neutral components keep the
+    // same focus geometry and motion as the rest of the system.
+    const { outline: primaryOutline, ...primaryRest } = getFocusRingStyles({ theme });
+    const { outline: neutralOutline, ...neutralRest } = getFocusRingStyles({
+      theme,
+      variant: 'neutral',
+    });
+
+    expect(neutralRest).toStrictEqual(primaryRest);
+    expect(neutralOutline).not.toBe(primaryOutline);
+    expect(neutralOutline).toBe(`4px solid ${theme.colors.interactive.border.neutral.faded}`);
+  });
 });

--- a/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.ts
@@ -1,20 +1,25 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import type { GetFocusRingArgs } from './types';
+import { focusRingColorTokens } from './focusRingTokens';
 import { castWebType, makeMotionTime } from '~utils';
+import getIn from '~utils/lodashButBetter/get';
 
 /**
  * @param props.theme Blade Theme Object
  * @param props.negativeOffset if set the outline offset will be set to -4px, this is useful
  * in table component where the outline will get cutoff by the table border
+ * @param props.variant `neutral` swaps the primary blue ring for the neutral one, for
+ * components that are themselves neutral
  */
 function getFocusRingStyles({
   theme,
   negativeOffset = false,
   isImportant = false,
+  variant = 'primary',
 }: GetFocusRingArgs) {
   const important = `${isImportant ? ' !important' : ''}`;
   return {
-    outline: `4px solid ${theme.colors.surface.border.primary.muted}${important}`,
+    outline: `4px solid ${getIn(theme.colors, focusRingColorTokens[variant])}${important}`,
     outlineOffset: `${negativeOffset ? '-4px' : '1px'}${important}`,
     transitionProperty: 'outline-width',
     transitionDuration: castWebType(makeMotionTime(theme.motion.duration['2xquick'])),

--- a/packages/blade/src/utils/getFocusRingStyles/index.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/index.ts
@@ -1,2 +1,2 @@
 export * from './getFocusRingStyles';
-export type { FocusRingWrapperProps } from './types';
+export type { FocusRingWrapperProps, FocusRingVariant } from './types';

--- a/packages/blade/src/utils/getFocusRingStyles/types.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/types.ts
@@ -1,10 +1,17 @@
 import type React from 'react';
 import type { Theme } from '~components/BladeProvider';
 
+/**
+ * Mirrors the variants of the BaseFocusRing component set in Figma. `neutral` is for neutral
+ * components, which a primary blue ring would give an accent they do not otherwise carry.
+ */
+type FocusRingVariant = 'primary' | 'neutral';
+
 type GetFocusRingArgs = {
   theme: Theme;
   negativeOffset?: boolean;
   isImportant?: boolean;
+  variant?: FocusRingVariant;
 };
 
 type FocusRingWrapperProps = {
@@ -13,7 +20,8 @@ type FocusRingWrapperProps = {
   borderRadius: number;
   /** When true the ring is suppressed (e.g. table input cells use a negative-offset ring instead) */
   disabled?: boolean;
+  variant?: FocusRingVariant;
   children: React.ReactNode;
 };
 
-export type { GetFocusRingArgs, FocusRingWrapperProps };
+export type { GetFocusRingArgs, FocusRingWrapperProps, FocusRingVariant };


### PR DESCRIPTION
## Summary

Adds a `neutral` variant to the focus ring, mirroring the primary/neutral component set that already exists in Figma.

The system focus ring is a faded primary blue. On neutral components that blue reads as an accent the component does not otherwise carry, so the design uses a faded neutral ring instead. This adds that as a first-class variant rather than something each component hand-rolls.

Split out of the `SliderInput` PR, which needs the neutral ring. It stands on its own.

## What changed

```ts
getFocusRingStyles({ theme, variant: 'neutral' });
```

`variant` accepts `'primary' | 'neutral'` and defaults to `'primary'`, so every existing call site is untouched.

The two token paths live in one shared map used by both platforms, so web and native cannot drift apart:

```ts
const focusRingColorTokens = {
  primary: 'surface.border.primary.muted',
  neutral: 'interactive.border.neutral.faded',
} as const;
```

`FocusRingWrapper` on native takes the same `variant` prop.

## Why this is not a new behaviour

`BaseButton` had already hand-rolled exactly this for its filled neutral surface, reaching for `interactive.border.neutral.faded` directly. That is now folded onto the shared map, so the ring colour is defined once.

Its snapshots are the evidence that nothing moved: **125 web and 101 native snapshots unchanged**.

## Review notes

- The token map is `as const` on purpose. Typing it as `Record<FocusRingVariant, string>` widens the values to `string` and breaks `getIn`'s `DotNotationToken` parameter in three places. Indexing by `FocusRingVariant` still forces every variant to have an entry.
- The new test destructures `outline` off both results and asserts the remainder is identical, so the variant is proven to change the colour and nothing else.

## Checks

- [x] Web and native typecheck
- [x] Lint
- [x] Unit tests, including `BaseButton`'s full snapshot suite
- [x] Changeset (patch)
