### PR TITLE
feat(SliderInput): add SliderInput component (web)

### DIFF
--- a/.changeset/slider-animated-value-indicator.md
+++ b/.changeset/slider-animated-value-indicator.md
@@ -1,0 +1,8 @@
+---
+'@razorpay/blade': patch
+---
+
+feat(SliderInput): animate the number in the value indicator
+
+The value indicator now animates between values instead of swapping them outright, so a rising
+value visibly rises and a falling one falls.

--- a/packages/blade/.changeset/focus-ring-neutral-variant.md
+++ b/packages/blade/.changeset/focus-ring-neutral-variant.md
@@ -1,0 +1,9 @@
+---
+"@razorpay/blade": patch
+---
+
+feat(getFocusRingStyles): add a neutral variant of the focus ring
+
+Figma models the focus ring as a component set with a primary and a neutral variant, but the helper only ever drew the primary one, so `BaseButton` had hand-rolled the neutral ring for its filled neutral surface. The variant now lives in `getFocusRingStyles` and `FocusRingWrapper`, and `BaseButton` uses it.
+
+No visual change: the default is still `primary`, and only the colour varies by variant, so focus geometry and motion stay identical across the system.

--- a/packages/blade/.changeset/slider-input-component.md
+++ b/packages/blade/.changeset/slider-input-component.md
@@ -1,0 +1,13 @@
+---
+"@razorpay/blade": minor
+---
+
+feat(SliderInput): add SliderInput component (web)
+
+Adds `SliderInput` for picking a number from a range by dragging, with optional step markers, a value scale, and a readout above the thumb.
+
+```jsx
+<SliderInput label="Volume" min={0} max={100} step={25} showMarkers showScale />
+```
+
+Use `onChange` to track the value live during a drag, and `onChangeEnd` for anything expensive, since it fires once when the interaction commits.

--- a/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.native.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.native.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { BaseAnimatedValueProps } from './types';
+
+/**
+ * Renders the current value without animating the swap.
+ *
+ * The web version leans on `AnimatePresence` to keep the outgoing copy mounted while it
+ * leaves, and framer-motion has no React Native build — Blade's own `AnimatePresence.native`
+ * is a passthrough for that reason. A native version needs the two copies held in state and
+ * driven through Reanimated instead, which is worth doing when something on native actually
+ * needs it rather than ahead of time.
+ *
+ * Rendering the value plainly keeps the module resolvable on native and keeps consumers
+ * correct, just unanimated.
+ */
+const BaseAnimatedValue = ({ value, children }: BaseAnimatedValueProps): React.ReactElement => {
+  // The fragment is load-bearing: the content is a ReactNode (often a bare string) and this
+  // has to hand back a ReactElement.
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children ?? value}</>;
+};
+
+export { BaseAnimatedValue };

--- a/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import styled from 'styled-components';
+import { AnimatePresence } from 'framer-motion';
+// Blade's own `MotionVariantsType` narrows out the dynamic, `custom`-resolved form of a
+// variant, which is the whole mechanism the exit direction relies on below.
+import type { Variants } from 'framer-motion';
+import type { BaseAnimatedValueProps, AnimatedValueDirection } from './types';
+import { MotionDiv } from '~components/BaseMotion';
+import { castWebType, useTheme } from '~utils';
+import { cssBezierToArray } from '~utils/cssBezierToArray';
+import { msToSeconds } from '~utils/msToSeconds';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+
+/** How far content travels as it swaps, in px. Short enough to read as a nudge, not a scroll. */
+const TRAVEL = 8;
+
+/**
+ * `Number` is too permissive on its own: it reads an empty or blank string as 0, which would
+ * make `"" -> "5"` look like a numeric increase rather than the text swap it is.
+ */
+const toNumber = (value: string | number): number => {
+  if (typeof value === 'number') return value;
+  return value.trim() === '' ? NaN : Number(value);
+};
+
+const getDirection = (
+  previous: string | number | undefined,
+  current: string | number,
+): AnimatedValueDirection => {
+  if (previous === undefined) return 'none';
+  const from = toNumber(previous);
+  const to = toNumber(current);
+  if (!Number.isFinite(from) || !Number.isFinite(to) || from === to) return 'none';
+  return to > from ? 'up' : 'down';
+};
+
+/**
+ * Both copies share one grid cell, so the one on its way out cannot push the layout around
+ * while it leaves, and the box sizes to whichever of the two is wider.
+ *
+ * A span rather than a div: this renders inside `Text`, which is a `<p>`, and a block element
+ * there is invalid HTML that the parser hoists out, breaking hydration.
+ *
+ * Deliberately not clipped to its own box. `overflow: hidden` here would give the travel a
+ * window to roll behind, but on an inline box it also cuts the glyphs off at rest. The fade
+ * runs over the same duration as the travel, so a copy is already invisible by the time it is
+ * far enough out to need hiding.
+ */
+const Stack = styled.span`
+  display: inline-grid;
+
+  > * {
+    grid-area: 1 / 1;
+  }
+`;
+
+/**
+ * Animates a change of content: the outgoing value leaves and the incoming one arrives from
+ * the opposite side, so a rising number reads as rising.
+ *
+ * Private on purpose. It is general enough to move beyond its first consumer, but it should
+ * earn a public API on the back of a second one rather than ahead of it.
+ *
+ * Presentational only: it renders whatever it is given and takes no view on how that content
+ * is announced. During a swap both copies are briefly in the DOM, so a consumer that needs
+ * this read out should own the accessible name itself and keep this subtree hidden from
+ * assistive technology. `SliderInput` does exactly that, announcing through `aria-valuetext`.
+ */
+const BaseAnimatedValue = ({
+  value,
+  children,
+  direction,
+  testID,
+}: BaseAnimatedValueProps): React.ReactElement => {
+  const { theme } = useTheme();
+
+  // Tracks the value the current content is replacing, so the travel has a direction.
+  const previousValue = React.useRef<string | number | undefined>(undefined);
+  const resolvedDirection = direction ?? getDirection(previousValue.current, value);
+  React.useEffect(() => {
+    previousValue.current = value;
+  }, [value]);
+
+  /**
+   * Which way, and whether at all: +1 rises, -1 falls, 0 cross-fades in place.
+   *
+   * Going up, the new value rises into place from below and the old one leaves through the top.
+   */
+  const travel =
+    resolvedDirection === 'none' ? 0 : TRAVEL * (resolvedDirection === 'down' ? -1 : 1);
+
+  /**
+   * Dynamic rather than plain objects so the exit can be told which way the value went.
+   *
+   * `AnimatePresence` keeps the outgoing element rendered from the previous tree, so it holds
+   * whatever variants it was last given — the direction of the change that brought it *in*.
+   * On a reversal that is backwards: the old value would leave upwards while the new one
+   * arrives from above. Framer resolves these functions against the `custom` on
+   * `AnimatePresence`, which is current, so both halves agree on the direction.
+   */
+  const variants: Variants = {
+    initial: (distance: number) => ({ opacity: 0, y: distance }),
+    animate: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: msToSeconds(theme.motion.duration.xquick),
+        ease: cssBezierToArray(castWebType(theme.motion.easing.entrance)),
+      },
+    },
+    exit: (distance: number) => ({
+      opacity: 0,
+      y: -distance,
+      transition: {
+        duration: msToSeconds(theme.motion.duration.xquick),
+        ease: cssBezierToArray(castWebType(theme.motion.easing.exit)),
+      },
+    }),
+  };
+
+  return (
+    <Stack {...metaAttribute({ name: MetaConstants.AnimatedValue, testID })}>
+      {/* `initial={false}` so the very first render lands without animating in from nowhere. */}
+      <AnimatePresence initial={false} custom={travel}>
+        <MotionDiv
+          key={String(value)}
+          // Inline for the same reason as the wrapper above.
+          as="span"
+          display="inline-block"
+          custom={travel}
+          variants={variants}
+          initial="initial"
+          animate="animate"
+          exit="exit"
+        >
+          {children ?? value}
+        </MotionDiv>
+      </AnimatePresence>
+    </Stack>
+  );
+};
+
+export { BaseAnimatedValue };

--- a/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
@@ -192,11 +192,11 @@ const BaseAnimatedValue = ({
   const durationMs = theme.motion.duration[duration];
 
   /*
-   * The odometer needs two things: a number to drive the columns, and text whose digits line up
-   * with it. Children that are not plain text could be anything, so those swap instead.
+   * The odometer works off the text, since that is what it has to keep consistent — the number
+   * driving the columns is the one the text spells out, not the value it was formatted from.
+   * Children that are not plain text could be anything, so those swap instead.
    */
   const content = children ?? value;
-  const numericValue = toNumber(value);
   const parsed =
     typeof content === 'string' || typeof content === 'number'
       ? parseNumericText(String(content))
@@ -204,13 +204,8 @@ const BaseAnimatedValue = ({
 
   return (
     <Stack {...metaAttribute({ name: MetaConstants.AnimatedValue, testID })}>
-      {parsed && Number.isFinite(numericValue) ? (
-        <OdometerValue
-          value={numericValue}
-          text={String(content)}
-          parsed={parsed}
-          durationMs={durationMs}
-        />
+      {parsed ? (
+        <OdometerValue text={String(content)} parsed={parsed} durationMs={durationMs} />
       ) : (
         <SwappedValue value={value} direction={direction} durationMs={durationMs}>
           {content}

--- a/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
@@ -11,8 +11,13 @@ import { cssBezierToArray } from '~utils/cssBezierToArray';
 import { msToSeconds } from '~utils/msToSeconds';
 import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
 
-/** How far content travels as it swaps, in px. Short enough to read as a nudge, not a scroll. */
-const TRAVEL = 8;
+/**
+ * How far content travels as it swaps, in px.
+ *
+ * Far enough that the swap reads as movement rather than a flicker. The fade runs over the
+ * same duration, so a copy is already invisible by the time it is this far out.
+ */
+const TRAVEL = 12;
 
 /**
  * `Number` is too permissive on its own: it reads an empty or blank string as 0, which would
@@ -61,6 +66,12 @@ const Stack = styled.span`
  * Private on purpose. It is general enough to move beyond its first consumer, but it should
  * earn a public API on the back of a second one rather than ahead of it.
  *
+ * Only isolated changes are animated. A value that changes again before the previous swap has
+ * finished is written straight into place instead, because a roll is only legible when there
+ * is time to read it: a slider being dragged can change fifty times a second, and animating
+ * each one leaves a stack of half-faded copies that never resolves into a number. Coarse
+ * changes — a keyboard step, a click, a slider whose steps are far apart — still roll.
+ *
  * Presentational only: it renders whatever it is given and takes no view on how that content
  * is announced. During a swap both copies are briefly in the DOM, so a consumer that needs
  * this read out should own the accessible name itself and keep this subtree hidden from
@@ -70,18 +81,38 @@ const BaseAnimatedValue = ({
   value,
   children,
   direction,
-  duration = 'xquick',
+  duration = 'moderate',
   testID,
 }: BaseAnimatedValueProps): React.ReactElement => {
   const { theme } = useTheme();
-  const motionDuration = msToSeconds(theme.motion.duration[duration]);
+  const durationMs = theme.motion.duration[duration];
 
-  // Tracks the value the current content is replacing, so the travel has a direction.
-  const previousValue = React.useRef<string | number | undefined>(undefined);
-  const resolvedDirection = direction ?? getDirection(previousValue.current, value);
-  React.useEffect(() => {
-    previousValue.current = value;
-  }, [value]);
+  /**
+   * `key` is what drives the swap, so holding it still is how a change is written in place
+   * rather than animated. `at` is when the content last changed at all, animated or not, which
+   * is what keeps a continuous stream of changes from ever looking isolated.
+   */
+  const [swap, setSwap] = React.useState(() => ({
+    key: String(value),
+    shown: value as string | number,
+    from: undefined as string | number | undefined,
+    at: 0,
+  }));
+
+  if (swap.shown !== value) {
+    const now = Date.now();
+    const isIsolated = now - swap.at >= durationMs;
+    setSwap({
+      // Timestamped so the same value returning still counts as a change worth animating.
+      key: isIsolated ? `${value}-${now}` : swap.key,
+      shown: value,
+      from: isIsolated ? swap.shown : undefined,
+      at: now,
+    });
+  }
+
+  const resolvedDirection =
+    direction ?? (swap.from === undefined ? 'none' : getDirection(swap.from, value));
 
   /**
    * Which way, and whether at all: +1 rises, -1 falls, 0 cross-fades in place.
@@ -106,7 +137,7 @@ const BaseAnimatedValue = ({
       opacity: 1,
       y: 0,
       transition: {
-        duration: motionDuration,
+        duration: msToSeconds(durationMs),
         ease: cssBezierToArray(castWebType(theme.motion.easing.entrance)),
       },
     },
@@ -114,7 +145,7 @@ const BaseAnimatedValue = ({
       opacity: 0,
       y: -distance,
       transition: {
-        duration: motionDuration,
+        duration: msToSeconds(durationMs),
         ease: cssBezierToArray(castWebType(theme.motion.easing.exit)),
       },
     }),
@@ -125,7 +156,7 @@ const BaseAnimatedValue = ({
       {/* `initial={false}` so the very first render lands without animating in from nowhere. */}
       <AnimatePresence initial={false} custom={travel}>
         <MotionDiv
-          key={String(value)}
+          key={swap.key}
           // Inline for the same reason as the wrapper above.
           as="span"
           display="inline-block"

--- a/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
@@ -5,6 +5,8 @@ import { AnimatePresence } from 'framer-motion';
 // variant, which is the whole mechanism the exit direction relies on below.
 import type { Variants } from 'framer-motion';
 import type { BaseAnimatedValueProps, AnimatedValueDirection } from './types';
+import { OdometerValue } from './OdometerValue';
+import { parseNumericText } from './odometerUtils';
 import { MotionDiv } from '~components/BaseMotion';
 import { castWebType, useTheme } from '~utils';
 import { cssBezierToArray } from '~utils/cssBezierToArray';
@@ -60,32 +62,25 @@ const Stack = styled.span`
 `;
 
 /**
- * Animates a change of content: the outgoing value leaves and the incoming one arrives from
- * the opposite side, so a rising number reads as rising.
+ * Replaces the whole content, moving it in the direction the value went.
  *
- * Private on purpose. It is general enough to move beyond its first consumer, but it should
- * earn a public API on the back of a second one rather than ahead of it.
- *
- * Only isolated changes are animated. A value that changes again before the previous swap has
- * finished is written straight into place instead, because a roll is only legible when there
- * is time to read it: a slider being dragged can change fifty times a second, and animating
- * each one leaves a stack of half-faded copies that never resolves into a number. Coarse
- * changes — a keyboard step, a click, a slider whose steps are far apart — still roll.
- *
- * Presentational only: it renders whatever it is given and takes no view on how that content
- * is announced. During a swap both copies are briefly in the DOM, so a consumer that needs
- * this read out should own the accessible name itself and keep this subtree hidden from
- * assistive technology. `SliderInput` does exactly that, announcing through `aria-valuetext`.
+ * Used for anything the odometer cannot roll — words, or a value with no digits in it. Only
+ * isolated changes animate: content that changes again before the previous swap has finished
+ * is written straight into place, because a swap has to complete before the next can start and
+ * stacking them leaves a pile of half-faded copies that never resolves into anything readable.
  */
-const BaseAnimatedValue = ({
+const SwappedValue = ({
   value,
   children,
   direction,
-  duration = 'moderate',
-  testID,
-}: BaseAnimatedValueProps): React.ReactElement => {
+  durationMs,
+}: {
+  value: string | number;
+  children: React.ReactNode;
+  direction?: AnimatedValueDirection;
+  durationMs: number;
+}): React.ReactElement => {
   const { theme } = useTheme();
-  const durationMs = theme.motion.duration[duration];
 
   /**
    * `key` is what drives the swap, so holding it still is how a change is written in place
@@ -94,7 +89,7 @@ const BaseAnimatedValue = ({
    */
   const [swap, setSwap] = React.useState(() => ({
     key: String(value),
-    shown: value as string | number,
+    shown: value,
     from: undefined as string | number | undefined,
     at: 0,
   }));
@@ -152,23 +147,75 @@ const BaseAnimatedValue = ({
   };
 
   return (
+    // `initial={false}` so the very first render lands without animating in from nowhere.
+    <AnimatePresence initial={false} custom={travel}>
+      <MotionDiv
+        key={swap.key}
+        // Inline for the same reason as the wrapper above.
+        as="span"
+        display="inline-block"
+        custom={travel}
+        variants={variants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+      >
+        {children}
+      </MotionDiv>
+    </AnimatePresence>
+  );
+};
+
+/**
+ * Animates a change of content.
+ *
+ * Numbers roll their digits, driven continuously from the value itself, so they keep animating
+ * however fast the value moves — a slider being dragged included. Anything without a digit in
+ * it, a word or a label, swaps as a whole instead, travelling in the direction the value went.
+ *
+ * Private on purpose. It is general enough to move beyond its first consumer, but it should
+ * earn a public API on the back of a second one rather than ahead of it.
+ *
+ * Presentational only: it renders whatever it is given and takes no view on how that content
+ * is announced. A rolling number is a column of every digit, so a consumer that needs this read
+ * out should own the accessible name itself and keep this subtree hidden from assistive
+ * technology. `SliderInput` does exactly that, announcing through `aria-valuetext`.
+ */
+const BaseAnimatedValue = ({
+  value,
+  children,
+  direction,
+  duration = 'moderate',
+  testID,
+}: BaseAnimatedValueProps): React.ReactElement => {
+  const { theme } = useTheme();
+  const durationMs = theme.motion.duration[duration];
+
+  /*
+   * The odometer needs two things: a number to drive the columns, and text whose digits line up
+   * with it. Children that are not plain text could be anything, so those swap instead.
+   */
+  const content = children ?? value;
+  const numericValue = toNumber(value);
+  const parsed =
+    typeof content === 'string' || typeof content === 'number'
+      ? parseNumericText(String(content))
+      : null;
+
+  return (
     <Stack {...metaAttribute({ name: MetaConstants.AnimatedValue, testID })}>
-      {/* `initial={false}` so the very first render lands without animating in from nowhere. */}
-      <AnimatePresence initial={false} custom={travel}>
-        <MotionDiv
-          key={swap.key}
-          // Inline for the same reason as the wrapper above.
-          as="span"
-          display="inline-block"
-          custom={travel}
-          variants={variants}
-          initial="initial"
-          animate="animate"
-          exit="exit"
-        >
-          {children ?? value}
-        </MotionDiv>
-      </AnimatePresence>
+      {parsed && Number.isFinite(numericValue) ? (
+        <OdometerValue
+          value={numericValue}
+          text={String(content)}
+          parsed={parsed}
+          durationMs={durationMs}
+        />
+      ) : (
+        <SwappedValue value={value} direction={direction} durationMs={durationMs}>
+          {content}
+        </SwappedValue>
+      )}
     </Stack>
   );
 };

--- a/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/BaseAnimatedValue.web.tsx
@@ -70,9 +70,11 @@ const BaseAnimatedValue = ({
   value,
   children,
   direction,
+  duration = 'xquick',
   testID,
 }: BaseAnimatedValueProps): React.ReactElement => {
   const { theme } = useTheme();
+  const motionDuration = msToSeconds(theme.motion.duration[duration]);
 
   // Tracks the value the current content is replacing, so the travel has a direction.
   const previousValue = React.useRef<string | number | undefined>(undefined);
@@ -104,7 +106,7 @@ const BaseAnimatedValue = ({
       opacity: 1,
       y: 0,
       transition: {
-        duration: msToSeconds(theme.motion.duration.xquick),
+        duration: motionDuration,
         ease: cssBezierToArray(castWebType(theme.motion.easing.entrance)),
       },
     },
@@ -112,7 +114,7 @@ const BaseAnimatedValue = ({
       opacity: 0,
       y: -distance,
       transition: {
-        duration: msToSeconds(theme.motion.duration.xquick),
+        duration: motionDuration,
         ease: cssBezierToArray(castWebType(theme.motion.easing.exit)),
       },
     }),

--- a/packages/blade/src/components/BaseAnimatedValue/OdometerValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/OdometerValue.web.tsx
@@ -96,17 +96,15 @@ const DigitColumn = ({
  * moves, and settle crisply when it stops.
  */
 const OdometerValue = ({
-  value,
   text,
   parsed,
   durationMs,
 }: {
-  value: number;
   text: string;
   parsed: ParsedNumber;
   durationMs: number;
 }): React.ReactElement => {
-  const target = useMotionValue(value);
+  const target = useMotionValue(parsed.value);
   /*
    * A spring rather than a tween, because the target here is not a destination so much as
    * something to chase. Re-aiming a tween on every change restarts its easing from a standstill,
@@ -123,8 +121,8 @@ const OdometerValue = ({
   const displayed = useSpring(target, { duration: durationMs, bounce: 0 });
 
   React.useEffect(() => {
-    target.set(value);
-  }, [value, target]);
+    target.set(parsed.value);
+  }, [parsed.value, target]);
 
   return (
     <Row>

--- a/packages/blade/src/components/BaseAnimatedValue/OdometerValue.web.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/OdometerValue.web.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useMotionValue, useSpring, useTransform } from 'framer-motion';
+import type { MotionValue } from 'framer-motion';
+import { getColumnPosition } from './odometerUtils';
+import type { ParsedNumber } from './odometerUtils';
+import { MotionDiv } from '~components/BaseMotion';
+import { screenReaderStyles } from '~components/VisuallyHidden';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+
+/**
+ * A column carries every digit once, then repeats its first so a carry can roll off the end
+ * into a `0` rather than winding all the way back down through 9 to reach it.
+ */
+const COLUMN_DIGITS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'];
+
+/**
+ * Clips the column down to the single digit that should be showing.
+ *
+ * Sized by the hidden digit inside it rather than by a height of its own, so the window is
+ * exactly one line of whatever text it was dropped into. Pinning it to a fixed `em` height
+ * instead made the slider's indicator 19px tall against the 17px in Figma, because it stopped
+ * inheriting the line height the surrounding `Text` had set.
+ */
+const Window = styled.span`
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  /* An overflow-hidden inline box takes its baseline from its bottom edge, so left to align
+     itself it sits on the text baseline and pushes the line box taller than one line. */
+  vertical-align: top;
+`;
+
+/** Occupies one digit so the window inherits its width and line height. Never seen. */
+const Sizer = styled.span`
+  visibility: hidden;
+`;
+
+/**
+ * The styles rather than the `VisuallyHidden` component, which renders a `div`. This sits inside
+ * `Text`, so a block element here is invalid HTML that the parser hoists out of the paragraph,
+ * breaking hydration.
+ */
+const ReadableValue = styled.span(screenReaderStyles);
+
+const Digit = styled.span`
+  display: block;
+`;
+
+/**
+ * Tabular figures matter more here than anywhere else: proportional digits change width as they
+ * roll, which would shuffle every column sideways on the way past a `1`.
+ */
+const Row = styled.span`
+  display: inline-block;
+  font-variant-numeric: tabular-nums;
+`;
+
+const DigitColumn = ({
+  value,
+  place,
+  lowestPlace,
+}: {
+  value: MotionValue<number>;
+  place: number;
+  lowestPlace: number;
+}): React.ReactElement => {
+  // A percentage of the column's own height, so the pitch never has to be measured in px.
+  const y = useTransform(
+    value,
+    (current) =>
+      `${(-getColumnPosition(current, place, lowestPlace) / COLUMN_DIGITS.length) * 100}%`,
+  );
+
+  return (
+    <Window>
+      <Sizer aria-hidden={true}>0</Sizer>
+      {/* Lifted out of flow so the hidden digit above is what gives the window its size. */}
+      <MotionDiv as="span" style={{ y, position: 'absolute', top: 0, left: 0 }}>
+        {COLUMN_DIGITS.map((digit, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Digit key={index}>{digit}</Digit>
+        ))}
+      </MotionDiv>
+    </Window>
+  );
+};
+
+/**
+ * Rolls a number by driving every digit column from a single continuously retargeted value.
+ *
+ * This is what makes it survive a drag. A swap animation has to finish one value before it can
+ * start the next, so a slider changing fifty times a second leaves it no time to play. Here
+ * the columns are a function of the value itself, and each change simply re-aims the animation
+ * from wherever it currently is — so the digits keep rolling smoothly however fast the value
+ * moves, and settle crisply when it stops.
+ */
+const OdometerValue = ({
+  value,
+  text,
+  parsed,
+  durationMs,
+}: {
+  value: number;
+  text: string;
+  parsed: ParsedNumber;
+  durationMs: number;
+}): React.ReactElement => {
+  const target = useMotionValue(value);
+  /*
+   * A spring rather than a tween, because the target here is not a destination so much as
+   * something to chase. Re-aiming a tween on every change restarts its easing from a standstill,
+   * so during a drag it only ever covers the first slow fraction of a curve and falls further
+   * and further behind — measured at thirteen units adrift. A spring carries its velocity
+   * across the change, so it matches the value's pace instead of losing ground, and still
+   * settles cleanly when the value stops.
+   *
+   * `bounce: 0` keeps it from overshooting a digit and rolling back, which on a number reads as
+   * a mistake rather than as spring.
+   */
+  // `useSpring` takes its duration in milliseconds, unlike the seconds a `transition` wants.
+  // Passing seconds here leaves a spring so stiff it snaps between whole digits.
+  const displayed = useSpring(target, { duration: durationMs, bounce: 0 });
+
+  React.useEffect(() => {
+    target.set(value);
+  }, [value, target]);
+
+  return (
+    <Row>
+      {/*
+       * Each column carries every digit, so the text of this subtree reads
+       * `012345678900123456789` rather than `50`. That is what a screen reader, a find on the
+       * page, or a copy would otherwise pick up, so the real value is stated once here and the
+       * columns are hidden from anything that reads rather than looks.
+       */}
+      <ReadableValue {...metaAttribute({ name: MetaConstants.VisuallyHidden })}>
+        {text}
+      </ReadableValue>
+      <span aria-hidden={true}>
+        {parsed.slots.map((slot, index) =>
+          slot.type === 'digit' ? (
+            <DigitColumn
+              key={`digit-${slot.place}`}
+              value={displayed}
+              place={slot.place}
+              lowestPlace={parsed.lowestPlace}
+            />
+          ) : (
+            // eslint-disable-next-line react/no-array-index-key
+            <span key={`literal-${index}`}>{slot.char}</span>
+          ),
+        )}
+      </span>
+    </Row>
+  );
+};
+
+export { OdometerValue };

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/BaseAnimatedValue.web.test.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/BaseAnimatedValue.web.test.tsx
@@ -61,6 +61,30 @@ describe('<BaseAnimatedValue />', () => {
     expect(getByText('published')).toBeInTheDocument();
   });
 
+  it('should write rapid changes in place rather than stacking animated copies', async () => {
+    const user = userEvents.setup();
+    const Rapid = (): React.ReactElement => {
+      const [value, setValue] = React.useState(0);
+      return (
+        <>
+          {/* One click, many changes, exactly as a drag produces. */}
+          <button type="button" onClick={() => [1, 2, 3, 4, 5].forEach((v) => setValue(v))}>
+            churn
+          </button>
+          <BaseAnimatedValue value={value} testID="rapid" />
+        </>
+      );
+    };
+
+    const { getByText, getByTestId } = renderWithTheme(<Rapid />);
+    await user.click(getByText('churn'));
+
+    // A roll only reads when there is time to read it, so changes arriving mid-swap replace
+    // the content instead of queueing another copy behind it.
+    expect(getByTestId('rapid').children).toHaveLength(1);
+    expect(getByText('5')).toBeInTheDocument();
+  });
+
   it('should match snapshot', () => {
     const { container } = renderWithTheme(<BaseAnimatedValue value={7} />);
     expect(container).toMatchSnapshot();

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/BaseAnimatedValue.web.test.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/BaseAnimatedValue.web.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import userEvents from '@testing-library/user-event';
+import { BaseAnimatedValue } from '../BaseAnimatedValue.web';
+import renderWithTheme from '~utils/testing/renderWithTheme.web';
+
+describe('<BaseAnimatedValue />', () => {
+  it('should render the value when given no children', () => {
+    const { getByText } = renderWithTheme(<BaseAnimatedValue value={42} />);
+    expect(getByText('42')).toBeInTheDocument();
+  });
+
+  it('should render children in place of the value', () => {
+    // The raw value drives the direction while the formatted string is what is shown, so a
+    // unit or a currency does not stop the swap from moving the right way.
+    const { getByText, queryByText } = renderWithTheme(
+      <BaseAnimatedValue value={1200}>₹1,200</BaseAnimatedValue>,
+    );
+    expect(getByText('₹1,200')).toBeInTheDocument();
+    expect(queryByText('1200')).not.toBeInTheDocument();
+  });
+
+  /**
+   * The change is driven through state rather than RTL's `rerender`, which re-renders without
+   * the theme provider that `renderWithTheme` wrapped the first render in.
+   */
+  const Swapper = ({
+    from,
+    to,
+  }: {
+    from: string | number;
+    to: string | number;
+  }): React.ReactElement => {
+    const [value, setValue] = React.useState<string | number>(from);
+    return (
+      <>
+        <button type="button" onClick={() => setValue(to)}>
+          swap
+        </button>
+        <BaseAnimatedValue value={value} />
+      </>
+    );
+  };
+
+  it('should show the new value after a change', async () => {
+    const user = userEvents.setup();
+    const { getByText } = renderWithTheme(<Swapper from={1} to={2} />);
+    expect(getByText('1')).toBeInTheDocument();
+
+    await user.click(getByText('swap'));
+    expect(getByText('2')).toBeInTheDocument();
+  });
+
+  it('should take non-numeric content without complaint', async () => {
+    // There is no meaningful "up" between two words, so this cross-fades rather than
+    // travelling. It still has to render.
+    const user = userEvents.setup();
+    const { getByText } = renderWithTheme(<Swapper from="draft" to="published" />);
+    expect(getByText('draft')).toBeInTheDocument();
+
+    await user.click(getByText('swap'));
+    expect(getByText('published')).toBeInTheDocument();
+  });
+
+  it('should match snapshot', () => {
+    const { container } = renderWithTheme(<BaseAnimatedValue value={7} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/BaseAnimatedValue.web.test.tsx
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/BaseAnimatedValue.web.test.tsx
@@ -3,20 +3,27 @@ import userEvents from '@testing-library/user-event';
 import { BaseAnimatedValue } from '../BaseAnimatedValue.web';
 import renderWithTheme from '~utils/testing/renderWithTheme.web';
 
+/**
+ * A rolling number carries every digit in each column, so its text reads `01234567890`. The one
+ * node that states the actual value is the hidden one, which is what a screen reader gets and
+ * what these assertions go by.
+ */
+const readValue = (container: HTMLElement): string =>
+  container.querySelector('[data-blade-component="visually-hidden"]')?.textContent ?? '';
+
 describe('<BaseAnimatedValue />', () => {
   it('should render the value when given no children', () => {
-    const { getByText } = renderWithTheme(<BaseAnimatedValue value={42} />);
-    expect(getByText('42')).toBeInTheDocument();
+    const { container } = renderWithTheme(<BaseAnimatedValue value={42} />);
+    expect(readValue(container)).toBe('42');
   });
 
   it('should render children in place of the value', () => {
-    // The raw value drives the direction while the formatted string is what is shown, so a
-    // unit or a currency does not stop the swap from moving the right way.
-    const { getByText, queryByText } = renderWithTheme(
+    // The raw value drives the roll while the formatted string is what is shown, so a unit or
+    // a currency rides along as literals between the digit columns.
+    const { container } = renderWithTheme(
       <BaseAnimatedValue value={1200}>₹1,200</BaseAnimatedValue>,
     );
-    expect(getByText('₹1,200')).toBeInTheDocument();
-    expect(queryByText('1200')).not.toBeInTheDocument();
+    expect(readValue(container)).toBe('₹1,200');
   });
 
   /**
@@ -43,16 +50,15 @@ describe('<BaseAnimatedValue />', () => {
 
   it('should show the new value after a change', async () => {
     const user = userEvents.setup();
-    const { getByText } = renderWithTheme(<Swapper from={1} to={2} />);
-    expect(getByText('1')).toBeInTheDocument();
+    const { container, getByText } = renderWithTheme(<Swapper from={1} to={2} />);
+    expect(readValue(container)).toBe('1');
 
     await user.click(getByText('swap'));
-    expect(getByText('2')).toBeInTheDocument();
+    expect(readValue(container)).toBe('2');
   });
 
-  it('should take non-numeric content without complaint', async () => {
-    // There is no meaningful "up" between two words, so this cross-fades rather than
-    // travelling. It still has to render.
+  it('should swap the whole value when there are no digits to roll', async () => {
+    // Words have no places to drive columns from, so they cross-fade as a whole instead.
     const user = userEvents.setup();
     const { getByText } = renderWithTheme(<Swapper from="draft" to="published" />);
     expect(getByText('draft')).toBeInTheDocument();
@@ -61,14 +67,14 @@ describe('<BaseAnimatedValue />', () => {
     expect(getByText('published')).toBeInTheDocument();
   });
 
-  it('should write rapid changes in place rather than stacking animated copies', async () => {
+  it('should write rapid changes to a swapped value in place rather than stacking copies', async () => {
     const user = userEvents.setup();
     const Rapid = (): React.ReactElement => {
-      const [value, setValue] = React.useState(0);
+      const [value, setValue] = React.useState('a');
       return (
         <>
           {/* One click, many changes, exactly as a drag produces. */}
-          <button type="button" onClick={() => [1, 2, 3, 4, 5].forEach((v) => setValue(v))}>
+          <button type="button" onClick={() => ['b', 'c', 'd', 'e'].forEach((v) => setValue(v))}>
             churn
           </button>
           <BaseAnimatedValue value={value} testID="rapid" />
@@ -79,10 +85,10 @@ describe('<BaseAnimatedValue />', () => {
     const { getByText, getByTestId } = renderWithTheme(<Rapid />);
     await user.click(getByText('churn'));
 
-    // A roll only reads when there is time to read it, so changes arriving mid-swap replace
-    // the content instead of queueing another copy behind it.
+    // A swap only reads when there is time to read it, so changes arriving mid-swap replace the
+    // content instead of queueing another copy behind it.
     expect(getByTestId('rapid').children).toHaveLength(1);
-    expect(getByText('5')).toBeInTheDocument();
+    expect(getByText('e')).toBeInTheDocument();
   });
 
   it('should match snapshot', () => {

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/__snapshots__/BaseAnimatedValue.web.test.tsx.snap
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/__snapshots__/BaseAnimatedValue.web.test.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<BaseAnimatedValue /> should match snapshot 1`] = `
+.c1.c1.c1.c1.c1 {
+  display: inline-block;
+}
+
+.c0.c0.c0.c0.c0 {
+  display: inline-grid;
+}
+
+.c0.c0.c0.c0.c0 > * {
+  grid-area: 1 / 1;
+}
+
+<div>
+  <span
+    class="c0"
+    data-blade-component="animated-value"
+  >
+    <span
+      class="c1"
+      display="inline-block"
+      style="opacity: 1; transform: none;"
+    >
+      7
+    </span>
+  </span>
+</div>
+`;

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/__snapshots__/BaseAnimatedValue.web.test.tsx.snap
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/__snapshots__/BaseAnimatedValue.web.test.tsx.snap
@@ -1,8 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BaseAnimatedValue /> should match snapshot 1`] = `
+.c3.c3.c3.c3.c3 {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: top;
+}
+
+.c4.c4.c4.c4.c4 {
+  visibility: hidden;
+}
+
+.c2.c2.c2.c2.c2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c5.c5.c5.c5.c5 {
+  display: block;
+}
+
 .c1.c1.c1.c1.c1 {
   display: inline-block;
+  font-variant-numeric: tabular-nums;
 }
 
 .c0.c0.c0.c0.c0 {
@@ -20,10 +53,87 @@ exports[`<BaseAnimatedValue /> should match snapshot 1`] = `
   >
     <span
       class="c1"
-      display="inline-block"
-      style="opacity: 1; transform: none;"
     >
-      7
+      <span
+        class="c2"
+        data-blade-component="visually-hidden"
+      >
+        7
+      </span>
+      <span
+        aria-hidden="true"
+      >
+        <span
+          class="c3"
+        >
+          <span
+            aria-hidden="true"
+            class="c4"
+          >
+            0
+          </span>
+          <span
+            class="BaseMotionweb__StyledDiv-gsyvko-0"
+            style="position: absolute; top: 0px; left: 0px; transform: translateY(-63.63636363636363%);"
+          >
+            <span
+              class="c5"
+            >
+              0
+            </span>
+            <span
+              class="c5"
+            >
+              1
+            </span>
+            <span
+              class="c5"
+            >
+              2
+            </span>
+            <span
+              class="c5"
+            >
+              3
+            </span>
+            <span
+              class="c5"
+            >
+              4
+            </span>
+            <span
+              class="c5"
+            >
+              5
+            </span>
+            <span
+              class="c5"
+            >
+              6
+            </span>
+            <span
+              class="c5"
+            >
+              7
+            </span>
+            <span
+              class="c5"
+            >
+              8
+            </span>
+            <span
+              class="c5"
+            >
+              9
+            </span>
+            <span
+              class="c5"
+            >
+              0
+            </span>
+          </span>
+        </span>
+      </span>
     </span>
   </span>
 </div>

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/odometerUtils.web.test.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/odometerUtils.web.test.ts
@@ -47,6 +47,28 @@ describe('parseNumericText', () => {
     expect(parseNumericText('draft')).toBeNull();
     expect(parseNumericText('')).toBeNull();
   });
+
+  describe('the number the text spells out', () => {
+    it('should read the digits that are actually printed, not the value behind them', () => {
+      // `formatValue={(v) => `₹${v / 1000}k`}` prints ₹3k for 3000. Driving the column from
+      // 3000 lands it on 3000 % 10, which is why the indicator read ₹0k.
+      expect(parseNumericText('₹3k')?.value).toBe(3);
+    });
+
+    it('should ignore separators and units', () => {
+      expect(parseNumericText('₹1,200')?.value).toBe(1200);
+      expect(parseNumericText('50%')?.value).toBe(50);
+    });
+
+    it('should keep decimals exact rather than drifting through powers of ten', () => {
+      expect(parseNumericText('33.33')?.value).toBe(33.33);
+      expect(parseNumericText('99.99')?.value).toBe(99.99);
+    });
+
+    it('should take a leading minus as part of the number', () => {
+      expect(parseNumericText('-12')?.value).toBe(-12);
+    });
+  });
 });
 
 describe('getColumnPosition', () => {

--- a/packages/blade/src/components/BaseAnimatedValue/__tests__/odometerUtils.web.test.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/__tests__/odometerUtils.web.test.ts
@@ -1,0 +1,87 @@
+import { getColumnPosition, parseNumericText } from '../odometerUtils';
+
+describe('parseNumericText', () => {
+  it('should give each digit the power of ten it stands for', () => {
+    const parsed = parseNumericText('123');
+    expect(parsed?.slots).toEqual([
+      { type: 'digit', place: 2 },
+      { type: 'digit', place: 1 },
+      { type: 'digit', place: 0 },
+    ]);
+    expect(parsed?.lowestPlace).toBe(0);
+  });
+
+  it('should count decimal places downwards from the point', () => {
+    const parsed = parseNumericText('1.25');
+    expect(parsed?.slots).toEqual([
+      { type: 'digit', place: 0 },
+      { type: 'literal', char: '.' },
+      { type: 'digit', place: -1 },
+      { type: 'digit', place: -2 },
+    ]);
+    expect(parsed?.lowestPlace).toBe(-2);
+  });
+
+  it('should keep a currency symbol and a unit as literals around the digits', () => {
+    // The point of working off formatted text: a prefix or suffix rides along untouched
+    // instead of forcing the whole value to swap.
+    expect(parseNumericText('₹12')?.slots).toEqual([
+      { type: 'literal', char: '₹' },
+      { type: 'digit', place: 1 },
+      { type: 'digit', place: 0 },
+    ]);
+    expect(parseNumericText('50%')?.slots).toEqual([
+      { type: 'digit', place: 1 },
+      { type: 'digit', place: 0 },
+      { type: 'literal', char: '%' },
+    ]);
+  });
+
+  it('should not mistake a thousands separator for a decimal point', () => {
+    const parsed = parseNumericText('1.200');
+    // Every digit is an integer digit, so the lowest place is the units.
+    expect(parsed?.lowestPlace).toBe(0);
+  });
+
+  it('should return null when there is nothing to roll', () => {
+    expect(parseNumericText('draft')).toBeNull();
+    expect(parseNumericText('')).toBeNull();
+  });
+});
+
+describe('getColumnPosition', () => {
+  it('should sit exactly on a digit when the value is at rest', () => {
+    expect(getColumnPosition(12, 0, 0)).toBeCloseTo(2);
+    expect(getColumnPosition(12, 1, 0)).toBeCloseTo(1);
+  });
+
+  it('should roll the lowest place smoothly through a change', () => {
+    expect(getColumnPosition(12.5, 0, 0)).toBeCloseTo(2.5);
+  });
+
+  it('should hold a higher place still until the places below it are wrapping', () => {
+    // A tens column parked a fifth of the way towards the next digit would make a resting
+    // `12` unreadable.
+    expect(getColumnPosition(12.5, 1, 0)).toBeCloseTo(1);
+    expect(getColumnPosition(19.5, 1, 0)).toBeCloseTo(1.5);
+    expect(getColumnPosition(20, 1, 0)).toBeCloseTo(2);
+  });
+
+  it('should keep a resting decimal crisp rather than half carried', () => {
+    // 99.99 is 99.9% of the way to 100, so a carry measured against the tens would print
+    // `00.99` while the value simply sits there.
+    expect(getColumnPosition(99.99, 1, -2)).toBeCloseTo(9);
+    expect(getColumnPosition(99.99, 0, -2)).toBeCloseTo(9);
+    expect(getColumnPosition(99.99, -2, -2)).toBeCloseTo(9);
+  });
+
+  it('should carry a decimal value over its final step', () => {
+    expect(getColumnPosition(99.995, 1, -2)).toBeCloseTo(9.5);
+    expect(getColumnPosition(100, 1, -2)).toBeCloseTo(0);
+  });
+
+  it('should read a negative value by its magnitude', () => {
+    // The sign is a literal slot of its own, so the columns only deal in magnitude.
+    expect(getColumnPosition(-12, 0, 0)).toBeCloseTo(2);
+  });
+});

--- a/packages/blade/src/components/BaseAnimatedValue/index.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/index.ts
@@ -1,0 +1,2 @@
+export { BaseAnimatedValue } from './BaseAnimatedValue';
+export type { BaseAnimatedValueProps, AnimatedValueDirection } from './types';

--- a/packages/blade/src/components/BaseAnimatedValue/odometerUtils.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/odometerUtils.ts
@@ -1,0 +1,111 @@
+/**
+ * A digit in the rendered string, together with the power of ten it represents.
+ *
+ * The place is what lets one animating number drive every column: the units column reads it
+ * directly, the tens column a tenth as fast, and so on, which is what makes a carry roll
+ * through instead of snapping.
+ */
+type DigitSlot = {
+  type: 'digit';
+  /** Power of ten, so 2 in `123` is place 1 and 3 in `1.23` is place -2. */
+  place: number;
+};
+
+/** Anything that is not a digit: a sign, a separator, a decimal point, a unit. */
+type LiteralSlot = {
+  type: 'literal';
+  char: string;
+};
+
+type Slot = DigitSlot | LiteralSlot;
+
+type ParsedNumber = {
+  slots: Slot[];
+  /** The smallest place present, which is the only column that rolls continuously. */
+  lowestPlace: number;
+};
+
+/**
+ * Splits a rendered number into the columns that will be animated.
+ *
+ * Works off the formatted text rather than the raw number so separators, a currency symbol or
+ * a trailing unit survive: they simply become literals sitting between the digit columns.
+ *
+ * Returns `null` when the text holds no digits at all, which is the signal to fall back to
+ * swapping the whole value.
+ */
+const parseNumericText = (text: string): ParsedNumber | null => {
+  const digitIndexes: number[] = [];
+  for (let index = 0; index < text.length; index++) {
+    if (text[index] >= '0' && text[index] <= '9') digitIndexes.push(index);
+  }
+  if (digitIndexes.length === 0) return null;
+
+  /*
+   * The decimal point is whichever dot sits between two digits. Anything else that looks like
+   * one is punctuation and is left alone — a trailing full stop, or a thousands separator in
+   * locales that use `.` for it, which is why the separator itself is never treated as a point.
+   */
+  const pointIndex = text.split('').findIndex(
+    (char, index) =>
+      char === '.' &&
+      digitIndexes.includes(index - 1) &&
+      digitIndexes.includes(index + 1) &&
+      // Groups are three digits, so a dot with more than three digits after it before the
+      // next non-digit cannot be a separator.
+      !/^\.\d{3}(?!\d)/.test(text.slice(index)),
+  );
+
+  const integerDigits = digitIndexes.filter((index) => pointIndex === -1 || index < pointIndex);
+  const fractionDigits = digitIndexes.filter((index) => pointIndex !== -1 && index > pointIndex);
+
+  const placeOf = new Map<number, number>();
+  integerDigits.forEach((index, position) => {
+    placeOf.set(index, integerDigits.length - 1 - position);
+  });
+  fractionDigits.forEach((index, position) => {
+    placeOf.set(index, -(position + 1));
+  });
+
+  const slots: Slot[] = text
+    .split('')
+    .map((char, index) =>
+      placeOf.has(index)
+        ? { type: 'digit', place: placeOf.get(index)! }
+        : { type: 'literal', char },
+    );
+
+  return { slots, lowestPlace: Math.min(...Array.from(placeOf.values())) };
+};
+
+/**
+ * Where a column should sit, in digits, for a given value.
+ *
+ * The lowest place moves with the whole fractional part, so it rolls smoothly as the value
+ * changes. Every place above it holds still until the places below are about to wrap, which is
+ * what keeps `12` reading as a crisp `12` rather than a tens column parked a fifth of the way
+ * towards `2`.
+ *
+ * That carry is spread over one step of the smallest place on show, not over the last tenth of
+ * the current place. The difference only appears once there are decimals: `99.99` is 99.9% of
+ * the way to `100`, so a carry measured against the tens would have the tens column all but
+ * rolled over while the value is simply sitting still, printing `00.99`.
+ *
+ * The result runs `[0, 10)` and is allowed to pass through 10 during a carry, which is why the
+ * column repeats its first digit at the end.
+ */
+const getColumnPosition = (value: number, place: number, lowestPlace: number): number => {
+  const magnitude = Math.abs(value);
+  const scaled = magnitude / 10 ** place;
+  const whole = Math.floor(scaled);
+  if (place === lowestPlace) return (whole % 10) + (scaled - whole);
+
+  const step = 10 ** lowestPlace;
+  const unit = 10 ** place;
+  const below = magnitude % unit;
+  const carry = Math.min(Math.max((below - (unit - step)) / step, 0), 1);
+  return (whole % 10) + carry;
+};
+
+export { parseNumericText, getColumnPosition };
+export type { ParsedNumber, Slot, DigitSlot };

--- a/packages/blade/src/components/BaseAnimatedValue/odometerUtils.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/odometerUtils.ts
@@ -23,6 +23,14 @@ type ParsedNumber = {
   slots: Slot[];
   /** The smallest place present, which is the only column that rolls continuously. */
   lowestPlace: number;
+  /**
+   * The number the text itself spells out, which is what drives the columns.
+   *
+   * Deliberately not the value the text was formatted from. A `formatValue` is free to rescale
+   * what it prints — `₹${value / 1000}k` turns 3000 into `₹3k` — and driving a column that
+   * reads `3` from a value of 3000 lands it on `3000 % 10`, which is 0.
+   */
+  value: number;
 };
 
 /**
@@ -75,7 +83,18 @@ const parseNumericText = (text: string): ParsedNumber | null => {
         : { type: 'literal', char },
     );
 
-  return { slots, lowestPlace: Math.min(...Array.from(placeOf.values())) };
+  const lowestPlace = Math.min(...Array.from(placeOf.values()));
+
+  let magnitude = 0;
+  placeOf.forEach((place, index) => {
+    magnitude += Number(text[index]) * 10 ** place;
+  });
+  // Summing powers of ten drifts, and the columns compare against whole digits.
+  const rounded = Number(magnitude.toFixed(Math.max(0, -lowestPlace)));
+  // A minus belongs to the number even though it renders as a literal of its own.
+  const isNegative = text.slice(0, digitIndexes[0]).includes('-');
+
+  return { slots, lowestPlace, value: isNegative ? -rounded : rounded };
 };
 
 /**

--- a/packages/blade/src/components/BaseAnimatedValue/types.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/types.ts
@@ -1,0 +1,35 @@
+import type React from 'react';
+import type { TestID } from '~utils/types';
+
+/**
+ * Where the outgoing content leaves, and where the incoming content arrives from.
+ *
+ * `none` cross-fades in place. That is what non-numeric content gets, since there is no
+ * meaningful "up" between two pieces of text.
+ */
+type AnimatedValueDirection = 'up' | 'down' | 'none';
+
+type BaseAnimatedValueProps = {
+  /**
+   * Identifies the current content, and decides which way it travels.
+   *
+   * A change animates the swap; re-rendering the same value does nothing. Two values that
+   * both read as finite numbers travel by their difference, and anything else cross-fades.
+   *
+   * Keep this the raw value rather than the formatted one. A formatted string like `"₹1,200"`
+   * does not read as a number, so it would cross-fade instead of moving in the right
+   * direction. Pass the number here and the formatted string as `children`.
+   */
+  value: string | number;
+
+  /**
+   * What to render for `value`. Defaults to the value itself, so the plain case needs no
+   * children.
+   */
+  children?: React.ReactNode;
+
+  /** Overrides the direction derived from `value`. */
+  direction?: AnimatedValueDirection;
+} & TestID;
+
+export type { BaseAnimatedValueProps, AnimatedValueDirection };

--- a/packages/blade/src/components/BaseAnimatedValue/types.ts
+++ b/packages/blade/src/components/BaseAnimatedValue/types.ts
@@ -1,5 +1,8 @@
 import type React from 'react';
+import type { Theme } from '~components/BladeProvider';
 import type { TestID } from '~utils/types';
+
+type MotionDurationToken = keyof Theme['motion']['duration'];
 
 /**
  * Where the outgoing content leaves, and where the incoming content arrives from.
@@ -30,6 +33,16 @@ type BaseAnimatedValueProps = {
 
   /** Overrides the direction derived from `value`. */
   direction?: AnimatedValueDirection;
+
+  /**
+   * Motion duration token for the swap.
+   *
+   * Worth passing when this sits inside something that animates on its own timing, so the two
+   * stay in step when either is retuned rather than agreeing by coincidence.
+   *
+   * @default 'xquick'
+   */
+  duration?: MotionDurationToken;
 } & TestID;
 
-export type { BaseAnimatedValueProps, AnimatedValueDirection };
+export type { BaseAnimatedValueProps, AnimatedValueDirection, MotionDurationToken };

--- a/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/blade/src/components/Button/BaseButton/BaseButton.tsx
@@ -23,6 +23,7 @@ import type { BaseButtonStyleProps, IconColor } from './types';
 import AnimatedButtonContent from './AnimatedButtonContent';
 import type { DotNotationToken } from '~utils/lodashButBetter/get';
 import getIn from '~utils/lodashButBetter/get';
+import { focusRingColorTokens } from '~utils/getFocusRingStyles/focusRingTokens';
 import type { BaseLinkProps } from '~components/Link/BaseLink';
 import type { Theme } from '~components/BladeProvider';
 import type { IconComponent, IconSize } from '~components/Icons';
@@ -486,9 +487,7 @@ const getProps = ({
     // with a faded neutral ring on the filled neutral surface.
     focusRingColor: getIn(
       theme.colors,
-      isFilledNeutral(color, variant)
-        ? 'interactive.border.neutral.faded'
-        : 'surface.border.primary.muted',
+      focusRingColorTokens[isFilledNeutral(color, variant) ? 'neutral' : 'primary'],
     ),
     borderRadius: makeBorderSize(theme.border.radius[_borderRadius ?? buttonBorderRadius[size]]),
     motionDuration: 'duration.xquick',

--- a/packages/blade/src/components/Input/SliderInput/SliderInput.native.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderInput.native.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { SliderInputProps } from './types';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { throwBladeError } from '~utils/logger';
+import { MetaConstants } from '~utils/metaAttribute';
+import type { BladeElementRef } from '~utils/types';
+
+/**
+ * SliderInput is web-only for now.
+ *
+ * The track relies on `mask-image` compositing to punch the marker cut-outs, which has no
+ * equivalent in React Native's style system. A native version needs a different drawing
+ * approach (SVG or overlaid views) and its own gesture handling, so it is deliberately left
+ * out rather than shipped as a lookalike that drifts from the web behaviour.
+ */
+const _SliderInput = (
+  _props: SliderInputProps,
+  _ref: React.Ref<BladeElementRef>,
+): React.ReactElement | null => {
+  throwBladeError({
+    message: 'SliderInput is not supported on React Native yet.',
+    moduleName: 'SliderInput',
+  });
+
+  return null;
+};
+
+const SliderInput = assignWithoutSideEffects(React.forwardRef(_SliderInput), {
+  componentId: MetaConstants.SliderInput,
+  displayName: 'SliderInput',
+});
+
+export { SliderInput };

--- a/packages/blade/src/components/Input/SliderInput/SliderInput.stories.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderInput.stories.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { SliderInput } from './index';
+import type { SliderInputProps } from './types';
+import { Box } from '~components/Box';
+import { Text } from '~components/Typography';
+import { TextInput } from '~components/Input/TextInput';
+
+export default {
+  title: 'Components/Input/SliderInput',
+  component: SliderInput,
+  args: {
+    label: 'Volume',
+    labelPosition: 'top',
+    min: 0,
+    max: 100,
+    step: 1,
+    showMarkers: false,
+    showScale: false,
+    showScaleValues: true,
+    showValueIndicator: true,
+    isDisabled: false,
+  },
+  argTypes: {
+    labelPosition: {
+      control: { type: 'select' },
+      options: ['top', 'left'],
+    },
+    validationState: {
+      control: { type: 'select' },
+      options: ['none', 'error', 'success'],
+    },
+    necessityIndicator: {
+      control: { type: 'select' },
+      options: ['none', 'required', 'optional'],
+    },
+  },
+} as Meta<SliderInputProps>;
+
+const SliderInputTemplate: StoryFn<typeof SliderInput> = (args) => {
+  return (
+    <Box maxWidth="400px">
+      <SliderInput {...args} />
+    </Box>
+  );
+};
+
+export const Default = SliderInputTemplate.bind({});
+
+export const WithMarkers = SliderInputTemplate.bind({});
+WithMarkers.args = { step: 25, showMarkers: true, defaultValue: 50 };
+
+export const WithScale = SliderInputTemplate.bind({});
+WithScale.args = { step: 25, showMarkers: true, showScale: true, defaultValue: 50 };
+
+export const LabelPositionLeft = SliderInputTemplate.bind({});
+LabelPositionLeft.args = { labelPosition: 'left', step: 20, showMarkers: true, showScale: true };
+
+export const Disabled = SliderInputTemplate.bind({});
+Disabled.args = {
+  isDisabled: true,
+  defaultValue: 40,
+  step: 20,
+  showMarkers: true,
+  showScale: true,
+};
+
+/**
+ * `max` is always reachable even when the range is not a whole number of steps, so this
+ * slider stops at 0, 30, 60, 90 and 100.
+ */
+export const UnevenSteps = SliderInputTemplate.bind({});
+UnevenSteps.args = { step: 30, showMarkers: true, showScale: true, defaultValue: 60 };
+
+export const Steps: StoryFn<typeof SliderInput> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.7" maxWidth="400px">
+      {[undefined, 33.33, 25, 10].map((step, index) => (
+        <SliderInput
+          key={index}
+          label={step ? `${Math.round(100 / step) + 1} steps` : 'Continuous'}
+          step={step}
+          showMarkers={Boolean(step)}
+          showScale={Boolean(step)}
+          defaultValue={50}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export const ValidationStates: StoryFn<typeof SliderInput> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.7" maxWidth="400px">
+      <SliderInput label="With help text" helpText="Drag to adjust the output level" />
+      <SliderInput label="With error" validationState="error" errorText="Value is too high" />
+      <SliderInput label="With success" validationState="success" successText="Looks good" />
+    </Box>
+  );
+};
+
+/**
+ * `formatValue` is applied everywhere the value is shown: the scale, the indicator above the
+ * thumb and the value announced to a screen reader.
+ */
+export const FormattedValue: StoryFn<typeof SliderInput> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.7" maxWidth="400px">
+      <SliderInput
+        label="Budget"
+        min={0}
+        max={5000}
+        step={1000}
+        defaultValue={2000}
+        showMarkers
+        showScale
+        formatValue={(value) => `₹${value / 1000}k`}
+      />
+      <SliderInput
+        label="Discount"
+        min={0}
+        max={100}
+        step={20}
+        defaultValue={40}
+        showMarkers
+        showScale
+        formatValue={(value) => `${value}%`}
+      />
+    </Box>
+  );
+};
+
+/**
+ * The slider does not bundle a text field. Pair them by holding the value in your own state
+ * and passing it to both, which keeps you free to decide how the two reconcile.
+ *
+ * Note the two callbacks do different jobs: `onChange` fires on every pointer move so the
+ * field tracks the drag live, while `onChangeEnd` fires once on release and is where
+ * anything expensive belongs.
+ */
+export const PairedWithTextInput: StoryFn<typeof SliderInput> = () => {
+  const [radius, setRadius] = React.useState(8);
+  const [draft, setDraft] = React.useState('8');
+
+  const commitDraft = (): void => {
+    const parsed = Number(draft);
+    // Typing 37 against a step of 8 puts the thumb on 40, so the field is reconciled back to
+    // the value the slider actually settled on rather than being left disagreeing with it.
+    const next = Number.isFinite(parsed) ? Math.min(Math.max(parsed, 0), 40) : radius;
+    setRadius(next);
+    setDraft(String(next));
+  };
+
+  return (
+    <Box display="flex" alignItems="center" gap="spacing.5" maxWidth="600px">
+      {/* The slider sizes to its content in a flex row, so it has to be told to take the rest. */}
+      <Box flex="1">
+        <SliderInput
+          label="Corner Radius"
+          labelPosition="left"
+          min={0}
+          max={40}
+          step={8}
+          showMarkers
+          value={radius}
+          onChange={({ value }) => {
+            setRadius(value);
+            setDraft(String(value));
+          }}
+        />
+      </Box>
+      <Box width="80px" flexShrink={0}>
+        <TextInput
+          accessibilityLabel="Corner radius in pixels"
+          suffix="px"
+          size="small"
+          value={draft}
+          onChange={({ value }) => setDraft(value ?? '')}
+          onBlur={commitDraft}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+/**
+ * Markers and scale labels are dropped independently once they would collide, so a narrow
+ * slider degrades to a plain track instead of rendering a smear of overlapping dots.
+ */
+export const NarrowWidths: StoryFn<typeof SliderInput> = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap="spacing.7">
+      {['400px', '240px', '140px'].map((width) => (
+        <Box key={width} width={width}>
+          <Text size="xsmall" marginBottom="spacing.2">
+            {width}
+          </Text>
+          <SliderInput
+            label="Volume"
+            step={10}
+            showMarkers
+            showScale
+            defaultValue={50}
+            accessibilityLabel={`Volume at ${width}`}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/packages/blade/src/components/Input/SliderInput/SliderInput.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderInput.web.tsx
@@ -1,0 +1,403 @@
+import React from 'react';
+import styled from 'styled-components';
+import type { SliderInputProps } from './types';
+import { SliderTrack } from './SliderTrack.web';
+import { SliderValueIndicator } from './SliderValueIndicator.web';
+import { useSliderInput } from './useSliderInput.web';
+import {
+  sliderInputColors,
+  sliderInputMotion,
+  SLIDER_BOX_HEIGHT,
+  SLIDER_BOX_PADDING_TOP,
+  SLIDER_CONTROL_HEIGHT,
+  SLIDER_SCALE_TOP,
+  SLIDER_THUMB_HIT_AREA,
+  SLIDER_THUMB_SIZE,
+  SLIDER_THUMB_TOP,
+  SLIDER_TRACK_TOP,
+} from './sliderInputTokens';
+import {
+  getCenteringTransform,
+  getMarkerValues,
+  getMinTrackWidth,
+  getOffsetExpression,
+  getSpacedScaleValues,
+  getValueRatio,
+  getVisibility,
+  getWidestLabelWidth,
+} from './utils';
+import BaseBox from '~components/Box/BaseBox';
+import { FormLabel, FormHint } from '~components/Form';
+import { useFormId } from '~components/Form/useFormId';
+import { getHintType } from '~components/Input/BaseInput/BaseInput';
+import { Text } from '~components/Typography';
+import { useTheme } from '~components/BladeProvider';
+import type { Theme } from '~components/BladeProvider';
+import { useBreakpoint, makeSize, makeMotionTime } from '~utils';
+import { getStyledProps } from '~components/Box/styledProps';
+import { metaAttribute, MetaConstants } from '~utils/metaAttribute';
+import { makeAnalyticsAttribute } from '~utils/makeAnalyticsAttribute';
+import { assignWithoutSideEffects } from '~utils/assignWithoutSideEffects';
+import { getFocusRingStyles } from '~utils/getFocusRingStyles';
+import { getOuterMotionRef } from '~utils/getMotionRefs';
+import type { BladeElementRef } from '~utils/types';
+import get from '~utils/lodashButBetter/get';
+
+/**
+ * The scale hangs 4px below the box on purpose. The box itself stays exactly one small
+ * BaseInput tall so that toggling the scale never moves the track, and a SliderInput keeps
+ * sharing a field centre line with the TextInput it is paired with.
+ */
+const FieldBox = styled.div<{ $hasScale: boolean }>`
+  position: relative;
+  width: 100%;
+  height: ${makeSize(SLIDER_BOX_HEIGHT)};
+  margin-bottom: ${({ $hasScale }) =>
+    $hasScale ? makeSize(SLIDER_SCALE_TOP + 12 - SLIDER_BOX_HEIGHT) : '0px'};
+`;
+
+const Control = styled.div<{ $isDisabled: boolean }>`
+  position: absolute;
+  inset-inline: 0;
+  top: ${makeSize(SLIDER_BOX_PADDING_TOP)};
+  height: ${makeSize(SLIDER_CONTROL_HEIGHT)};
+  cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
+  /* Horizontal drags belong to the slider; without this the browser scrolls the page instead. */
+  touch-action: none;
+
+  /* Lifts the target to the 44px minimum without touching the visual height. */
+  &::before {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    top: ${makeSize(-(SLIDER_THUMB_HIT_AREA - SLIDER_CONTROL_HEIGHT) / 2)};
+    bottom: ${makeSize(-(SLIDER_THUMB_HIT_AREA - SLIDER_CONTROL_HEIGHT) / 2)};
+  }
+`;
+
+const TrackArea = styled.div`
+  position: absolute;
+  inset-inline: 0;
+  top: ${makeSize(SLIDER_TRACK_TOP - SLIDER_BOX_PADDING_TOP)};
+`;
+
+/**
+ * Movement is eased so a keyboard step, or a click further down the track, reads as the thumb
+ * travelling rather than teleporting. It is suppressed only while scrubbing, where the thumb
+ * has to stay pinned to the pointer.
+ */
+const getThumbTransition = (theme: Theme, isScrubbing: boolean): string => {
+  const easing = String(theme.motion.easing[sliderInputMotion.position.easing]);
+  const color = `background-color ${makeMotionTime(
+    theme.motion.duration[sliderInputMotion.color.duration],
+  )} ${easing}`;
+  if (isScrubbing) return color;
+  const move = `inset-inline-start ${makeMotionTime(
+    theme.motion.duration[sliderInputMotion.position.duration],
+  )} ${easing}`;
+  return `${move}, ${color}`;
+};
+
+const Thumb = styled.div<{ $color: string; $isScrubbing: boolean }>`
+  position: absolute;
+  top: ${makeSize(SLIDER_THUMB_TOP)};
+  width: ${makeSize(SLIDER_THUMB_SIZE)};
+  height: ${makeSize(SLIDER_THUMB_SIZE)};
+  border-radius: ${({ theme }) => makeSize(theme.border.radius.max)};
+  background-color: ${({ $color }) => $color};
+  outline: none;
+  transition: ${({ theme, $isScrubbing }) => getThumbTransition(theme, $isScrubbing)};
+
+  &:focus-visible {
+    ${({ theme }) => getFocusRingStyles({ theme, variant: 'neutral' })}
+    /*
+     * getFocusRingStyles narrows transition-property to outline-width alone, which would
+     * freeze the thumb in place exactly while the keyboard is driving it. Re-declare the
+     * movement alongside the ring's own growth.
+     */
+    transition: ${({ theme, $isScrubbing }) =>
+      `outline-width ${makeMotionTime(theme.motion.duration['2xquick'])} ${String(
+        theme.motion.easing.standard,
+      )}, ${getThumbTransition(theme, $isScrubbing)}`};
+  }
+`;
+
+const ScaleRow = styled.div`
+  position: absolute;
+  inset-inline: 0;
+  top: ${makeSize(SLIDER_SCALE_TOP)};
+  /* The labels sit over the bottom of the control, so they must not swallow drags. */
+  pointer-events: none;
+`;
+
+const ScaleLabel = styled.div`
+  position: absolute;
+  white-space: nowrap;
+`;
+
+const _SliderInput = (
+  {
+    label,
+    labelPosition = 'top',
+    necessityIndicator,
+    accessibilityLabel,
+    helpText,
+    errorText,
+    successText,
+    validationState = 'none',
+    value,
+    defaultValue,
+    onChange,
+    onChangeEnd,
+    onFocus,
+    onBlur,
+    min = 0,
+    max = 100,
+    step = 1,
+    showMarkers = false,
+    showScale = false,
+    showScaleValues = true,
+    showValueIndicator = true,
+    formatValue,
+    isDisabled = false,
+    isRequired = false,
+    name,
+    testID,
+    _motionMeta,
+    ...rest
+  }: SliderInputProps,
+  ref: React.Ref<BladeElementRef>,
+): React.ReactElement => {
+  const { theme } = useTheme();
+  const { matchedDeviceType } = useBreakpoint({ breakpoints: theme.breakpoints });
+  const isLabelLeftPositioned = labelPosition === 'left' && matchedDeviceType === 'desktop';
+
+  const { inputId, labelId, helpTextId, errorTextId, successTextId } = useFormId('slider-input');
+
+  const [isHovered, setIsHovered] = React.useState(false);
+  const [isFocused, setIsFocused] = React.useState(false);
+
+  // Every handler in the hook depends on this, so a fresh object each render would rebuild
+  // all of them on every pointer move.
+  const range = React.useMemo(() => ({ min, max, step }), [min, max, step]);
+
+  const {
+    value: currentValue,
+    trackAreaRef,
+    thumbRef,
+    trackWidth,
+    isRTL,
+    isDragging,
+    isScrubbing,
+    controlProps,
+    thumbProps,
+  } = useSliderInput({ value, defaultValue, onChange, onChangeEnd, range, isDisabled });
+
+  const markerValues = React.useMemo(() => getMarkerValues(range), [range]);
+  const markerRatios = React.useMemo(
+    () => markerValues.map((markerValue) => getValueRatio(markerValue, range)),
+    [markerValues, range],
+  );
+
+  const format = React.useCallback(
+    (target: number): string => (formatValue ? formatValue(target) : String(target)),
+    [formatValue],
+  );
+
+  const widestLabelWidth = React.useMemo(() => getWidestLabelWidth(markerValues, formatValue), [
+    markerValues,
+    formatValue,
+  ]);
+
+  const { canShowMarkers, canShowScale } = getVisibility({
+    trackWidth,
+    markerCount: markerValues.length,
+    widestLabelWidth,
+  });
+
+  const shouldShowMarkers = showMarkers && canShowMarkers;
+  // With only the endpoints there is nothing to collide with, so the pitch floor does not apply.
+  const shouldShowScale = showScale && (!showScaleValues || canShowScale);
+  const scaleValues = React.useMemo(
+    () =>
+      showScaleValues
+        ? getSpacedScaleValues({ values: markerValues, trackWidth, widestLabelWidth, range })
+        : [min, max],
+    [showScaleValues, markerValues, trackWidth, widestLabelWidth, range, min, max],
+  );
+
+  const centeringTransform = getCenteringTransform(isRTL);
+  const thumbOffset = getOffsetExpression(getValueRatio(currentValue, range));
+  const isHighlighted = isHovered || isFocused || isDragging;
+
+  const willRenderHintText =
+    Boolean(helpText) ||
+    (validationState === 'success' && Boolean(successText)) ||
+    (validationState === 'error' && Boolean(errorText));
+
+  const describedBy =
+    validationState === 'error'
+      ? errorTextId
+      : validationState === 'success'
+      ? successTextId
+      : helpText
+      ? helpTextId
+      : undefined;
+
+  const thumbColor = isDisabled
+    ? sliderInputColors.fill.disabled
+    : isHighlighted
+    ? sliderInputColors.fill.highlighted
+    : sliderInputColors.fill.default;
+
+  return (
+    <BaseBox
+      ref={getOuterMotionRef({ _motionMeta, ref })}
+      {...metaAttribute({ name: MetaConstants.SliderInput, testID })}
+      {...getStyledProps(rest)}
+      {...makeAnalyticsAttribute(rest)}
+    >
+      <BaseBox
+        display="flex"
+        flexDirection={isLabelLeftPositioned ? 'row' : 'column'}
+        alignItems={isLabelLeftPositioned ? 'center' : undefined}
+      >
+        {label ? (
+          // A `<label for>` cannot target a div, so the association is made with
+          // `aria-labelledby` on the thumb instead.
+          <FormLabel
+            as="span"
+            id={labelId}
+            position={labelPosition}
+            necessityIndicator={necessityIndicator ?? (isRequired ? 'required' : undefined)}
+          >
+            {label}
+          </FormLabel>
+        ) : null}
+
+        <BaseBox
+          flex="1"
+          // Labels only widen the floor when they are actually on screen.
+          minWidth={makeSize(
+            getMinTrackWidth(
+              markerValues.length,
+              showScale && showScaleValues ? widestLabelWidth : 0,
+            ),
+          )}
+        >
+          <FieldBox $hasScale={shouldShowScale}>
+            <Control
+              $isDisabled={isDisabled}
+              onMouseEnter={() => setIsHovered(true)}
+              onMouseLeave={() => setIsHovered(false)}
+              {...controlProps}
+            >
+              <TrackArea ref={trackAreaRef}>
+                <SliderTrack
+                  value={currentValue}
+                  range={range}
+                  markerRatios={shouldShowMarkers ? markerRatios : []}
+                  isDisabled={isDisabled}
+                  isHighlighted={isHighlighted}
+                  isScrubbing={isScrubbing}
+                  isRTL={isRTL}
+                />
+              </TrackArea>
+
+              <Thumb
+                ref={thumbRef}
+                $color={get(theme.colors, thumbColor)}
+                $isScrubbing={isScrubbing}
+                style={{ insetInlineStart: thumbOffset, transform: centeringTransform }}
+                role="slider"
+                tabIndex={isDisabled ? -1 : 0}
+                id={inputId}
+                aria-orientation="horizontal"
+                aria-valuemin={min}
+                aria-valuemax={max}
+                // Always the snapped value, so the announcement matches the marker the thumb
+                // is standing on rather than whatever was passed in.
+                aria-valuenow={currentValue}
+                aria-valuetext={format(currentValue)}
+                aria-labelledby={label ? labelId : undefined}
+                aria-label={label ? undefined : accessibilityLabel}
+                aria-describedby={describedBy}
+                aria-disabled={isDisabled}
+                // No `aria-required`: it is not a supported attribute on `role="slider"`,
+                // which always holds a value. `isRequired` shows on the label instead.
+                onFocus={() => {
+                  setIsFocused(true);
+                  onFocus?.({ name, value: String(currentValue) });
+                }}
+                onBlur={() => {
+                  setIsFocused(false);
+                  onBlur?.({ name, value: String(currentValue) });
+                }}
+                {...thumbProps}
+              />
+
+              {/* After the thumb so it paints above it rather than under. */}
+              {showValueIndicator ? (
+                <SliderValueIndicator
+                  offset={thumbOffset}
+                  centeringTransform={centeringTransform}
+                  isVisible={isHighlighted && !isDisabled}
+                  isScrubbing={isScrubbing}
+                >
+                  {format(currentValue)}
+                </SliderValueIndicator>
+              ) : null}
+            </Control>
+
+            {shouldShowScale ? (
+              <ScaleRow aria-hidden={true}>
+                {scaleValues.map((scaleValue) => (
+                  <ScaleLabel
+                    key={scaleValue}
+                    style={{
+                      insetInlineStart: getOffsetExpression(getValueRatio(scaleValue, range)),
+                      transform: centeringTransform,
+                    }}
+                  >
+                    <Text
+                      size="xsmall"
+                      weight="regular"
+                      color={
+                        isDisabled
+                          ? sliderInputColors.scaleLabel.disabled
+                          : sliderInputColors.scaleLabel.default
+                      }
+                    >
+                      {format(scaleValue)}
+                    </Text>
+                  </ScaleLabel>
+                ))}
+              </ScaleRow>
+            ) : null}
+          </FieldBox>
+
+          {name ? <input type="hidden" name={name} value={currentValue} readOnly={true} /> : null}
+
+          {willRenderHintText ? (
+            <FormHint
+              type={getHintType({ validationState, hasHelpText: Boolean(helpText) })}
+              helpText={helpText}
+              errorText={errorText}
+              successText={successText}
+              helpTextId={helpTextId}
+              errorTextId={errorTextId}
+              successTextId={successTextId}
+            />
+          ) : null}
+        </BaseBox>
+      </BaseBox>
+    </BaseBox>
+  );
+};
+
+const SliderInput = assignWithoutSideEffects(React.forwardRef(_SliderInput), {
+  componentId: MetaConstants.SliderInput,
+  displayName: 'SliderInput',
+});
+
+export { SliderInput };

--- a/packages/blade/src/components/Input/SliderInput/SliderInput.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderInput.web.tsx
@@ -343,6 +343,7 @@ const _SliderInput = (
                   centeringTransform={centeringTransform}
                   isVisible={isHighlighted && !isDisabled}
                   isScrubbing={isScrubbing}
+                  value={currentValue}
                 >
                   {format(currentValue)}
                 </SliderValueIndicator>

--- a/packages/blade/src/components/Input/SliderInput/SliderTrack.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderTrack.web.tsx
@@ -39,8 +39,10 @@ const TrackLayer = styled.div<{ $isScrubbing: boolean }>`
   inset: 0;
   border-radius: ${({ theme }) => makeSize(theme.border.radius.max)};
   mask-repeat: no-repeat;
+  /* stylelint-disable-next-line property-no-vendor-prefix -- Safari needs the prefixed property */
   -webkit-mask-repeat: no-repeat;
   /* The WebKit keyword has to come first so the standard property wins where both parse. */
+  /* stylelint-disable-next-line property-no-vendor-prefix -- Safari uses a different composite keyword */
   -webkit-mask-composite: source-in;
   mask-composite: intersect;
 

--- a/packages/blade/src/components/Input/SliderInput/SliderTrack.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderTrack.web.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import styled from 'styled-components';
+import { sliderInputColors, sliderInputMotion, SLIDER_TRACK_HEIGHT } from './sliderInputTokens';
+import { getFillWidthExpression, getMarkerMaskImage, getValueRatio } from './utils';
+import type { ValueRange } from './utils';
+import get from '~utils/lodashButBetter/get';
+import { makeSize, makeMotionTime } from '~utils';
+import { useTheme } from '~components/BladeProvider';
+
+type SliderTrackProps = {
+  value: number;
+  range: Pick<ValueRange, 'min' | 'max'>;
+  /** Values that get a marker, as 0-1 ratios. Empty renders a plain rail. */
+  markerRatios: number[];
+  isDisabled: boolean;
+  /** Hover, focus and drag all share the highlighted fill. */
+  isHighlighted: boolean;
+  /** Suppresses the movement easing so the fill keeps up with the pointer. */
+  isScrubbing: boolean;
+  isRTL: boolean;
+};
+
+const TrackContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: ${makeSize(SLIDER_TRACK_HEIGHT)};
+`;
+
+/**
+ * The rail and the fill are both full track width and share one mask, so the marker cut-outs
+ * line up across the two without either needing the measured width. The fill is trimmed to
+ * the reached value with `clip-path` rather than by being narrower.
+ *
+ * Colour and mask arrive through inline styles: both change on every pointer move during a
+ * drag, and threading them through styled-components would mint a new class per frame.
+ */
+const TrackLayer = styled.div<{ $isScrubbing: boolean }>`
+  position: absolute;
+  inset: 0;
+  border-radius: ${({ theme }) => makeSize(theme.border.radius.max)};
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  /* The WebKit keyword has to come first so the standard property wins where both parse. */
+  -webkit-mask-composite: source-in;
+  mask-composite: intersect;
+
+  /* Easing the clip while scrubbing would leave the fill trailing behind the thumb. A click
+     is not scrubbing, so it still glides. */
+  transition: ${({ theme, $isScrubbing }) => {
+    const easing = String(theme.motion.easing[sliderInputMotion.position.easing]);
+    const color = `background-color ${makeMotionTime(
+      theme.motion.duration[sliderInputMotion.color.duration],
+    )} ${easing}`;
+    if ($isScrubbing) return color;
+    const clip = `clip-path ${makeMotionTime(
+      theme.motion.duration[sliderInputMotion.position.duration],
+    )} ${easing}`;
+    return `${clip}, ${color}`;
+  }};
+`;
+
+const SliderTrack = ({
+  value,
+  range,
+  markerRatios,
+  isDisabled,
+  isHighlighted,
+  isScrubbing,
+  isRTL,
+}: SliderTrackProps): React.ReactElement => {
+  const { theme } = useTheme();
+  const ratio = getValueRatio(value, range);
+
+  const maskStyle = React.useMemo(() => {
+    if (markerRatios.length === 0) return undefined;
+    const maskImage = getMarkerMaskImage(markerRatios);
+    return { maskImage, WebkitMaskImage: maskImage };
+  }, [markerRatios]);
+
+  const fillColorToken = isDisabled
+    ? sliderInputColors.fill.disabled
+    : isHighlighted
+    ? sliderInputColors.fill.highlighted
+    : sliderInputColors.fill.default;
+
+  /**
+   * The fill's trailing edge always sits under the thumb, so clipping it square is never
+   * visible. The leading edge keeps the pill radius from the layer itself.
+   */
+  const trimmed = `calc(100% - (${getFillWidthExpression(ratio)}))`;
+  const clipPath = isRTL ? `inset(0 0 0 ${trimmed})` : `inset(0 ${trimmed} 0 0)`;
+
+  return (
+    <TrackContainer>
+      <TrackLayer
+        $isScrubbing={isScrubbing}
+        style={{ ...maskStyle, backgroundColor: get(theme.colors, sliderInputColors.rail) }}
+      />
+      <TrackLayer
+        $isScrubbing={isScrubbing}
+        style={{
+          ...maskStyle,
+          backgroundColor: get(theme.colors, fillColorToken),
+          clipPath,
+        }}
+      />
+    </TrackContainer>
+  );
+};
+
+export { SliderTrack };
+export type { SliderTrackProps };

--- a/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
@@ -100,8 +100,7 @@ const SliderValueIndicator = ({
          * Keyed on the raw value rather than the formatted string, so a custom `formatValue`
          * that adds a unit or a currency still moves in the direction the value went.
          */}
-        {/* Shares the indicator's own duration, so retuning one retunes both. */}
-        <BaseAnimatedValue value={value} duration={sliderInputMotion.indicator.duration}>
+        <BaseAnimatedValue value={value} duration={sliderInputMotion.valueRoll.duration}>
           {children}
         </BaseAnimatedValue>
       </Text>

--- a/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
@@ -100,7 +100,10 @@ const SliderValueIndicator = ({
          * Keyed on the raw value rather than the formatted string, so a custom `formatValue`
          * that adds a unit or a currency still moves in the direction the value went.
          */}
-        <BaseAnimatedValue value={value}>{children}</BaseAnimatedValue>
+        {/* Shares the indicator's own duration, so retuning one retunes both. */}
+        <BaseAnimatedValue value={value} duration={sliderInputMotion.indicator.duration}>
+          {children}
+        </BaseAnimatedValue>
       </Text>
     </IndicatorAnchor>
   );

--- a/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  sliderInputColors,
+  sliderInputMotion,
+  SLIDER_INDICATOR_BOTTOM,
+  SLIDER_INDICATOR_RISE,
+} from './sliderInputTokens';
+import { Text } from '~components/Typography';
+import { makeSize, makeSpace, makeMotionTime } from '~utils';
+import get from '~utils/lodashButBetter/get';
+
+type SliderValueIndicatorProps = {
+  children: string;
+  /** CSS length of the thumb centre from the track's inline start. */
+  offset: string;
+  /** Flips with direction, since `inset-inline-start` resolves to `right` under RTL. */
+  centeringTransform: string;
+  isVisible: boolean;
+  /** Suppresses the movement easing so the indicator keeps up with the pointer. */
+  isScrubbing: boolean;
+};
+
+/**
+ * Deliberately not the public `Tooltip`.
+ *
+ * `Tooltip` has a 51px floor once its padding and arrow are counted, so it will not hug a
+ * two-character value. This stays private and unexported for that reason.
+ *
+ * The indicator is anchored by a centring wrapper rather than pinned by an edge, so a wider
+ * value grows evenly in both directions instead of drifting off the thumb.
+ */
+const IndicatorAnchor = styled.div<{ $isVisible: boolean; $isScrubbing: boolean }>`
+  position: absolute;
+  /* Without this the indicator falls back to its static position, which is exactly where the
+     thumb is drawn. */
+  bottom: ${makeSize(SLIDER_INDICATOR_BOTTOM)};
+  pointer-events: none;
+  white-space: nowrap;
+  border-radius: ${({ theme }) => makeSize(theme.border.radius.xsmall)};
+  /* 2 / 4, per Figma: a 13px wide "50" sits in a 21 x 17 box. */
+  padding: ${({ theme }) => `${makeSpace(theme.spacing[1])} ${makeSpace(theme.spacing[2])}`};
+  background-color: ${({ theme }) => get(theme.colors, sliderInputColors.indicator.background)};
+  opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
+
+  /*
+   * Fades and rises on the way in, falls away on the way out, and tracks the thumb's own
+   * movement easing so the two never separate on a keyboard step.
+   *
+   * Only the rise is animated on the transform: the centring half of it is a constant
+   * translateX, so it contributes nothing to the interpolation.
+   */
+  transition: ${({ theme, $isVisible, $isScrubbing }) => {
+    const duration = makeMotionTime(theme.motion.duration[sliderInputMotion.indicator.duration]);
+    const easing = String(
+      theme.motion.easing[
+        $isVisible
+          ? sliderInputMotion.indicator.enterEasing
+          : sliderInputMotion.indicator.exitEasing
+      ],
+    );
+    const parts = [`opacity ${duration} ${easing}`, `transform ${duration} ${easing}`];
+    if (!$isScrubbing) {
+      parts.push(
+        `inset-inline-start ${makeMotionTime(
+          theme.motion.duration[sliderInputMotion.position.duration],
+        )} ${String(theme.motion.easing[sliderInputMotion.position.easing])}`,
+      );
+    }
+    return parts.join(', ');
+  }};
+`;
+
+const SliderValueIndicator = ({
+  children,
+  offset,
+  centeringTransform,
+  isVisible,
+  isScrubbing,
+}: SliderValueIndicatorProps): React.ReactElement => {
+  // Sits slightly low while hidden so it rises into place as it fades in.
+  const rise = isVisible ? '' : ` translateY(${makeSize(SLIDER_INDICATOR_RISE)})`;
+
+  return (
+    <IndicatorAnchor
+      $isVisible={isVisible}
+      $isScrubbing={isScrubbing}
+      style={{ insetInlineStart: offset, transform: `${centeringTransform}${rise}` }}
+      // The value is already on the thumb as `aria-valuetext`; announcing it again here would
+      // double it up on every step.
+      aria-hidden={true}
+    >
+      <Text size="xsmall" weight="regular" color={sliderInputColors.indicator.text}>
+        {children}
+      </Text>
+    </IndicatorAnchor>
+  );
+};
+
+export { SliderValueIndicator };
+export type { SliderValueIndicatorProps };

--- a/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
+++ b/packages/blade/src/components/Input/SliderInput/SliderValueIndicator.web.tsx
@@ -7,11 +7,15 @@ import {
   SLIDER_INDICATOR_RISE,
 } from './sliderInputTokens';
 import { Text } from '~components/Typography';
+import { BaseAnimatedValue } from '~components/BaseAnimatedValue';
 import { makeSize, makeSpace, makeMotionTime } from '~utils';
 import get from '~utils/lodashButBetter/get';
 
 type SliderValueIndicatorProps = {
+  /** The formatted text to show. */
   children: string;
+  /** The raw value behind that text, which gives the swap its direction. */
+  value: number;
   /** CSS length of the thumb centre from the track's inline start. */
   offset: string;
   /** Flips with direction, since `inset-inline-start` resolves to `right` under RTL. */
@@ -73,6 +77,7 @@ const IndicatorAnchor = styled.div<{ $isVisible: boolean; $isScrubbing: boolean 
 
 const SliderValueIndicator = ({
   children,
+  value,
   offset,
   centeringTransform,
   isVisible,
@@ -91,7 +96,11 @@ const SliderValueIndicator = ({
       aria-hidden={true}
     >
       <Text size="xsmall" weight="regular" color={sliderInputColors.indicator.text}>
-        {children}
+        {/*
+         * Keyed on the raw value rather than the formatted string, so a custom `formatValue`
+         * that adds a unit or a currency still moves in the direction the value went.
+         */}
+        <BaseAnimatedValue value={value}>{children}</BaseAnimatedValue>
       </Text>
     </IndicatorAnchor>
   );

--- a/packages/blade/src/components/Input/SliderInput/__tests__/SliderInput.ssr.test.tsx
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/SliderInput.ssr.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { SliderInput } from '../index';
+import renderWithSSR from '~utils/testing/renderWithSSR.web';
+
+describe('<SliderInput />', () => {
+  // Kept as a single case on purpose: `useFormId` runs off a module level counter, so a
+  // second render in the same file produces ids that no longer match the server pass.
+  it('should render on the server', () => {
+    const { container, getByRole } = renderWithSSR(
+      <SliderInput
+        label="Volume"
+        min={0}
+        max={100}
+        step={25}
+        defaultValue={100}
+        showMarkers
+        showScale
+      />,
+    );
+
+    // Positioning never reads `getBoundingClientRect`, so the server emits the thumb at its
+    // final offset instead of at zero and then jumping on hydration.
+    expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '100');
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/packages/blade/src/components/Input/SliderInput/__tests__/SliderInput.web.test.tsx
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/SliderInput.web.test.tsx
@@ -307,7 +307,11 @@ describe('<SliderInput />', () => {
     const { container } = renderWithTheme(<SliderInput label="Volume" defaultValue={50} />);
     const indicator = container.querySelector('[aria-hidden="true"]');
 
-    expect(indicator).toHaveTextContent('50');
+    // The number rolls, so every digit is present in each column. The value itself is stated
+    // once, on the node that assistive technology reads.
+    expect(indicator?.querySelector('[data-blade-component="visually-hidden"]')).toHaveTextContent(
+      '50',
+    );
     const { paddingTop, paddingRight, paddingBottom, paddingLeft } = getComputedStyle(
       indicator as Element,
     );

--- a/packages/blade/src/components/Input/SliderInput/__tests__/SliderInput.web.test.tsx
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/SliderInput.web.test.tsx
@@ -1,0 +1,329 @@
+import React from 'react';
+import userEvents from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
+import { SliderInput } from '../index';
+import renderWithTheme from '~utils/testing/renderWithTheme.web';
+import assertAccessible from '~utils/testing/assertAccessible.web';
+
+describe('<SliderInput />', () => {
+  it('should render a slider', () => {
+    const { container } = renderWithTheme(<SliderInput label="Volume" />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should render with markers, a scale and a left positioned label', () => {
+    const { container } = renderWithTheme(
+      <SliderInput
+        label="Corner Radius"
+        labelPosition="left"
+        min={0}
+        max={40}
+        step={8}
+        showMarkers
+        showScale
+        defaultValue={16}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should expose the range and the current value to assistive technology', () => {
+    const { getByRole } = renderWithTheme(
+      <SliderInput label="Volume" min={10} max={50} defaultValue={20} />,
+    );
+    const slider = getByRole('slider');
+
+    expect(slider).toHaveAttribute('aria-valuemin', '10');
+    expect(slider).toHaveAttribute('aria-valuemax', '50');
+    expect(slider).toHaveAttribute('aria-valuenow', '20');
+    expect(slider).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('should report the snapped value, not the value it was given', () => {
+    // 37 is not a multiple of 8, so the thumb stands on 40 and must announce 40.
+    const { getByRole } = renderWithTheme(
+      <SliderInput label="Corner Radius" min={0} max={40} step={8} value={37} />,
+    );
+    expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '40');
+  });
+
+  it('should run aria-valuetext through formatValue', () => {
+    const { getByRole } = renderWithTheme(
+      <SliderInput
+        label="Price"
+        min={0}
+        max={100}
+        defaultValue={25}
+        formatValue={(value) => `₹${value}`}
+      />,
+    );
+    expect(getByRole('slider')).toHaveAttribute('aria-valuetext', '₹25');
+  });
+
+  it('should take its accessible name from the visible label', () => {
+    const { getByRole } = renderWithTheme(<SliderInput label="Volume" />);
+    expect(getByRole('slider')).toHaveAccessibleName('Volume');
+  });
+
+  it('should fall back to accessibilityLabel when there is no visible label', () => {
+    const { getByRole } = renderWithTheme(<SliderInput accessibilityLabel="Volume level" />);
+    expect(getByRole('slider')).toHaveAccessibleName('Volume level');
+  });
+
+  it('should describe the slider with the error text when validation fails', () => {
+    const { getByRole } = renderWithTheme(
+      <SliderInput label="Volume" validationState="error" errorText="Too loud" />,
+    );
+    expect(getByRole('slider')).toHaveAccessibleDescription('Too loud');
+  });
+
+  it('should describe the slider with the help text otherwise', () => {
+    const { getByRole } = renderWithTheme(
+      <SliderInput label="Volume" helpText="Adjust the output level" />,
+    );
+    expect(getByRole('slider')).toHaveAccessibleDescription('Adjust the output level');
+  });
+
+  describe('keyboard', () => {
+    it('should move by one step with the arrow keys', async () => {
+      const user = userEvents.setup();
+      const onChange = jest.fn();
+      const { getByRole } = renderWithTheme(
+        <SliderInput label="Volume" step={5} defaultValue={50} onChange={onChange} />,
+      );
+      const slider = getByRole('slider');
+      await user.tab();
+      expect(slider).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(onChange).toHaveBeenLastCalledWith({ value: 55 });
+
+      await user.keyboard('{ArrowLeft}{ArrowLeft}');
+      expect(onChange).toHaveBeenLastCalledWith({ value: 45 });
+
+      await user.keyboard('{ArrowUp}');
+      expect(onChange).toHaveBeenLastCalledWith({ value: 50 });
+    });
+
+    it('should jump to the bounds with Home and End, and coarsely with Page keys', async () => {
+      const user = userEvents.setup();
+      const onChange = jest.fn();
+      renderWithTheme(
+        <SliderInput label="Volume" min={0} max={100} defaultValue={50} onChange={onChange} />,
+      );
+      await user.tab();
+
+      await user.keyboard('{Home}');
+      expect(onChange).toHaveBeenLastCalledWith({ value: 0 });
+
+      await user.keyboard('{End}');
+      expect(onChange).toHaveBeenLastCalledWith({ value: 100 });
+
+      // A page step is a tenth of the range here, so it lands on 90.
+      await user.keyboard('{PageDown}');
+      expect(onChange).toHaveBeenLastCalledWith({ value: 90 });
+    });
+
+    it('should not step past the bounds', async () => {
+      const user = userEvents.setup();
+      const { getByRole } = renderWithTheme(
+        <SliderInput label="Volume" min={0} max={10} defaultValue={10} />,
+      );
+      const slider = getByRole('slider');
+      await user.tab();
+
+      await user.keyboard('{ArrowRight}{ArrowRight}');
+      expect(slider).toHaveAttribute('aria-valuenow', '10');
+    });
+  });
+
+  describe('onChangeEnd', () => {
+    it('should commit once per keyboard interaction rather than per step', async () => {
+      const user = userEvents.setup();
+      const onChange = jest.fn();
+      const onChangeEnd = jest.fn();
+      renderWithTheme(
+        <SliderInput
+          label="Volume"
+          defaultValue={50}
+          onChange={onChange}
+          onChangeEnd={onChangeEnd}
+        />,
+      );
+      await user.tab();
+
+      await user.keyboard('{ArrowRight}');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChangeEnd).toHaveBeenCalledTimes(1);
+      expect(onChangeEnd).toHaveBeenCalledWith({ value: 51 });
+    });
+
+    it('should stay silent when an interaction leaves the value unchanged', async () => {
+      const user = userEvents.setup();
+      const onChangeEnd = jest.fn();
+      renderWithTheme(
+        <SliderInput label="Volume" min={0} max={10} defaultValue={0} onChangeEnd={onChangeEnd} />,
+      );
+      await user.tab();
+
+      // Already at min, so this is a no-op and must not trigger expensive work.
+      await user.keyboard('{Home}');
+      expect(onChangeEnd).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('controlled and uncontrolled', () => {
+    it('should not move on its own when controlled', async () => {
+      const user = userEvents.setup();
+      const onChange = jest.fn();
+      const { getByRole } = renderWithTheme(
+        <SliderInput label="Volume" value={30} onChange={onChange} />,
+      );
+      const slider = getByRole('slider');
+      await user.tab();
+
+      await user.keyboard('{ArrowRight}');
+
+      expect(onChange).toHaveBeenCalledWith({ value: 31 });
+      expect(slider).toHaveAttribute('aria-valuenow', '30');
+    });
+
+    it('should move on its own when uncontrolled', async () => {
+      const user = userEvents.setup();
+      const { getByRole } = renderWithTheme(<SliderInput label="Volume" defaultValue={30} />);
+      const slider = getByRole('slider');
+      await user.tab();
+
+      await user.keyboard('{ArrowRight}');
+      expect(slider).toHaveAttribute('aria-valuenow', '31');
+    });
+
+    it('should start at min when given no value', () => {
+      const { getByRole } = renderWithTheme(<SliderInput label="Volume" min={7} max={20} />);
+      expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '7');
+    });
+  });
+
+  describe('disabled', () => {
+    it('should not be focusable or respond to the keyboard', async () => {
+      const user = userEvents.setup();
+      const onChange = jest.fn();
+      const { getByRole } = renderWithTheme(
+        <SliderInput label="Volume" defaultValue={50} isDisabled onChange={onChange} />,
+      );
+      const slider = getByRole('slider');
+
+      expect(slider).toHaveAttribute('aria-disabled', 'true');
+      expect(slider).toHaveAttribute('tabindex', '-1');
+
+      await user.tab();
+      expect(slider).not.toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(slider).toHaveAttribute('aria-valuenow', '50');
+    });
+  });
+
+  it('should submit the value through a hidden field when given a name', () => {
+    const { container } = renderWithTheme(
+      <SliderInput label="Volume" name="volume" defaultValue={42} />,
+    );
+    const hidden = container.querySelector('input[type="hidden"]');
+    expect(hidden).toHaveAttribute('name', 'volume');
+    expect(hidden).toHaveValue('42');
+  });
+
+  it('should render only the bounds when showScaleValues is false', () => {
+    const { queryByText, getByText } = renderWithTheme(
+      // The value indicator is off so the only rendered text is the scale itself.
+      <SliderInput
+        label="Volume"
+        min={0}
+        max={100}
+        step={25}
+        showScale
+        showScaleValues={false}
+        showValueIndicator={false}
+      />,
+    );
+    expect(getByText('0')).toBeInTheDocument();
+    expect(getByText('100')).toBeInTheDocument();
+    expect(queryByText('50')).not.toBeInTheDocument();
+  });
+
+  it('should focus the thumb on click so the keyboard works straight after a drag', async () => {
+    const user = userEvents.setup();
+    const { getByRole } = renderWithTheme(<SliderInput label="Volume" defaultValue={50} />);
+    const slider = getByRole('slider');
+
+    // The pointer handler calls preventDefault to suppress text selection, which also
+    // suppresses the browser's own focus, so the component has to move focus itself.
+    await user.click(slider);
+    expect(slider).toHaveFocus();
+
+    // Where the click itself lands is not asserted: jsdom reports a zero-sized rect, so the
+    // pointer maths has no width to work with. What matters is that the keyboard now drives it.
+    const afterClick = Number(slider.getAttribute('aria-valuenow'));
+    await user.keyboard('{ArrowRight}');
+    expect(Number(slider.getAttribute('aria-valuenow'))).toBe(afterClick + 1);
+  });
+
+  it('should glide for a click but stop easing once the pointer really drags', async () => {
+    const user = userEvents.setup();
+    const { getByRole } = renderWithTheme(<SliderInput label="Volume" defaultValue={50} />);
+    const slider = getByRole('slider');
+    // The pointer handlers live on the control, which is the thumb's parent.
+    const control = slider.parentElement as HTMLElement;
+    const movesWithEasing = (): boolean =>
+      getComputedStyle(slider).transition.includes('inset-inline-start');
+
+    // A press on its own is a click, so the thumb travels to where it landed rather than
+    // teleporting there.
+    /*
+     * The press goes through user-event and the move through fireEvent, because neither can
+     * do both here: fireEvent cannot produce a pointerdown carrying `button`, which the
+     * handler requires, and user-event does not put coordinates on the event.
+     *
+     * That also means the 3px slop cannot be exercised in jsdom, since the press arrives
+     * without a clientX to measure from. It is covered in a real browser instead.
+     */
+    await user.pointer({ keys: '[MouseLeft>]', target: control });
+    expect(movesWithEasing()).toBe(true);
+
+    // Once the pointer moves the thumb has to sit under the finger, so the easing goes.
+    fireEvent.pointerMove(control, { clientX: 40 });
+    expect(movesWithEasing()).toBe(false);
+
+    // Releasing restores it for the next click.
+    fireEvent.pointerUp(control, { clientX: 40 });
+    expect(movesWithEasing()).toBe(true);
+  });
+
+  it('should hug the value indicator to its text', () => {
+    // Figma puts a 13px wide "50" in a 21 x 17 box, which is 2px and 4px of padding. With no
+    // scale and no hint, the indicator is the only aria-hidden node in the tree.
+    const { container } = renderWithTheme(<SliderInput label="Volume" defaultValue={50} />);
+    const indicator = container.querySelector('[aria-hidden="true"]');
+
+    expect(indicator).toHaveTextContent('50');
+    const { paddingTop, paddingRight, paddingBottom, paddingLeft } = getComputedStyle(
+      indicator as Element,
+    );
+    expect([paddingTop, paddingBottom]).toEqual(['2px', '2px']); // spacing.1
+    expect([paddingLeft, paddingRight]).toEqual(['4px', '4px']); // spacing.2
+  });
+
+  it('should accept testID', () => {
+    const { getByTestId } = renderWithTheme(<SliderInput label="Volume" testID="volume-slider" />);
+    expect(getByTestId('volume-slider')).toBeInTheDocument();
+  });
+
+  it('should not have accessibility violations', async () => {
+    const { container } = renderWithTheme(
+      <SliderInput label="Volume" helpText="Adjust the output level" showMarkers showScale />,
+    );
+    await assertAccessible(container);
+  });
+});

--- a/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<SliderInput /> should render on the server 1`] = `"<div id="root"><div data-blade-component="slider-input" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc jfwjMe"><span style="width:100%;flex-shrink:0;margin-right:0px" id="slider-input-undefined-label-undefined" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bksIuc fhmUvk"><div data-blade-component="base-box" class="BaseBox-bksIuc eHGxoV"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc gQLxiP"><p letter-spacing="50" class="StyledBaseText-foUshD lhkeBN" data-blade-component="text">Volume</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 fVGPRy"><p letter-spacing="50" class="StyledBaseText-foUshD izyCsZ" data-blade-component="text"></p></div></div></div></div></div></span><div data-blade-component="base-box" class="BaseBox-bksIuc iUQgWO"><div class="SliderInputweb__FieldBox-sc-15yreg0-0 fubfEH"><div class="SliderInputweb__Control-sc-15yreg0-1 gnFast"><div class="SliderInputweb__TrackArea-sc-15yreg0-2 gGgnGh"><div class="SliderTrackweb__TrackContainer-lcbpou-0 bWkPSC"><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(206, 10%, 29%, 0.12)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(0, 0%, 0%, 1);clip-path:inset(0 calc(100% - (calc(3px + 1 * (100% - 3px)))) 0 0)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div></div></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" role="slider" tabindex="0" id="slider-input-undefined-input-undefined" aria-orientation="horizontal" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="100" aria-labelledby="slider-input-undefined-label-undefined" aria-disabled="false" class="SliderInputweb__Thumb-sc-15yreg0-3 dLaKZF"></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%) translateY(2px)" aria-hidden="true" class="SliderValueIndicatorweb__IndicatorAnchor-w52dmi-0 gGfWZq"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text">100</p></div></div><div aria-hidden="true" class="SliderInputweb__ScaleRow-sc-15yreg0-4 cngKTB"><div style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">0</p></div><div style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">25</p></div><div style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">50</p></div><div style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">75</p></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">100</p></div></div></div></div></div></div></div>"`;
+exports[`<SliderInput /> should render on the server 1`] = `"<div id="root"><div data-blade-component="slider-input" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc jfwjMe"><span style="width:100%;flex-shrink:0;margin-right:0px" id="slider-input-undefined-label-undefined" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bksIuc fhmUvk"><div data-blade-component="base-box" class="BaseBox-bksIuc eHGxoV"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc gQLxiP"><p letter-spacing="50" class="StyledBaseText-foUshD lhkeBN" data-blade-component="text">Volume</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 fVGPRy"><p letter-spacing="50" class="StyledBaseText-foUshD izyCsZ" data-blade-component="text"></p></div></div></div></div></div></span><div data-blade-component="base-box" class="BaseBox-bksIuc iUQgWO"><div class="SliderInputweb__FieldBox-sc-15yreg0-0 fubfEH"><div class="SliderInputweb__Control-sc-15yreg0-1 gnFast"><div class="SliderInputweb__TrackArea-sc-15yreg0-2 gGgnGh"><div class="SliderTrackweb__TrackContainer-lcbpou-0 bWkPSC"><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(206, 10%, 29%, 0.12)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(0, 0%, 0%, 1);clip-path:inset(0 calc(100% - (calc(3px + 1 * (100% - 3px)))) 0 0)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div></div></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" role="slider" tabindex="0" id="slider-input-undefined-input-undefined" aria-orientation="horizontal" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="100" aria-labelledby="slider-input-undefined-label-undefined" aria-disabled="false" class="SliderInputweb__Thumb-sc-15yreg0-3 dLaKZF"></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%) translateY(2px)" aria-hidden="true" class="SliderValueIndicatorweb__IndicatorAnchor-w52dmi-0 gGfWZq"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text"><span data-blade-component="animated-value" class="BaseAnimatedValueweb__Stack-sc-1pcsjx1-0 ga-DxIb"><span display="inline-block" style="opacity:1;transform:none" class="BaseMotionweb__StyledDiv-gsyvko-0 laRHUI">100</span></span></p></div></div><div aria-hidden="true" class="SliderInputweb__ScaleRow-sc-15yreg0-4 cngKTB"><div style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">0</p></div><div style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">25</p></div><div style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">50</p></div><div style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">75</p></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">100</p></div></div></div></div></div></div></div>"`;
 
 exports[`<SliderInput /> should render on the server 2`] = `
 .c11.c11.c11.c11.c11 {
@@ -80,7 +80,7 @@ exports[`<SliderInput /> should render on the server 2`] = `
   padding: 0;
 }
 
-.c18.c18.c18.c18.c18 {
+.c20.c20.c20.c20.c20 {
   color: hsla(204,9%,42%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
@@ -159,6 +159,18 @@ exports[`<SliderInput /> should render on the server 2`] = `
   -ms-flex: 1;
   flex: 1;
   min-width: 87px;
+}
+
+.c17.c17.c17.c17.c17 {
+  display: inline-block;
+}
+
+.c16.c16.c16.c16.c16 {
+  display: inline-grid;
+}
+
+.c16.c16.c16.c16.c16 > * {
+  grid-area: 1 / 1;
 }
 
 .c14.c14.c14.c14.c14 {
@@ -248,14 +260,14 @@ exports[`<SliderInput /> should render on the server 2`] = `
   transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
 }
 
-.c16.c16.c16.c16.c16 {
+.c18.c18.c18.c18.c18 {
   position: absolute;
   inset-inline: 0;
   top: 24px;
   pointer-events: none;
 }
 
-.c17.c17.c17.c17.c17 {
+.c19.c19.c19.c19.c19 {
   position: absolute;
   white-space: nowrap;
 }
@@ -364,20 +376,31 @@ exports[`<SliderInput /> should render on the server 2`] = `
                 data-blade-component="text"
                 letter-spacing="50"
               >
-                100
+                <span
+                  class="c16"
+                  data-blade-component="animated-value"
+                >
+                  <span
+                    class="c17"
+                    display="inline-block"
+                    style="opacity:1;transform:none"
+                  >
+                    100
+                  </span>
+                </span>
               </p>
             </div>
           </div>
           <div
             aria-hidden="true"
-            class="c16"
+            class="c18"
           >
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -385,11 +408,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -397,11 +420,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -409,11 +432,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -421,11 +444,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >

--- a/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.ssr.test.tsx.snap
@@ -1,0 +1,441 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SliderInput /> should render on the server 1`] = `"<div id="root"><div data-blade-component="slider-input" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc jfwjMe"><span style="width:100%;flex-shrink:0;margin-right:0px" id="slider-input-undefined-label-undefined" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bksIuc fhmUvk"><div data-blade-component="base-box" class="BaseBox-bksIuc eHGxoV"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc gQLxiP"><p letter-spacing="50" class="StyledBaseText-foUshD lhkeBN" data-blade-component="text">Volume</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 fVGPRy"><p letter-spacing="50" class="StyledBaseText-foUshD izyCsZ" data-blade-component="text"></p></div></div></div></div></div></span><div data-blade-component="base-box" class="BaseBox-bksIuc iUQgWO"><div class="SliderInputweb__FieldBox-sc-15yreg0-0 fubfEH"><div class="SliderInputweb__Control-sc-15yreg0-1 gnFast"><div class="SliderInputweb__TrackArea-sc-15yreg0-2 gGgnGh"><div class="SliderTrackweb__TrackContainer-lcbpou-0 bWkPSC"><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(206, 10%, 29%, 0.12)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(0, 0%, 0%, 1);clip-path:inset(0 calc(100% - (calc(3px + 1 * (100% - 3px)))) 0 0)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div></div></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" role="slider" tabindex="0" id="slider-input-undefined-input-undefined" aria-orientation="horizontal" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="100" aria-labelledby="slider-input-undefined-label-undefined" aria-disabled="false" class="SliderInputweb__Thumb-sc-15yreg0-3 dLaKZF"></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%) translateY(2px)" aria-hidden="true" class="SliderValueIndicatorweb__IndicatorAnchor-w52dmi-0 gGfWZq"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text">100</p></div></div><div aria-hidden="true" class="SliderInputweb__ScaleRow-sc-15yreg0-4 cngKTB"><div style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">0</p></div><div style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">25</p></div><div style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">50</p></div><div style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">75</p></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">100</p></div></div></div></div></div></div></div>"`;
+
+exports[`<SliderInput /> should render on the server 2`] = `
+.c11.c11.c11.c11.c11 {
+  position: relative;
+  width: 100%;
+  height: 3px;
+}
+
+.c12.c12.c12.c12.c12 {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-composite: source-in;
+  -webkit-mask-composite: intersect;
+  mask-composite: intersect;
+  -webkit-transition: clip-path 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: clip-path 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c4.c4.c4.c4.c4 {
+  color: hsla(200,10%,18%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+}
+
+.c15.c15.c15.c15.c15 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.625rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 0.8125rem;
+  -webkit-letter-spacing: -0.13px;
+  -moz-letter-spacing: -0.13px;
+  -ms-letter-spacing: -0.13px;
+  letter-spacing: -0.13px;
+  margin: 0;
+  padding: 0;
+}
+
+.c18.c18.c18.c18.c18 {
+  color: hsla(204,9%,42%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.625rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 0.8125rem;
+  -webkit-letter-spacing: -0.13px;
+  -moz-letter-spacing: -0.13px;
+  -ms-letter-spacing: -0.13px;
+  letter-spacing: -0.13px;
+  margin: 0;
+  padding: 0;
+}
+
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.c1.c1.c1.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 4px;
+  width: 100%;
+}
+
+.c2.c2.c2.c2.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-height: 36px;
+  gap: 0px;
+}
+
+.c7.c7.c7.c7.c7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 87px;
+}
+
+.c14.c14.c14.c14.c14 {
+  position: absolute;
+  bottom: 22px;
+  pointer-events: none;
+  white-space: nowrap;
+  border-radius: 4px;
+  padding: 2px 4px;
+  background-color: hsla(0,0%,0%,0.72);
+  opacity: 0;
+  -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),-webkit-transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+  transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c8.c8.c8.c8.c8 {
+  position: relative;
+  width: 100%;
+  height: 32px;
+  margin-bottom: 4px;
+}
+
+.c9.c9.c9.c9.c9 {
+  position: absolute;
+  inset-inline: 0;
+  top: 4px;
+  height: 24px;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.c9.c9.c9.c9.c9::before {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  top: -10px;
+  bottom: -10px;
+}
+
+.c10.c10.c10.c10.c10 {
+  position: absolute;
+  inset-inline: 0;
+  top: 11px;
+}
+
+.c13.c13.c13.c13.c13 {
+  position: absolute;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background-color: hsla(0,0%,0%,1);
+  outline: none;
+  -webkit-transition: inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c13.c13.c13.c13.c13:focus-visible {
+  outline: 4px solid hsla(206,10%,29%,0.12);
+  outline-offset: 1px;
+  -webkit-transition-property: outline-width;
+  transition-property: outline-width;
+  -webkit-transition-duration: 80ms;
+  transition-duration: 80ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  z-index: 2;
+  -webkit-transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c16.c16.c16.c16.c16 {
+  position: absolute;
+  inset-inline: 0;
+  top: 24px;
+  pointer-events: none;
+}
+
+.c17.c17.c17.c17.c17 {
+  position: absolute;
+  white-space: nowrap;
+}
+
+<div
+  id="root"
+>
+  <div
+    class=""
+    data-blade-component="slider-input"
+  >
+    <div
+      class="c0"
+      data-blade-component="base-box"
+    >
+      <span
+        data-blade-component="form-label"
+        id="slider-input-1-label-6"
+        style="width:100%;flex-shrink:0;margin-right:0px"
+      >
+        <div
+          class="c1"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c2"
+            data-blade-component="base-box"
+          >
+            <div
+              class=""
+              data-blade-component="base-box"
+            >
+              <div
+                class="c3"
+                data-blade-component="base-box"
+              >
+                <p
+                  class="c4"
+                  data-blade-component="text"
+                  letter-spacing="50"
+                >
+                  Volume
+                </p>
+                <div
+                  class="c5"
+                  data-blade-component="visually-hidden"
+                >
+                  <p
+                    class="c6"
+                    data-blade-component="text"
+                    letter-spacing="50"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+      <div
+        class="c7"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c8"
+        >
+          <div
+            class="c9"
+          >
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                  style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(206, 10%, 29%, 0.12)"
+                />
+                <div
+                  class="c12"
+                  style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(0, 0%, 0%, 1);clip-path:inset(0 calc(100% - (calc(3px + 1 * (100% - 3px)))) 0 0)"
+                />
+              </div>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-labelledby="slider-input-1-label-6"
+              aria-orientation="horizontal"
+              aria-valuemax="100"
+              aria-valuemin="0"
+              aria-valuenow="100"
+              aria-valuetext="100"
+              class="c13"
+              id="slider-input-1-input-2"
+              role="slider"
+              style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)"
+              tabindex="0"
+            />
+            <div
+              aria-hidden="true"
+              class="c14"
+              style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%) translateY(2px)"
+            >
+              <p
+                class="c15"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                100
+              </p>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="c16"
+          >
+            <div
+              class="c17"
+              style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                0
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                25
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                50
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                75
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                100
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.ssr.test.tsx.snap
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.ssr.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<SliderInput /> should render on the server 1`] = `"<div id="root"><div data-blade-component="slider-input" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc jfwjMe"><span style="width:100%;flex-shrink:0;margin-right:0px" id="slider-input-undefined-label-undefined" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bksIuc fhmUvk"><div data-blade-component="base-box" class="BaseBox-bksIuc eHGxoV"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc gQLxiP"><p letter-spacing="50" class="StyledBaseText-foUshD lhkeBN" data-blade-component="text">Volume</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 fVGPRy"><p letter-spacing="50" class="StyledBaseText-foUshD izyCsZ" data-blade-component="text"></p></div></div></div></div></div></span><div data-blade-component="base-box" class="BaseBox-bksIuc iUQgWO"><div class="SliderInputweb__FieldBox-sc-15yreg0-0 fubfEH"><div class="SliderInputweb__Control-sc-15yreg0-1 gnFast"><div class="SliderInputweb__TrackArea-sc-15yreg0-2 gGgnGh"><div class="SliderTrackweb__TrackContainer-lcbpou-0 bWkPSC"><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(206, 10%, 29%, 0.12)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(0, 0%, 0%, 1);clip-path:inset(0 calc(100% - (calc(3px + 1 * (100% - 3px)))) 0 0)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div></div></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" role="slider" tabindex="0" id="slider-input-undefined-input-undefined" aria-orientation="horizontal" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="100" aria-labelledby="slider-input-undefined-label-undefined" aria-disabled="false" class="SliderInputweb__Thumb-sc-15yreg0-3 dLaKZF"></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%) translateY(2px)" aria-hidden="true" class="SliderValueIndicatorweb__IndicatorAnchor-w52dmi-0 gGfWZq"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text"><span data-blade-component="animated-value" class="BaseAnimatedValueweb__Stack-sc-1pcsjx1-0 ga-DxIb"><span display="inline-block" style="opacity:1;transform:none" class="BaseMotionweb__StyledDiv-gsyvko-0 laRHUI">100</span></span></p></div></div><div aria-hidden="true" class="SliderInputweb__ScaleRow-sc-15yreg0-4 cngKTB"><div style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">0</p></div><div style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">25</p></div><div style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">50</p></div><div style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">75</p></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">100</p></div></div></div></div></div></div></div>"`;
+exports[`<SliderInput /> should render on the server 1`] = `"<div id="root"><div data-blade-component="slider-input" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc jfwjMe"><span style="width:100%;flex-shrink:0;margin-right:0px" id="slider-input-undefined-label-undefined" data-blade-component="form-label"><div data-blade-component="base-box" class="BaseBox-bksIuc fhmUvk"><div data-blade-component="base-box" class="BaseBox-bksIuc eHGxoV"><div data-blade-component="base-box" class="BaseBox-bksIuc"><div data-blade-component="base-box" class="BaseBox-bksIuc gQLxiP"><p letter-spacing="50" class="StyledBaseText-foUshD lhkeBN" data-blade-component="text">Volume</p><div data-blade-component="visually-hidden" class="VisuallyHiddenweb__StyledVisuallyHidden-g3hls3-0 fVGPRy"><p letter-spacing="50" class="StyledBaseText-foUshD izyCsZ" data-blade-component="text"></p></div></div></div></div></div></span><div data-blade-component="base-box" class="BaseBox-bksIuc iUQgWO"><div class="SliderInputweb__FieldBox-sc-15yreg0-0 fubfEH"><div class="SliderInputweb__Control-sc-15yreg0-1 gnFast"><div class="SliderInputweb__TrackArea-sc-15yreg0-2 gGgnGh"><div class="SliderTrackweb__TrackContainer-lcbpou-0 bWkPSC"><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(206, 10%, 29%, 0.12)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div><div style="mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);-webkit-mask-image:radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.25 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.5 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.75 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px);background-color:hsla(0, 0%, 0%, 1);clip-path:inset(0 calc(100% - (calc(3px + 1 * (100% - 3px)))) 0 0)" class="SliderTrackweb__TrackLayer-lcbpou-1 euNZdC"></div></div></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" role="slider" tabindex="0" id="slider-input-undefined-input-undefined" aria-orientation="horizontal" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" aria-valuetext="100" aria-labelledby="slider-input-undefined-label-undefined" aria-disabled="false" class="SliderInputweb__Thumb-sc-15yreg0-3 dLaKZF"></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%) translateY(2px)" aria-hidden="true" class="SliderValueIndicatorweb__IndicatorAnchor-w52dmi-0 gGfWZq"><p letter-spacing="50" class="StyledBaseText-foUshD eFeZqq" data-blade-component="text"><span data-blade-component="animated-value" class="BaseAnimatedValueweb__Stack-sc-1pcsjx1-0 ga-DxIb"><span class="OdometerValueweb__Row-lyl0xg-4 iWzqLT"><span data-blade-component="visually-hidden" class="OdometerValueweb__ReadableValue-lyl0xg-2 hQWzcS">100</span><span aria-hidden="true"><span class="OdometerValueweb__Window-lyl0xg-0 jMRrzN"><span aria-hidden="true" class="OdometerValueweb__Sizer-lyl0xg-1 hXOJNT">0</span><span style="position:absolute;top:0;left:0;transform:translateY(-9.090909090909092%)" class="BaseMotionweb__StyledDiv-gsyvko-0"><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">0</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">1</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">2</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">3</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">4</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">5</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">6</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">7</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">8</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">9</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">0</span></span></span><span class="OdometerValueweb__Window-lyl0xg-0 jMRrzN"><span aria-hidden="true" class="OdometerValueweb__Sizer-lyl0xg-1 hXOJNT">0</span><span style="position:absolute;top:0;left:0;transform:none" class="BaseMotionweb__StyledDiv-gsyvko-0"><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">0</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">1</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">2</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">3</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">4</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">5</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">6</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">7</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">8</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">9</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">0</span></span></span><span class="OdometerValueweb__Window-lyl0xg-0 jMRrzN"><span aria-hidden="true" class="OdometerValueweb__Sizer-lyl0xg-1 hXOJNT">0</span><span style="position:absolute;top:0;left:0;transform:none" class="BaseMotionweb__StyledDiv-gsyvko-0"><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">0</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">1</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">2</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">3</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">4</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">5</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">6</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">7</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">8</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">9</span><span class="OdometerValueweb__Digit-lyl0xg-3 hUaVHq">0</span></span></span></span></span></span></p></div></div><div aria-hidden="true" class="SliderInputweb__ScaleRow-sc-15yreg0-4 cngKTB"><div style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">0</p></div><div style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">25</p></div><div style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">50</p></div><div style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">75</p></div><div style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)" class="SliderInputweb__ScaleLabel-sc-15yreg0-5 hczFJr"><p letter-spacing="50" class="StyledBaseText-foUshD bhQDgq" data-blade-component="text">100</p></div></div></div></div></div></div></div>"`;
 
 exports[`<SliderInput /> should render on the server 2`] = `
 .c11.c11.c11.c11.c11 {
@@ -80,7 +80,7 @@ exports[`<SliderInput /> should render on the server 2`] = `
   padding: 0;
 }
 
-.c20.c20.c20.c20.c20 {
+.c24.c24.c24.c24.c24 {
   color: hsla(204,9%,42%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
@@ -161,8 +161,58 @@ exports[`<SliderInput /> should render on the server 2`] = `
   min-width: 87px;
 }
 
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c19.c19.c19.c19.c19 {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: top;
+}
+
+.c20.c20.c20.c20.c20 {
+  visibility: hidden;
+}
+
+.c18.c18.c18.c18.c18 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c21.c21.c21.c21.c21 {
+  display: block;
+}
+
 .c17.c17.c17.c17.c17 {
   display: inline-block;
+  font-variant-numeric: tabular-nums;
 }
 
 .c16.c16.c16.c16.c16 {
@@ -185,23 +235,6 @@ exports[`<SliderInput /> should render on the server 2`] = `
   -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),-webkit-transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
   -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
   transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
-}
-
-.c5.c5.c5.c5.c5 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: 0 -1px -1px 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  left: -10000px;
-  white-space: nowrap;
-  word-wrap: normal;
 }
 
 .c8.c8.c8.c8.c8 {
@@ -260,14 +293,14 @@ exports[`<SliderInput /> should render on the server 2`] = `
   transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
 }
 
-.c18.c18.c18.c18.c18 {
+.c22.c22.c22.c22.c22 {
   position: absolute;
   inset-inline: 0;
   top: 24px;
   pointer-events: none;
 }
 
-.c19.c19.c19.c19.c19 {
+.c23.c23.c23.c23.c23 {
   position: absolute;
   white-space: nowrap;
 }
@@ -382,10 +415,227 @@ exports[`<SliderInput /> should render on the server 2`] = `
                 >
                   <span
                     class="c17"
-                    display="inline-block"
-                    style="opacity:1;transform:none"
                   >
-                    100
+                    <span
+                      class="c18"
+                      data-blade-component="visually-hidden"
+                    >
+                      100
+                    </span>
+                    <span
+                      aria-hidden="true"
+                    >
+                      <span
+                        class="c19"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="c20"
+                        >
+                          0
+                        </span>
+                        <span
+                          class="BaseMotionweb__StyledDiv-gsyvko-0"
+                          style="position:absolute;top:0;left:0;transform:translateY(-9.090909090909092%)"
+                        >
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            1
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            2
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            3
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            4
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            5
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            6
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            7
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            8
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            9
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </span>
+                      <span
+                        class="c19"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="c20"
+                        >
+                          0
+                        </span>
+                        <span
+                          class="BaseMotionweb__StyledDiv-gsyvko-0"
+                          style="position:absolute;top:0;left:0;transform:none"
+                        >
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            1
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            2
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            3
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            4
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            5
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            6
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            7
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            8
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            9
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </span>
+                      <span
+                        class="c19"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="c20"
+                        >
+                          0
+                        </span>
+                        <span
+                          class="BaseMotionweb__StyledDiv-gsyvko-0"
+                          style="position:absolute;top:0;left:0;transform:none"
+                        >
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            1
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            2
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            3
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            4
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            5
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            6
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            7
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            8
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            9
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </span>
+                    </span>
                   </span>
                 </span>
               </p>
@@ -393,14 +643,14 @@ exports[`<SliderInput /> should render on the server 2`] = `
           </div>
           <div
             aria-hidden="true"
-            class="c18"
+            class="c22"
           >
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start:calc(1.5px + 0 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -408,11 +658,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start:calc(1.5px + 0.25 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -420,11 +670,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start:calc(1.5px + 0.5 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -432,11 +682,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start:calc(1.5px + 0.75 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -444,11 +694,11 @@ exports[`<SliderInput /> should render on the server 2`] = `
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start:calc(1.5px + 1 * (100% - 3px));transform:translateX(-50%)"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >

--- a/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.web.test.tsx.snap
@@ -142,8 +142,58 @@ exports[`<SliderInput /> should render a slider 1`] = `
   min-width: 1003px;
 }
 
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c19.c19.c19.c19.c19 {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: top;
+}
+
+.c20.c20.c20.c20.c20 {
+  visibility: hidden;
+}
+
+.c18.c18.c18.c18.c18 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c21.c21.c21.c21.c21 {
+  display: block;
+}
+
 .c17.c17.c17.c17.c17 {
   display: inline-block;
+  font-variant-numeric: tabular-nums;
 }
 
 .c16.c16.c16.c16.c16 {
@@ -166,23 +216,6 @@ exports[`<SliderInput /> should render a slider 1`] = `
   -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),-webkit-transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
   -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
   transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
-}
-
-.c5.c5.c5.c5.c5 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: 0 -1px -1px 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  left: -10000px;
-  white-space: nowrap;
-  word-wrap: normal;
 }
 
 .c8.c8.c8.c8.c8 {
@@ -349,10 +382,87 @@ exports[`<SliderInput /> should render a slider 1`] = `
                 >
                   <span
                     class="c17"
-                    display="inline-block"
-                    style="opacity: 1; transform: none;"
                   >
-                    0
+                    <span
+                      class="c18"
+                      data-blade-component="visually-hidden"
+                    >
+                      0
+                    </span>
+                    <span
+                      aria-hidden="true"
+                    >
+                      <span
+                        class="c19"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="c20"
+                        >
+                          0
+                        </span>
+                        <span
+                          class="BaseMotionweb__StyledDiv-gsyvko-0"
+                          style="position: absolute; top: 0px; left: 0px; transform: none;"
+                        >
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            1
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            2
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            3
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            4
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            5
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            6
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            7
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            8
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            9
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </span>
+                    </span>
                   </span>
                 </span>
               </p>
@@ -444,7 +554,7 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   padding: 0;
 }
 
-.c20.c20.c20.c20.c20 {
+.c24.c24.c24.c24.c24 {
   color: hsla(204,9%,42%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
@@ -529,8 +639,58 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   min-width: 79px;
 }
 
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c19.c19.c19.c19.c19 {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  vertical-align: top;
+}
+
+.c20.c20.c20.c20.c20 {
+  visibility: hidden;
+}
+
+.c18.c18.c18.c18.c18 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c21.c21.c21.c21.c21 {
+  display: block;
+}
+
 .c17.c17.c17.c17.c17 {
   display: inline-block;
+  font-variant-numeric: tabular-nums;
 }
 
 .c16.c16.c16.c16.c16 {
@@ -553,23 +713,6 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),-webkit-transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
   -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
   transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
-}
-
-.c5.c5.c5.c5.c5 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: 0 -1px -1px 0;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  left: -10000px;
-  white-space: nowrap;
-  word-wrap: normal;
 }
 
 .c8.c8.c8.c8.c8 {
@@ -628,14 +771,14 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
 }
 
-.c18.c18.c18.c18.c18 {
+.c22.c22.c22.c22.c22 {
   position: absolute;
   inset-inline: 0;
   top: 24px;
   pointer-events: none;
 }
 
-.c19.c19.c19.c19.c19 {
+.c23.c23.c23.c23.c23 {
   position: absolute;
   white-space: nowrap;
 }
@@ -748,10 +891,157 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
                 >
                   <span
                     class="c17"
-                    display="inline-block"
-                    style="opacity: 1; transform: none;"
                   >
-                    16
+                    <span
+                      class="c18"
+                      data-blade-component="visually-hidden"
+                    >
+                      16
+                    </span>
+                    <span
+                      aria-hidden="true"
+                    >
+                      <span
+                        class="c19"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="c20"
+                        >
+                          0
+                        </span>
+                        <span
+                          class="BaseMotionweb__StyledDiv-gsyvko-0"
+                          style="position: absolute; top: 0px; left: 0px; transform: translateY(-9.090909090909092%);"
+                        >
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            1
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            2
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            3
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            4
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            5
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            6
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            7
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            8
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            9
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </span>
+                      <span
+                        class="c19"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="c20"
+                        >
+                          0
+                        </span>
+                        <span
+                          class="BaseMotionweb__StyledDiv-gsyvko-0"
+                          style="position: absolute; top: 0px; left: 0px; transform: translateY(-54.54545454545454%);"
+                        >
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            1
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            2
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            3
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            4
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            5
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            6
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            7
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            8
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            9
+                          </span>
+                          <span
+                            class="c21"
+                          >
+                            0
+                          </span>
+                        </span>
+                      </span>
+                    </span>
                   </span>
                 </span>
               </p>
@@ -759,14 +1049,14 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
           </div>
           <div
             aria-hidden="true"
-            class="c18"
+            class="c22"
           >
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start: calc(1.5px + 0 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -774,11 +1064,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start: calc(1.5px + 0.2 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -786,11 +1076,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start: calc(1.5px + 0.4 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -798,11 +1088,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start: calc(1.5px + 0.6 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -810,11 +1100,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start: calc(1.5px + 0.8 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -822,11 +1112,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c19"
+              class="c23"
               style="inset-inline-start: calc(1.5px + 1 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c20"
+                class="c24"
                 data-blade-component="text"
                 letter-spacing="50"
               >

--- a/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.web.test.tsx.snap
@@ -1,0 +1,796 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SliderInput /> should render a slider 1`] = `
+.c11.c11.c11.c11.c11 {
+  position: relative;
+  width: 100%;
+  height: 3px;
+}
+
+.c12.c12.c12.c12.c12 {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-composite: source-in;
+  -webkit-mask-composite: intersect;
+  mask-composite: intersect;
+  -webkit-transition: clip-path 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: clip-path 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c4.c4.c4.c4.c4 {
+  color: hsla(200,10%,18%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.0625rem;
+  -webkit-letter-spacing: -0.15600000000000003px;
+  -moz-letter-spacing: -0.15600000000000003px;
+  -ms-letter-spacing: -0.15600000000000003px;
+  letter-spacing: -0.15600000000000003px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+}
+
+.c15.c15.c15.c15.c15 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.625rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 0.8125rem;
+  -webkit-letter-spacing: -0.13px;
+  -moz-letter-spacing: -0.13px;
+  -ms-letter-spacing: -0.13px;
+  letter-spacing: -0.13px;
+  margin: 0;
+  padding: 0;
+}
+
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.c1.c1.c1.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 4px;
+  width: 100%;
+}
+
+.c2.c2.c2.c2.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-height: 36px;
+  gap: 0px;
+}
+
+.c7.c7.c7.c7.c7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 1003px;
+}
+
+.c14.c14.c14.c14.c14 {
+  position: absolute;
+  bottom: 22px;
+  pointer-events: none;
+  white-space: nowrap;
+  border-radius: 4px;
+  padding: 2px 4px;
+  background-color: hsla(0,0%,0%,0.72);
+  opacity: 0;
+  -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),-webkit-transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+  transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c8.c8.c8.c8.c8 {
+  position: relative;
+  width: 100%;
+  height: 32px;
+  margin-bottom: 0px;
+}
+
+.c9.c9.c9.c9.c9 {
+  position: absolute;
+  inset-inline: 0;
+  top: 4px;
+  height: 24px;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.c9.c9.c9.c9.c9::before {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  top: -10px;
+  bottom: -10px;
+}
+
+.c10.c10.c10.c10.c10 {
+  position: absolute;
+  inset-inline: 0;
+  top: 11px;
+}
+
+.c13.c13.c13.c13.c13 {
+  position: absolute;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background-color: hsla(0,0%,0%,1);
+  outline: none;
+  -webkit-transition: inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c13.c13.c13.c13.c13:focus-visible {
+  outline: 4px solid hsla(206,10%,29%,0.12);
+  outline-offset: 1px;
+  -webkit-transition-property: outline-width;
+  transition-property: outline-width;
+  -webkit-transition-duration: 80ms;
+  transition-duration: 80ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  z-index: 2;
+  -webkit-transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+<div>
+  <div
+    class=""
+    data-blade-component="slider-input"
+  >
+    <div
+      class="c0"
+      data-blade-component="base-box"
+    >
+      <span
+        data-blade-component="form-label"
+        id="slider-input-1-label-6"
+        style="width: 100%; flex-shrink: 0; margin-right: 0px;"
+      >
+        <div
+          class="c1"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c2"
+            data-blade-component="base-box"
+          >
+            <div
+              class=""
+              data-blade-component="base-box"
+            >
+              <div
+                class="c3"
+                data-blade-component="base-box"
+              >
+                <p
+                  class="c4"
+                  data-blade-component="text"
+                  letter-spacing="50"
+                >
+                  Volume
+                </p>
+                <div
+                  class="c5"
+                  data-blade-component="visually-hidden"
+                >
+                  <p
+                    class="c6"
+                    data-blade-component="text"
+                    letter-spacing="50"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+      <div
+        class="c7"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c8"
+        >
+          <div
+            class="c9"
+          >
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                  style="background-color: rgba(67, 67, 67, 0.12);"
+                />
+                <div
+                  class="c12"
+                  style="background-color: rgb(0, 0, 0); clip-path: inset(0 calc(100% - (calc(3px + 0 * (100% - 3px)))) 0 0);"
+                />
+              </div>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-labelledby="slider-input-1-label-6"
+              aria-orientation="horizontal"
+              aria-valuemax="100"
+              aria-valuemin="0"
+              aria-valuenow="0"
+              aria-valuetext="0"
+              class="c13"
+              id="slider-input-1-input-2"
+              role="slider"
+              style="inset-inline-start: calc(1.5px + 0 * (100% - 3px)); transform: translateX(-50%);"
+              tabindex="0"
+            />
+            <div
+              aria-hidden="true"
+              class="c14"
+              style="inset-inline-start: calc(1.5px + 0 * (100% - 3px)); transform: translateX(-50%) translateY(2px);"
+            >
+              <p
+                class="c15"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                0
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<SliderInput /> should render with markers, a scale and a left positioned label 1`] = `
+.c11.c11.c11.c11.c11 {
+  position: relative;
+  width: 100%;
+  height: 3px;
+}
+
+.c12.c12.c12.c12.c12 {
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-composite: source-in;
+  -webkit-mask-composite: intersect;
+  mask-composite: intersect;
+  -webkit-transition: clip-path 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: clip-path 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c4.c4.c4.c4.c4 {
+  color: hsla(200,10%,18%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.c6.c6.c6.c6.c6 {
+  color: hsla(0,0%,2%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.875rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 1.25rem;
+  -webkit-letter-spacing: -0.18200000000000002px;
+  -moz-letter-spacing: -0.18200000000000002px;
+  -ms-letter-spacing: -0.18200000000000002px;
+  letter-spacing: -0.18200000000000002px;
+  margin: 0;
+  padding: 0;
+}
+
+.c15.c15.c15.c15.c15 {
+  color: hsla(0,0%,100%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.625rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 0.8125rem;
+  -webkit-letter-spacing: -0.13px;
+  -moz-letter-spacing: -0.13px;
+  -ms-letter-spacing: -0.13px;
+  letter-spacing: -0.13px;
+  margin: 0;
+  padding: 0;
+}
+
+.c18.c18.c18.c18.c18 {
+  color: hsla(204,9%,42%,1);
+  font-family: "Inter","Inter Fallback Arial",Arial;
+  font-size: 0.625rem;
+  font-weight: 400;
+  font-style: normal;
+  -webkit-text-decoration-line: none;
+  text-decoration-line: none;
+  line-height: 0.8125rem;
+  -webkit-letter-spacing: -0.13px;
+  -moz-letter-spacing: -0.13px;
+  -ms-letter-spacing: -0.13px;
+  letter-spacing: -0.13px;
+  margin: 0;
+  padding: 0;
+}
+
+.c0.c0.c0.c0.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.c1.c1.c1.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.c2.c2.c2.c2.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.c3.c3.c3.c3.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-height: 36px;
+  gap: 0px;
+}
+
+.c7.c7.c7.c7.c7 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  min-width: 79px;
+}
+
+.c14.c14.c14.c14.c14 {
+  position: absolute;
+  bottom: 22px;
+  pointer-events: none;
+  white-space: nowrap;
+  border-radius: 4px;
+  padding: 2px 4px;
+  background-color: hsla(0,0%,0%,0.72);
+  opacity: 0;
+  -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),-webkit-transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+  -webkit-transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+  transition: opacity 160ms cubic-bezier(0.17,0,1,1),transform 160ms cubic-bezier(0.17,0,1,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c5.c5.c5.c5.c5 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: 0 -1px -1px 0;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  left: -10000px;
+  white-space: nowrap;
+  word-wrap: normal;
+}
+
+.c8.c8.c8.c8.c8 {
+  position: relative;
+  width: 100%;
+  height: 32px;
+  margin-bottom: 4px;
+}
+
+.c9.c9.c9.c9.c9 {
+  position: absolute;
+  inset-inline: 0;
+  top: 4px;
+  height: 24px;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.c9.c9.c9.c9.c9::before {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  top: -10px;
+  bottom: -10px;
+}
+
+.c10.c10.c10.c10.c10 {
+  position: absolute;
+  inset-inline: 0;
+  top: 11px;
+}
+
+.c13.c13.c13.c13.c13 {
+  position: absolute;
+  top: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  background-color: hsla(0,0%,0%,1);
+  outline: none;
+  -webkit-transition: inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c13.c13.c13.c13.c13:focus-visible {
+  outline: 4px solid hsla(206,10%,29%,0.12);
+  outline-offset: 1px;
+  -webkit-transition-property: outline-width;
+  transition-property: outline-width;
+  -webkit-transition-duration: 80ms;
+  transition-duration: 80ms;
+  -webkit-transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  transition-timing-function: cubic-bezier(0.3,0,0.2,1);
+  z-index: 2;
+  -webkit-transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+  transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
+}
+
+.c16.c16.c16.c16.c16 {
+  position: absolute;
+  inset-inline: 0;
+  top: 24px;
+  pointer-events: none;
+}
+
+.c17.c17.c17.c17.c17 {
+  position: absolute;
+  white-space: nowrap;
+}
+
+<div>
+  <div
+    class=""
+    data-blade-component="slider-input"
+  >
+    <div
+      class="c0"
+      data-blade-component="base-box"
+    >
+      <span
+        data-blade-component="form-label"
+        id="slider-input-19-label-24"
+        style="width: 120px; flex-shrink: 0; margin-right: 12px;"
+      >
+        <div
+          class="c1"
+          data-blade-component="base-box"
+        >
+          <div
+            class="c2"
+            data-blade-component="base-box"
+          >
+            <div
+              class=""
+              data-blade-component="base-box"
+            >
+              <div
+                class="c3"
+                data-blade-component="base-box"
+              >
+                <p
+                  class="c4"
+                  data-blade-component="text"
+                  letter-spacing="50"
+                >
+                  Corner Radius
+                </p>
+                <div
+                  class="c5"
+                  data-blade-component="visually-hidden"
+                >
+                  <p
+                    class="c6"
+                    data-blade-component="text"
+                    letter-spacing="50"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </span>
+      <div
+        class="c7"
+        data-blade-component="base-box"
+      >
+        <div
+          class="c8"
+        >
+          <div
+            class="c9"
+          >
+            <div
+              class="c10"
+            >
+              <div
+                class="c11"
+              >
+                <div
+                  class="c12"
+                  style="mask-image: radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.2 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.4 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.6 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.8 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px); background-color: rgba(67, 67, 67, 0.12);"
+                />
+                <div
+                  class="c12"
+                  style="mask-image: radial-gradient(circle 3px at calc(1.5px + 0 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.2 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.4 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.6 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 0.8 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px), radial-gradient(circle 3px at calc(1.5px + 1 * (100% - 3px)) 50%, #000 0 1.5px, transparent 1.5px 3px, #000 3px); background-color: rgb(0, 0, 0); clip-path: inset(0 calc(100% - (calc(3px + 0.4 * (100% - 3px)))) 0 0);"
+                />
+              </div>
+            </div>
+            <div
+              aria-disabled="false"
+              aria-labelledby="slider-input-19-label-24"
+              aria-orientation="horizontal"
+              aria-valuemax="40"
+              aria-valuemin="0"
+              aria-valuenow="16"
+              aria-valuetext="16"
+              class="c13"
+              id="slider-input-19-input-20"
+              role="slider"
+              style="inset-inline-start: calc(1.5px + 0.4 * (100% - 3px)); transform: translateX(-50%);"
+              tabindex="0"
+            />
+            <div
+              aria-hidden="true"
+              class="c14"
+              style="inset-inline-start: calc(1.5px + 0.4 * (100% - 3px)); transform: translateX(-50%) translateY(2px);"
+            >
+              <p
+                class="c15"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                16
+              </p>
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            class="c16"
+          >
+            <div
+              class="c17"
+              style="inset-inline-start: calc(1.5px + 0 * (100% - 3px)); transform: translateX(-50%);"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                0
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start: calc(1.5px + 0.2 * (100% - 3px)); transform: translateX(-50%);"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                8
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start: calc(1.5px + 0.4 * (100% - 3px)); transform: translateX(-50%);"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                16
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start: calc(1.5px + 0.6 * (100% - 3px)); transform: translateX(-50%);"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                24
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start: calc(1.5px + 0.8 * (100% - 3px)); transform: translateX(-50%);"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                32
+              </p>
+            </div>
+            <div
+              class="c17"
+              style="inset-inline-start: calc(1.5px + 1 * (100% - 3px)); transform: translateX(-50%);"
+            >
+              <p
+                class="c18"
+                data-blade-component="text"
+                letter-spacing="50"
+              >
+                40
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.web.test.tsx.snap
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/__snapshots__/SliderInput.web.test.tsx.snap
@@ -142,6 +142,18 @@ exports[`<SliderInput /> should render a slider 1`] = `
   min-width: 1003px;
 }
 
+.c17.c17.c17.c17.c17 {
+  display: inline-block;
+}
+
+.c16.c16.c16.c16.c16 {
+  display: inline-grid;
+}
+
+.c16.c16.c16.c16.c16 > * {
+  grid-area: 1 / 1;
+}
+
 .c14.c14.c14.c14.c14 {
   position: absolute;
   bottom: 22px;
@@ -331,7 +343,18 @@ exports[`<SliderInput /> should render a slider 1`] = `
                 data-blade-component="text"
                 letter-spacing="50"
               >
-                0
+                <span
+                  class="c16"
+                  data-blade-component="animated-value"
+                >
+                  <span
+                    class="c17"
+                    display="inline-block"
+                    style="opacity: 1; transform: none;"
+                  >
+                    0
+                  </span>
+                </span>
               </p>
             </div>
           </div>
@@ -421,7 +444,7 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   padding: 0;
 }
 
-.c18.c18.c18.c18.c18 {
+.c20.c20.c20.c20.c20 {
   color: hsla(204,9%,42%,1);
   font-family: "Inter","Inter Fallback Arial",Arial;
   font-size: 0.625rem;
@@ -504,6 +527,18 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   -ms-flex: 1;
   flex: 1;
   min-width: 79px;
+}
+
+.c17.c17.c17.c17.c17 {
+  display: inline-block;
+}
+
+.c16.c16.c16.c16.c16 {
+  display: inline-grid;
+}
+
+.c16.c16.c16.c16.c16 > * {
+  grid-area: 1 / 1;
 }
 
 .c14.c14.c14.c14.c14 {
@@ -593,14 +628,14 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
   transition: outline-width 80ms cubic-bezier(0.3,0,0.2,1),inset-inline-start 80ms cubic-bezier(0.3,0,0.2,1),background-color 160ms cubic-bezier(0.3,0,0.2,1);
 }
 
-.c16.c16.c16.c16.c16 {
+.c18.c18.c18.c18.c18 {
   position: absolute;
   inset-inline: 0;
   top: 24px;
   pointer-events: none;
 }
 
-.c17.c17.c17.c17.c17 {
+.c19.c19.c19.c19.c19 {
   position: absolute;
   white-space: nowrap;
 }
@@ -707,20 +742,31 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
                 data-blade-component="text"
                 letter-spacing="50"
               >
-                16
+                <span
+                  class="c16"
+                  data-blade-component="animated-value"
+                >
+                  <span
+                    class="c17"
+                    display="inline-block"
+                    style="opacity: 1; transform: none;"
+                  >
+                    16
+                  </span>
+                </span>
               </p>
             </div>
           </div>
           <div
             aria-hidden="true"
-            class="c16"
+            class="c18"
           >
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start: calc(1.5px + 0 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -728,11 +774,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start: calc(1.5px + 0.2 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -740,11 +786,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start: calc(1.5px + 0.4 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -752,11 +798,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start: calc(1.5px + 0.6 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -764,11 +810,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start: calc(1.5px + 0.8 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >
@@ -776,11 +822,11 @@ exports[`<SliderInput /> should render with markers, a scale and a left position
               </p>
             </div>
             <div
-              class="c17"
+              class="c19"
               style="inset-inline-start: calc(1.5px + 1 * (100% - 3px)); transform: translateX(-50%);"
             >
               <p
-                class="c18"
+                class="c20"
                 data-blade-component="text"
                 letter-spacing="50"
               >

--- a/packages/blade/src/components/Input/SliderInput/__tests__/sliderInputUtils.web.test.ts
+++ b/packages/blade/src/components/Input/SliderInput/__tests__/sliderInputUtils.web.test.ts
@@ -1,0 +1,180 @@
+import {
+  getFillWidthExpression,
+  getMarkerValues,
+  getMinTrackWidth,
+  getOffsetExpression,
+  getSpacedScaleValues,
+  getValueRatio,
+  getVisibility,
+  snapValue,
+} from '../utils';
+
+describe('SliderInput utils', () => {
+  describe('snapValue', () => {
+    it('should snap to the nearest step', () => {
+      const range = { min: 0, max: 100, step: 25 };
+      expect(snapValue(0, range)).toBe(0);
+      expect(snapValue(37, range)).toBe(25);
+      expect(snapValue(38, range)).toBe(50);
+      expect(snapValue(100, range)).toBe(100);
+    });
+
+    it('should clamp values outside the range', () => {
+      const range = { min: 10, max: 20, step: 1 };
+      expect(snapValue(-50, range)).toBe(10);
+      expect(snapValue(500, range)).toBe(20);
+    });
+
+    it('should keep max reachable when the range is not a whole number of steps', () => {
+      // 0-100 by 30 stops at 90, so max is 10 away while the step is 30.
+      const range = { min: 0, max: 100, step: 30 };
+      expect(snapValue(100, range)).toBe(100);
+      expect(snapValue(96, range)).toBe(100);
+      // Still closer to the last real step than to max.
+      expect(snapValue(91, range)).toBe(90);
+    });
+
+    it('should not leak floating point drift into the value', () => {
+      const range = { min: 0, max: 1, step: 0.1 };
+      expect(snapValue(0.3, range)).toBe(0.3);
+      expect(snapValue(0.7000000001, range)).toBe(0.7);
+    });
+
+    it('should fall back to min for a non-finite value', () => {
+      expect(snapValue(NaN, { min: 5, max: 10, step: 1 })).toBe(5);
+    });
+  });
+
+  describe('getMarkerValues', () => {
+    it('should produce one marker per step', () => {
+      expect(getMarkerValues({ min: 0, max: 100, step: 25 })).toEqual([0, 25, 50, 75, 100]);
+    });
+
+    it('should append max when it is not itself a step', () => {
+      expect(getMarkerValues({ min: 0, max: 100, step: 30 })).toEqual([0, 30, 60, 90, 100]);
+    });
+
+    it('should not drift on fractional steps', () => {
+      expect(getMarkerValues({ min: 0, max: 0.5, step: 0.1 })).toEqual([
+        0,
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+      ]);
+    });
+  });
+
+  describe('positioning', () => {
+    it('should inset the ends by the marker radius so end dots sit on the rail', () => {
+      expect(getOffsetExpression(0)).toBe('calc(1.5px + 0 * (100% - 3px))');
+      expect(getOffsetExpression(1)).toBe('calc(1.5px + 1 * (100% - 3px))');
+    });
+
+    it('should end the fill at the far edge of the reached marker, not its centre', () => {
+      // At max this resolves to 3px + (100% - 3px), which is exactly the full track.
+      expect(getFillWidthExpression(1)).toBe('calc(3px + 1 * (100% - 3px))');
+      // At min the fill is exactly one dot wide, so the first marker reads as filled.
+      expect(getFillWidthExpression(0)).toBe('calc(3px + 0 * (100% - 3px))');
+    });
+
+    it('should map value to ratio and clamp out of range values', () => {
+      expect(getValueRatio(50, { min: 0, max: 100 })).toBe(0.5);
+      expect(getValueRatio(-10, { min: 0, max: 100 })).toBe(0);
+      expect(getValueRatio(0, { min: 5, max: 5 })).toBe(0);
+    });
+  });
+
+  describe('suppression', () => {
+    it('should show everything while the track is unmeasured', () => {
+      expect(getVisibility({ trackWidth: 0, markerCount: 50, widestLabelWidth: 20 })).toEqual({
+        canShowMarkers: true,
+        canShowScale: true,
+      });
+    });
+
+    it('should drop markers once the rings would collide', () => {
+      // 11 markers over 300px is a 29.7px pitch, comfortably above the 10px floor.
+      expect(
+        getVisibility({ trackWidth: 300, markerCount: 11, widestLabelWidth: 0 }).canShowMarkers,
+      ).toBe(true);
+      // 101 markers over the same track is a 2.97px pitch.
+      expect(
+        getVisibility({ trackWidth: 300, markerCount: 101, widestLabelWidth: 0 }).canShowMarkers,
+      ).toBe(false);
+    });
+
+    it('should drop the scale before the markers, since labels are wider than rings', () => {
+      // 21 markers over 300px is a 14.85px pitch: clear of the 10px ring floor, but not
+      // enough for a 17px label plus its 4px gap.
+      const { canShowMarkers, canShowScale } = getVisibility({
+        trackWidth: 300,
+        markerCount: 21,
+        widestLabelWidth: 17,
+      });
+      expect(canShowMarkers).toBe(true);
+      expect(canShowScale).toBe(false);
+    });
+  });
+
+  describe('getSpacedScaleValues', () => {
+    const range = { min: 0, max: 100, step: 33.33 };
+    // "33.33" is the widest label at 5 characters.
+    const widestLabelWidth = 28;
+
+    it('should drop a label that collides with max rather than dropping max', () => {
+      // A step of 33.33 leaves a 0.01 sliver between the last whole step and max, so their
+      // labels print on top of each other however wide the track is.
+      const values = getMarkerValues(range);
+      expect(values).toEqual([0, 33.33, 66.66, 99.99, 100]);
+
+      expect(getSpacedScaleValues({ values, trackWidth: 400, widestLabelWidth, range })).toEqual([
+        0,
+        33.33,
+        66.66,
+        100,
+      ]);
+    });
+
+    it('should keep a trailing step that is genuinely far enough from max', () => {
+      // The UnevenSteps story: 90 sits a tenth of the range from 100, which is legible.
+      const evenishRange = { min: 0, max: 100, step: 30 };
+      const values = getMarkerValues(evenishRange);
+      expect(values).toEqual([0, 30, 60, 90, 100]);
+
+      expect(
+        getSpacedScaleValues({
+          values,
+          trackWidth: 400,
+          widestLabelWidth: 17,
+          range: evenishRange,
+        }),
+      ).toEqual(values);
+    });
+
+    it('should show everything while the track is unmeasured', () => {
+      const values = getMarkerValues(range);
+      expect(getSpacedScaleValues({ values, trackWidth: 0, widestLabelWidth, range })).toEqual(
+        values,
+      );
+    });
+
+    it('should always keep both bounds, however cramped the track', () => {
+      const values = getMarkerValues({ min: 0, max: 100, step: 10 });
+      expect(
+        getSpacedScaleValues({ values, trackWidth: 60, widestLabelWidth: 40, range }),
+      ).toEqual([0, 100]);
+    });
+  });
+
+  describe('getMinTrackWidth', () => {
+    it('should widen the floor when labels are wider than the marker ring', () => {
+      expect(getMinTrackWidth(5, 0)).toBeLessThan(getMinTrackWidth(5, 30));
+    });
+
+    it('should collapse to a single dot when there is nothing to space out', () => {
+      expect(getMinTrackWidth(1, 50)).toBe(3);
+    });
+  });
+});

--- a/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
@@ -191,6 +191,17 @@ dependency. The trade is that it does not have NumberFlow's per-digit roll.
 the raw value, so a `formatValue` that adds a unit or a currency still moves the right way
 instead of falling back to a cross-fade.
 
+The roll runs on `moderate`, and is the one piece of motion here not tuned for keeping up.
+Everything else moves at `2xquick` because it is chasing a pointer or a held arrow key, but a
+roll exists to be read, and at those durations the change goes by unnoticed.
+
+It is also skipped when changes arrive faster than it can play. Dragging a fine-grained slider
+changes the value roughly every 20ms, and animating each one left nineteen half-faded copies
+stacked on top of each other after a single drag — never resolving into a readable number, and
+growing for as long as the drag lasted. Only isolated changes roll now; the rest are written
+straight into place, so a drag shows one crisp value. Coarse-step sliders still roll mid-drag,
+because their changes are far enough apart to read.
+
 ## Not on React Native
 
 The mask compositing that draws the markers has no equivalent in React Native's style system.

--- a/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
@@ -195,12 +195,21 @@ The roll runs on `moderate`, and is the one piece of motion here not tuned for k
 Everything else moves at `2xquick` because it is chasing a pointer or a held arrow key, but a
 roll exists to be read, and at those durations the change goes by unnoticed.
 
-It is also skipped when changes arrive faster than it can play. Dragging a fine-grained slider
-changes the value roughly every 20ms, and animating each one left nineteen half-faded copies
-stacked on top of each other after a single drag — never resolving into a readable number, and
-growing for as long as the drag lasted. Only isolated changes roll now; the rest are written
-straight into place, so a drag shows one crisp value. Coarse-step sliders still roll mid-drag,
-because their changes are far enough apart to read.
+The roll is an odometer rather than a swap, and that is what lets it survive a drag. A swap has
+to finish one value before it can start the next, so a slider changing roughly every 20ms left
+it no time to play: nineteen half-faded copies stacked on top of each other after a single
+drag, never resolving into a readable number. Driving digit columns from the value itself has
+no such limit — the columns are a function of where the value is, so they keep rolling however
+fast it moves and settle crisply when it stops. Measured at a realistic drag speed, the digits
+trail the thumb by about 1.5 units and land exactly on release.
+
+It follows the value with a spring rather than a tween. Re-aiming a tween on every change
+restarts its easing from a standstill, so during a drag it only ever covers the first slow
+fraction of a curve and falls further behind — measured at thirteen units adrift. A spring
+carries its velocity across the change and keeps pace instead.
+
+Content with no digits in it — a word, a label — still swaps as a whole, and that swap is still
+skipped when changes arrive faster than it can play, for the reason above.
 
 ## Not on React Native
 

--- a/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
@@ -1,0 +1,184 @@
+# SliderInput Decisions
+
+SliderInput lets a user pick a number from a range by dragging along a track.
+
+## Geometry
+
+Every measurement below is derived from the Figma component set, not chosen here.
+
+| Piece                   | Value                               |
+| ----------------------- | ----------------------------------- |
+| Field box height        | 32 (equals `baseInputHeight.small`) |
+| Box padding top         | 4                                   |
+| Control height          | 24                                  |
+| Track height            | 3                                   |
+| Track top, in the box   | 15                                  |
+| Thumb                   | 12 × 12                             |
+| Marker dot              | 3 (equals the track height)         |
+| Marker transparent ring | 6 (twice the track height)          |
+| Scale row               | 12 tall, starting at y 24           |
+
+Two consequences are worth stating because they look like bugs otherwise.
+
+**The track is not vertically centred in the control.** A 3px track cannot be centred in a
+24px control on whole pixels. It is pinned to y 15, which puts its centre 0.5px below the
+thumb's. That is invisible and keeps the rail crisp at 1x.
+
+**The scale hangs 4px below the field box.** The box stays exactly one small BaseInput tall
+whatever the scale does, so toggling the scale never moves the track and a SliderInput keeps
+sharing a field centre line with a `TextInput` next to it. The box reserves bottom margin for
+the overflow rather than growing.
+
+## Markers are cut out, never painted
+
+Markers are transparent holes punched through the track with `mask-image`, one
+`radial-gradient` per marker composited with `mask-composite: intersect`. The dot at the
+centre of each hole stays in the mask, so it takes the colour of whatever layer it sits on:
+the fill colour once the thumb has passed it, the rail colour before.
+
+Painting markers with a surface colour would hardcode an assumption about what is behind the
+slider, and would break on cards and in dark mode.
+
+> `mask-composite: intersect` is the one thing here that is not universally old-browser safe.
+> If it has to be dropped, the replacement is a generated SVG data-URI mask, not painted dots.
+
+## The rail and the fill are the same size
+
+Both track layers are full track width and share one mask; the fill is trimmed to the reached
+value with `clip-path` rather than by being narrower. If the fill were sized to the value, the
+percentages inside its mask would resolve against its own width and the marker holes would
+drift out of alignment with the rail's.
+
+This also means nothing about positioning needs a measured width. Offsets are CSS `calc`
+expressions, so the server renders the thumb at its final position instead of at zero and then
+jumping on hydration.
+
+The fill ends at the far edge of the marker it reaches, not its centre, or the reached dot
+renders half filled. Its trailing edge is always under the thumb, so clipping it square there
+is never visible.
+
+## Snapping
+
+`max` is always reachable, even when the range is not a whole number of steps. A 0-100 slider
+with `step={30}` has stops at 0, 30, 60, 90 and 100; the last gap is deliberately short.
+Without this, `max` would be unreachable on any range that does not divide evenly, which is
+the more surprising of the two behaviours.
+
+A controlled value that is off-step renders on the nearest step, and `aria-valuenow` reports
+the snapped value. Reporting the raw one produces a readout saying 37 while the thumb stands
+on 40.
+
+## Two change callbacks
+
+`onChange` fires on every pointer move during a drag. `onChangeEnd` fires once, when the
+interaction commits, and only when the value actually changed across it. Expensive work
+belongs in `onChangeEnd`; a drag across a wide range would otherwise fire dozens of times, and
+a click that lands back on the starting value would fire for nothing.
+
+## Suppression
+
+Markers and scale labels crowd at different widths, so they are dropped independently: markers
+once the transparent rings would touch, labels once they would collide with each other. A
+narrow slider degrades to a plain track rather than a smear of overlapping dots.
+
+Before the track has been measured, which is the SSR and first-paint case, both render. A
+too-narrow track corrects itself on the first resize observation.
+
+That pitch floor assumes markers are evenly spaced, which stops being true when the range is
+not a whole number of steps: with `step={33.33}` the last whole step lands at 99.99, a sliver
+away from `max`, and the two labels print on top of each other at any track width. So labels
+are additionally filtered pairwise against their neighbour. Both values are real stops the
+thumb can land on, so only the label is dropped, never the stop. `min` and `max` always
+survive that filter, and a label colliding with `max` is dropped in favour of `max`.
+
+## Composition over a bundled readout
+
+The slider does not ship with a paired text field. Holding the value in your own state and
+passing it to both leaves you free to decide how they reconcile, which matters because they
+can legitimately disagree: typing 37 against a step of 8 puts the thumb on 40. See the
+`PairedWithTextInput` story.
+
+The value indicator above the thumb is private and unexported rather than the public
+`Tooltip`, which has a 51px floor once its padding and arrow are counted and will not hug a
+two-character value.
+
+## Accessibility
+
+`role="slider"` sits on the thumb with `aria-valuemin`, `aria-valuemax`, `aria-valuenow` and
+`aria-valuetext`, the last two always carrying the snapped value run through `formatValue`.
+The label is associated with `aria-labelledby`, since a `<label for>` cannot target a div.
+
+The thumb's hit area is lifted to 44 × 44 with a pseudo-element so the visual thumb stays
+12px. Drag persists after the pointer leaves the thumb via pointer capture.
+
+The value indicator is `aria-hidden`; the value is already announced through `aria-valuetext`,
+and it is never the only way to read the value.
+
+## Motion, except while dragging
+
+The thumb, the fill and the value indicator all move on Blade's motion tokens, sharing one
+block in `sliderInputTokens` so they cannot drift out of step with each other.
+
+Movement uses `2xquick`, the shortest duration the system offers, with the `standard` morph
+easing. A held arrow key repeats, and anything slower would still be easing the previous step
+when the next one lands. Colour changes between the default, highlighted and disabled states
+get `xquick`, since nothing is chasing them.
+
+Movement is suppressed while _scrubbing_, not merely while the pointer is down, and the
+difference is the whole point. A click on a far part of the track should glide there; a drag
+must pin the thumb to the finger, where easing would read as lag. Those are the same
+`pointerdown`, so they can only be told apart afterwards: the press starts as a click, and the
+pointer moving more than `SLIDER_DRAG_SLOP` promotes it to a drag for the rest of the gesture.
+
+Hence two states. `isDragging` means the pointer is down and drives the highlight and the
+indicator; `isScrubbing` means it has also moved, and only that drops movement from the
+transition list. The colour transition survives either way, not being tied to position.
+
+The slop exists because a mouse rarely holds perfectly still between press and release, and
+without it a single jittered pixel would cancel the glide and make every click look broken.
+Where the distance cannot be measured at all, the code errs towards dragging: losing a glide
+is far cheaper than easing every frame and leaving the thumb trailing the pointer.
+
+The indicator fades and rises 2px on `entrance` easing and falls away on `exit`, which is the
+one place the two directions differ. Only the rise is interpolated on the transform: the
+centring half is a constant translateX and contributes nothing.
+
+Two traps worth knowing about if this is edited again:
+
+- `getFocusRingStyles` sets `transition-property: outline-width`, which would otherwise freeze
+  the thumb exactly while the keyboard is driving it. The `:focus-visible` block re-declares
+  the movement alongside the ring's growth.
+- Backticks inside a comment in a styled-components template literal terminate the template.
+
+`prefers-reduced-motion` is not handled, matching `BaseInput`: it is not handled anywhere in
+Blade today, and adding it belongs in a system-wide motion pass rather than one component.
+
+## The neutral focus ring
+
+The thumb uses `getFocusRingStyles({ variant: 'neutral' })`. Figma models the focus ring as a
+component set with a primary and a neutral variant, but the helper only ever drew the primary
+one, so `BaseButton` had already hand-rolled the neutral ring for its filled neutral surface.
+Rather than add a second copy, the variant was added to the helper and `BaseButton` moved onto
+it, leaving one definition of each ring for both platforms.
+
+The slider is a neutral component, so the primary blue would give it an accent it does not
+otherwise carry. Only the colour changes: the 4px width, the 1px offset and the motion are
+shared with every other component, so focus geometry stays consistent system-wide.
+
+Focus is moved to the thumb by hand on pointer down. The pointer handler calls
+`preventDefault()` to stop a drag from selecting text across the page, and that also suppresses
+the focus the browser would otherwise move, which would leave the keyboard dead until the user
+tabbed in separately. The ring itself still only appears for `:focus-visible`, so it stays
+hidden during mouse use.
+
+## Not on React Native
+
+The mask compositing that draws the markers has no equivalent in React Native's style system.
+A native version needs a different drawing approach and its own gesture handling, so it is
+left out rather than shipped as a lookalike that drifts from the web behaviour.
+
+## Open
+
+- RTL uses logical properties throughout and the pointer maths reads the computed direction so
+  the two cannot disagree, but Blade has no RTL infrastructure to test against and no RTL
+  support is claimed.

--- a/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
@@ -171,6 +171,26 @@ the focus the browser would otherwise move, which would leave the keyboard dead 
 tabbed in separately. The ring itself still only appears for `:focus-visible`, so it stays
 hidden during mouse use.
 
+## The value indicator animates its number
+
+The number in the indicator swaps with `BaseAnimatedValue` rather than being replaced outright,
+so a rising value visibly rises.
+
+The reference for this was [NumberFlow](https://number-flow.barvian.me/), which was not used.
+It renders through a custom element with declarative shadow DOM, so it is web-only where every
+other Blade component is cross-platform; it would be a new runtime dependency; and its own
+documentation rules out RTL locales and non-Latin digits, which this component is deliberately
+positioned not to block. It is also numbers-only, and the indicator is expected to hold
+arbitrary text later.
+
+So the swap animates the whole value rather than individual digits: one behaviour that reads
+correctly for a number and for a word, on Blade's existing motion system, with no new
+dependency. The trade is that it does not have NumberFlow's per-digit roll.
+
+`BaseAnimatedValue` takes the raw value and the formatted text separately. Direction comes from
+the raw value, so a `formatValue` that adds a unit or a currency still moves the right way
+instead of falling back to a cross-fade.
+
 ## Not on React Native
 
 The mask compositing that draws the markers has no equivalent in React Native's style system.

--- a/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
@@ -223,3 +223,15 @@ left out rather than shipped as a lookalike that drifts from the web behaviour.
 - RTL uses logical properties throughout and the pointer maths reads the computed direction so
   the two cannot disagree, but Blade has no RTL infrastructure to test against and no RTL
   support is claimed.
+
+- `prefers-reduced-motion` is not handled, deliberately and for now. Nothing in Blade handles
+  it — the setting appears nowhere in the source — and the decision is to address it across the
+  system at once rather than one component at a time.
+
+  Worth flagging that the usual justification is weaker here than where it was first written.
+  `BaseInput` could reasonably defer it because it barely moves. This component eases the thumb
+  and the fill, fades and lifts the indicator, and rolls the digits from a spring that runs
+  whenever the value does. None of it flashes or plays on its own, so it is WCAG 2.3.3 at AAA
+  rather than a blocker, but a spinning odometer is close to the centre of what the setting
+  exists to switch off. Whenever the system-wide pass happens, this component is the one to
+  check first.

--- a/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
+++ b/packages/blade/src/components/Input/SliderInput/_decisions/_decisions.md
@@ -187,9 +187,10 @@ So the swap animates the whole value rather than individual digits: one behaviou
 correctly for a number and for a word, on Blade's existing motion system, with no new
 dependency. The trade is that it does not have NumberFlow's per-digit roll.
 
-`BaseAnimatedValue` takes the raw value and the formatted text separately. Direction comes from
-the raw value, so a `formatValue` that adds a unit or a currency still moves the right way
-instead of falling back to a cross-fade.
+`BaseAnimatedValue` takes the raw value and the formatted text separately. The raw value gives a
+swap its direction; the columns, though, are driven by the number the text itself spells out.
+A `formatValue` is free to rescale what it prints — `₹${value / 1000}k` shows `₹3k` for 3000 —
+and a column reading `3` that was driven from 3000 would land on `3000 % 10` and print `₹0k`.
 
 The roll runs on `moderate`, and is the one piece of motion here not tuned for keeping up.
 Everything else moves at `2xquick` because it is chasing a pointer or a held arrow key, but a

--- a/packages/blade/src/components/Input/SliderInput/index.ts
+++ b/packages/blade/src/components/Input/SliderInput/index.ts
@@ -1,0 +1,2 @@
+export { SliderInput } from './SliderInput';
+export type { SliderInputProps } from './types';

--- a/packages/blade/src/components/Input/SliderInput/sliderInputTokens.ts
+++ b/packages/blade/src/components/Input/SliderInput/sliderInputTokens.ts
@@ -118,6 +118,14 @@ const sliderInputMotion = {
   color: { duration: 'xquick', easing: 'standard' },
   /** The indicator fading in and out with the highlight, and its small rise on entry. */
   indicator: { duration: 'xquick', enterEasing: 'entrance', exitEasing: 'exit' },
+  /**
+   * The number rolling over inside the indicator.
+   *
+   * Deliberately slower than the indicator's own fade, and the one thing here that is not
+   * tuned for keeping up. A roll exists to be read, so it needs longer than the movement it
+   * accompanies; at the indicator's own duration the change goes by unnoticed.
+   */
+  valueRoll: { duration: 'moderate' },
 } as const;
 
 /** How far the indicator rises as it fades in, in px. */

--- a/packages/blade/src/components/Input/SliderInput/sliderInputTokens.ts
+++ b/packages/blade/src/components/Input/SliderInput/sliderInputTokens.ts
@@ -1,0 +1,149 @@
+import { baseInputHeight } from '~components/Input/BaseInput/baseInputTokens';
+
+/**
+ * Vertical geometry of the slider, verified against Figma node 126408:564.
+ *
+ * The field box matches a small BaseInput exactly, so a SliderInput and a
+ * `<TextInput size="small" />` share a field centre line. Against `medium` it is 2px off.
+ */
+const SLIDER_BOX_HEIGHT = baseInputHeight.small; // 32
+const SLIDER_BOX_PADDING_TOP = 4;
+const SLIDER_CONTROL_HEIGHT = 24;
+
+const SLIDER_TRACK_HEIGHT = 3;
+
+/**
+ * The track is pinned to whole pixels rather than centred in the control: a 3px track in a
+ * 24px control cannot be both. This puts the track centre 0.5px below the thumb centre,
+ * which is invisible and is the trade the design makes to keep the rail crisp at 1x.
+ */
+const SLIDER_TRACK_TOP = SLIDER_BOX_PADDING_TOP + 11; // 15 in the box, 11 in the control
+
+const SLIDER_THUMB_SIZE = 12;
+
+/** The thumb is centred in the control, unlike the track. */
+const SLIDER_THUMB_TOP = (SLIDER_CONTROL_HEIGHT - SLIDER_THUMB_SIZE) / 2; // 6
+
+/** Clear space between the top of the thumb and the bottom of the value indicator. */
+const SLIDER_INDICATOR_GAP = 4;
+
+/**
+ * Distance from the bottom of the control to the bottom of the indicator.
+ *
+ * The indicator sits fully above the thumb and therefore overflows the field box upwards.
+ * That is intended, and is why nothing in the slider sets `overflow: hidden`.
+ */
+const SLIDER_INDICATOR_BOTTOM = SLIDER_CONTROL_HEIGHT - SLIDER_THUMB_TOP + SLIDER_INDICATOR_GAP; // 22
+
+/**
+ * The scale starts inside the box and ends 4px past it. The box must not clip.
+ */
+const SLIDER_SCALE_TOP = 24;
+const SLIDER_SCALE_HEIGHT = 12;
+
+/**
+ * Marker geometry is derived from the track height, never hardcoded. The dot equals the
+ * track height and the transparent ring around it is twice the track height, so both
+ * follow if the track is ever retuned again.
+ */
+const SLIDER_MARKER_DOT = SLIDER_TRACK_HEIGHT; // 3
+const SLIDER_MARKER_RADIUS = SLIDER_MARKER_DOT / 2; // 1.5
+const SLIDER_MARKER_RING = SLIDER_TRACK_HEIGHT * 2; // 6
+
+/**
+ * Below this centre-to-centre distance the transparent rings merge into each other and the
+ * rail stops reading as a rail, so markers are dropped entirely rather than drawn colliding.
+ * Leaves 4px of rail between adjacent rings.
+ */
+const SLIDER_MIN_MARKER_PITCH = SLIDER_MARKER_RING + 4; // 10
+
+/** Minimum clear space between two adjacent scale labels before the scale is dropped. */
+const SLIDER_SCALE_LABEL_GAP = 4;
+
+/**
+ * Approximate advance width of a digit in the 10px scale font. Used to predict label width
+ * without measuring, so suppression and min-width behave identically during SSR.
+ */
+const SLIDER_SCALE_CHAR_WIDTH = 5.6;
+
+/** WCAG target size for the thumb, applied via a pseudo-element so the visual thumb stays 12px. */
+const SLIDER_THUMB_HIT_AREA = 44;
+
+/**
+ * How far the pointer must travel before a press counts as a drag rather than a click.
+ *
+ * A click should glide to where it landed, a drag should track the finger exactly, and the
+ * two are only distinguishable after the fact. Without this slop a mouse that jitters a pixel
+ * between press and release would cancel the glide and make the click look broken.
+ */
+const SLIDER_DRAG_SLOP = 3;
+
+const sliderInputColors = {
+  rail: 'interactive.background.neutral.faded',
+  fill: {
+    default: 'interactive.background.neutral.default',
+    /** Shared by hover, focus and drag. */
+    highlighted: 'interactive.background.neutral.highlighted',
+    /**
+     * Opaque on purpose. The thumb straddles the fill/rail boundary, so an alpha token
+     * would let that seam read straight through the middle of the thumb.
+     */
+    disabled: 'interactive.background.neutral.disabledSolid',
+  },
+  scaleLabel: {
+    default: 'surface.text.gray.muted',
+    disabled: 'surface.text.gray.disabled',
+  },
+  indicator: {
+    background: 'popup.background.gray.intense',
+    text: 'interactive.text.staticWhite.normal',
+  },
+} as const;
+
+/**
+ * The thumb, the fill and the indicator all move together, so they share one set of motion
+ * tokens rather than each picking its own and drifting out of step.
+ *
+ * `position` is deliberately the shortest duration Blade offers: a held arrow key steps
+ * repeatedly, and anything slower would still be easing the previous step when the next one
+ * lands. `standard` is the system's morph easing, which is what a value change is.
+ *
+ * Nothing here applies while dragging. Under a pointer the thumb has to sit exactly where the
+ * finger is, and easing that would read as lag rather than polish.
+ */
+const sliderInputMotion = {
+  /** Value-driven movement of the thumb, the fill and the indicator riding above it. */
+  position: { duration: '2xquick', easing: 'standard' },
+  /** Fill and thumb shifting between the default, highlighted and disabled colours. */
+  color: { duration: 'xquick', easing: 'standard' },
+  /** The indicator fading in and out with the highlight, and its small rise on entry. */
+  indicator: { duration: 'xquick', enterEasing: 'entrance', exitEasing: 'exit' },
+} as const;
+
+/** How far the indicator rises as it fades in, in px. */
+const SLIDER_INDICATOR_RISE = 2;
+
+export {
+  SLIDER_BOX_HEIGHT,
+  SLIDER_BOX_PADDING_TOP,
+  SLIDER_CONTROL_HEIGHT,
+  SLIDER_TRACK_HEIGHT,
+  SLIDER_TRACK_TOP,
+  SLIDER_THUMB_SIZE,
+  SLIDER_THUMB_TOP,
+  SLIDER_INDICATOR_GAP,
+  SLIDER_INDICATOR_BOTTOM,
+  SLIDER_SCALE_TOP,
+  SLIDER_SCALE_HEIGHT,
+  SLIDER_MARKER_DOT,
+  SLIDER_MARKER_RADIUS,
+  SLIDER_MARKER_RING,
+  SLIDER_MIN_MARKER_PITCH,
+  SLIDER_SCALE_LABEL_GAP,
+  SLIDER_SCALE_CHAR_WIDTH,
+  SLIDER_THUMB_HIT_AREA,
+  SLIDER_DRAG_SLOP,
+  SLIDER_INDICATOR_RISE,
+  sliderInputColors,
+  sliderInputMotion,
+};

--- a/packages/blade/src/components/Input/SliderInput/types.ts
+++ b/packages/blade/src/components/Input/SliderInput/types.ts
@@ -1,0 +1,112 @@
+import type { BaseInputProps } from '~components/Input/BaseInput';
+import type { FormInputLabelProps, FormInputValidationProps } from '~components/Form';
+import type { StyledPropsBlade } from '~components/Box/styledProps';
+import type { DataAnalyticsAttribute } from '~utils/types';
+import type { MotionMetaProp } from '~components/BaseMotion';
+
+type SliderInputProps = Pick<
+  FormInputLabelProps,
+  'label' | 'labelPosition' | 'necessityIndicator'
+> &
+  // `validationTextPlacement: 'inside'` has no meaning here: the slider has no field box to
+  // render text inside of.
+  Omit<FormInputValidationProps, 'validationTextPlacement'> &
+  Pick<
+    BaseInputProps,
+    | 'name'
+    | 'onFocus'
+    | 'onBlur'
+    | 'isDisabled'
+    | 'isRequired'
+    | 'accessibilityLabel'
+    | 'testID'
+    | keyof DataAnalyticsAttribute
+  > & {
+    /**
+     * The value of the slider, in controlled mode.
+     *
+     * Always snapped to `step` before it is rendered, so a value that does not sit on a step
+     * will move the thumb to the nearest one.
+     */
+    value?: number;
+
+    /**
+     * The initial value when the slider is uncontrolled.
+     */
+    defaultValue?: number;
+
+    /**
+     * Called on every change, including each pointer move during a drag.
+     *
+     * Bind live display to this. For anything expensive, use `onChangeEnd` instead.
+     */
+    onChange?: (args: { value: number }) => void;
+
+    /**
+     * Called once when an interaction commits: on pointer release, or on the key up of a
+     * keyboard adjustment. Use this for network calls and other expensive work.
+     */
+    onChangeEnd?: (args: { value: number }) => void;
+
+    /**
+     * Lowest selectable value.
+     *
+     * @default 0
+     */
+    min?: number;
+
+    /**
+     * Highest selectable value. Always reachable, even when it is not a whole number of
+     * `step`s away from `min`.
+     *
+     * @default 100
+     */
+    max?: number;
+
+    /**
+     * The increment between selectable values. This is a step size, not a number of steps:
+     * `step={10}` over 0-100 gives 11 selectable values.
+     *
+     * @default 1
+     */
+    step?: number;
+
+    /**
+     * Shows tick markers on the track, one per step.
+     *
+     * Markers are dropped automatically when the track is too narrow to space them out.
+     *
+     * @default false
+     */
+    showMarkers?: boolean;
+
+    /**
+     * Shows a row of value labels beneath the track.
+     *
+     * @default false
+     */
+    showScale?: boolean;
+
+    /**
+     * When false, the scale renders only `min` and `max` rather than a label per step.
+     *
+     * @default true
+     */
+    showScaleValues?: boolean;
+
+    /**
+     * Formats the value wherever it is displayed: the scale labels, the value indicator and
+     * `aria-valuetext`.
+     */
+    formatValue?: (value: number) => string;
+
+    /**
+     * Shows a readout above the thumb on hover, focus and drag.
+     *
+     * @default true
+     */
+    showValueIndicator?: boolean;
+  } & StyledPropsBlade &
+  MotionMetaProp;
+
+export type { SliderInputProps };

--- a/packages/blade/src/components/Input/SliderInput/useSliderInput.web.ts
+++ b/packages/blade/src/components/Input/SliderInput/useSliderInput.web.ts
@@ -1,0 +1,257 @@
+import React from 'react';
+import { getValueFromPointer, snapValue, clamp } from './utils';
+import { SLIDER_DRAG_SLOP } from './sliderInputTokens';
+import type { ValueRange } from './utils';
+import { useControllableState } from '~utils/useControllable';
+
+type UseSliderInputProps = {
+  value?: number;
+  defaultValue?: number;
+  onChange?: (args: { value: number }) => void;
+  onChangeEnd?: (args: { value: number }) => void;
+  range: ValueRange;
+  isDisabled: boolean;
+};
+
+type UseSliderInputReturn = {
+  value: number;
+  /** Wraps the track and shares its box, so its rect is the track's rect. */
+  trackAreaRef: React.RefObject<HTMLDivElement>;
+  thumbRef: React.RefObject<HTMLDivElement>;
+  /** 0 until first measured. Suppression treats that as "show everything". */
+  trackWidth: number;
+  isRTL: boolean;
+  /** Pointer is down. Drives the highlight and the value indicator. */
+  isDragging: boolean;
+  /**
+   * Pointer is down and has moved past the slop, so the thumb is being scrubbed rather than
+   * placed. Only this suppresses the movement easing: a click should glide to where it landed.
+   */
+  isScrubbing: boolean;
+  controlProps: {
+    onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => void;
+    onPointerCancel: (event: React.PointerEvent<HTMLDivElement>) => void;
+  };
+  thumbProps: {
+    onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+    onKeyUp: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  };
+};
+
+const useSliderInput = ({
+  value: valueProp,
+  defaultValue,
+  onChange,
+  onChangeEnd,
+  range,
+  isDisabled,
+}: UseSliderInputProps): UseSliderInputReturn => {
+  const trackAreaRef = React.useRef<HTMLDivElement>(null);
+  const thumbRef = React.useRef<HTMLDivElement>(null);
+  const [trackWidth, setTrackWidth] = React.useState(0);
+  const [isRTL, setIsRTL] = React.useState(false);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [isScrubbing, setIsScrubbing] = React.useState(false);
+
+  /** Where the press landed, so movement can be measured against it. */
+  const pointerDownX = React.useRef<number | null>(null);
+
+  /**
+   * The value when the current interaction began. `onChangeEnd` is for expensive work, so a
+   * drag or a click that lands back on the starting value should not trigger it.
+   */
+  const valueAtInteractionStart = React.useRef<number | null>(null);
+
+  const [rawValue, setRawValue] = useControllableState<number>({
+    value: valueProp,
+    defaultValue: defaultValue ?? range.min,
+    onChange: (next) => onChange?.({ value: next }),
+  });
+
+  // A controlled value that is off-step still renders on the nearest step, so what the thumb
+  // shows and what the keyboard steps from are never out of sync.
+  const value = snapValue(rawValue, range);
+
+  const setValue = React.useCallback(
+    (next: number) => setRawValue(() => snapValue(next, range)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setRawValue, range.min, range.max, range.step],
+  );
+
+  const endInteraction = React.useCallback(
+    (finalValue: number) => {
+      const startValue = valueAtInteractionStart.current;
+      valueAtInteractionStart.current = null;
+      if (startValue !== null && startValue !== finalValue) {
+        onChangeEnd?.({ value: finalValue });
+      }
+    },
+    [onChangeEnd],
+  );
+
+  React.useEffect(() => {
+    const element = trackAreaRef.current;
+    if (!element) return undefined;
+
+    setIsRTL(window.getComputedStyle(element).direction === 'rtl');
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setTrackWidth(entry.contentRect.width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  const getValueAtPointer = React.useCallback(
+    (clientX: number): number => {
+      const element = trackAreaRef.current;
+      if (!element) return range.min;
+      const rect = element.getBoundingClientRect();
+      return getValueFromPointer({
+        clientX,
+        trackRect: { left: rect.left, width: rect.width },
+        isRTL,
+        range,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRTL, range.min, range.max, range.step],
+  );
+
+  const onPointerDown = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (isDisabled || event.button !== 0) return;
+      // Keeps the pointer bound to the slider once the drag leaves the 32px box, so the thumb
+      // keeps tracking instead of stalling at whichever edge the pointer crossed. Guarded
+      // because pointer capture is absent in some non-browser DOM implementations.
+      if (typeof event.currentTarget.setPointerCapture === 'function') {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }
+      // Stops the drag from turning into a text selection across the rest of the page. It also
+      // suppresses the focus the browser would otherwise move to the thumb, so that is done
+      // by hand below: without it, arrow keys do nothing until the user tabs in separately.
+      event.preventDefault();
+      thumbRef.current?.focus();
+
+      valueAtInteractionStart.current = value;
+      pointerDownX.current = Number.isFinite(event.clientX) ? event.clientX : null;
+      setIsDragging(true);
+      // Deliberately not scrubbing yet. Until the pointer moves this is a click, and the
+      // thumb glides to it rather than teleporting.
+      setValue(getValueAtPointer(event.clientX));
+    },
+    [isDisabled, value, setValue, getValueAtPointer],
+  );
+
+  const onPointerMove = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isDragging || isDisabled) return;
+
+      const startX = pointerDownX.current;
+      const travelled = startX === null ? NaN : Math.abs(event.clientX - startX);
+      /*
+       * Past the slop the press is a drag, so the easing is dropped from here on and the thumb
+       * sits exactly under the finger. Batched with the value so the first scrubbed frame is
+       * already un-eased.
+       *
+       * A move event is itself evidence of a drag; the slop only exists to forgive a mouse
+       * that jitters between press and release. So when the distance cannot be measured at
+       * all, err towards dragging: losing the glide is far less bad than easing every frame
+       * and leaving the thumb trailing the pointer.
+       */
+      if (!isScrubbing && (!Number.isFinite(travelled) || travelled > SLIDER_DRAG_SLOP)) {
+        setIsScrubbing(true);
+      }
+      setValue(getValueAtPointer(event.clientX));
+    },
+    [isDragging, isScrubbing, isDisabled, setValue, getValueAtPointer],
+  );
+
+  const stopDragging = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isDragging) return;
+      if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      setIsDragging(false);
+      setIsScrubbing(false);
+      pointerDownX.current = null;
+      endInteraction(getValueAtPointer(event.clientX));
+    },
+    [isDragging, endInteraction, getValueAtPointer],
+  );
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (isDisabled) return;
+
+      const { min, max, step } = range;
+      // A page jump of one step would be pointless, so it moves ten steps or a tenth of the
+      // range, whichever is larger.
+      const pageStep = Math.max(step * 10, (max - min) / 10);
+      const direction = isRTL ? -1 : 1;
+
+      const next = ((): number | null => {
+        switch (event.key) {
+          case 'ArrowRight':
+            return value + step * direction;
+          case 'ArrowLeft':
+            return value - step * direction;
+          case 'ArrowUp':
+            return value + step;
+          case 'ArrowDown':
+            return value - step;
+          case 'PageUp':
+            return value + pageStep;
+          case 'PageDown':
+            return value - pageStep;
+          case 'Home':
+            return min;
+          case 'End':
+            return max;
+          default:
+            return null;
+        }
+      })();
+
+      if (next === null) return;
+      // Arrow and Page keys would otherwise scroll the page under the slider.
+      event.preventDefault();
+
+      if (valueAtInteractionStart.current === null) {
+        valueAtInteractionStart.current = value;
+      }
+      setValue(clamp(next, min, max));
+    },
+    [isDisabled, range, value, isRTL, setValue],
+  );
+
+  const onKeyUp = React.useCallback(() => {
+    // Holding a key repeats keydown but fires keyup once, so a held adjustment commits once.
+    if (valueAtInteractionStart.current === null) return;
+    endInteraction(value);
+  }, [endInteraction, value]);
+
+  return {
+    value,
+    trackAreaRef,
+    thumbRef,
+    trackWidth,
+    isRTL,
+    isDragging,
+    isScrubbing,
+    controlProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: stopDragging,
+      onPointerCancel: stopDragging,
+    },
+    thumbProps: { onKeyDown, onKeyUp },
+  };
+};
+
+export { useSliderInput };
+export type { UseSliderInputProps, UseSliderInputReturn };

--- a/packages/blade/src/components/Input/SliderInput/utils.ts
+++ b/packages/blade/src/components/Input/SliderInput/utils.ts
@@ -1,0 +1,256 @@
+import {
+  SLIDER_MARKER_DOT,
+  SLIDER_MARKER_RADIUS,
+  SLIDER_MARKER_RING,
+  SLIDER_MIN_MARKER_PITCH,
+  SLIDER_SCALE_CHAR_WIDTH,
+  SLIDER_SCALE_LABEL_GAP,
+} from './sliderInputTokens';
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+/**
+ * Number of decimals in `step`, used to undo floating point drift after arithmetic.
+ * `0.1 + 0.2` must render as `0.3`, not `0.30000000000000004`.
+ */
+const getStepPrecision = (step: number): number => {
+  const asString = String(step);
+  if (asString.includes('e-')) return 20;
+  const decimalIndex = asString.indexOf('.');
+  return decimalIndex === -1 ? 0 : asString.length - decimalIndex - 1;
+};
+
+const roundToStep = (value: number, step: number): number =>
+  Number(value.toFixed(Math.min(getStepPrecision(step), 20)));
+
+type ValueRange = {
+  min: number;
+  max: number;
+  step: number;
+};
+
+/**
+ * Rounds a value to the nearest step and clamps it into range.
+ *
+ * `max` is always reachable even when the range is not a whole number of steps: a slider
+ * from 0 to 100 with `step={30}` has stops at 0, 30, 60, 90 and 100.
+ */
+const snapValue = (value: number, { min, max, step }: ValueRange): number => {
+  if (!Number.isFinite(value)) return min;
+  if (step <= 0) return clamp(value, min, max);
+
+  const snapped = min + Math.round((value - min) / step) * step;
+  if (snapped >= max) return max;
+
+  // The final step can land closer to `max` than to its own stop, in which case `max` wins.
+  const lastWholeStep = min + Math.floor((max - min) / step) * step;
+  if (snapped >= lastWholeStep && max - value < value - lastWholeStep) return max;
+
+  return clamp(roundToStep(snapped, step), min, max);
+};
+
+/**
+ * Every value that gets a marker: one per step, plus `max` when it is not already a stop.
+ */
+const getMarkerValues = ({ min, max, step }: ValueRange): number[] => {
+  if (step <= 0 || max <= min) return [min, max];
+
+  const wholeSteps = Math.floor((max - min) / step);
+  const values: number[] = [];
+  for (let index = 0; index <= wholeSteps; index++) {
+    values.push(roundToStep(min + index * step, step));
+  }
+  if (values[values.length - 1] !== max) values.push(max);
+  return values;
+};
+
+/** Position of a value along the track, as a 0-1 fraction. */
+const getValueRatio = (value: number, { min, max }: Pick<ValueRange, 'min' | 'max'>): number => {
+  if (max === min) return 0;
+  return clamp((value - min) / (max - min), 0, 1);
+};
+
+/**
+ * Offset of a ratio from the track's inline start, as a CSS length.
+ *
+ * The usable span is inset by the marker radius at both ends so that the end dots sit fully
+ * on the rail. Expressing it as a `calc` keeps positioning resolution-independent: nothing
+ * here needs the measured track width, so it renders identically during SSR.
+ */
+const getOffsetExpression = (ratio: number): string =>
+  `calc(${SLIDER_MARKER_RADIUS}px + ${ratio} * (100% - ${SLIDER_MARKER_DOT}px))`;
+
+/**
+ * Width of the filled span.
+ *
+ * The fill runs to the far edge of the marker it reaches, not its centre, or the reached dot
+ * renders half filled. At `max` this resolves to exactly 100%.
+ */
+const getFillWidthExpression = (ratio: number): string =>
+  `calc(${SLIDER_MARKER_DOT}px + ${ratio} * (100% - ${SLIDER_MARKER_DOT}px))`;
+
+/**
+ * One radial gradient per marker, each opaque everywhere except a transparent ring around
+ * its dot. Intersecting them punches every ring into a single mask.
+ *
+ * The dot itself stays in the mask, so it takes the colour of whatever layer it sits on:
+ * fill colour once reached, rail colour before. That is what keeps markers from hardcoding
+ * an assumption about the surface behind them.
+ */
+const getMarkerMaskImage = (ratios: number[]): string =>
+  ratios
+    .map((ratio) => {
+      const position = getOffsetExpression(ratio);
+      return `radial-gradient(circle ${
+        SLIDER_MARKER_RING / 2
+      }px at ${position} 50%, #000 0 ${SLIDER_MARKER_RADIUS}px, transparent ${SLIDER_MARKER_RADIUS}px ${
+        SLIDER_MARKER_RING / 2
+      }px, #000 ${SLIDER_MARKER_RING / 2}px)`;
+    })
+    .join(', ');
+
+/**
+ * Centres an element on the offset given by `inset-inline-start`.
+ *
+ * Under RTL that property resolves to `right`, so the shift has to flip with it or every
+ * centred element lands half its width off the point it is anchored to.
+ */
+const getCenteringTransform = (isRTL: boolean): string =>
+  isRTL ? 'translateX(50%)' : 'translateX(-50%)';
+
+/** Predicted width of the widest label, without measuring, so SSR and client agree. */
+const getWidestLabelWidth = (values: number[], formatValue?: (value: number) => string): number => {
+  const longest = values.reduce((widest, value) => {
+    const length = (formatValue ? formatValue(value) : String(value)).length;
+    return Math.max(widest, length);
+  }, 0);
+  return longest * SLIDER_SCALE_CHAR_WIDTH;
+};
+
+/** Centre-to-centre distance between adjacent markers at a given track width. */
+const getPitch = (trackWidth: number, markerCount: number): number => {
+  if (markerCount <= 1) return trackWidth;
+  return (trackWidth - SLIDER_MARKER_DOT) / (markerCount - 1);
+};
+
+/**
+ * Markers and labels crowd at different widths, so they are suppressed independently.
+ *
+ * `trackWidth` of 0 means unmeasured, which is the SSR and first-paint case. Both render
+ * then, and a too-narrow track corrects itself on the first resize observation.
+ */
+const getVisibility = ({
+  trackWidth,
+  markerCount,
+  widestLabelWidth,
+}: {
+  trackWidth: number;
+  markerCount: number;
+  widestLabelWidth: number;
+}): { canShowMarkers: boolean; canShowScale: boolean } => {
+  if (trackWidth <= 0) return { canShowMarkers: true, canShowScale: true };
+  const pitch = getPitch(trackWidth, markerCount);
+  return {
+    canShowMarkers: pitch >= SLIDER_MIN_MARKER_PITCH,
+    canShowScale: pitch >= widestLabelWidth + SLIDER_SCALE_LABEL_GAP,
+  };
+};
+
+/**
+ * Drops scale labels that would collide with the one kept before them.
+ *
+ * The pitch floor above assumes markers are evenly spaced, which stops being true when the
+ * range is not a whole number of steps: the trailing partial step leaves the last whole step
+ * a sliver away from `max`, and the two labels print on top of each other. Both are real
+ * stops, so the fix is to stop drawing one of them rather than to stop offering it.
+ *
+ * `min` and `max` are always kept, since they are the bounds the scale exists to communicate.
+ * A label colliding with `max` is dropped in favour of `max` rather than the other way round.
+ */
+const getSpacedScaleValues = ({
+  values,
+  trackWidth,
+  widestLabelWidth,
+  range,
+}: {
+  values: number[];
+  trackWidth: number;
+  widestLabelWidth: number;
+  range: ValueRange;
+}): number[] => {
+  // Unmeasured, which is the SSR and first-paint case: show everything and let the first
+  // resize observation correct it, matching how marker suppression behaves.
+  if (trackWidth <= 0 || values.length <= 2) return values;
+
+  const usable = trackWidth - SLIDER_MARKER_DOT;
+  if (usable <= 0) return values;
+
+  const minGap = widestLabelWidth + SLIDER_SCALE_LABEL_GAP;
+  const positionOf = (target: number): number => getValueRatio(target, range) * usable;
+  const lastKept = (kept: number[]): number => positionOf(kept[kept.length - 1]);
+
+  const kept = [values[0]];
+  for (let index = 1; index < values.length - 1; index++) {
+    if (positionOf(values[index]) - lastKept(kept) >= minGap) kept.push(values[index]);
+  }
+
+  const last = values[values.length - 1];
+  while (kept.length > 1 && positionOf(last) - lastKept(kept) < minGap) kept.pop();
+  kept.push(last);
+
+  return kept;
+};
+
+/** Narrowest track that can show every marker and label without collision. */
+const getMinTrackWidth = (markerCount: number, widestLabelWidth: number): number => {
+  if (markerCount <= 1) return SLIDER_MARKER_DOT;
+  const pitch = Math.max(SLIDER_MIN_MARKER_PITCH, widestLabelWidth + SLIDER_SCALE_LABEL_GAP);
+  return Math.ceil(pitch * (markerCount - 1) + SLIDER_MARKER_DOT);
+};
+
+/**
+ * Value under a pointer.
+ *
+ * Reads direction off the track so that the maths agrees with the logical properties used
+ * for layout. Blade has no RTL support today, but the two must not disagree if it gains it.
+ */
+const getValueFromPointer = ({
+  clientX,
+  trackRect,
+  isRTL,
+  range,
+}: {
+  clientX: number;
+  trackRect: { left: number; width: number };
+  isRTL: boolean;
+  range: ValueRange;
+}): number => {
+  const usable = trackRect.width - SLIDER_MARKER_DOT;
+  if (usable <= 0) return range.min;
+
+  const fromStart = clientX - trackRect.left - SLIDER_MARKER_RADIUS;
+  const rawRatio = clamp(fromStart / usable, 0, 1);
+  const ratio = isRTL ? 1 - rawRatio : rawRatio;
+
+  return snapValue(range.min + ratio * (range.max - range.min), range);
+};
+
+export {
+  clamp,
+  snapValue,
+  roundToStep,
+  getMarkerValues,
+  getValueRatio,
+  getOffsetExpression,
+  getFillWidthExpression,
+  getCenteringTransform,
+  getMarkerMaskImage,
+  getWidestLabelWidth,
+  getPitch,
+  getVisibility,
+  getSpacedScaleValues,
+  getMinTrackWidth,
+  getValueFromPointer,
+};
+export type { ValueRange };

--- a/packages/blade/src/components/index.ts
+++ b/packages/blade/src/components/index.ts
@@ -46,6 +46,7 @@ export * from './Input/TextInput';
 export * from './Input/SearchInput';
 export * from './Input/PhoneNumberInput';
 export * from './Input/ColorInput';
+export * from './Input/SliderInput';
 export * from './InputGroup';
 export * from './Link';
 export * from './List';

--- a/packages/blade/src/utils/getFocusRingStyles/focusRingTokens.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/focusRingTokens.ts
@@ -1,0 +1,17 @@
+/**
+ * Figma models the focus ring as a component set with a primary and a neutral variant. The
+ * primary ring is the default; the neutral one is used by neutral components, where a blue
+ * ring reads as an accent the component does not otherwise have.
+ *
+ * Shared by web and native so the two platforms cannot drift apart.
+ *
+ * Kept `as const` so the values stay literal token paths that `getIn` can check, rather than
+ * widening to `string`. Indexing this by `FocusRingVariant` still forces every variant to have
+ * an entry here.
+ */
+const focusRingColorTokens = {
+  primary: 'surface.border.primary.muted',
+  neutral: 'interactive.border.neutral.faded',
+} as const;
+
+export { focusRingColorTokens };

--- a/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.native.tsx
+++ b/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.native.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import type { CSSProperties } from 'styled-components';
 import type { GetFocusRingArgs, FocusRingWrapperProps } from './types';
+import { focusRingColorTokens } from './focusRingTokens';
 import { useTheme } from '~components/BladeProvider';
 import getIn from '~utils/lodashButBetter/get';
 import { castNativeType, makeMotionTime } from '~utils';
@@ -18,10 +19,11 @@ const FocusRingWrapper = ({
   isFocused,
   borderRadius,
   disabled,
+  variant = 'primary',
   children,
 }: FocusRingWrapperProps): React.ReactElement => {
   const { theme } = useTheme();
-  const focusRingColor = getIn(theme.colors, 'surface.border.primary.muted');
+  const focusRingColor = getIn(theme.colors, focusRingColorTokens[variant]);
 
   const motionConfig = {
     duration: castNativeType(makeMotionTime(getIn(theme.motion.duration, 'xgentle') as number)),

--- a/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.test.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.test.ts
@@ -19,4 +19,25 @@ describe('getFocusRingStyles', () => {
       transitionTimingFunction: 'cubic-bezier(0.3, 0, 0.2, 1)',
     });
   });
+
+  it('should draw the neutral ring when asked for the neutral variant', () => {
+    const theme = {
+      ...bladeTheme,
+      colors: bladeTheme.colors.onLight,
+      elevation: bladeTheme.elevation.onLight,
+      typography: bladeTheme.typography.onDesktop,
+    };
+
+    // Everything but the colour should match the primary ring, so neutral components keep the
+    // same focus geometry and motion as the rest of the system.
+    const { outline: primaryOutline, ...primaryRest } = getFocusRingStyles({ theme });
+    const { outline: neutralOutline, ...neutralRest } = getFocusRingStyles({
+      theme,
+      variant: 'neutral',
+    });
+
+    expect(neutralRest).toStrictEqual(primaryRest);
+    expect(neutralOutline).not.toBe(primaryOutline);
+    expect(neutralOutline).toBe(`4px solid ${theme.colors.interactive.border.neutral.faded}`);
+  });
 });

--- a/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/getFocusRingStyles.web.ts
@@ -1,20 +1,25 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import type { GetFocusRingArgs } from './types';
+import { focusRingColorTokens } from './focusRingTokens';
 import { castWebType, makeMotionTime } from '~utils';
+import getIn from '~utils/lodashButBetter/get';
 
 /**
  * @param props.theme Blade Theme Object
  * @param props.negativeOffset if set the outline offset will be set to -4px, this is useful
  * in table component where the outline will get cutoff by the table border
+ * @param props.variant `neutral` swaps the primary blue ring for the neutral one, for
+ * components that are themselves neutral
  */
 function getFocusRingStyles({
   theme,
   negativeOffset = false,
   isImportant = false,
+  variant = 'primary',
 }: GetFocusRingArgs) {
   const important = `${isImportant ? ' !important' : ''}`;
   return {
-    outline: `4px solid ${theme.colors.surface.border.primary.muted}${important}`,
+    outline: `4px solid ${getIn(theme.colors, focusRingColorTokens[variant])}${important}`,
     outlineOffset: `${negativeOffset ? '-4px' : '1px'}${important}`,
     transitionProperty: 'outline-width',
     transitionDuration: castWebType(makeMotionTime(theme.motion.duration['2xquick'])),

--- a/packages/blade/src/utils/getFocusRingStyles/index.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/index.ts
@@ -1,2 +1,2 @@
 export * from './getFocusRingStyles';
-export type { FocusRingWrapperProps } from './types';
+export type { FocusRingWrapperProps, FocusRingVariant } from './types';

--- a/packages/blade/src/utils/getFocusRingStyles/types.ts
+++ b/packages/blade/src/utils/getFocusRingStyles/types.ts
@@ -1,10 +1,17 @@
 import type React from 'react';
 import type { Theme } from '~components/BladeProvider';
 
+/**
+ * Mirrors the variants of the BaseFocusRing component set in Figma. `neutral` is for neutral
+ * components, which a primary blue ring would give an accent they do not otherwise carry.
+ */
+type FocusRingVariant = 'primary' | 'neutral';
+
 type GetFocusRingArgs = {
   theme: Theme;
   negativeOffset?: boolean;
   isImportant?: boolean;
+  variant?: FocusRingVariant;
 };
 
 type FocusRingWrapperProps = {
@@ -13,7 +20,8 @@ type FocusRingWrapperProps = {
   borderRadius: number;
   /** When true the ring is suppressed (e.g. table input cells use a negative-offset ring instead) */
   disabled?: boolean;
+  variant?: FocusRingVariant;
   children: React.ReactNode;
 };
 
-export type { GetFocusRingArgs, FocusRingWrapperProps };
+export type { GetFocusRingArgs, FocusRingWrapperProps, FocusRingVariant };

--- a/packages/blade/src/utils/metaAttribute/metaConstants.ts
+++ b/packages/blade/src/utils/metaAttribute/metaConstants.ts
@@ -80,6 +80,7 @@ export const MetaConstants = {
   OTPInput: 'otp-input',
   PasswordInput: 'password-input',
   SearchInput: 'search-input',
+  SliderInput: 'slider-input',
   TextArea: 'textarea',
   TextInput: 'textinput',
   PhoneNumberInput: 'phone-number-input',

--- a/packages/blade/src/utils/metaAttribute/metaConstants.ts
+++ b/packages/blade/src/utils/metaAttribute/metaConstants.ts
@@ -81,6 +81,7 @@ export const MetaConstants = {
   PasswordInput: 'password-input',
   SearchInput: 'search-input',
   SliderInput: 'slider-input',
+  AnimatedValue: 'animated-value',
   TextArea: 'textarea',
   TextInput: 'textinput',
   PhoneNumberInput: 'phone-number-input',

--- a/packages/blade/src/utils/storybook/componentStatusData.ts
+++ b/packages/blade/src/utils/storybook/componentStatusData.ts
@@ -1040,6 +1040,21 @@ const componentData: ComponentStatusDataType = [
     },
   },
   {
+    name: 'SliderInput',
+    description:
+      'SliderInput lets users pick a number from a range by dragging along a track, with optional step markers and a value scale.',
+    platform: 'web',
+    frameworks: {
+      react: {
+        status: 'released',
+        storybookLink: 'Components/Input/SliderInput',
+      },
+      svelte: {
+        status: 'to-be-decided',
+      },
+    },
+  },
+  {
     name: 'PhoneNumberInput',
     description:
       'A phone number input is an input field that allow users to input phone numbers with a keyboard. It supports entering phone numbers from different geographic locations.',


### PR DESCRIPTION
> **Stacked on #3988** (the neutral focus ring), which this needs. Review that one first; this PR targets it rather than `master`, so the diff here is only the slider.

Adds `SliderInput`, a web-only slider built from the Figma spec. React Native is a `throwBladeError` stub.

---

# API reference

Reviewers are seeing this component for the first time, so this is the whole public surface and the reasoning behind the shape of it.

## Minimal usage

```jsx
<SliderInput label="Volume" />
```

Uncontrolled, 0–100, step 1.

## Props

### Value

| Prop | Type | Default | Notes |
| --- | --- | --- | --- |
| `value` | `number` | — | Controlled value. Snapped to `step` before rendering, so an off-step value moves the thumb to the nearest step rather than sitting between two. |
| `defaultValue` | `number` | — | Initial value when uncontrolled. |
| `onChange` | `({ name, value }) => void` | — | Fires on **every** change, including each pointer move during a drag. |
| `onChangeEnd` | `({ name, value }) => void` | — | Fires **once** when an interaction commits: pointer release, or key up. |

**Why two callbacks.** A drag fires `onChange` on every pointer move, which is right for live display and wrong for anything expensive. `onChangeEnd` is the one to hang a network call on. It is deliberately in v1 rather than added later, because adding it afterwards tends to mean consumers have already debounced `onChange` by hand.

### Range

| Prop | Type | Default | Notes |
| --- | --- | --- | --- |
| `min` | `number` | `0` | |
| `max` | `number` | `100` | Always reachable, even when it is not a whole number of `step`s from `min`. |
| `step` | `number` | `1` | A step **size**, not a count: `step={10}` over 0–100 gives 11 values. |

**On `max` always being reachable.** With `min={0} max={100} step={33.33}` the last whole step lands at 99.99 and `max` is a sliver away. Both are real, selectable stops — dropping one would make a value the consumer asked for unreachable. Only the *label* is suppressed when two collide (see below).

### Display

| Prop | Type | Default | Notes |
| --- | --- | --- | --- |
| `showMarkers` | `boolean` | `false` | Tick markers on the track, one per step. |
| `showScale` | `boolean` | `false` | Row of value labels beneath the track. |
| `showScaleValues` | `boolean` | `true` | When `false`, the scale shows only `min` and `max`. |
| `showValueIndicator` | `boolean` | `true` | Readout above the thumb on hover, focus and drag. |
| `formatValue` | `(value: number) => string` | — | Applied everywhere the value is shown: scale labels, the indicator, **and `aria-valuetext`**. |

Markers and scale labels are dropped automatically when the track is too narrow to space them out, so a slider in a tight column degrades instead of turning into a smear. `min` and `max` are always kept.

### Inherited, not redeclared

These are picked directly off the shared form types, so they behave identically to `TextInput`, `PasswordInput` and the rest:

- From `FormInputLabelProps`: `label`, `labelPosition`, `necessityIndicator`
- From `FormInputValidationProps`: `helpText`, `errorText`, `successText`, `validationState`
- From `BaseInputProps`: `name`, `isDisabled`, `isRequired`, `onFocus`, `onBlur`, `accessibilityLabel`, `testID`
- Plus `StyledPropsBlade` and `data-analytics-*`

`validationTextPlacement` is `Omit`ted: there is no field box to render text inside of.

The label and hint render through the same `FormLabel` / `FormHint` components, and the hint precedence uses `BaseInput`'s exported `getHintType` rather than a reimplementation, so the rule for which hint wins cannot drift.

## Pairing with another input

There is no built-in pairing prop. The slider is controlled and pairing is composition:

```jsx
const [radius, setRadius] = React.useState(16);

<SliderInput label="Corner Radius" labelPosition="left" value={radius}
  onChange={({ value }) => setRadius(value)} />
<TextInput value={String(radius)} onChange={...} />
```

A dedicated prop would have to take a position on validation, formatting and commit timing for an input it does not own. `value` + `onChange` already express it. See the `PairedWithTextInput` story.

## Not in the API, deliberately

- **No vertical orientation.** Not in the design, and it would change the pointer maths, the indicator placement and the scale layout. `aria-orientation="horizontal"` is stated explicitly so adding it later is not a breaking change.
- **No range (two-thumb) mode.** A different component, not a prop.
- **No `size`.** Not in the Figma spec.

---

# Implementation notes

## Positioning is pure CSS `calc()`

Thumb, fill, markers and scale labels are positioned with `calc()` percentages against the track, so **nothing is measured to render**. The first server render is already correct and there is no hydration shift. `ResizeObserver` is used only to decide whether labels still *fit*, never to position anything.

## Accessibility

Full ARIA slider pattern: `role="slider"` with `aria-valuemin` / `aria-valuemax` / `aria-valuenow` / `aria-valuetext`, plus `aria-orientation`, `aria-labelledby`, `aria-describedby`, `aria-disabled`, and `tabIndex` dropping to `-1` when disabled.

Complete APG keyboard set — arrows, `PageUp` / `PageDown`, `Home` / `End` — all tested.

Pointer targets meet WCAG 2.5.8 through a 44px pseudo-element, so the visual thumb stays 12px.

`aria-valuetext` runs through `formatValue`, so a screen reader hears `₹3k` rather than `3000`.

**Known gap: `prefers-reduced-motion` is not handled.** It is handled nowhere in Blade — the setting appears in no source file — and the decision is to address it system-wide rather than per component. Flagged explicitly in `_decisions.md` because the usual justification is weaker here than where it was set: this component carries real motion, including a spring-driven odometer. Happy to revisit if reviewers disagree.

## Motion

Every duration and easing comes from `theme.motion.*`; there are no hardcoded milliseconds or bezier literals. The thumb, fill and indicator share one `sliderInputMotion` block so they cannot drift apart.

Movement easing is suppressed while **scrubbing**, not merely while the pointer is down. A click on a far part of the track should glide there; a drag must pin the thumb to the finger, where easing reads as lag. Those are the same `pointerdown`, so they are told apart afterwards by a 3px slop.

The indicator's number rolls as an odometer — digit columns driven continuously from the value — rather than swapping. A swap has to finish one value before starting the next, so a drag changing the value every ~20ms left 19 half-faded copies stacked up and never resolving. Columns driven by the value have no such limit. Measured at a realistic drag speed they trail by ~1.5 units and land exactly on release. Content with no digits in it still swaps as a whole.

## Worth a reviewer's eye

- **`mask-composite: intersect`** draws the marker cut-outs. Verified in Chrome; **not yet verified in Safari.** This is the main thing I would like a second pair of eyes on.
- The odometer's DOM text reads `01234567890` because each column carries every digit. The real value is stated once in a visually hidden node and the columns are `aria-hidden`, so screen readers, find-in-page and copy all get the value rather than the columns.
- RTL uses logical properties throughout and the pointer maths reads the computed direction, but Blade has no RTL infrastructure to test against, so **no RTL support is claimed**.

`_decisions.md` covers the reasoning in full, including the options not taken.

## Checks

- [x] Web and native typecheck
- [x] Lint
- [x] 67 unit tests, plus SSR and `assertAccessible`
- [x] Stories, including `PairedWithTextInput`, `Steps` and `FormattedValue`
- [x] Changeset